### PR TITLE
Move timestamp and lock file generation earlier

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -56,6 +56,8 @@ func DoFlagValidation() {
 // This function handles setup that must be done after parsing flags.
 func DoSetup() {
 	SetLoggerVerbosity()
+	timestamp := utils.CurrentTimestamp()
+	utils.CreateBackupLockFile(timestamp)
 	logger.Info("Starting backup of database %s", *dbname)
 	InitializeConnection()
 
@@ -64,9 +66,7 @@ func DoSetup() {
 	validateFilterLists()
 
 	segConfig := utils.GetSegmentConfiguration(connection)
-	timestamp := utils.CurrentTimestamp()
 	segPrefix := utils.GetSegPrefix(connection)
-	utils.CreateBackupLockFile(timestamp)
 	globalCluster = utils.NewCluster(segConfig, *backupDir, timestamp, segPrefix)
 	globalCluster.CreateBackupDirectoriesOnAllHosts()
 	globalTOC = &utils.TOC{}


### PR DESCRIPTION
Previously, we were generating the timestamp and the associated lock
file after we had validated the filter lists. Since this validation
requires querying the database, it can take long enough that the
timestamp generated could be over a second later than when the 
user started the backup. Now, we generate the timestamp and 
lock file before this validation closer to the beginning of the backup.

Author: Chris Hajas <chajas@pivotal.io>