### PR TITLE
Remove logging and progress bars to stdout when -quiet flag used

### DIFF
--- a/backup/data.go
+++ b/backup/data.go
@@ -68,7 +68,7 @@ func BackupDataForAllTables(tables []Relation, tableDefs map[uint32]TableDefinit
 		}
 	}
 	totalRegTables := len(tables) - totalExtTables
-	dataProgressBar := utils.NewProgressBar(totalRegTables, "Tables backed up: ", logger.GetVerbosity() == utils.LOGINFO)
+	dataProgressBar := utils.NewProgressBar(totalRegTables, "Tables backed up: ", true)
 	dataProgressBar.Start()
 	backupFile := ""
 	if *singleDataFile {

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -59,12 +59,12 @@ func DoValidation() {
 	if !utils.IsValidTimestamp(*timestamp) {
 		logger.Fatal(errors.Errorf("Timestamp %s is invalid.  Timestamps must be in the format YYYYMMDDHHMMSS.", *timestamp), "")
 	}
-	logger.Info("Restore Key = %s", *timestamp)
 }
 
 // This function handles setup that must be done after parsing flags.
 func DoSetup() {
 	SetLoggerVerbosity()
+	logger.Info("Restore Key = %s", *timestamp)
 
 	InitializeConnection("postgres")
 	DoPostgresValidation()
@@ -151,7 +151,7 @@ func restoreData(gucStatements []utils.StatementWithType) {
 
 	filteredMasterDataEntries := globalTOC.GetDataEntriesMatching(includeSchemas, includeTables)
 	totalTables := len(filteredMasterDataEntries)
-	dataProgressBar := utils.NewProgressBar(totalTables, "Tables restored: ", logger.GetVerbosity() == utils.LOGINFO)
+	dataProgressBar := utils.NewProgressBar(totalTables, "Tables restored: ", true)
 	dataProgressBar.Start()
 
 	if connection.NumConns == 1 {

--- a/utils/log.go
+++ b/utils/log.go
@@ -214,6 +214,6 @@ func NewProgressBar(count int, prefix string, showProgressBar bool) *pb.Progress
 	progressBar.ShowTimeLeft = false
 	progressBar.SetMaxWidth(100)
 	progressBar.SetRefreshRate(time.Millisecond * 200)
-	progressBar.NotPrint = !(showProgressBar && count > 0)
+	progressBar.NotPrint = !(showProgressBar && count > 0 && logger.GetVerbosity() == LOGINFO)
 	return progressBar
 }

--- a/utils/log_test.go
+++ b/utils/log_test.go
@@ -387,5 +387,15 @@ var _ = Describe("utils/log tests", func() {
 			progressBar := utils.NewProgressBar(10, "test progress bar", false)
 			Expect(progressBar.NotPrint).To(Equal(true))
 		})
+		It("will not print with verbosity LOGERROR", func() {
+			logger.SetVerbosity(utils.LOGERROR)
+			progressBar := utils.NewProgressBar(10, "test progress bar", true)
+			Expect(progressBar.NotPrint).To(Equal(true))
+		})
+		It("will not print with verbosity LOGVERBOSE", func() {
+			logger.SetVerbosity(utils.LOGVERBOSE)
+			progressBar := utils.NewProgressBar(10, "test progress bar", true)
+			Expect(progressBar.NotPrint).To(Equal(true))
+		})
 	})
 })


### PR DESCRIPTION
Also, don't print progress bars when -verbose flag used or to log file

Author: Chris Hajas <chajas@pivotal.io>