### PR TITLE
Log in increments of 10% for progress bar in verbose mode

### DIFF
--- a/backup/data.go
+++ b/backup/data.go
@@ -68,7 +68,7 @@ func BackupDataForAllTables(tables []Relation, tableDefs map[uint32]TableDefinit
 		}
 	}
 	totalRegTables := len(tables) - totalExtTables
-	dataProgressBar := utils.NewProgressBar(totalRegTables, "Tables backed up: ", logger.GetVerbosity() == utils.LOGINFO)
+	dataProgressBar := utils.NewProgressBar(totalRegTables, "Tables backed up: ", utils.PB_INFO)
 	dataProgressBar.Start()
 	backupFile := ""
 	if *singleDataFile {

--- a/backup/data.go
+++ b/backup/data.go
@@ -68,7 +68,7 @@ func BackupDataForAllTables(tables []Relation, tableDefs map[uint32]TableDefinit
 		}
 	}
 	totalRegTables := len(tables) - totalExtTables
-	dataProgressBar := utils.NewProgressBar(totalRegTables, "Tables backed up: ", true)
+	dataProgressBar := utils.NewProgressBar(totalRegTables, "Tables backed up: ", logger.GetVerbosity() == utils.LOGINFO)
 	dataProgressBar.Start()
 	backupFile := ""
 	if *singleDataFile {

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -519,7 +519,7 @@ ORDER BY v2.oid, referencedobject;`, SchemaFilterClause("n"))
 
 func LockTables(connection *utils.DBConn, tables []Relation) {
 	logger.Info("Acquiring ACCESS SHARE locks on tables")
-	progressBar := utils.NewProgressBar(len(tables), "Locks acquired: ", true)
+	progressBar := utils.NewProgressBar(len(tables), "Locks acquired: ", utils.PB_VERBOSE)
 	progressBar.Start()
 	for _, table := range tables {
 		_, err := connection.Exec(fmt.Sprintf("LOCK TABLE %s IN ACCESS SHARE MODE", table.ToString()))

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -527,5 +527,4 @@ func LockTables(connection *utils.DBConn, tables []Relation) {
 		progressBar.Increment()
 	}
 	progressBar.Finish()
-	logger.Verbose("All table locks acquired")
 }

--- a/integration/parallel_queries_test.go
+++ b/integration/parallel_queries_test.go
@@ -84,14 +84,14 @@ var _ = Describe("backup, utils, and restore integration tests related to parall
 			It("can execute all statements in the list serially", func() {
 				shouldExecute := utils.NewEmptyIncludeSet()
 				expectedOrderArray := []string{"1", "2", "3", "4"}
-				restore.ExecuteStatements(statements, "", 0, shouldExecute, false)
+				restore.ExecuteStatements(statements, "", utils.PB_NONE, shouldExecute, false)
 				resultOrderArray := utils.SelectStringSlice(tempConn, orderQuery)
 				Expect(resultOrderArray).To(Equal(expectedOrderArray))
 			})
 			It("can execute all statements in the list that are not of the specified object type serially", func() {
 				shouldExecute := utils.NewExcludeSet([]string{"DATABASE"})
 				expectedOrderArray := []string{"1", "3"}
-				restore.ExecuteStatements(statements, "", 0, shouldExecute, false)
+				restore.ExecuteStatements(statements, "", utils.PB_NONE, shouldExecute, false)
 				resultOrderArray := utils.SelectStringSlice(tempConn, orderQuery)
 				Expect(resultOrderArray).To(Equal(expectedOrderArray))
 			})
@@ -105,14 +105,14 @@ var _ = Describe("backup, utils, and restore integration tests related to parall
 			It("can execute all statements in the list in parallel", func() {
 				shouldExecute := utils.NewEmptyIncludeSet()
 				expectedOrderArray := []string{"3", "1", "4", "2"}
-				restore.ExecuteStatements(statements, "", 0, shouldExecute, true)
+				restore.ExecuteStatements(statements, "", utils.PB_NONE, shouldExecute, true)
 				resultOrderArray := utils.SelectStringSlice(tempConn, orderQuery)
 				Expect(resultOrderArray).To(Equal(expectedOrderArray))
 			})
 			It("can execute all statements in the list that are not of the specified object type in parallel", func() {
 				shouldExecute := utils.NewExcludeSet([]string{"DATABASE"})
 				expectedOrderArray := []string{"3", "1"}
-				restore.ExecuteStatements(statements, "", 0, shouldExecute, true)
+				restore.ExecuteStatements(statements, "", utils.PB_NONE, shouldExecute, true)
 				resultOrderArray := utils.SelectStringSlice(tempConn, orderQuery)
 				Expect(resultOrderArray).To(Equal(expectedOrderArray))
 			})

--- a/integration/parallel_queries_test.go
+++ b/integration/parallel_queries_test.go
@@ -84,14 +84,14 @@ var _ = Describe("backup, utils, and restore integration tests related to parall
 			It("can execute all statements in the list serially", func() {
 				shouldExecute := utils.NewEmptyIncludeSet()
 				expectedOrderArray := []string{"1", "2", "3", "4"}
-				restore.ExecuteStatements(statements, "", false, shouldExecute, false)
+				restore.ExecuteStatements(statements, "", 0, shouldExecute, false)
 				resultOrderArray := utils.SelectStringSlice(tempConn, orderQuery)
 				Expect(resultOrderArray).To(Equal(expectedOrderArray))
 			})
 			It("can execute all statements in the list that are not of the specified object type serially", func() {
 				shouldExecute := utils.NewExcludeSet([]string{"DATABASE"})
 				expectedOrderArray := []string{"1", "3"}
-				restore.ExecuteStatements(statements, "", false, shouldExecute, false)
+				restore.ExecuteStatements(statements, "", 0, shouldExecute, false)
 				resultOrderArray := utils.SelectStringSlice(tempConn, orderQuery)
 				Expect(resultOrderArray).To(Equal(expectedOrderArray))
 			})
@@ -105,14 +105,14 @@ var _ = Describe("backup, utils, and restore integration tests related to parall
 			It("can execute all statements in the list in parallel", func() {
 				shouldExecute := utils.NewEmptyIncludeSet()
 				expectedOrderArray := []string{"3", "1", "4", "2"}
-				restore.ExecuteStatements(statements, "", false, shouldExecute, true)
+				restore.ExecuteStatements(statements, "", 0, shouldExecute, true)
 				resultOrderArray := utils.SelectStringSlice(tempConn, orderQuery)
 				Expect(resultOrderArray).To(Equal(expectedOrderArray))
 			})
 			It("can execute all statements in the list that are not of the specified object type in parallel", func() {
 				shouldExecute := utils.NewExcludeSet([]string{"DATABASE"})
 				expectedOrderArray := []string{"3", "1"}
-				restore.ExecuteStatements(statements, "", false, shouldExecute, true)
+				restore.ExecuteStatements(statements, "", 0, shouldExecute, true)
 				resultOrderArray := utils.SelectStringSlice(tempConn, orderQuery)
 				Expect(resultOrderArray).To(Equal(expectedOrderArray))
 			})

--- a/restore/parallel.go
+++ b/restore/parallel.go
@@ -19,12 +19,12 @@ import (
  * The return value for this function is the number of errors encountered, not
  * an error code.
  */
-func executeStatement(statement utils.StatementWithType, showProgressBar bool, shouldExecute *utils.FilterSet, whichConn int) uint32 {
+func executeStatement(statement utils.StatementWithType, showProgressBar int, shouldExecute *utils.FilterSet, whichConn int) uint32 {
 	whichConn = connection.ValidateConnNum(whichConn)
 	if shouldExecute.MatchesFilter(statement.ObjectType) {
 		_, err := connection.Exec(statement.Statement, whichConn)
 		if err != nil {
-			if showProgressBar {
+			if showProgressBar >= utils.PB_INFO && logger.GetVerbosity() == utils.LOGINFO {
 				fmt.Println() // Move error message to its own line, since the cursor is currently at the end of the progress bar
 			}
 			logger.Verbose("Error encountered when executing statement: %s Error was: %s", strings.TrimSpace(statement.Statement), err.Error())
@@ -41,7 +41,7 @@ func executeStatement(statement utils.StatementWithType, showProgressBar bool, s
  * This function creates a worker pool of N goroutines to be able to execute up
  * to N statements in parallel.
  */
-func ExecuteStatements(statements []utils.StatementWithType, objectsTitle string, showProgressBar bool, shouldExecute *utils.FilterSet, executeInParallel bool, whichConn ...int) {
+func ExecuteStatements(statements []utils.StatementWithType, objectsTitle string, showProgressBar int, shouldExecute *utils.FilterSet, executeInParallel bool, whichConn ...int) {
 	var numErrors uint32
 	progressBar := utils.NewProgressBar(len(statements), fmt.Sprintf("%s restored: ", objectsTitle), showProgressBar)
 	progressBar.Start()

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -153,7 +153,7 @@ func restoreData(gucStatements []utils.StatementWithType) {
 
 	filteredMasterDataEntries := globalTOC.GetDataEntriesMatching(includeSchemas, includeTables)
 	totalTables := len(filteredMasterDataEntries)
-	dataProgressBar := utils.NewProgressBar(totalTables, "Tables restored: ", true)
+	dataProgressBar := utils.NewProgressBar(totalTables, "Tables restored: ", logger.GetVerbosity() == utils.LOGINFO)
 	dataProgressBar.Start()
 
 	if connection.NumConns == 1 {

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -122,7 +122,7 @@ func createDatabase(metadataFilename string) {
 	if *redirect != "" {
 		statements = utils.SubstituteRedirectDatabaseInStatements(statements, backupConfig.DatabaseName, *redirect)
 	}
-	ExecuteRestoreMetadataStatements(statements, "", false, false)
+	ExecuteRestoreMetadataStatements(statements, "", utils.PB_NONE, false)
 	logger.Info("Database creation complete")
 }
 
@@ -133,14 +133,14 @@ func restoreGlobal(metadataFilename string) {
 	if *redirect != "" {
 		statements = utils.SubstituteRedirectDatabaseInStatements(statements, backupConfig.DatabaseName, *redirect)
 	}
-	ExecuteRestoreMetadataStatements(statements, "Global objects", false, false)
+	ExecuteRestoreMetadataStatements(statements, "Global objects", utils.PB_VERBOSE, false)
 	logger.Info("Global database metadata restore complete")
 }
 
 func restorePredata(metadataFilename string) {
 	logger.Info("Restoring pre-data metadata")
 	statements := GetRestoreMetadataStatements("predata", metadataFilename, []string{}, includeSchemas, includeTables)
-	ExecuteRestoreMetadataStatements(statements, "Pre-data objects", true, false)
+	ExecuteRestoreMetadataStatements(statements, "Pre-data objects", utils.PB_VERBOSE, false)
 	logger.Info("Pre-data metadata restore complete")
 }
 
@@ -153,7 +153,7 @@ func restoreData(gucStatements []utils.StatementWithType) {
 
 	filteredMasterDataEntries := globalTOC.GetDataEntriesMatching(includeSchemas, includeTables)
 	totalTables := len(filteredMasterDataEntries)
-	dataProgressBar := utils.NewProgressBar(totalTables, "Tables restored: ", logger.GetVerbosity() == utils.LOGINFO)
+	dataProgressBar := utils.NewProgressBar(totalTables, "Tables restored: ", utils.PB_INFO)
 	dataProgressBar.Start()
 
 	if connection.NumConns == 1 {
@@ -190,7 +190,7 @@ func restoreData(gucStatements []utils.StatementWithType) {
 func restorePostdata(metadataFilename string) {
 	logger.Info("Restoring post-data metadata")
 	statements := GetRestoreMetadataStatements("postdata", metadataFilename, []string{}, includeSchemas, []string{})
-	ExecuteRestoreMetadataStatements(statements, "Post-data objects", true, false)
+	ExecuteRestoreMetadataStatements(statements, "Post-data objects", utils.PB_VERBOSE, false)
 	logger.Info("Post-data metadata restore complete")
 }
 
@@ -198,7 +198,7 @@ func restoreStatistics() {
 	statisticsFilename := globalCluster.GetStatisticsFilePath()
 	logger.Info("Restoring query planner statistics from %s", statisticsFilename)
 	statements := GetRestoreMetadataStatements("statistics", statisticsFilename, []string{}, includeSchemas, []string{})
-	ExecuteRestoreMetadataStatements(statements, "Table statistics", false, false)
+	ExecuteRestoreMetadataStatements(statements, "Table statistics", utils.PB_VERBOSE, false)
 	logger.Info("Query planner statistics restore complete")
 }
 

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -105,7 +105,7 @@ func GetRestoreMetadataStatements(section string, filename string, objectTypes [
 	return statements
 }
 
-func ExecuteRestoreMetadataStatements(statements []utils.StatementWithType, objectsTitle string, showProgressBar bool, executeInParallel bool) {
+func ExecuteRestoreMetadataStatements(statements []utils.StatementWithType, objectsTitle string, showProgressBar int, executeInParallel bool) {
 	var shouldExecute *utils.FilterSet
 	if connection.Version.AtLeast("5") {
 		shouldExecute = utils.NewExcludeSet([]string{"GPDB4 SESSION GUCS"})
@@ -130,7 +130,7 @@ func setGUCsForConnection(gucStatements []utils.StatementWithType, whichConn int
 		// We only need to set the following GUC for data restores, but it doesn't hurt if we set it for metadata restores as well.
 		gucStatements = append(gucStatements, utils.StatementWithType{ObjectType: "SESSION GUCS", Statement: "SET gp_enable_segment_copy_checking TO false;"})
 	}
-	ExecuteStatements(gucStatements, "", false, utils.NewEmptyIncludeSet(), false, whichConn)
+	ExecuteStatements(gucStatements, "", utils.PB_NONE, utils.NewEmptyIncludeSet(), false, whichConn)
 	return gucStatements
 }
 

--- a/utils/log.go
+++ b/utils/log.go
@@ -209,15 +209,37 @@ func formatStackTrace(err error) string {
 /*
  * Progress bar functions
  */
-func NewProgressBar(count int, prefix string, showInVerbose bool) ProgressBar {
-	if showInVerbose && logger.GetVerbosity() >= LOGVERBOSE {
-		return NewVerboseProgressBar(count, prefix)
-	}
+
+/*
+ * The following constants are used for determining when to display a progress bar
+ *
+ * PB_INFO only shows in info mode because some methods have a different way of
+ * logging in verbose mode and we don't want them to conflict
+ * PB_VERBOSE show a progress bar in INFO and VERBOSE mode
+ *
+ * A simple incremental progress tracker will be shown in info mode and
+ * in verbose mode we will log progress at increments of 10%
+ */
+const (
+	PB_NONE = iota
+	PB_INFO
+	PB_VERBOSE
+
+	//Verbose progress bar logs every 10 percent
+	INCR_PERCENT = 10
+)
+
+func NewProgressBar(count int, prefix string, showProgressBar int) ProgressBar {
 	progressBar := pb.New(count).Prefix(prefix)
 	progressBar.ShowTimeLeft = false
 	progressBar.SetMaxWidth(100)
 	progressBar.SetRefreshRate(time.Millisecond * 200)
-	progressBar.NotPrint = !(count > 0 && logger.GetVerbosity() == LOGINFO)
+	progressBar.NotPrint = !(showProgressBar >= PB_INFO && count > 0 && logger.GetVerbosity() == LOGINFO)
+	if showProgressBar == PB_VERBOSE {
+		verboseProgressBar := NewVerboseProgressBar(count, prefix)
+		verboseProgressBar.ProgressBar = progressBar
+		return verboseProgressBar
+	}
 	return progressBar
 }
 
@@ -232,24 +254,18 @@ type VerboseProgressBar struct {
 	total              int
 	prefix             string
 	nextPercentToPrint int
+	*pb.ProgressBar
 }
 
 func NewVerboseProgressBar(count int, prefix string) *VerboseProgressBar {
-	newPb := VerboseProgressBar{total: count, prefix: prefix, nextPercentToPrint: 10}
+	newPb := VerboseProgressBar{total: count, prefix: prefix, nextPercentToPrint: INCR_PERCENT}
 	return &newPb
 }
 
-func (vpb *VerboseProgressBar) Start() *pb.ProgressBar {
-	return nil
-}
-
-func (vpb *VerboseProgressBar) Finish() {
-	return
-}
-
 func (vpb *VerboseProgressBar) Increment() int {
+	vpb.ProgressBar.Increment()
 	if vpb.current < vpb.total {
-		vpb.current += 1
+		vpb.current++
 		vpb.checkPercent()
 	}
 	return vpb.current
@@ -262,10 +278,10 @@ func (vpb *VerboseProgressBar) Increment() int {
 func (vpb *VerboseProgressBar) checkPercent() {
 	currPercent := int(float64(vpb.current) / float64(vpb.total) * 100)
 	//closestMult is the nearest percentage <= currPercent that is a multiple of 10
-	closestMult := currPercent / 10 * 10
+	closestMult := currPercent / INCR_PERCENT * INCR_PERCENT
 	if closestMult >= vpb.nextPercentToPrint {
 		vpb.nextPercentToPrint = closestMult
 		logger.Verbose("%s %d%% (%d/%d)", vpb.prefix, vpb.nextPercentToPrint, vpb.current, vpb.total)
-		vpb.nextPercentToPrint += 10
+		vpb.nextPercentToPrint += INCR_PERCENT
 	}
 }

--- a/utils/log_test.go
+++ b/utils/log_test.go
@@ -2,6 +2,7 @@ package utils_test
 
 import (
 	"fmt"
+	pb "gopkg.in/cheggaaa/pb.v1"
 	"io"
 	"os"
 	"os/user"
@@ -379,23 +380,114 @@ var _ = Describe("utils/log tests", func() {
 		})
 	})
 	Describe("NewProgressBar", func() {
-		It("will print when passed a value that the progress bar should show", func() {
-			progressBar := utils.NewProgressBar(10, "test progress bar", true)
-			Expect(progressBar.NotPrint).To(Equal(false))
+		Context("PB_NONE", func() {
+			It("will not print when passed a none value", func() {
+				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_NONE)
+				infoPb, ok := progressBar.(*pb.ProgressBar)
+				Expect(ok).To(BeTrue())
+				Expect(infoPb.NotPrint).To(Equal(true))
+			})
 		})
-		It("will not print when passed a value that the progress bar should not show", func() {
-			progressBar := utils.NewProgressBar(10, "test progress bar", false)
-			Expect(progressBar.NotPrint).To(Equal(true))
+		Context("PB_INFO", func() {
+			It("will create a pb.ProgressBar when passed an info value", func() {
+				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_INFO)
+				_, ok := progressBar.(*pb.ProgressBar)
+				Expect(ok).To(BeTrue())
+			})
+			It("will not print with verbosity LOGERROR", func() {
+				logger.SetVerbosity(utils.LOGERROR)
+				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_INFO)
+				infoPb, _ := progressBar.(*pb.ProgressBar)
+				Expect(infoPb.NotPrint).To(Equal(true))
+			})
+			It("will print with verbosity LOGINFO", func() {
+				logger.SetVerbosity(utils.LOGINFO)
+				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_INFO)
+				infoPb, _ := progressBar.(*pb.ProgressBar)
+				Expect(infoPb.NotPrint).To(Equal(false))
+			})
+			It("will not print with verbosity LOGVERBOSE", func() {
+				logger.SetVerbosity(utils.LOGVERBOSE)
+				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_INFO)
+				infoPb, _ := progressBar.(*pb.ProgressBar)
+				Expect(infoPb.NotPrint).To(Equal(true))
+			})
+			It("will create a verboseProgressBar when passed a verbose value", func() {
+				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_VERBOSE)
+				_, ok := progressBar.(*utils.VerboseProgressBar)
+				Expect(ok).To(BeTrue())
+			})
 		})
-		It("will not print with verbosity LOGERROR", func() {
-			logger.SetVerbosity(utils.LOGERROR)
-			progressBar := utils.NewProgressBar(10, "test progress bar", true)
-			Expect(progressBar.NotPrint).To(Equal(true))
+		Context("PB_VERBOSE", func() {
+			It("verboseProgressBar's infoPb will not print with verbosity LOGERROR", func() {
+				logger.SetVerbosity(utils.LOGERROR)
+				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_VERBOSE)
+				vPb, _ := progressBar.(*utils.VerboseProgressBar)
+				Expect(vPb.ProgressBar.NotPrint).To(Equal(true))
+			})
+			It("verboseProgressBar's infoPb will print with verbosity LOGINFO", func() {
+				logger.SetVerbosity(utils.LOGINFO)
+				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_VERBOSE)
+				vPb, _ := progressBar.(*utils.VerboseProgressBar)
+				Expect(vPb.ProgressBar.NotPrint).To(Equal(false))
+			})
+			It("verboseProgressBar's infoPb will not print with verbosity LOGVERBOSE", func() {
+				logger.SetVerbosity(utils.LOGVERBOSE)
+				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_VERBOSE)
+				vPb, _ := progressBar.(*utils.VerboseProgressBar)
+				Expect(vPb.ProgressBar.NotPrint).To(Equal(true))
+			})
 		})
-		It("will not print with verbosity LOGVERBOSE", func() {
-			logger.SetVerbosity(utils.LOGVERBOSE)
-			progressBar := utils.NewProgressBar(10, "test progress bar", true)
-			Expect(progressBar.NotPrint).To(Equal(true))
+	})
+	Describe("Increment", func() {
+		var vPb *utils.VerboseProgressBar
+		BeforeEach(func() {
+			progressBar := utils.NewProgressBar(10, "test progress bar:", utils.PB_VERBOSE)
+			vPb, _ = progressBar.(*utils.VerboseProgressBar)
+		})
+		It("writes to the log file at 10% increments", func() {
+			progressBar := utils.NewProgressBar(10, "test progress bar:", utils.PB_VERBOSE)
+			vPb, _ = progressBar.(*utils.VerboseProgressBar)
+			vPb.Increment()
+			expectedMessage := "test progress bar: 10% (1/10)"
+			testutils.ExpectRegexp(logfile, expectedMessage)
+			vPb.Increment()
+			expectedMessage = "test progress bar: 20% (2/10)"
+			testutils.ExpectRegexp(logfile, expectedMessage)
+		})
+		It("only logs when it hits a new % marker", func() {
+			progressBar := utils.NewProgressBar(20, "test progress bar:", utils.PB_VERBOSE)
+			vPb, _ = progressBar.(*utils.VerboseProgressBar)
+
+			expectedMessage := "test progress bar: 10% (2/20)"
+			vPb.Increment()
+			testutils.NotExpectRegexp(logfile, expectedMessage)
+			vPb.Increment()
+			testutils.ExpectRegexp(logfile, expectedMessage)
+			expectedMessage = "test progress bar: 20% (4/20)"
+			vPb.Increment()
+			testutils.NotExpectRegexp(logfile, expectedMessage)
+			vPb.Increment()
+			testutils.ExpectRegexp(logfile, expectedMessage)
+		})
+		It("writes accurate percentages if < 10 items", func() {
+			progressBar := utils.NewProgressBar(5, "test progress bar:", utils.PB_VERBOSE)
+			vPb, _ = progressBar.(*utils.VerboseProgressBar)
+			vPb.Increment()
+			expectedMessage := "test progress bar: 20% (1/5)"
+			testutils.ExpectRegexp(logfile, expectedMessage)
+			vPb.Increment()
+			expectedMessage = "test progress bar: 40% (2/5)"
+			testutils.ExpectRegexp(logfile, expectedMessage)
+		})
+		It("does not log if called again after hitting 100%", func() {
+			progressBar := utils.NewProgressBar(1, "test progress bar:", utils.PB_VERBOSE)
+			vPb, _ = progressBar.(*utils.VerboseProgressBar)
+			vPb.Increment()
+			expectedMessage := "test progress bar: 100% (1/1)"
+			testutils.ExpectRegexp(logfile, expectedMessage)
+			vPb.Increment()
+			testutils.NotExpectRegexp(logfile, expectedMessage)
 		})
 	})
 })

--- a/utils/log_test.go
+++ b/utils/log_test.go
@@ -412,13 +412,13 @@ var _ = Describe("utils/log tests", func() {
 				infoPb, _ := progressBar.(*pb.ProgressBar)
 				Expect(infoPb.NotPrint).To(Equal(true))
 			})
+		})
+		Context("PB_VERBOSE", func() {
 			It("will create a verboseProgressBar when passed a verbose value", func() {
 				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_VERBOSE)
 				_, ok := progressBar.(*utils.VerboseProgressBar)
 				Expect(ok).To(BeTrue())
 			})
-		})
-		Context("PB_VERBOSE", func() {
 			It("verboseProgressBar's infoPb will not print with verbosity LOGERROR", func() {
 				logger.SetVerbosity(utils.LOGERROR)
 				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_VERBOSE)


### PR DESCRIPTION
The previous progress bar doesn't work well when redirected to a file so
replace it with logging statements every 10% of progress when in verbose
mode (we guess users will often direct to a file when in this mode).

This is not used for tracking the progress of backing up or restoring data
for tables because we have a different mode of logging in that case.

Author: Karen Huddleston <khuddleston@pivotal.io>