### PR TITLE
Treat backups/restores with no tables as metadata backups/restores

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -78,13 +78,14 @@ func DoBackup() {
 
 	objectCounts = make(map[string]int, 0)
 
-	isTableFiltered := len(includeTables) > 0 || len(excludeTables) > 0
 	metadataTables, dataTables, tableDefs := RetrieveAndProcessTables()
+	CheckTablesContainData(dataTables, tableDefs)
 	metadataFilename := globalCluster.GetMetadataFilePath()
 	logger.Verbose("Metadata will be written to %s", metadataFilename)
 	metadataFile := utils.NewFileWithByteCountFromFile(metadataFilename)
 	defer metadataFile.Close()
 	if !*dataOnly {
+		isTableFiltered := len(includeTables) > 0 || len(excludeTables) > 0
 		if isTableFiltered {
 			backupTablePredata(metadataFile, metadataTables, tableDefs)
 		} else {
@@ -96,7 +97,7 @@ func DoBackup() {
 		BackupSessionGUCs(metadataFile)
 	}
 
-	if !*metadataOnly {
+	if !backupReport.MetadataOnly {
 		backupData(dataTables, tableDefs)
 	}
 

--- a/backup/data.go
+++ b/backup/data.go
@@ -112,3 +112,15 @@ func printDataBackupWarnings(numExtTables int) {
 		logger.Warn("See %s for a complete list of skipped tables.", logger.GetLogFilePath())
 	}
 }
+
+func CheckTablesContainData(tables []Relation, tableDefs map[uint32]TableDefinition) {
+	if !backupReport.MetadataOnly {
+		for _, table := range tables {
+			if !tableDefs[table.Oid].IsExternal {
+				return
+			}
+		}
+		logger.Warn("No tables in backup set contain data. Performing metadata-only backup instead.")
+		backupReport.MetadataOnly = true
+	}
+}

--- a/backup/data_test.go
+++ b/backup/data_test.go
@@ -80,4 +80,32 @@ var _ = Describe("backup/data tests", func() {
 			backup.CopyTableOut(connection, testTable, filename)
 		})
 	})
+	Describe("CheckDBContainsData", func() {
+		config := utils.BackupConfig{}
+		testTable := []backup.Relation{backup.BasicRelation("public", "testtable")}
+
+		BeforeEach(func() {
+			config.MetadataOnly = false
+			backup.SetReport(&utils.Report{BackupConfig: config})
+		})
+		It("changes backup type to metadata if no tables in DB", func() {
+			backup.CheckTablesContainData([]backup.Relation{}, map[uint32]backup.TableDefinition{})
+			Expect(backup.GetReport().BackupConfig.MetadataOnly).To(BeTrue())
+		})
+		It("changes backup type to metadata if only external tables in database", func() {
+			tableDef := backup.TableDefinition{IsExternal: true}
+			backup.CheckTablesContainData(testTable, map[uint32]backup.TableDefinition{0: tableDef})
+			Expect(backup.GetReport().BackupConfig.MetadataOnly).To(BeTrue())
+		})
+		It("does not change backup type if metadata-only backup", func() {
+			config.MetadataOnly = true
+			backup.SetReport(&utils.Report{BackupConfig: config})
+			backup.CheckTablesContainData([]backup.Relation{}, map[uint32]backup.TableDefinition{})
+			Expect(backup.GetReport().BackupConfig.MetadataOnly).To(BeTrue())
+		})
+		It("does not change backup type if tables present in database", func() {
+			backup.CheckTablesContainData(testTable, map[uint32]backup.TableDefinition{0: backup.TableDefinition{}})
+			Expect(backup.GetReport().BackupConfig.MetadataOnly).To(BeFalse())
+		})
+	})
 })

--- a/backup/global_variables.go
+++ b/backup/global_variables.go
@@ -81,6 +81,14 @@ func SetLogger(log *utils.Logger) {
 	logger = log
 }
 
+func SetReport(report *utils.Report) {
+	backupReport = report
+}
+
+func GetReport() *utils.Report {
+	return backupReport
+}
+
 func SetSingleDataFile(which bool) {
 	singleDataFile = &which
 }


### PR DESCRIPTION
Previously, backups and restores would fail if no tables were present
due to the logic around segment TOC files. Instead, don't attempt to
backup/restore data if no tables exist.

Author: Chris Hajas <chajas@pivotal.io>