### PR TITLE
Combine global, predata and postdata into a single metadata file

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -70,7 +70,7 @@ func DoSetup() {
 	globalCluster = utils.NewCluster(segConfig, *backupDir, timestamp, segPrefix)
 	globalCluster.CreateBackupDirectoriesOnAllHosts()
 	globalTOC = &utils.TOC{}
-	globalTOC.InitializeEntryMapFromCluster(globalCluster)
+	globalTOC.InitializeEntryMap()
 }
 
 func DoBackup() {
@@ -80,16 +80,20 @@ func DoBackup() {
 
 	isTableFiltered := len(includeTables) > 0 || len(excludeTables) > 0
 	metadataTables, dataTables, tableDefs := RetrieveAndProcessTables()
+	metadataFilename := globalCluster.GetMetadataFilePath()
+	logger.Info("Metadata will be written to %s", metadataFilename)
+	metadataFile := utils.NewFileWithByteCountFromFile(metadataFilename)
+	defer metadataFile.Close()
 	if !*dataOnly {
 		if isTableFiltered {
-			backupTablePredata(metadataTables, tableDefs)
+			backupTablePredata(metadataFile, metadataTables, tableDefs)
 		} else {
-			backupGlobal()
-			backupPredata(metadataTables, tableDefs)
-			backupPostdata()
+			backupGlobal(metadataFile)
+			backupPredata(metadataFile, metadataTables, tableDefs)
+			backupPostdata(metadataFile)
 		}
 	} else {
-		backupSessionGUCs()
+		BackupSessionGUCs(metadataFile)
 	}
 
 	if !*metadataOnly {
@@ -104,106 +108,90 @@ func DoBackup() {
 	connection.Commit()
 }
 
-func backupGlobal() {
-	globalFilename := globalCluster.GetGlobalFilePath()
-	logger.Info("Writing global database metadata to %s", globalFilename)
-	globalFile := utils.NewFileWithByteCountFromFile(globalFilename)
-	defer globalFile.Close()
+func backupGlobal(metadataFile *utils.FileWithByteCount) {
+	logger.Info("Writing global database metadata")
 
-	BackupSessionGUCs(globalFile)
-	BackupTablespaces(globalFile)
-	BackupCreateDatabase(globalFile)
-	BackupDatabaseGUCs(globalFile)
+	BackupSessionGUCs(metadataFile)
+	BackupTablespaces(metadataFile)
+	BackupCreateDatabase(metadataFile)
+	BackupDatabaseGUCs(metadataFile)
 
 	if len(includeSchemas) == 0 {
-		BackupResourceQueues(globalFile)
+		BackupResourceQueues(metadataFile)
 		if connection.Version.AtLeast("5") {
-			BackupResourceGroups(globalFile)
+			BackupResourceGroups(metadataFile)
 		}
-		BackupRoles(globalFile)
-		BackupRoleGrants(globalFile)
+		BackupRoles(metadataFile)
+		BackupRoleGrants(metadataFile)
 	}
 	logger.Info("Global database metadata backup complete")
 }
 
-func backupPredata(tables []Relation, tableDefs map[uint32]TableDefinition) {
-	predataFilename := globalCluster.GetPredataFilePath()
-	logger.Info("Writing pre-data metadata to %s", predataFilename)
-	predataFile := utils.NewFileWithByteCountFromFile(predataFilename)
-	defer predataFile.Close()
+func backupPredata(metadataFile *utils.FileWithByteCount, tables []Relation, tableDefs map[uint32]TableDefinition) {
+	logger.Info("Writing pre-data metadata")
 
-	BackupSessionGUCs(predataFile)
-	BackupSchemas(predataFile)
+	BackupSessionGUCs(metadataFile)
+	BackupSchemas(metadataFile)
 
 	procLangs := GetProceduralLanguages(connection)
 	langFuncs, otherFuncs, functionMetadata := RetrieveFunctions(procLangs)
 	types, typeMetadata, funcInfoMap := RetrieveTypes()
 
 	if len(includeSchemas) == 0 {
-		BackupProceduralLanguages(predataFile, procLangs, langFuncs, functionMetadata, funcInfoMap)
+		BackupProceduralLanguages(metadataFile, procLangs, langFuncs, functionMetadata, funcInfoMap)
 	}
 
-	BackupShellTypes(predataFile, types)
+	BackupShellTypes(metadataFile, types)
 	if connection.Version.AtLeast("5") {
-		BackupEnumTypes(predataFile, typeMetadata)
+		BackupEnumTypes(metadataFile, typeMetadata)
 	}
 
 	relationMetadata := GetMetadataForObjectType(connection, TYPE_RELATION)
 	sequences := GetAllSequences(connection)
-	BackupCreateSequences(predataFile, sequences, relationMetadata)
+	BackupCreateSequences(metadataFile, sequences, relationMetadata)
 
 	constraints, conMetadata := RetrieveConstraints()
 
-	BackupFunctionsAndTypesAndTables(predataFile, otherFuncs, types, tables, functionMetadata, typeMetadata, relationMetadata, tableDefs, constraints)
-	BackupAlterSequences(predataFile, sequences)
+	BackupFunctionsAndTypesAndTables(metadataFile, otherFuncs, types, tables, functionMetadata, typeMetadata, relationMetadata, tableDefs, constraints)
+	BackupAlterSequences(metadataFile, sequences)
 
 	if len(includeSchemas) == 0 {
-		BackupProtocols(predataFile, funcInfoMap)
+		BackupProtocols(metadataFile, funcInfoMap)
 	}
 
 	if connection.Version.AtLeast("5") {
-		BackupTSParsers(predataFile)
-		BackupTSTemplates(predataFile)
-		BackupTSDictionaries(predataFile)
-		BackupTSConfigurations(predataFile)
+		BackupTSParsers(metadataFile)
+		BackupTSTemplates(metadataFile)
+		BackupTSDictionaries(metadataFile)
+		BackupTSConfigurations(metadataFile)
 	}
 
-	BackupOperators(predataFile)
+	BackupOperators(metadataFile)
 	if connection.Version.AtLeast("5") {
-		BackupOperatorFamilies(predataFile)
+		BackupOperatorFamilies(metadataFile)
 	}
-	BackupOperatorClasses(predataFile)
+	BackupOperatorClasses(metadataFile)
 
-	BackupConversions(predataFile)
-	BackupAggregates(predataFile, funcInfoMap)
-	BackupCasts(predataFile)
-	BackupViews(predataFile, relationMetadata)
-	BackupConstraints(predataFile, constraints, conMetadata)
+	BackupConversions(metadataFile)
+	BackupAggregates(metadataFile, funcInfoMap)
+	BackupCasts(metadataFile)
+	BackupViews(metadataFile, relationMetadata)
+	BackupConstraints(metadataFile, constraints, conMetadata)
 	logger.Info("Pre-data metadata backup complete")
 }
 
-func backupTablePredata(tables []Relation, tableDefs map[uint32]TableDefinition) {
-	predataFilename := globalCluster.GetPredataFilePath()
-	logger.Info("Writing table metadata to %s", predataFilename)
-	predataFile := utils.NewFileWithByteCountFromFile(predataFilename)
-	defer predataFile.Close()
+func backupTablePredata(metadataFile *utils.FileWithByteCount, tables []Relation, tableDefs map[uint32]TableDefinition) {
+	logger.Info("Writing table metadata")
 
-	BackupSessionGUCs(predataFile)
+	BackupSessionGUCs(metadataFile)
 
 	relationMetadata := GetMetadataForObjectType(connection, TYPE_RELATION)
 
 	constraints, conMetadata := RetrieveConstraints(tables...)
 
-	BackupTables(predataFile, tables, relationMetadata, tableDefs, constraints)
-	BackupConstraints(predataFile, constraints, conMetadata)
+	BackupTables(metadataFile, tables, relationMetadata, tableDefs, constraints)
+	BackupConstraints(metadataFile, constraints, conMetadata)
 	logger.Info("Table metadata backup complete")
-}
-
-func backupSessionGUCs() {
-	predataFilename := globalCluster.GetPredataFilePath()
-	predataFile := utils.NewFileWithByteCountFromFile(predataFilename)
-	defer predataFile.Close()
-	BackupSessionGUCs(predataFile)
 }
 
 func backupData(tables []Relation, tableDefs map[uint32]TableDefinition) {
@@ -216,16 +204,13 @@ func backupData(tables []Relation, tableDefs map[uint32]TableDefinition) {
 	logger.Info("Data backup complete")
 }
 
-func backupPostdata() {
-	postdataFilename := globalCluster.GetPostdataFilePath()
-	logger.Info("Writing post-data metadata to %s", postdataFilename)
-	postdataFile := utils.NewFileWithByteCountFromFile(postdataFilename)
-	defer postdataFile.Close()
+func backupPostdata(metadataFile *utils.FileWithByteCount) {
+	logger.Info("Writing post-data metadata")
 
-	BackupSessionGUCs(postdataFile)
-	BackupIndexes(postdataFile)
-	BackupRules(postdataFile)
-	BackupTriggers(postdataFile)
+	BackupSessionGUCs(metadataFile)
+	BackupIndexes(metadataFile)
+	BackupRules(metadataFile)
+	BackupTriggers(metadataFile)
 	logger.Info("Post-data metadata backup complete")
 }
 
@@ -233,6 +218,7 @@ func backupStatistics(tables []Relation) {
 	statisticsFilename := globalCluster.GetStatisticsFilePath()
 	logger.Info("Writing query planner statistics to %s", statisticsFilename)
 	statisticsFile := utils.NewFileWithByteCountFromFile(statisticsFilename)
+	defer statisticsFile.Close()
 	BackupStatistics(statisticsFile, tables)
 	logger.Info("Query planner statistics backup complete")
 }

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -81,7 +81,7 @@ func DoBackup() {
 	isTableFiltered := len(includeTables) > 0 || len(excludeTables) > 0
 	metadataTables, dataTables, tableDefs := RetrieveAndProcessTables()
 	metadataFilename := globalCluster.GetMetadataFilePath()
-	logger.Info("Metadata will be written to %s", metadataFilename)
+	logger.Verbose("Metadata will be written to %s", metadataFilename)
 	metadataFile := utils.NewFileWithByteCountFromFile(metadataFilename)
 	defer metadataFile.Close()
 	if !*dataOnly {

--- a/backup/postdata.go
+++ b/backup/postdata.go
@@ -10,34 +10,34 @@ import (
 	"github.com/greenplum-db/gpbackup/utils"
 )
 
-func PrintCreateIndexStatements(postdataFile *utils.FileWithByteCount, toc *utils.TOC, indexes []QuerySimpleDefinition, indexMetadata MetadataMap) {
+func PrintCreateIndexStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, indexes []QuerySimpleDefinition, indexMetadata MetadataMap) {
 	for _, index := range indexes {
-		start := postdataFile.ByteCount
-		postdataFile.MustPrintf("\n\n%s;", index.Def)
+		start := metadataFile.ByteCount
+		metadataFile.MustPrintf("\n\n%s;", index.Def)
 		if index.Tablespace != "" {
-			postdataFile.MustPrintf("\nALTER INDEX %s SET TABLESPACE %s;", index.Name, index.Tablespace)
+			metadataFile.MustPrintf("\nALTER INDEX %s SET TABLESPACE %s;", index.Name, index.Tablespace)
 		}
-		PrintObjectMetadata(postdataFile, indexMetadata[index.Oid], index.Name, "INDEX")
-		toc.AddMetadataEntry(index.OwningSchema, index.Name, "INDEX", start, postdataFile)
+		PrintObjectMetadata(metadataFile, indexMetadata[index.Oid], index.Name, "INDEX")
+		toc.AddPostdataEntry(index.OwningSchema, index.Name, "INDEX", start, metadataFile)
 	}
 }
 
-func PrintCreateRuleStatements(postdataFile *utils.FileWithByteCount, toc *utils.TOC, rules []QuerySimpleDefinition, ruleMetadata MetadataMap) {
+func PrintCreateRuleStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, rules []QuerySimpleDefinition, ruleMetadata MetadataMap) {
 	for _, rule := range rules {
-		start := postdataFile.ByteCount
-		postdataFile.MustPrintf("\n\n%s", rule.Def)
+		start := metadataFile.ByteCount
+		metadataFile.MustPrintf("\n\n%s", rule.Def)
 		tableFQN := utils.MakeFQN(rule.OwningSchema, rule.OwningTable)
-		PrintObjectMetadata(postdataFile, ruleMetadata[rule.Oid], rule.Name, "RULE", tableFQN)
-		toc.AddMetadataEntry(rule.OwningSchema, rule.Name, "RULE", start, postdataFile)
+		PrintObjectMetadata(metadataFile, ruleMetadata[rule.Oid], rule.Name, "RULE", tableFQN)
+		toc.AddPostdataEntry(rule.OwningSchema, rule.Name, "RULE", start, metadataFile)
 	}
 }
 
-func PrintCreateTriggerStatements(postdataFile *utils.FileWithByteCount, toc *utils.TOC, triggers []QuerySimpleDefinition, triggerMetadata MetadataMap) {
+func PrintCreateTriggerStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, triggers []QuerySimpleDefinition, triggerMetadata MetadataMap) {
 	for _, trigger := range triggers {
-		start := postdataFile.ByteCount
-		postdataFile.MustPrintf("\n\n%s;", trigger.Def)
+		start := metadataFile.ByteCount
+		metadataFile.MustPrintf("\n\n%s;", trigger.Def)
 		tableFQN := utils.MakeFQN(trigger.OwningSchema, trigger.OwningTable)
-		PrintObjectMetadata(postdataFile, triggerMetadata[trigger.Oid], trigger.Name, "TRIGGER", tableFQN)
-		toc.AddMetadataEntry(trigger.OwningSchema, trigger.Name, "TRIGGER", start, postdataFile)
+		PrintObjectMetadata(metadataFile, triggerMetadata[trigger.Oid], trigger.Name, "TRIGGER", tableFQN)
+		toc.AddPostdataEntry(trigger.OwningSchema, trigger.Name, "TRIGGER", start, metadataFile)
 	}
 }

--- a/backup/predata_textsearch.go
+++ b/backup/predata_textsearch.go
@@ -16,61 +16,61 @@ import (
 	"github.com/greenplum-db/gpbackup/utils"
 )
 
-func PrintCreateTextSearchParserStatements(predataFile *utils.FileWithByteCount, toc *utils.TOC, parsers []TextSearchParser, parserMetadata MetadataMap) {
+func PrintCreateTextSearchParserStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, parsers []TextSearchParser, parserMetadata MetadataMap) {
 	for _, parser := range parsers {
-		start := predataFile.ByteCount
+		start := metadataFile.ByteCount
 		parserFQN := utils.MakeFQN(parser.Schema, parser.Name)
-		predataFile.MustPrintf("\n\nCREATE TEXT SEARCH PARSER %s (", parserFQN)
-		predataFile.MustPrintf("\n\tSTART = %s,", parser.StartFunc)
-		predataFile.MustPrintf("\n\tGETTOKEN = %s,", parser.TokenFunc)
-		predataFile.MustPrintf("\n\tEND = %s,", parser.EndFunc)
-		predataFile.MustPrintf("\n\tLEXTYPES = %s", parser.LexTypesFunc)
+		metadataFile.MustPrintf("\n\nCREATE TEXT SEARCH PARSER %s (", parserFQN)
+		metadataFile.MustPrintf("\n\tSTART = %s,", parser.StartFunc)
+		metadataFile.MustPrintf("\n\tGETTOKEN = %s,", parser.TokenFunc)
+		metadataFile.MustPrintf("\n\tEND = %s,", parser.EndFunc)
+		metadataFile.MustPrintf("\n\tLEXTYPES = %s", parser.LexTypesFunc)
 		if parser.HeadlineFunc != "" {
-			predataFile.MustPrintf(",\n\tHEADLINE = %s", parser.HeadlineFunc)
+			metadataFile.MustPrintf(",\n\tHEADLINE = %s", parser.HeadlineFunc)
 		}
-		predataFile.MustPrintf("\n);")
-		PrintObjectMetadata(predataFile, parserMetadata[parser.Oid], parserFQN, "TEXT SEARCH PARSER")
-		toc.AddMetadataEntry(parser.Schema, parser.Name, "TEXT SEARCH PARSER", start, predataFile)
+		metadataFile.MustPrintf("\n);")
+		PrintObjectMetadata(metadataFile, parserMetadata[parser.Oid], parserFQN, "TEXT SEARCH PARSER")
+		toc.AddPredataEntry(parser.Schema, parser.Name, "TEXT SEARCH PARSER", start, metadataFile)
 	}
 }
 
-func PrintCreateTextSearchTemplateStatements(predataFile *utils.FileWithByteCount, toc *utils.TOC, templates []TextSearchTemplate, templateMetadata MetadataMap) {
+func PrintCreateTextSearchTemplateStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, templates []TextSearchTemplate, templateMetadata MetadataMap) {
 	for _, template := range templates {
-		start := predataFile.ByteCount
+		start := metadataFile.ByteCount
 		templateFQN := utils.MakeFQN(template.Schema, template.Name)
-		predataFile.MustPrintf("\n\nCREATE TEXT SEARCH TEMPLATE %s (", templateFQN)
+		metadataFile.MustPrintf("\n\nCREATE TEXT SEARCH TEMPLATE %s (", templateFQN)
 		if template.InitFunc != "" {
-			predataFile.MustPrintf("\n\tINIT = %s,", template.InitFunc)
+			metadataFile.MustPrintf("\n\tINIT = %s,", template.InitFunc)
 		}
-		predataFile.MustPrintf("\n\tLEXIZE = %s", template.LexizeFunc)
-		predataFile.MustPrintf("\n);")
-		PrintObjectMetadata(predataFile, templateMetadata[template.Oid], templateFQN, "TEXT SEARCH TEMPLATE")
-		toc.AddMetadataEntry(template.Schema, template.Name, "TEXT SEARCH TEMPLATE", start, predataFile)
+		metadataFile.MustPrintf("\n\tLEXIZE = %s", template.LexizeFunc)
+		metadataFile.MustPrintf("\n);")
+		PrintObjectMetadata(metadataFile, templateMetadata[template.Oid], templateFQN, "TEXT SEARCH TEMPLATE")
+		toc.AddPredataEntry(template.Schema, template.Name, "TEXT SEARCH TEMPLATE", start, metadataFile)
 	}
 }
 
-func PrintCreateTextSearchDictionaryStatements(predataFile *utils.FileWithByteCount, toc *utils.TOC, dictionaries []TextSearchDictionary, dictionaryMetadata MetadataMap) {
+func PrintCreateTextSearchDictionaryStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, dictionaries []TextSearchDictionary, dictionaryMetadata MetadataMap) {
 	for _, dictionary := range dictionaries {
 		dictionaryFQN := utils.MakeFQN(dictionary.Schema, dictionary.Name)
-		start := predataFile.ByteCount
-		predataFile.MustPrintf("\n\nCREATE TEXT SEARCH DICTIONARY %s (", dictionaryFQN)
-		predataFile.MustPrintf("\n\tTEMPLATE = %s", dictionary.Template)
+		start := metadataFile.ByteCount
+		metadataFile.MustPrintf("\n\nCREATE TEXT SEARCH DICTIONARY %s (", dictionaryFQN)
+		metadataFile.MustPrintf("\n\tTEMPLATE = %s", dictionary.Template)
 		if dictionary.InitOption != "" {
-			predataFile.MustPrintf(",\n\t%s", dictionary.InitOption)
+			metadataFile.MustPrintf(",\n\t%s", dictionary.InitOption)
 		}
-		predataFile.MustPrintf("\n);")
-		PrintObjectMetadata(predataFile, dictionaryMetadata[dictionary.Oid], dictionaryFQN, "TEXT SEARCH DICTIONARY")
-		toc.AddMetadataEntry(dictionary.Schema, dictionary.Name, "TEXT SEARCH DICTIONARY", start, predataFile)
+		metadataFile.MustPrintf("\n);")
+		PrintObjectMetadata(metadataFile, dictionaryMetadata[dictionary.Oid], dictionaryFQN, "TEXT SEARCH DICTIONARY")
+		toc.AddPredataEntry(dictionary.Schema, dictionary.Name, "TEXT SEARCH DICTIONARY", start, metadataFile)
 	}
 }
 
-func PrintCreateTextSearchConfigurationStatements(predataFile *utils.FileWithByteCount, toc *utils.TOC, configurations []TextSearchConfiguration, configurationMetadata MetadataMap) {
+func PrintCreateTextSearchConfigurationStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, configurations []TextSearchConfiguration, configurationMetadata MetadataMap) {
 	for _, configuration := range configurations {
 		configurationFQN := utils.MakeFQN(configuration.Schema, configuration.Name)
-		start := predataFile.ByteCount
-		predataFile.MustPrintf("\n\nCREATE TEXT SEARCH CONFIGURATION %s (", configurationFQN)
-		predataFile.MustPrintf("\n\tPARSER = %s", configuration.Parser)
-		predataFile.MustPrintf("\n);")
+		start := metadataFile.ByteCount
+		metadataFile.MustPrintf("\n\nCREATE TEXT SEARCH CONFIGURATION %s (", configurationFQN)
+		metadataFile.MustPrintf("\n\tPARSER = %s", configuration.Parser)
+		metadataFile.MustPrintf("\n);")
 		tokens := []string{}
 		for token := range configuration.TokenToDicts {
 			tokens = append(tokens, token)
@@ -78,10 +78,10 @@ func PrintCreateTextSearchConfigurationStatements(predataFile *utils.FileWithByt
 		sort.Strings(tokens)
 		for _, token := range tokens {
 			dicts := configuration.TokenToDicts[token]
-			predataFile.MustPrintf("\n\nALTER TEXT SEARCH CONFIGURATION %s", configurationFQN)
-			predataFile.MustPrintf("\n\tADD MAPPING FOR \"%s\" WITH %s;", token, strings.Join(dicts, ", "))
+			metadataFile.MustPrintf("\n\nALTER TEXT SEARCH CONFIGURATION %s", configurationFQN)
+			metadataFile.MustPrintf("\n\tADD MAPPING FOR \"%s\" WITH %s;", token, strings.Join(dicts, ", "))
 		}
-		PrintObjectMetadata(predataFile, configurationMetadata[configuration.Oid], configurationFQN, "TEXT SEARCH CONFIGURATION")
-		toc.AddMetadataEntry(configuration.Schema, configuration.Name, "TEXT SEARCH CONFIGURATION", start, predataFile)
+		PrintObjectMetadata(metadataFile, configurationMetadata[configuration.Oid], configurationFQN, "TEXT SEARCH CONFIGURATION")
+		toc.AddPredataEntry(configuration.Schema, configuration.Name, "TEXT SEARCH CONFIGURATION", start, metadataFile)
 	}
 }

--- a/backup/predata_types.go
+++ b/backup/predata_types.go
@@ -19,116 +19,116 @@ import (
  * Because only base types are dependent on functions, we only need to print
  * shell type statements for base types.
  */
-func PrintCreateShellTypeStatements(predataFile *utils.FileWithByteCount, toc *utils.TOC, types []Type) {
-	start := predataFile.ByteCount
-	predataFile.MustPrintln("\n")
+func PrintCreateShellTypeStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, types []Type) {
+	start := metadataFile.ByteCount
+	metadataFile.MustPrintln("\n")
 	for _, typ := range types {
 		if typ.Type == "b" || typ.Type == "p" {
 			typeFQN := utils.MakeFQN(typ.Schema, typ.Name)
-			predataFile.MustPrintf("CREATE TYPE %s;\n", typeFQN)
-			toc.AddMetadataEntry(typ.Schema, typ.Name, "TYPE", start, predataFile)
-			start = predataFile.ByteCount
+			metadataFile.MustPrintf("CREATE TYPE %s;\n", typeFQN)
+			toc.AddPredataEntry(typ.Schema, typ.Name, "TYPE", start, metadataFile)
+			start = metadataFile.ByteCount
 		}
 	}
 }
 
-func PrintCreateDomainStatement(predataFile *utils.FileWithByteCount, toc *utils.TOC, domain Type, typeMetadata ObjectMetadata, constraints []Constraint) {
-	start := predataFile.ByteCount
+func PrintCreateDomainStatement(metadataFile *utils.FileWithByteCount, toc *utils.TOC, domain Type, typeMetadata ObjectMetadata, constraints []Constraint) {
+	start := metadataFile.ByteCount
 	typeFQN := utils.MakeFQN(domain.Schema, domain.Name)
-	predataFile.MustPrintf("\nCREATE DOMAIN %s AS %s", typeFQN, domain.BaseType)
+	metadataFile.MustPrintf("\nCREATE DOMAIN %s AS %s", typeFQN, domain.BaseType)
 	if domain.DefaultVal != "" {
-		predataFile.MustPrintf(" DEFAULT %s", domain.DefaultVal)
+		metadataFile.MustPrintf(" DEFAULT %s", domain.DefaultVal)
 	}
 	if domain.NotNull {
-		predataFile.MustPrintf(" NOT NULL")
+		metadataFile.MustPrintf(" NOT NULL")
 	}
 	for _, constraint := range constraints {
-		predataFile.MustPrintf("\n\tCONSTRAINT %s %s", constraint.Name, constraint.ConDef)
+		metadataFile.MustPrintf("\n\tCONSTRAINT %s %s", constraint.Name, constraint.ConDef)
 	}
-	predataFile.MustPrintln(";")
-	PrintObjectMetadata(predataFile, typeMetadata, typeFQN, "DOMAIN")
-	toc.AddMetadataEntry(domain.Schema, domain.Name, "DOMAIN", start, predataFile)
+	metadataFile.MustPrintln(";")
+	PrintObjectMetadata(metadataFile, typeMetadata, typeFQN, "DOMAIN")
+	toc.AddPredataEntry(domain.Schema, domain.Name, "DOMAIN", start, metadataFile)
 }
 
-func PrintCreateBaseTypeStatement(predataFile *utils.FileWithByteCount, toc *utils.TOC, base Type, typeMetadata ObjectMetadata) {
-	start := predataFile.ByteCount
+func PrintCreateBaseTypeStatement(metadataFile *utils.FileWithByteCount, toc *utils.TOC, base Type, typeMetadata ObjectMetadata) {
+	start := metadataFile.ByteCount
 	typeFQN := utils.MakeFQN(base.Schema, base.Name)
-	predataFile.MustPrintf("\n\nCREATE TYPE %s (\n", typeFQN)
+	metadataFile.MustPrintf("\n\nCREATE TYPE %s (\n", typeFQN)
 
 	// All of the following functions are stored in quoted form and don't need to be quoted again
-	predataFile.MustPrintf("\tINPUT = %s,\n\tOUTPUT = %s", base.Input, base.Output)
+	metadataFile.MustPrintf("\tINPUT = %s,\n\tOUTPUT = %s", base.Input, base.Output)
 	if base.Receive != "" {
-		predataFile.MustPrintf(",\n\tRECEIVE = %s", base.Receive)
+		metadataFile.MustPrintf(",\n\tRECEIVE = %s", base.Receive)
 	}
 	if base.Send != "" {
-		predataFile.MustPrintf(",\n\tSEND = %s", base.Send)
+		metadataFile.MustPrintf(",\n\tSEND = %s", base.Send)
 	}
 	if connection.Version.AtLeast("5") {
 		if base.ModIn != "" {
-			predataFile.MustPrintf(",\n\tTYPMOD_IN = %s", base.ModIn)
+			metadataFile.MustPrintf(",\n\tTYPMOD_IN = %s", base.ModIn)
 		}
 		if base.ModOut != "" {
-			predataFile.MustPrintf(",\n\tTYPMOD_OUT = %s", base.ModOut)
+			metadataFile.MustPrintf(",\n\tTYPMOD_OUT = %s", base.ModOut)
 		}
 	}
 	if base.InternalLength > 0 {
-		predataFile.MustPrintf(",\n\tINTERNALLENGTH = %d", base.InternalLength)
+		metadataFile.MustPrintf(",\n\tINTERNALLENGTH = %d", base.InternalLength)
 	}
 	if base.IsPassedByValue {
-		predataFile.MustPrintf(",\n\tPASSEDBYVALUE")
+		metadataFile.MustPrintf(",\n\tPASSEDBYVALUE")
 	}
 	if base.Alignment != "" {
 		switch base.Alignment {
 		case "d":
-			predataFile.MustPrintf(",\n\tALIGNMENT = double")
+			metadataFile.MustPrintf(",\n\tALIGNMENT = double")
 		case "i":
-			predataFile.MustPrintf(",\n\tALIGNMENT = int4")
+			metadataFile.MustPrintf(",\n\tALIGNMENT = int4")
 		case "s":
-			predataFile.MustPrintf(",\n\tALIGNMENT = int2")
+			metadataFile.MustPrintf(",\n\tALIGNMENT = int2")
 		case "c": // Default case, don't print anything else
 		}
 	}
 	if base.Storage != "" {
 		switch base.Storage {
 		case "e":
-			predataFile.MustPrintf(",\n\tSTORAGE = extended")
+			metadataFile.MustPrintf(",\n\tSTORAGE = extended")
 		case "m":
-			predataFile.MustPrintf(",\n\tSTORAGE = main")
+			metadataFile.MustPrintf(",\n\tSTORAGE = main")
 		case "x":
-			predataFile.MustPrintf(",\n\tSTORAGE = external")
+			metadataFile.MustPrintf(",\n\tSTORAGE = external")
 		case "p": // Default case, don't print anything else
 		}
 	}
 	if base.DefaultVal != "" {
-		predataFile.MustPrintf(",\n\tDEFAULT = '%s'", base.DefaultVal)
+		metadataFile.MustPrintf(",\n\tDEFAULT = '%s'", base.DefaultVal)
 	}
 	if base.Element != "" {
-		predataFile.MustPrintf(",\n\tELEMENT = %s", base.Element)
+		metadataFile.MustPrintf(",\n\tELEMENT = %s", base.Element)
 	}
 	if base.Delimiter != "" {
-		predataFile.MustPrintf(",\n\tDELIMITER = '%s'", base.Delimiter)
+		metadataFile.MustPrintf(",\n\tDELIMITER = '%s'", base.Delimiter)
 	}
-	predataFile.MustPrintln("\n);")
-	PrintObjectMetadata(predataFile, typeMetadata, typeFQN, "TYPE")
-	toc.AddMetadataEntry(base.Schema, base.Name, "TYPE", start, predataFile)
+	metadataFile.MustPrintln("\n);")
+	PrintObjectMetadata(metadataFile, typeMetadata, typeFQN, "TYPE")
+	toc.AddPredataEntry(base.Schema, base.Name, "TYPE", start, metadataFile)
 }
 
-func PrintCreateCompositeTypeStatement(predataFile *utils.FileWithByteCount, toc *utils.TOC, composite Type, typeMetadata ObjectMetadata) {
-	start := predataFile.ByteCount
+func PrintCreateCompositeTypeStatement(metadataFile *utils.FileWithByteCount, toc *utils.TOC, composite Type, typeMetadata ObjectMetadata) {
+	start := metadataFile.ByteCount
 	typeFQN := utils.MakeFQN(composite.Schema, composite.Name)
-	predataFile.MustPrintf("\n\nCREATE TYPE %s AS (\n", typeFQN)
-	predataFile.MustPrintln(strings.Join(composite.Attributes, ",\n"))
-	predataFile.MustPrintf(");")
-	PrintObjectMetadata(predataFile, typeMetadata, typeFQN, "TYPE")
-	toc.AddMetadataEntry(composite.Schema, composite.Name, "TYPE", start, predataFile)
+	metadataFile.MustPrintf("\n\nCREATE TYPE %s AS (\n", typeFQN)
+	metadataFile.MustPrintln(strings.Join(composite.Attributes, ",\n"))
+	metadataFile.MustPrintf(");")
+	PrintObjectMetadata(metadataFile, typeMetadata, typeFQN, "TYPE")
+	toc.AddPredataEntry(composite.Schema, composite.Name, "TYPE", start, metadataFile)
 }
 
-func PrintCreateEnumTypeStatements(predataFile *utils.FileWithByteCount, toc *utils.TOC, enums []Type, typeMetadata MetadataMap) {
-	start := predataFile.ByteCount
+func PrintCreateEnumTypeStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, enums []Type, typeMetadata MetadataMap) {
+	start := metadataFile.ByteCount
 	for _, enum := range enums {
 		typeFQN := utils.MakeFQN(enum.Schema, enum.Name)
-		predataFile.MustPrintf("\n\nCREATE TYPE %s AS ENUM (\n\t%s\n);\n", typeFQN, enum.EnumLabels)
-		PrintObjectMetadata(predataFile, typeMetadata[enum.Oid], typeFQN, "TYPE")
-		toc.AddMetadataEntry(enum.Schema, enum.Name, "TYPE", start, predataFile)
+		metadataFile.MustPrintf("\n\nCREATE TYPE %s AS ENUM (\n\t%s\n);\n", typeFQN, enum.EnumLabels)
+		PrintObjectMetadata(metadataFile, typeMetadata[enum.Oid], typeFQN, "TYPE")
+		toc.AddPredataEntry(enum.Schema, enum.Name, "TYPE", start, metadataFile)
 	}
 }

--- a/backup/statistics.go
+++ b/backup/statistics.go
@@ -16,7 +16,7 @@ import (
 func PrintStatisticsStatements(statisticsFile *utils.FileWithByteCount, toc *utils.TOC, tables []Relation, attStats map[uint32][]AttributeStatistic, tupleStats map[uint32]TupleStatistic) {
 	start := statisticsFile.ByteCount
 	statisticsFile.MustPrintf(`SET allow_system_table_mods="DML";`)
-	toc.AddMetadataEntry("", "", "STATISTICS GUC", start, statisticsFile)
+	toc.AddStatisticsEntry("", "", "STATISTICS GUC", start, statisticsFile)
 	for _, table := range tables {
 		PrintStatisticsStatementsForTable(statisticsFile, toc, table, attStats[table.Oid], tupleStats[table.Oid])
 	}
@@ -30,7 +30,7 @@ func PrintStatisticsStatementsForTable(statisticsFile *utils.FileWithByteCount, 
 		attributeQuery := GenerateAttributeStatisticsQuery(table, attStat)
 		statisticsFile.MustPrintf("\n\n%s\n", attributeQuery)
 	}
-	toc.AddMetadataEntry(table.Schema, table.Name, "STATISTICS", start, statisticsFile)
+	toc.AddStatisticsEntry(table.Schema, table.Name, "STATISTICS", start, statisticsFile)
 }
 
 func GenerateTupleStatisticsQuery(table Relation, tupleStat TupleStatistic) string {

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -146,125 +146,125 @@ func LogBackupInfo() {
 	logger.Info("Backup Type = %s", backupReport.BackupType)
 }
 
-func BackupSessionGUCs(postdataFile *utils.FileWithByteCount) {
+func BackupSessionGUCs(metadataFile *utils.FileWithByteCount) {
 	gucs := GetSessionGUCs(connection)
-	PrintSessionGUCs(postdataFile, globalTOC, gucs)
+	PrintSessionGUCs(metadataFile, globalTOC, gucs)
 }
 
 /*
  * Global metadata wrapper functions
  */
 
-func BackupTablespaces(globalFile *utils.FileWithByteCount) {
+func BackupTablespaces(metadataFile *utils.FileWithByteCount) {
 	logger.Verbose("Writing CREATE TABLESPACE statements to global file")
 	tablespaces := GetTablespaces(connection)
 	objectCounts["Tablespaces"] = len(tablespaces)
 	tablespaceMetadata := GetMetadataForObjectType(connection, TYPE_TABLESPACE)
-	PrintCreateTablespaceStatements(globalFile, globalTOC, tablespaces, tablespaceMetadata)
+	PrintCreateTablespaceStatements(metadataFile, globalTOC, tablespaces, tablespaceMetadata)
 }
 
-func BackupCreateDatabase(globalFile *utils.FileWithByteCount) {
+func BackupCreateDatabase(metadataFile *utils.FileWithByteCount) {
 	logger.Verbose("Writing CREATE DATABASE statement to global file")
 	db := GetDatabaseName(connection)
 	dbMetadata := GetMetadataForObjectType(connection, TYPE_DATABASE)
-	PrintCreateDatabaseStatement(globalFile, globalTOC, db, dbMetadata)
+	PrintCreateDatabaseStatement(metadataFile, globalTOC, db, dbMetadata)
 }
 
-func BackupDatabaseGUCs(globalFile *utils.FileWithByteCount) {
+func BackupDatabaseGUCs(metadataFile *utils.FileWithByteCount) {
 	logger.Verbose("Writing database GUCs to global file")
 	databaseGucs := GetDatabaseGUCs(connection)
 	objectCounts["Database GUCs"] = len(databaseGucs)
-	PrintDatabaseGUCs(globalFile, globalTOC, databaseGucs, connection.DBName)
+	PrintDatabaseGUCs(metadataFile, globalTOC, databaseGucs, connection.DBName)
 }
 
-func BackupResourceQueues(globalFile *utils.FileWithByteCount) {
+func BackupResourceQueues(metadataFile *utils.FileWithByteCount) {
 	logger.Verbose("Writing CREATE RESOURCE QUEUE statements to global file")
 	resQueues := GetResourceQueues(connection)
 	objectCounts["Resource Queues"] = len(resQueues)
 	resQueueMetadata := GetCommentsForObjectType(connection, TYPE_RESOURCEQUEUE)
-	PrintCreateResourceQueueStatements(globalFile, globalTOC, resQueues, resQueueMetadata)
+	PrintCreateResourceQueueStatements(metadataFile, globalTOC, resQueues, resQueueMetadata)
 }
 
-func BackupResourceGroups(globalFile *utils.FileWithByteCount) {
+func BackupResourceGroups(metadataFile *utils.FileWithByteCount) {
 	logger.Verbose("Writing CREATE RESOURCE GROUP statements to global file")
 	resGroups := GetResourceGroups(connection)
 	objectCounts["Resource Groups"] = len(resGroups)
 	resGroupMetadata := GetCommentsForObjectType(connection, TYPE_RESOURCEGROUP)
-	PrintCreateResourceGroupStatements(globalFile, globalTOC, resGroups, resGroupMetadata)
+	PrintCreateResourceGroupStatements(metadataFile, globalTOC, resGroups, resGroupMetadata)
 }
 
-func BackupRoles(globalFile *utils.FileWithByteCount) {
+func BackupRoles(metadataFile *utils.FileWithByteCount) {
 	logger.Verbose("Writing CREATE ROLE statements to global file")
 	roles := GetRoles(connection)
 	objectCounts["Roles"] = len(roles)
 	roleMetadata := GetCommentsForObjectType(connection, TYPE_ROLE)
-	PrintCreateRoleStatements(globalFile, globalTOC, roles, roleMetadata)
+	PrintCreateRoleStatements(metadataFile, globalTOC, roles, roleMetadata)
 }
 
-func BackupRoleGrants(globalFile *utils.FileWithByteCount) {
+func BackupRoleGrants(metadataFile *utils.FileWithByteCount) {
 	logger.Verbose("Writing GRANT ROLE statements to global file")
 	roleMembers := GetRoleMembers(connection)
-	PrintRoleMembershipStatements(globalFile, globalTOC, roleMembers)
+	PrintRoleMembershipStatements(metadataFile, globalTOC, roleMembers)
 }
 
 /*
  * Predata wrapper functions
  */
 
-func BackupSchemas(predataFile *utils.FileWithByteCount) {
+func BackupSchemas(metadataFile *utils.FileWithByteCount) {
 	logger.Verbose("Writing CREATE SCHEMA statements to predata file")
 	schemas := GetAllUserSchemas(connection)
 	objectCounts["Schemas"] = len(schemas)
 	schemaMetadata := GetMetadataForObjectType(connection, TYPE_SCHEMA)
-	PrintCreateSchemaStatements(predataFile, globalTOC, schemas, schemaMetadata)
+	PrintCreateSchemaStatements(metadataFile, globalTOC, schemas, schemaMetadata)
 }
 
-func BackupProceduralLanguages(predataFile *utils.FileWithByteCount, procLangs []ProceduralLanguage, langFuncs []Function, functionMetadata MetadataMap, funcInfoMap map[uint32]FunctionInfo) {
+func BackupProceduralLanguages(metadataFile *utils.FileWithByteCount, procLangs []ProceduralLanguage, langFuncs []Function, functionMetadata MetadataMap, funcInfoMap map[uint32]FunctionInfo) {
 	logger.Verbose("Writing CREATE PROCEDURAL LANGUAGE statements to predata file")
 	objectCounts["Procedural Languages"] = len(procLangs)
 	for _, langFunc := range langFuncs {
-		PrintCreateFunctionStatement(predataFile, globalTOC, langFunc, functionMetadata[langFunc.Oid])
+		PrintCreateFunctionStatement(metadataFile, globalTOC, langFunc, functionMetadata[langFunc.Oid])
 	}
 	procLangMetadata := GetMetadataForObjectType(connection, TYPE_PROCLANGUAGE)
-	PrintCreateLanguageStatements(predataFile, globalTOC, procLangs, funcInfoMap, procLangMetadata)
+	PrintCreateLanguageStatements(metadataFile, globalTOC, procLangs, funcInfoMap, procLangMetadata)
 }
 
-func BackupShellTypes(predataFile *utils.FileWithByteCount, types []Type) {
+func BackupShellTypes(metadataFile *utils.FileWithByteCount, types []Type) {
 	logger.Verbose("Writing CREATE TYPE statements for shell types to predata file")
-	PrintCreateShellTypeStatements(predataFile, globalTOC, types)
+	PrintCreateShellTypeStatements(metadataFile, globalTOC, types)
 }
 
-func BackupEnumTypes(predataFile *utils.FileWithByteCount, typeMetadata MetadataMap) {
+func BackupEnumTypes(metadataFile *utils.FileWithByteCount, typeMetadata MetadataMap) {
 	enums := GetEnumTypes(connection)
 	logger.Verbose("Writing CREATE TYPE statements for enum types to predata file")
 	objectCounts["Types"] += len(enums)
-	PrintCreateEnumTypeStatements(predataFile, globalTOC, enums, typeMetadata)
+	PrintCreateEnumTypeStatements(metadataFile, globalTOC, enums, typeMetadata)
 }
 
-func BackupCreateSequences(predataFile *utils.FileWithByteCount, sequences []Sequence, relationMetadata MetadataMap) {
+func BackupCreateSequences(metadataFile *utils.FileWithByteCount, sequences []Sequence, relationMetadata MetadataMap) {
 	logger.Verbose("Writing CREATE SEQUENCE statements to predata file")
 	objectCounts["Sequences"] = len(sequences)
-	PrintCreateSequenceStatements(predataFile, globalTOC, sequences, relationMetadata)
+	PrintCreateSequenceStatements(metadataFile, globalTOC, sequences, relationMetadata)
 }
 
 // This function is fairly unwieldy, but there's not really a good way to break it down
-func BackupFunctionsAndTypesAndTables(predataFile *utils.FileWithByteCount, otherFuncs []Function, types []Type, tables []Relation, functionMetadata MetadataMap, typeMetadata MetadataMap, relationMetadata MetadataMap, tableDefs map[uint32]TableDefinition, constraints []Constraint) {
+func BackupFunctionsAndTypesAndTables(metadataFile *utils.FileWithByteCount, otherFuncs []Function, types []Type, tables []Relation, functionMetadata MetadataMap, typeMetadata MetadataMap, relationMetadata MetadataMap, tableDefs map[uint32]TableDefinition, constraints []Constraint) {
 	logger.Verbose("Writing CREATE FUNCTION statements to predata file")
 	logger.Verbose("Writing CREATE TYPE statements for base, composite, and domain types to predata file")
 	logger.Verbose("Writing CREATE TABLE statements to predata file")
 	tables = ConstructTableDependencies(connection, tables, tableDefs, false)
 	sortedSlice := SortFunctionsAndTypesAndTablesInDependencyOrder(otherFuncs, types, tables)
 	filteredMetadata := ConstructFunctionAndTypeAndTableMetadataMap(functionMetadata, typeMetadata, relationMetadata)
-	PrintCreateDependentTypeAndFunctionAndTablesStatements(predataFile, globalTOC, sortedSlice, filteredMetadata, tableDefs, constraints)
+	PrintCreateDependentTypeAndFunctionAndTablesStatements(metadataFile, globalTOC, sortedSlice, filteredMetadata, tableDefs, constraints)
 	extPartInfo, partInfoMap := GetExternalPartitionInfo(connection)
 	if len(extPartInfo) > 0 {
 		logger.Verbose("Writing EXCHANGE PARTITION statements to predata file")
-		PrintExchangeExternalPartitionStatements(predataFile, globalTOC, extPartInfo, partInfoMap, tables)
+		PrintExchangeExternalPartitionStatements(metadataFile, globalTOC, extPartInfo, partInfoMap, tables)
 	}
 }
 
 // This function should be used only with a table-only backup.  For an unfiltered backup, the above function is used.
-func BackupTables(predataFile *utils.FileWithByteCount, tables []Relation, relationMetadata MetadataMap, tableDefs map[uint32]TableDefinition, constraints []Constraint) {
+func BackupTables(metadataFile *utils.FileWithByteCount, tables []Relation, relationMetadata MetadataMap, tableDefs map[uint32]TableDefinition, constraints []Constraint) {
 	logger.Verbose("Writing CREATE TABLE statements to predata file")
 	tables = ConstructTableDependencies(connection, tables, tableDefs, true)
 	sortable := make([]Sortable, 0)
@@ -272,149 +272,149 @@ func BackupTables(predataFile *utils.FileWithByteCount, tables []Relation, relat
 		sortable = append(sortable, table)
 	}
 	sortedSlice := TopologicalSort(sortable)
-	PrintCreateDependentTypeAndFunctionAndTablesStatements(predataFile, globalTOC, sortedSlice, relationMetadata, tableDefs, constraints)
+	PrintCreateDependentTypeAndFunctionAndTablesStatements(metadataFile, globalTOC, sortedSlice, relationMetadata, tableDefs, constraints)
 	extPartInfo, partInfoMap := GetExternalPartitionInfo(connection)
 	if len(extPartInfo) > 0 {
 		logger.Verbose("Writing EXCHANGE PARTITION statements to predata file")
-		PrintExchangeExternalPartitionStatements(predataFile, globalTOC, extPartInfo, partInfoMap, tables)
+		PrintExchangeExternalPartitionStatements(metadataFile, globalTOC, extPartInfo, partInfoMap, tables)
 	}
 }
 
-func BackupAlterSequences(predataFile *utils.FileWithByteCount, sequences []Sequence) {
+func BackupAlterSequences(metadataFile *utils.FileWithByteCount, sequences []Sequence) {
 	logger.Verbose("Writing ALTER SEQUENCE statements to predata file")
 	sequenceColumnOwners := GetSequenceColumnOwnerMap(connection)
-	PrintAlterSequenceStatements(predataFile, globalTOC, sequences, sequenceColumnOwners)
+	PrintAlterSequenceStatements(metadataFile, globalTOC, sequences, sequenceColumnOwners)
 }
 
-func BackupProtocols(predataFile *utils.FileWithByteCount, funcInfoMap map[uint32]FunctionInfo) {
+func BackupProtocols(metadataFile *utils.FileWithByteCount, funcInfoMap map[uint32]FunctionInfo) {
 	logger.Verbose("Writing CREATE PROTOCOL statements to predata file")
 	protocols := GetExternalProtocols(connection)
 	objectCounts["Protocols"] = len(protocols)
 	protoMetadata := GetMetadataForObjectType(connection, TYPE_PROTOCOL)
-	PrintCreateExternalProtocolStatements(predataFile, globalTOC, protocols, funcInfoMap, protoMetadata)
+	PrintCreateExternalProtocolStatements(metadataFile, globalTOC, protocols, funcInfoMap, protoMetadata)
 }
 
-func BackupTSParsers(predataFile *utils.FileWithByteCount) {
+func BackupTSParsers(metadataFile *utils.FileWithByteCount) {
 	logger.Verbose("Writing CREATE TEXT SEARCH PARSER statements to predata file")
 	parsers := GetTextSearchParsers(connection)
 	objectCounts["Text Search Parsers"] = len(parsers)
 	parserMetadata := GetCommentsForObjectType(connection, TYPE_TSPARSER)
-	PrintCreateTextSearchParserStatements(predataFile, globalTOC, parsers, parserMetadata)
+	PrintCreateTextSearchParserStatements(metadataFile, globalTOC, parsers, parserMetadata)
 }
 
-func BackupTSTemplates(predataFile *utils.FileWithByteCount) {
+func BackupTSTemplates(metadataFile *utils.FileWithByteCount) {
 	logger.Verbose("Writing CREATE TEXT SEARCH TEMPLATE statements to predata file")
 	templates := GetTextSearchTemplates(connection)
 	objectCounts["Text Search Templates"] = len(templates)
 	templateMetadata := GetCommentsForObjectType(connection, TYPE_TSTEMPLATE)
-	PrintCreateTextSearchTemplateStatements(predataFile, globalTOC, templates, templateMetadata)
+	PrintCreateTextSearchTemplateStatements(metadataFile, globalTOC, templates, templateMetadata)
 }
 
-func BackupTSDictionaries(predataFile *utils.FileWithByteCount) {
+func BackupTSDictionaries(metadataFile *utils.FileWithByteCount) {
 	logger.Verbose("Writing CREATE TEXT SEARCH DICTIONARY statements to predata file")
 	dictionaries := GetTextSearchDictionaries(connection)
 	objectCounts["Text Search Dictionaries"] = len(dictionaries)
 	dictionaryMetadata := GetMetadataForObjectType(connection, TYPE_TSDICTIONARY)
-	PrintCreateTextSearchDictionaryStatements(predataFile, globalTOC, dictionaries, dictionaryMetadata)
+	PrintCreateTextSearchDictionaryStatements(metadataFile, globalTOC, dictionaries, dictionaryMetadata)
 }
 
-func BackupTSConfigurations(predataFile *utils.FileWithByteCount) {
+func BackupTSConfigurations(metadataFile *utils.FileWithByteCount) {
 	logger.Verbose("Writing CREATE TEXT SEARCH CONFIGURATION statements to predata file")
 	configurations := GetTextSearchConfigurations(connection)
 	objectCounts["Text Search Configurations"] = len(configurations)
 	configurationMetadata := GetMetadataForObjectType(connection, TYPE_TSCONFIGURATION)
-	PrintCreateTextSearchConfigurationStatements(predataFile, globalTOC, configurations, configurationMetadata)
+	PrintCreateTextSearchConfigurationStatements(metadataFile, globalTOC, configurations, configurationMetadata)
 }
 
-func BackupConversions(predataFile *utils.FileWithByteCount) {
+func BackupConversions(metadataFile *utils.FileWithByteCount) {
 	logger.Verbose("Writing CREATE CONVERSION statements to predata file")
 	conversions := GetConversions(connection)
 	objectCounts["Conversions"] = len(conversions)
 	convMetadata := GetMetadataForObjectType(connection, TYPE_CONVERSION)
-	PrintCreateConversionStatements(predataFile, globalTOC, conversions, convMetadata)
+	PrintCreateConversionStatements(metadataFile, globalTOC, conversions, convMetadata)
 }
 
-func BackupOperators(predataFile *utils.FileWithByteCount) {
+func BackupOperators(metadataFile *utils.FileWithByteCount) {
 	logger.Verbose("Writing CREATE OPERATOR statements to predata file")
 	operators := GetOperators(connection)
 	objectCounts["Operators"] = len(operators)
 	operatorMetadata := GetMetadataForObjectType(connection, TYPE_OPERATOR)
-	PrintCreateOperatorStatements(predataFile, globalTOC, operators, operatorMetadata)
+	PrintCreateOperatorStatements(metadataFile, globalTOC, operators, operatorMetadata)
 }
 
-func BackupOperatorFamilies(predataFile *utils.FileWithByteCount) {
+func BackupOperatorFamilies(metadataFile *utils.FileWithByteCount) {
 	logger.Verbose("Writing CREATE OPERATOR FAMILY statements to predata file")
 	operatorFamilies := GetOperatorFamilies(connection)
 	objectCounts["Operator Families"] = len(operatorFamilies)
 	operatorFamilyMetadata := GetMetadataForObjectType(connection, TYPE_OPERATORFAMILY)
-	PrintCreateOperatorFamilyStatements(predataFile, globalTOC, operatorFamilies, operatorFamilyMetadata)
+	PrintCreateOperatorFamilyStatements(metadataFile, globalTOC, operatorFamilies, operatorFamilyMetadata)
 }
 
-func BackupOperatorClasses(predataFile *utils.FileWithByteCount) {
+func BackupOperatorClasses(metadataFile *utils.FileWithByteCount) {
 	logger.Verbose("Writing CREATE OPERATOR CLASS statements to predata file")
 	operatorClasses := GetOperatorClasses(connection)
 	objectCounts["Operator Classes"] = len(operatorClasses)
 	operatorClassMetadata := GetMetadataForObjectType(connection, TYPE_OPERATORCLASS)
-	PrintCreateOperatorClassStatements(predataFile, globalTOC, operatorClasses, operatorClassMetadata)
+	PrintCreateOperatorClassStatements(metadataFile, globalTOC, operatorClasses, operatorClassMetadata)
 }
 
-func BackupAggregates(predataFile *utils.FileWithByteCount, funcInfoMap map[uint32]FunctionInfo) {
+func BackupAggregates(metadataFile *utils.FileWithByteCount, funcInfoMap map[uint32]FunctionInfo) {
 	logger.Verbose("Writing CREATE AGGREGATE statements to predata file")
 	aggregates := GetAggregates(connection)
 	objectCounts["Aggregates"] = len(aggregates)
 	aggMetadata := GetMetadataForObjectType(connection, TYPE_AGGREGATE)
-	PrintCreateAggregateStatements(predataFile, globalTOC, aggregates, funcInfoMap, aggMetadata)
+	PrintCreateAggregateStatements(metadataFile, globalTOC, aggregates, funcInfoMap, aggMetadata)
 }
 
-func BackupCasts(predataFile *utils.FileWithByteCount) {
+func BackupCasts(metadataFile *utils.FileWithByteCount) {
 	logger.Verbose("Writing CREATE CAST statements to predata file")
 	casts := GetCasts(connection)
 	objectCounts["Casts"] = len(casts)
 	castMetadata := GetCommentsForObjectType(connection, TYPE_CAST)
-	PrintCreateCastStatements(predataFile, globalTOC, casts, castMetadata)
+	PrintCreateCastStatements(metadataFile, globalTOC, casts, castMetadata)
 }
 
-func BackupViews(predataFile *utils.FileWithByteCount, relationMetadata MetadataMap) {
+func BackupViews(metadataFile *utils.FileWithByteCount, relationMetadata MetadataMap) {
 	logger.Verbose("Writing CREATE VIEW statements to predata file")
 	views := GetViews(connection)
 	objectCounts["Views"] = len(views)
 	views = ConstructViewDependencies(connection, views)
 	views = SortViews(views)
-	PrintCreateViewStatements(predataFile, globalTOC, views, relationMetadata)
+	PrintCreateViewStatements(metadataFile, globalTOC, views, relationMetadata)
 }
 
-func BackupConstraints(predataFile *utils.FileWithByteCount, constraints []Constraint, conMetadata MetadataMap) {
+func BackupConstraints(metadataFile *utils.FileWithByteCount, constraints []Constraint, conMetadata MetadataMap) {
 	logger.Verbose("Writing ADD CONSTRAINT statements to predata file")
-	PrintConstraintStatements(predataFile, globalTOC, constraints, conMetadata)
+	PrintConstraintStatements(metadataFile, globalTOC, constraints, conMetadata)
 }
 
 /*
  * Postdata wrapper functions
  */
 
-func BackupIndexes(postdataFile *utils.FileWithByteCount) {
+func BackupIndexes(metadataFile *utils.FileWithByteCount) {
 	logger.Verbose("Writing CREATE INDEX statements to postdata file")
 	indexNameMap := ConstructImplicitIndexNames(connection)
 	indexes := GetIndexes(connection, indexNameMap)
 	objectCounts["Indexes"] = len(indexes)
 	indexMetadata := GetCommentsForObjectType(connection, TYPE_INDEX)
-	PrintCreateIndexStatements(postdataFile, globalTOC, indexes, indexMetadata)
+	PrintCreateIndexStatements(metadataFile, globalTOC, indexes, indexMetadata)
 }
 
-func BackupRules(postdataFile *utils.FileWithByteCount) {
+func BackupRules(metadataFile *utils.FileWithByteCount) {
 	logger.Verbose("Writing CREATE RULE statements to postdata file")
 	rules := GetRules(connection)
 	objectCounts["Rules"] = len(rules)
 	ruleMetadata := GetCommentsForObjectType(connection, TYPE_RULE)
-	PrintCreateRuleStatements(postdataFile, globalTOC, rules, ruleMetadata)
+	PrintCreateRuleStatements(metadataFile, globalTOC, rules, ruleMetadata)
 }
 
-func BackupTriggers(postdataFile *utils.FileWithByteCount) {
+func BackupTriggers(metadataFile *utils.FileWithByteCount) {
 	logger.Verbose("Writing CREATE TRIGGER statements to postdata file")
 	triggers := GetTriggers(connection)
 	objectCounts["Triggers"] = len(triggers)
 	triggerMetadata := GetCommentsForObjectType(connection, TYPE_TRIGGER)
-	PrintCreateTriggerStatements(postdataFile, globalTOC, triggers, triggerMetadata)
+	PrintCreateTriggerStatements(metadataFile, globalTOC, triggers, triggerMetadata)
 }
 
 /*

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -68,13 +68,17 @@ func DoSetup() {
 
 	InitializeConnection("postgres")
 	DoPostgresValidation()
+	metadataFilename := globalCluster.GetMetadataFilePath()
+	if !backupConfig.DataOnly {
+		logger.Info("Metadata will be restored from %s", metadataFilename)
+	}
 	if *createdb {
-		createDatabase()
+		createDatabase(metadataFilename)
 	}
 	ConnectToRestoreDatabase()
 
 	if *restoreGlobals {
-		restoreGlobal()
+		restoreGlobal(metadataFilename)
 	}
 
 	/*
@@ -88,8 +92,9 @@ func DoSetup() {
 
 func DoRestore() {
 	gucStatements := setGUCsForConnection(nil, 0)
+	metadataFilename := globalCluster.GetMetadataFilePath()
 	if !backupConfig.DataOnly {
-		restorePredata()
+		restorePredata(metadataFilename)
 	}
 
 	if !backupConfig.MetadataOnly {
@@ -102,7 +107,7 @@ func DoRestore() {
 	}
 
 	if !backupConfig.DataOnly && !backupConfig.TableFiltered {
-		restorePostdata()
+		restorePostdata(metadataFilename)
 	}
 
 	if *withStats && backupConfig.WithStatistics {
@@ -110,11 +115,10 @@ func DoRestore() {
 	}
 }
 
-func createDatabase() {
+func createDatabase(metadataFilename string) {
 	objectTypes := []string{"SESSION GUCS", "GPDB4 SESSION GUCS", "DATABASE GUC", "DATABASE", "DATABASE METADATA"}
-	globalFilename := globalCluster.GetGlobalFilePath()
 	logger.Info("Creating database")
-	statements := GetRestoreMetadataStatements(globalFilename, objectTypes, []string{}, []string{})
+	statements := GetRestoreMetadataStatements("global", metadataFilename, objectTypes, []string{}, []string{})
 	if *redirect != "" {
 		statements = utils.SubstituteRedirectDatabaseInStatements(statements, backupConfig.DatabaseName, *redirect)
 	}
@@ -122,11 +126,10 @@ func createDatabase() {
 	logger.Info("Database creation complete")
 }
 
-func restoreGlobal() {
+func restoreGlobal(metadataFilename string) {
 	objectTypes := []string{"SESSION GUCS", "GPDB4 SESSION GUCS", "DATABASE GUC", "DATABASE METADATA", "RESOURCE QUEUE", "RESOURCE GROUP", "ROLE", "ROLE GRANT", "TABLESPACE"}
-	globalFilename := globalCluster.GetGlobalFilePath()
-	logger.Info("Restoring global metadata from %s", globalCluster.GetGlobalFilePath())
-	statements := GetRestoreMetadataStatements(globalFilename, objectTypes, []string{}, []string{})
+	logger.Info("Restoring global metadata")
+	statements := GetRestoreMetadataStatements("global", metadataFilename, objectTypes, []string{}, []string{})
 	if *redirect != "" {
 		statements = utils.SubstituteRedirectDatabaseInStatements(statements, backupConfig.DatabaseName, *redirect)
 	}
@@ -134,10 +137,9 @@ func restoreGlobal() {
 	logger.Info("Global database metadata restore complete")
 }
 
-func restorePredata() {
-	predataFilename := globalCluster.GetPredataFilePath()
-	logger.Info("Restoring pre-data metadata from %s", predataFilename)
-	statements := GetRestoreMetadataStatements(predataFilename, []string{}, includeSchemas, includeTables)
+func restorePredata(metadataFilename string) {
+	logger.Info("Restoring pre-data metadata")
+	statements := GetRestoreMetadataStatements("predata", metadataFilename, []string{}, includeSchemas, includeTables)
 	ExecuteRestoreMetadataStatements(statements, "Pre-data objects", true, false)
 	logger.Info("Pre-data metadata restore complete")
 }
@@ -185,10 +187,9 @@ func restoreData(gucStatements []utils.StatementWithType) {
 	logger.Info("Data restore complete")
 }
 
-func restorePostdata() {
-	postdataFilename := globalCluster.GetPostdataFilePath()
-	logger.Info("Restoring post-data metadata from %s", postdataFilename)
-	statements := GetRestoreMetadataStatements(postdataFilename, []string{}, includeSchemas, []string{})
+func restorePostdata(metadataFilename string) {
+	logger.Info("Restoring post-data metadata")
+	statements := GetRestoreMetadataStatements("postdata", metadataFilename, []string{}, includeSchemas, []string{})
 	ExecuteRestoreMetadataStatements(statements, "Post-data objects", true, false)
 	logger.Info("Post-data metadata restore complete")
 }
@@ -196,7 +197,7 @@ func restorePostdata() {
 func restoreStatistics() {
 	statisticsFilename := globalCluster.GetStatisticsFilePath()
 	logger.Info("Restoring query planner statistics from %s", statisticsFilename)
-	statements := GetRestoreMetadataStatements(statisticsFilename, []string{}, includeSchemas, []string{})
+	statements := GetRestoreMetadataStatements("statistics", statisticsFilename, []string{}, includeSchemas, []string{})
 	ExecuteRestoreMetadataStatements(statements, "Table statistics", false, false)
 	logger.Info("Query planner statistics restore complete")
 }

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -70,7 +70,7 @@ func DoSetup() {
 	DoPostgresValidation()
 	metadataFilename := globalCluster.GetMetadataFilePath()
 	if !backupConfig.DataOnly {
-		logger.Info("Metadata will be restored from %s", metadataFilename)
+		logger.Verbose("Metadata will be restored from %s", metadataFilename)
 	}
 	if *createdb {
 		createDatabase(metadataFilename)

--- a/restore/validate_test.go
+++ b/restore/validate_test.go
@@ -53,13 +53,13 @@ var _ = Describe("restore/validate tests", func() {
 		BeforeEach(func() {
 			toc, backupfile = testutils.InitializeTestTOC(buffer, "predata")
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntry("schema1", "table1", "TABLE", 0, backupfile)
+			toc.AddPredataEntry("schema1", "table1", "TABLE", 0, backupfile)
 			toc.AddMasterDataEntry("schema1", "table1", 1, "(i)")
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntry("schema2", "table2", "TABLE", table1Len, backupfile)
+			toc.AddPredataEntry("schema2", "table2", "TABLE", table1Len, backupfile)
 			toc.AddMasterDataEntry("schema2", "table2", 2, "(j)")
 			backupfile.ByteCount += sequenceLen
-			toc.AddMetadataEntry("schema", "somesequence", "SEQUENCE", table1Len+table2Len, backupfile)
+			toc.AddPredataEntry("schema", "somesequence", "SEQUENCE", table1Len+table2Len, backupfile)
 			restore.SetTOC(toc)
 		})
 		It("schema exists in normal backup", func() {
@@ -124,13 +124,13 @@ var _ = Describe("restore/validate tests", func() {
 		BeforeEach(func() {
 			toc, backupfile = testutils.InitializeTestTOC(buffer, "predata")
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntry("schema1", "table1", "TABLE", 0, backupfile)
+			toc.AddPredataEntry("schema1", "table1", "TABLE", 0, backupfile)
 			toc.AddMasterDataEntry("schema1", "table1", 1, "(i)")
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntry("schema2", "table2", "TABLE", table1Len, backupfile)
+			toc.AddPredataEntry("schema2", "table2", "TABLE", table1Len, backupfile)
 			toc.AddMasterDataEntry("schema2", "table2", 2, "(j)")
 			backupfile.ByteCount += sequenceLen
-			toc.AddMetadataEntry("schema1", "somesequence", "SEQUENCE", table1Len+table2Len, backupfile)
+			toc.AddPredataEntry("schema1", "somesequence", "SEQUENCE", table1Len+table2Len, backupfile)
 			restore.SetTOC(toc)
 		})
 		It("table exists in normal backup", func() {

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -71,7 +71,7 @@ func DoPostgresValidation() {
 
 	tocFilename := globalCluster.GetTOCFilePath()
 	globalTOC = utils.NewTOC(tocFilename)
-	globalTOC.InitializeEntryMapFromCluster(globalCluster)
+	globalTOC.InitializeEntryMap()
 
 	validateFilterListsInBackupSet()
 }
@@ -94,13 +94,13 @@ func DoRestoreDatabaseValidation() {
  * Metadata and/or data restore wrapper functions
  */
 
-func GetRestoreMetadataStatements(filename string, objectTypes []string, includeSchemas []string, includeTables []string) []utils.StatementWithType {
+func GetRestoreMetadataStatements(section string, filename string, objectTypes []string, includeSchemas []string, includeTables []string) []utils.StatementWithType {
 	metadataFile := utils.MustOpenFileForReading(filename)
 	var statements []utils.StatementWithType
 	if len(objectTypes) > 0 || len(includeSchemas) > 0 || len(includeTables) > 0 {
-		statements = globalTOC.GetSQLStatementForObjectTypes(filename, metadataFile, objectTypes, includeSchemas, includeTables)
+		statements = globalTOC.GetSQLStatementForObjectTypes(section, metadataFile, objectTypes, includeSchemas, includeTables)
 	} else {
-		statements = globalTOC.GetAllSQLStatements(filename, metadataFile)
+		statements = globalTOC.GetAllSQLStatements(section, metadataFile)
 	}
 	return statements
 }
@@ -126,7 +126,7 @@ func setGUCsForConnection(gucStatements []utils.StatementWithType, whichConn int
 		if connection.Version.Before("5") {
 			objectTypes = append(objectTypes, "GPDB4 SESSION GUCS")
 		}
-		gucStatements = GetRestoreMetadataStatements(globalCluster.GetPredataFilePath(), objectTypes, []string{}, []string{})
+		gucStatements = GetRestoreMetadataStatements("global", globalCluster.GetMetadataFilePath(), objectTypes, []string{}, []string{})
 		// We only need to set the following GUC for data restores, but it doesn't hurt if we set it for metadata restores as well.
 		gucStatements = append(gucStatements, utils.StatementWithType{ObjectType: "SESSION GUCS", Statement: "SET gp_enable_segment_copy_checking TO false;"})
 	}

--- a/testutils/functions.go
+++ b/testutils/functions.go
@@ -399,7 +399,7 @@ func SkipIfBefore6(dbconn *utils.DBConn) {
 
 func InitializeTestTOC(buffer io.Writer, which string) (*utils.TOC, *utils.FileWithByteCount) {
 	toc := &utils.TOC{}
-	toc.InitializeEntryMap("global", "predata", "postdata", "statistics")
+	toc.InitializeEntryMap()
 	backupfile := utils.NewFileWithByteCount(buffer)
 	backupfile.Filename = which
 	return toc, backupfile

--- a/utils/cluster.go
+++ b/utils/cluster.go
@@ -404,9 +404,7 @@ func (cluster *Cluster) GetTableBackupFilePathForCopyCommand(tableOid uint32, si
 
 var metadataFilenameMap = map[string]string{
 	"config":            "config.yaml",
-	"global":            "global.sql",
-	"predata":           "predata.sql",
-	"postdata":          "postdata.sql",
+	"metadata":          "metadata.sql",
 	"statistics":        "statistics.sql",
 	"table of contents": "toc.yaml",
 	"report":            "report",
@@ -416,16 +414,8 @@ func (cluster *Cluster) GetBackupFilePath(filetype string) string {
 	return path.Join(cluster.GetDirForContent(-1), fmt.Sprintf("gpbackup_%s_%s", cluster.Timestamp, metadataFilenameMap[filetype]))
 }
 
-func (cluster *Cluster) GetGlobalFilePath() string {
-	return cluster.GetBackupFilePath("global")
-}
-
-func (cluster *Cluster) GetPredataFilePath() string {
-	return cluster.GetBackupFilePath("predata")
-}
-
-func (cluster *Cluster) GetPostdataFilePath() string {
-	return cluster.GetBackupFilePath("postdata")
+func (cluster *Cluster) GetMetadataFilePath() string {
+	return cluster.GetBackupFilePath("metadata")
 }
 
 func (cluster *Cluster) GetStatisticsFilePath() string {
@@ -456,9 +446,7 @@ func (cluster *Cluster) VerifyMetadataFilePaths(dataOnly bool, withStats bool, t
 	filetypes := []string{"config", "table of contents"}
 	if !dataOnly {
 		if !tableFiltered {
-			filetypes = append(filetypes, []string{"global", "predata", "postdata"}...)
-		} else {
-			filetypes = append(filetypes, []string{"predata"}...)
+			filetypes = append(filetypes, "metadata")
 		}
 	}
 	missing := false

--- a/utils/cluster.go
+++ b/utils/cluster.go
@@ -445,9 +445,7 @@ func (cluster *Cluster) GetSegmentTOCFilePath(topDir string, contentStr string) 
 func (cluster *Cluster) VerifyMetadataFilePaths(dataOnly bool, withStats bool, tableFiltered bool) {
 	filetypes := []string{"config", "table of contents"}
 	if !dataOnly {
-		if !tableFiltered {
-			filetypes = append(filetypes, "metadata")
-		}
+		filetypes = append(filetypes, "metadata")
 	}
 	missing := false
 	for _, filetype := range filetypes {

--- a/utils/toc_test.go
+++ b/utils/toc_test.go
@@ -30,84 +30,84 @@ var _ = Describe("utils/toc tests", func() {
 	Context("GetSqlStatementForObjectTypes", func() {
 		It("returns statement for a single object type", func() {
 			backupfile.ByteCount = commentLen + createLen
-			toc.AddMetadataEntry("", "somedatabase", "DATABASE", commentLen, backupfile)
+			toc.AddMetadataEntry("", "somedatabase", "DATABASE", commentLen, backupfile, "global")
 
-			globalFile := bytes.NewReader([]byte(comment.Statement + create.Statement))
-			statements := toc.GetSQLStatementForObjectTypes("global", globalFile, []string{"DATABASE"}, []string{}, []string{})
+			metadataFile := bytes.NewReader([]byte(comment.Statement + create.Statement))
+			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, []string{"DATABASE"}, []string{}, []string{})
 
 			Expect(statements).To(Equal([]utils.StatementWithType{create}))
 		})
 		It("returns statement for multiple object types", func() {
 			backupfile.ByteCount = commentLen + createLen
-			toc.AddMetadataEntry("", "somedatabase", "DATABASE", commentLen, backupfile)
+			toc.AddMetadataEntry("", "somedatabase", "DATABASE", commentLen, backupfile, "global")
 			backupfile.ByteCount += role1Len
-			toc.AddMetadataEntry("", "somerole1", "ROLE", commentLen+createLen, backupfile)
+			toc.AddMetadataEntry("", "somerole1", "ROLE", commentLen+createLen, backupfile, "global")
 			backupfile.ByteCount += role2Len
-			toc.AddMetadataEntry("", "somerole2", "ROLE", commentLen+createLen+role1Len, backupfile)
+			toc.AddMetadataEntry("", "somerole2", "ROLE", commentLen+createLen+role1Len, backupfile, "global")
 
-			globalFile := bytes.NewReader([]byte(comment.Statement + create.Statement + role1.Statement + role2.Statement))
-			statements := toc.GetSQLStatementForObjectTypes("global", globalFile, []string{"DATABASE", "ROLE"}, []string{}, []string{})
+			metadataFile := bytes.NewReader([]byte(comment.Statement + create.Statement + role1.Statement + role2.Statement))
+			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, []string{"DATABASE", "ROLE"}, []string{}, []string{})
 
 			Expect(statements).To(Equal([]utils.StatementWithType{create, role1, role2}))
 		})
 		It("returns empty statement when no object types are found", func() {
 			backupfile.ByteCount = commentLen + createLen
-			toc.AddMetadataEntry("", "somedatabase", "DATABASE", commentLen, backupfile)
+			toc.AddMetadataEntry("", "somedatabase", "DATABASE", commentLen, backupfile, "global")
 
-			globalFile := bytes.NewReader([]byte(comment.Statement + create.Statement))
-			statements := toc.GetSQLStatementForObjectTypes("global", globalFile, []string{"TABLE"}, []string{}, []string{})
+			metadataFile := bytes.NewReader([]byte(comment.Statement + create.Statement))
+			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, []string{"TABLE"}, []string{}, []string{})
 
 			Expect(statements).To(Equal([]utils.StatementWithType{}))
 		})
 		It("returns statement for a single object type with matching schema", func() {
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntry("schema", "table1", "TABLE", 0, backupfile)
+			toc.AddMetadataEntry("schema", "table1", "TABLE", 0, backupfile, "global")
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntry("schema2", "table2", "TABLE", table1Len, backupfile)
+			toc.AddMetadataEntry("schema2", "table2", "TABLE", table1Len, backupfile, "global")
 			backupfile.ByteCount += sequenceLen
-			toc.AddMetadataEntry("schema", "somesequence", "SEQUENCE", table1Len+table2Len, backupfile)
+			toc.AddMetadataEntry("schema", "somesequence", "SEQUENCE", table1Len+table2Len, backupfile, "global")
 
-			globalFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement))
-			statements := toc.GetSQLStatementForObjectTypes("global", globalFile, []string{"TABLE"}, []string{"schema"}, []string{})
+			metadataFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement))
+			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, []string{"TABLE"}, []string{"schema"}, []string{})
 
 			Expect(statements).To(Equal([]utils.StatementWithType{table1}))
 		})
 		It("returns statement for any object type with matching schema", func() {
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntry("schema", "table1", "TABLE", 0, backupfile)
+			toc.AddMetadataEntry("schema", "table1", "TABLE", 0, backupfile, "global")
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntry("schema2", "table2", "TABLE", table1Len, backupfile)
+			toc.AddMetadataEntry("schema2", "table2", "TABLE", table1Len, backupfile, "global")
 			backupfile.ByteCount += sequenceLen
-			toc.AddMetadataEntry("schema", "somesequence", "SEQUENCE", table1Len+table2Len, backupfile)
+			toc.AddMetadataEntry("schema", "somesequence", "SEQUENCE", table1Len+table2Len, backupfile, "global")
 
-			globalFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement))
-			statements := toc.GetSQLStatementForObjectTypes("global", globalFile, []string{}, []string{"schema"}, []string{})
+			metadataFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement))
+			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, []string{}, []string{"schema"}, []string{})
 
 			Expect(statements).To(Equal([]utils.StatementWithType{table1, sequence}))
 		})
 		It("returns statement for any object type with matching table", func() {
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntry("schema", "table1", "TABLE", 0, backupfile)
+			toc.AddMetadataEntry("schema", "table1", "TABLE", 0, backupfile, "global")
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntry("schema2", "table2", "TABLE", table1Len, backupfile)
+			toc.AddMetadataEntry("schema2", "table2", "TABLE", table1Len, backupfile, "global")
 			backupfile.ByteCount += sequenceLen
-			toc.AddMetadataEntry("schema", "somesequence", "SEQUENCE", table1Len+table2Len, backupfile)
+			toc.AddMetadataEntry("schema", "somesequence", "SEQUENCE", table1Len+table2Len, backupfile, "global")
 
-			globalFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement))
-			statements := toc.GetSQLStatementForObjectTypes("global", globalFile, []string{}, []string{}, []string{"schema.table1"})
+			metadataFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement))
+			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, []string{}, []string{}, []string{"schema.table1"})
 
 			Expect(statements).To(Equal([]utils.StatementWithType{table1}))
 		})
 		It("returns no statements for a non-table object with matching name from table list", func() {
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntry("schema", "table1", "TABLE", 0, backupfile)
+			toc.AddMetadataEntry("schema", "table1", "TABLE", 0, backupfile, "global")
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntry("schema2", "table2", "TABLE", table1Len, backupfile)
+			toc.AddMetadataEntry("schema2", "table2", "TABLE", table1Len, backupfile, "global")
 			backupfile.ByteCount += sequenceLen
-			toc.AddMetadataEntry("schema", "somesequence", "SEQUENCE", table1Len+table2Len, backupfile)
+			toc.AddMetadataEntry("schema", "somesequence", "SEQUENCE", table1Len+table2Len, backupfile, "global")
 
-			globalFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement))
-			statements := toc.GetSQLStatementForObjectTypes("global", globalFile, []string{}, []string{}, []string{"schema.somesequence"})
+			metadataFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement))
+			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, []string{}, []string{}, []string{"schema.somesequence"})
 
 			Expect(statements).To(Equal([]utils.StatementWithType{}))
 		})
@@ -138,29 +138,29 @@ var _ = Describe("utils/toc tests", func() {
 	Context("GetAllSqlStatements", func() {
 		It("returns statement for a single object type", func() {
 			backupfile.ByteCount = createLen
-			toc.AddMetadataEntry("", "somedatabase", "DATABASE", 0, backupfile)
+			toc.AddMetadataEntry("", "somedatabase", "DATABASE", 0, backupfile, "global")
 
-			globalFile := bytes.NewReader([]byte(create.Statement))
-			statements := toc.GetAllSQLStatements("global", globalFile)
+			metadataFile := bytes.NewReader([]byte(create.Statement))
+			statements := toc.GetAllSQLStatements("global", metadataFile)
 
 			Expect(statements).To(Equal([]utils.StatementWithType{create}))
 		})
 		It("returns statement for a multiple object types", func() {
 			backupfile.ByteCount = createLen
-			toc.AddMetadataEntry("", "somedatabase", "DATABASE", 0, backupfile)
+			toc.AddMetadataEntry("", "somedatabase", "DATABASE", 0, backupfile, "global")
 			backupfile.ByteCount += role1Len
-			toc.AddMetadataEntry("", "somerole1", "ROLE", createLen, backupfile)
+			toc.AddMetadataEntry("", "somerole1", "ROLE", createLen, backupfile, "global")
 			backupfile.ByteCount += role2Len
-			toc.AddMetadataEntry("", "somerole2", "ROLE", createLen+role1Len, backupfile)
+			toc.AddMetadataEntry("", "somerole2", "ROLE", createLen+role1Len, backupfile, "global")
 
-			globalFile := bytes.NewReader([]byte(create.Statement + role1.Statement + role2.Statement))
-			statements := toc.GetAllSQLStatements("global", globalFile)
+			metadataFile := bytes.NewReader([]byte(create.Statement + role1.Statement + role2.Statement))
+			statements := toc.GetAllSQLStatements("global", metadataFile)
 
 			Expect(statements).To(Equal([]utils.StatementWithType{create, role1, role2}))
 		})
 		It("returns empty statement when no object types are found", func() {
-			globalFile := bytes.NewReader([]byte(create.Statement))
-			statements := toc.GetAllSQLStatements("global", globalFile)
+			metadataFile := bytes.NewReader([]byte(create.Statement))
+			statements := toc.GetAllSQLStatements("global", metadataFile)
 
 			Expect(statements).To(Equal([]utils.StatementWithType{}))
 		})


### PR DESCRIPTION
Now that we have the toc and the ability to selectively restore any
objects, we can combine these sections into a single file. Behind the
scenes, we still maintain separate lists of the three for easier
isolation of the various sections on the restore side.

Author: Karen Huddleston <khuddleston@pivotal.io>