### PR TITLE
Exit gracefully if error encountered during COPY statement.

### DIFF
--- a/backup/data.go
+++ b/backup/data.go
@@ -47,7 +47,7 @@ func CopyTableOut(connection *utils.DBConn, table Relation, backupFile string) {
 	tocFile := globalCluster.GetSegmentTOCFilePath("<SEG_DATA_DIR>", "<SEGID>")
 	helperCommand := fmt.Sprintf("$GPHOME/bin/gpbackup_helper --oid=%d --toc-file=%s", table.Oid, tocFile)
 	if *singleDataFile && usingCompression {
-		copyCommand = fmt.Sprintf("PROGRAM '%s | %s >> %s'", helperCommand, compressionProgram.CompressCommand, backupFile)
+		copyCommand = fmt.Sprintf("PROGRAM 'set -o pipefail; %s | %s >> %s'", helperCommand, compressionProgram.CompressCommand, backupFile)
 	} else if *singleDataFile {
 		copyCommand = fmt.Sprintf("PROGRAM '%s >> %s'", helperCommand, backupFile)
 	} else if usingCompression {

--- a/backup/data_test.go
+++ b/backup/data_test.go
@@ -74,7 +74,7 @@ var _ = Describe("backup/data tests", func() {
 			backup.SetSingleDataFile(true)
 			utils.SetCompressionParameters(true, utils.Compression{Name: "gzip", CompressCommand: "gzip -c -1", DecompressCommand: "gzip -d -c", Extension: ".gz"})
 			testTable := backup.Relation{SchemaOid: 2345, Oid: 3456, Schema: "public", Name: "foo", DependsUpon: nil, Inherits: nil}
-			execStr := regexp.QuoteMeta("COPY public.foo TO PROGRAM '$GPHOME/bin/gpbackup_helper --oid=3456 --toc-file=<SEG_DATA_DIR>/gpbackup_<SEGID>_20170101010101_toc.yaml | gzip -c -1 >> <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101.gz' WITH CSV DELIMITER ',' ON SEGMENT;")
+			execStr := regexp.QuoteMeta("COPY public.foo TO PROGRAM 'set -o pipefail; $GPHOME/bin/gpbackup_helper --oid=3456 --toc-file=<SEG_DATA_DIR>/gpbackup_<SEGID>_20170101010101_toc.yaml | gzip -c -1 >> <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101.gz' WITH CSV DELIMITER ',' ON SEGMENT;")
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101.gz"
 			backup.CopyTableOut(connection, testTable, filename)

--- a/restore/data.go
+++ b/restore/data.go
@@ -20,7 +20,7 @@ func CopyTableIn(connection *utils.DBConn, tableName string, tableAttributes str
 	helperCommand := fmt.Sprintf("$GPHOME/bin/gpbackup_helper --restore --toc-file=%s --oid=%d", tocFile, oid)
 	copyCommand := ""
 	if singleDataFile && usingCompression {
-		copyCommand = fmt.Sprintf("PROGRAM '%s %s | %s'", compressionProgram.DecompressCommand, backupFile, helperCommand)
+		copyCommand = fmt.Sprintf("PROGRAM 'set -o pipefail; %s %s | %s'", compressionProgram.DecompressCommand, backupFile, helperCommand)
 	} else if usingCompression {
 		copyCommand = fmt.Sprintf("PROGRAM '%s < %s'", compressionProgram.DecompressCommand, backupFile)
 	} else if singleDataFile {

--- a/restore/data_test.go
+++ b/restore/data_test.go
@@ -28,7 +28,7 @@ var _ = Describe("restore/data tests", func() {
 		})
 		It("will restore a table from a single data file with compression", func() {
 			utils.SetCompressionParameters(true, utils.Compression{Name: "gzip", CompressCommand: "gzip -c -1", DecompressCommand: "gzip -d -c", Extension: ".gz"})
-			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'gzip -d -c <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101.gz | $GPHOME/bin/gpbackup_helper --restore --toc-file=<SEG_DATA_DIR>/gpbackup_<SEGID>_20170101010101_toc.yaml --oid=2' WITH CSV DELIMITER ',' ON SEGMENT;")
+			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'set -o pipefail; gzip -d -c <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101.gz | $GPHOME/bin/gpbackup_helper --restore --toc-file=<SEG_DATA_DIR>/gpbackup_<SEGID>_20170101010101_toc.yaml --oid=2' WITH CSV DELIMITER ',' ON SEGMENT;")
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101.gz"
 			restore.CopyTableIn(connection, "public.foo", "(i,j)", filename, true, 2)


### PR DESCRIPTION
Previously, when piping output in our COPY statements, errors would be
ignored as pipes will ignore errors in a previous command by default.