### PR TITLE
Set gp_default_storage_options session GUC during restore

### DIFF
--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -35,6 +35,8 @@ func InitializeConnection(dbname string) {
 	utils.CheckError(err)
 	_, err = connection.Exec("SET gp_enable_segment_copy_checking TO false")
 	utils.CheckError(err)
+	_, err = connection.Exec("SET gp_default_storage_options='';")
+	utils.CheckError(err)
 }
 
 func InitializeBackupConfig() {


### PR DESCRIPTION
Previously, when creating tables during the restore, the storage options
were inherited from the database setting at the time of the backup. However,
this would be incorrect if a table was initially created with no storage
options, as the database GUC would cause storage options to be added. Instead,
we set a session level GUC so that the table is created with the storage
options at the time of table creation.

Author: Chris Hajas <chajas@pivotal.io>