### PR TITLE
Fix linting issues

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -82,7 +82,7 @@ func DoBackup() {
 	metadataTables, dataTables, tableDefs := RetrieveAndProcessTables()
 	if !*dataOnly {
 		if isTableFiltered {
-			backupTablePredata(metadataTables, tableDefs, objectCounts)
+			backupTablePredata(metadataTables, tableDefs)
 		} else {
 			backupGlobal(objectCounts)
 			backupPredata(metadataTables, tableDefs, objectCounts)
@@ -182,7 +182,7 @@ func backupPredata(tables []Relation, tableDefs map[uint32]TableDefinition, obje
 	logger.Info("Pre-data metadata backup complete")
 }
 
-func backupTablePredata(tables []Relation, tableDefs map[uint32]TableDefinition, objectCounts map[string]int) {
+func backupTablePredata(tables []Relation, tableDefs map[uint32]TableDefinition) {
 	predataFilename := globalCluster.GetPredataFilePath()
 	logger.Info("Writing table metadata to %s", predataFilename)
 	predataFile := utils.NewFileWithByteCountFromFile(predataFilename)

--- a/gometalinter.config
+++ b/gometalinter.config
@@ -1,6 +1,6 @@
 {
   "DisableAll": true,
-  "Enable": ["golint", "vet"],
+  "Enable": ["golint", "vet", "varcheck", "unparam"],
   "Exclude": [
     "should have comment",
     "comment on exported",

--- a/helper/helper_test.go
+++ b/helper/helper_test.go
@@ -15,10 +15,10 @@ import (
 var _ = Describe("helper/helper", func() {
 	var stdout *gbytes.Buffer
 	var stdinRead, stdinWrite *os.File
-	var tocFileRead, tocFileWrite *os.File
+	var tocFileRead *os.File
 	BeforeEach(func() {
 		stdinRead, stdinWrite, _ = os.Pipe()
-		tocFileRead, tocFileWrite, _ = os.Pipe()
+		tocFileRead, _, _ = os.Pipe()
 		utils.System.Stdin = stdinRead
 		stdout = gbytes.NewBuffer()
 		utils.System.Stdout = stdout

--- a/restore/validate_test.go
+++ b/restore/validate_test.go
@@ -1,8 +1,6 @@
 package restore_test
 
 import (
-	"bytes"
-
 	"github.com/greenplum-db/gpbackup/restore"
 	"github.com/greenplum-db/gpbackup/testutils"
 	"github.com/greenplum-db/gpbackup/utils"
@@ -52,7 +50,6 @@ var _ = Describe("restore/validate tests", func() {
 		table2Len := uint64(len(table2.Statement))
 		var toc *utils.TOC
 		var backupfile *utils.FileWithByteCount
-		var predataFile *bytes.Reader
 		BeforeEach(func() {
 			toc, backupfile = testutils.InitializeTestTOC(buffer, "predata")
 			backupfile.ByteCount = table1Len
@@ -64,8 +61,6 @@ var _ = Describe("restore/validate tests", func() {
 			backupfile.ByteCount += sequenceLen
 			toc.AddMetadataEntry("schema", "somesequence", "SEQUENCE", table1Len+table2Len, backupfile)
 			restore.SetTOC(toc)
-
-			predataFile = bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement))
 		})
 		It("schema exists in normal backup", func() {
 			restore.SetBackupConfig(&utils.BackupConfig{})
@@ -126,7 +121,6 @@ var _ = Describe("restore/validate tests", func() {
 		table2Len := uint64(len(table2.Statement))
 		var toc *utils.TOC
 		var backupfile *utils.FileWithByteCount
-		var predataFile *bytes.Reader
 		BeforeEach(func() {
 			toc, backupfile = testutils.InitializeTestTOC(buffer, "predata")
 			backupfile.ByteCount = table1Len
@@ -138,8 +132,6 @@ var _ = Describe("restore/validate tests", func() {
 			backupfile.ByteCount += sequenceLen
 			toc.AddMetadataEntry("schema1", "somesequence", "SEQUENCE", table1Len+table2Len, backupfile)
 			restore.SetTOC(toc)
-
-			predataFile = bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement))
 		})
 		It("table exists in normal backup", func() {
 			restore.SetBackupConfig(&utils.BackupConfig{})


### PR DESCRIPTION
This fixes linting issues that prevented GoRename from successfully
running in some cases. It also adds two more linters to `make lint`:
- varcheck: Identifies unused variables
- unparam: Identifies unused parameters in functions

Author: Chris Hajas <chajas@pivotal.io>