### PR TITLE
Back up new aggregate features from 8.4 window function merge

### DIFF
--- a/backup/predata_functions.go
+++ b/backup/predata_functions.go
@@ -105,11 +105,17 @@ func PrintCreateAggregateStatements(predataFile *utils.FileWithByteCount, toc *u
 		if aggDef.FinalFunction != 0 {
 			predataFile.MustPrintf(",\n\tFINALFUNC = %s", funcInfoMap[aggDef.FinalFunction].QualifiedName)
 		}
+		if aggDef.FinalFuncExtra {
+			predataFile.MustPrintf(",\n\tFINALFUNC_EXTRA")
+		}
 		if !aggDef.InitValIsNull {
 			predataFile.MustPrintf(",\n\tINITCOND = '%s'", aggDef.InitialValue)
 		}
 		if aggDef.SortOperator != 0 {
 			predataFile.MustPrintf(",\n\tSORTOP = %s", funcInfoMap[aggDef.SortOperator].QualifiedName)
+		}
+		if aggDef.Hypothetical {
+			predataFile.MustPrintf(",\n\tHYPOTHETICAL")
 		}
 		predataFile.MustPrintln("\n);")
 

--- a/testutils/functions.go
+++ b/testutils/functions.go
@@ -374,6 +374,12 @@ func SkipIfNot4(dbconn *utils.DBConn) {
 	}
 }
 
+func SkipIfBefore6(dbconn *utils.DBConn) {
+	if dbconn.Version.Before("6") {
+		Skip("Test only applicable to GPDB6 and above")
+	}
+}
+
 func InitializeTestTOC(buffer io.Writer, which string) (*utils.TOC, *utils.FileWithByteCount) {
 	toc := &utils.TOC{}
 	toc.InitializeEntryMap("global", "predata", "postdata", "statistics")


### PR DESCRIPTION
Some features from 9.0 and 9.4 have been pulled in to preserve functionality
that GPDB had before the window function change. Commits
https://github.com/greenplum-db/gpdb/commit/65d82a39240eea6c26dd5274eff4e606d4fd3530 and
https://github.com/greenplum-db/gpdb/commit/fd6212ce130bb34fdb8d7c11ae723e0d71872a3b seem to be the main ones with
pg_dump changes
* The ORDERED keyword is no longer supported (though it will not error if
passed)
* The HYPOTHETICAL keyword has been added
* The FUNCFINAL_EXTRA keyword has been added