### PR TITLE
Add and clarify information in report file

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -246,16 +246,18 @@ func DoTeardown() {
 		}
 		reportFilename := globalCluster.GetReportFilePath()
 		configFilename := globalCluster.GetConfigFilePath()
-		backupReport.WriteReportFile(reportFilename, globalCluster.Timestamp, objectCounts, errMsg)
-		backupReport.WriteConfigFile(configFilename)
-		utils.EmailReport(globalCluster)
-		// We sleep for 1 second to ensure multiple backups do not start within the same second.
-		time.Sleep(1000 * time.Millisecond)
+
+		time.Sleep(time.Second) // We sleep for 1 second to ensure multiple backups do not start within the same second.
 		timestampLockFile := fmt.Sprintf("/tmp/%s.lck", globalCluster.Timestamp)
 		err := os.Remove(timestampLockFile)
 		if err != nil {
 			logger.Warn("Failed to remove lock file %s.", timestampLockFile)
 		}
+
+		endTime := time.Now()
+		backupReport.WriteConfigFile(configFilename)
+		backupReport.WriteReportFile(reportFilename, globalCluster.Timestamp, objectCounts, endTime, errMsg)
+		utils.EmailReport(globalCluster)
 	}
 
 	if exitCode == 0 {

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -2,6 +2,7 @@ package backup
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/greenplum-db/gpbackup/utils"
 )
@@ -58,7 +59,7 @@ func InitializeBackupReport() {
 	utils.InitializeCompressionParameters(!*noCompression, *compressionLevel)
 	isSchemaFiltered := len(includeSchemas) > 0 || len(excludeSchemas) > 0
 	isTableFiltered := len(includeTables) > 0 || len(excludeTables) > 0
-	backupReport.SetBackupTypeFromFlags(*dataOnly, *metadataOnly, *noCompression, isSchemaFiltered, isTableFiltered, *singleDataFile, *withStats)
+	backupReport.ConstructBackupParamsStringFromFlags(*dataOnly, *metadataOnly, isSchemaFiltered, isTableFiltered, *singleDataFile, *withStats)
 }
 
 func InitializeFilterLists() {
@@ -143,7 +144,10 @@ func RetrieveConstraints(tables ...Relation) ([]Constraint, MetadataMap) {
 func LogBackupInfo() {
 	logger.Info("Backup Timestamp = %s", globalCluster.Timestamp)
 	logger.Info("Backup Database = %s", connection.DBName)
-	logger.Info("Backup Type = %s", backupReport.BackupType)
+	params := strings.Split(backupReport.BackupParamsString, "\n")
+	for _, param := range params {
+		logger.Verbose(param)
+	}
 }
 
 func BackupSessionGUCs(metadataFile *utils.FileWithByteCount) {

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -67,7 +67,7 @@ func DoPostgresValidation() {
 
 	InitializeBackupConfig()
 	ValidateBackupFlagCombinations()
-	globalCluster.VerifyMetadataFilePaths(backupConfig.DataOnly, *withStats, backupConfig.TableFiltered)
+	globalCluster.VerifyMetadataFilePaths(backupConfig.DataOnly, *withStats)
 
 	tocFilename := globalCluster.GetTOCFilePath()
 	globalTOC = utils.NewTOC(tocFilename)

--- a/utils/cluster.go
+++ b/utils/cluster.go
@@ -442,7 +442,7 @@ func (cluster *Cluster) GetSegmentTOCFilePath(topDir string, contentStr string) 
 	return path.Join(topDir, fmt.Sprintf("gpbackup_%s_%s_toc.yaml", contentStr, cluster.Timestamp))
 }
 
-func (cluster *Cluster) VerifyMetadataFilePaths(dataOnly bool, withStats bool, tableFiltered bool) {
+func (cluster *Cluster) VerifyMetadataFilePaths(dataOnly bool, withStats bool) {
 	filetypes := []string{"config", "table of contents"}
 	if !dataOnly {
 		filetypes = append(filetypes, "metadata")


### PR DESCRIPTION
This commit adds the start time, end time, and duration of a backup to the
report file, and also breaks out the "backup type" string into separate fields
for the various parameters to make it easier to understand.

Author: Jamie McAtamney <jmcatamney@pivotal.io>