### PR TITLE
 Set session GUCs during backup to ensure backup portability

### DIFF
--- a/backup/data.go
+++ b/backup/data.go
@@ -54,8 +54,7 @@ func CopyTableOut(connection *utils.DBConn, table Relation, backupFile string) {
 		copyCommand = fmt.Sprintf("'%s'", backupFile)
 	}
 	query := fmt.Sprintf("COPY %s TO %s WITH CSV DELIMITER '%s' ON SEGMENT IGNORE EXTERNAL PARTITIONS;", table.ToString(), copyCommand, tableDelim)
-	_, err := connection.Exec(query)
-	utils.CheckError(err)
+	connection.MustExec(query)
 }
 
 func BackupDataForAllTables(tables []Relation, tableDefs map[uint32]TableDefinition) {

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -522,8 +522,7 @@ func LockTables(connection *utils.DBConn, tables []Relation) {
 	progressBar := utils.NewProgressBar(len(tables), "Locks acquired: ", true)
 	progressBar.Start()
 	for _, table := range tables {
-		_, err := connection.Exec(fmt.Sprintf("LOCK TABLE %s IN ACCESS SHARE MODE", table.ToString()))
-		utils.CheckError(err)
+		connection.MustExec(fmt.Sprintf("LOCK TABLE %s IN ACCESS SHARE MODE", table.ToString()))
 		progressBar.Increment()
 	}
 	progressBar.Finish()

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -31,13 +31,11 @@ func SetLoggerVerbosity() {
 func InitializeConnection() {
 	connection = utils.NewDBConn(*dbname)
 	connection.Connect(1)
-	_, err := connection.Exec("SET application_name TO 'gpbackup'")
-	utils.CheckError(err)
+	connection.MustExec("SET application_name TO 'gpbackup'")
 	connection.SetDatabaseVersion()
 	InitializeMetadataParams(connection)
 	connection.Begin()
-	_, err = connection.Exec("SET search_path TO pg_catalog")
-	utils.CheckError(err)
+	connection.MustExec("SET search_path TO pg_catalog")
 }
 
 func InitializeBackupReport() {

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -35,7 +35,20 @@ func InitializeConnection() {
 	connection.SetDatabaseVersion()
 	InitializeMetadataParams(connection)
 	connection.Begin()
+	SetSessionGUCs()
+}
+
+func SetSessionGUCs() {
+	// These GUCs ensure the dumps portability accross systems
 	connection.MustExec("SET search_path TO pg_catalog")
+	connection.MustExec("SET statement_timeout = 0")
+	connection.MustExec("SET DATESTYLE = ISO")
+	if connection.Version.AtLeast("5") {
+		connection.MustExec("SET synchronize_seqscans TO off")
+	}
+	if connection.Version.AtLeast("6") {
+		connection.MustExec("SET INTERVALSTYLE = POSTGRES")
+	}
 }
 
 func InitializeBackupReport() {

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -28,15 +28,11 @@ func SetLoggerVerbosity() {
 func InitializeConnection(dbname string) {
 	connection = utils.NewDBConn(dbname)
 	connection.Connect(*numJobs)
-	_, err := connection.Exec("SET application_name TO 'gprestore'")
-	utils.CheckError(err)
+	connection.MustExec("SET application_name TO 'gprestore'")
 	connection.SetDatabaseVersion()
-	_, err = connection.Exec("SET search_path TO pg_catalog")
-	utils.CheckError(err)
-	_, err = connection.Exec("SET gp_enable_segment_copy_checking TO false")
-	utils.CheckError(err)
-	_, err = connection.Exec("SET gp_default_storage_options='';")
-	utils.CheckError(err)
+	connection.MustExec("SET search_path TO pg_catalog")
+	connection.MustExec("SET gp_enable_segment_copy_checking TO false")
+	connection.MustExec("SET gp_default_storage_options='';")
 }
 
 func InitializeBackupConfig() {

--- a/utils/db.go
+++ b/utils/db.go
@@ -100,8 +100,7 @@ func (dbconn *DBConn) Begin() {
 	 * "snapshot" of the database via MVCC, to keep backups consistent without
 	 * requiring a pg_class lock.
 	 */
-	_, err = dbconn.Exec("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")
-	CheckError(err)
+	dbconn.MustExec("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")
 }
 
 func (dbconn *DBConn) Close() {
@@ -176,6 +175,11 @@ func (dbconn *DBConn) Exec(query string, whichConn ...int) (sql.Result, error) {
 	}
 	connNum := dbconn.ValidateConnNum(whichConn...)
 	return dbconn.ConnPool[connNum].Exec(query)
+}
+
+func (dbconn *DBConn) MustExec(query string, whichConn ...int) {
+	_, err := dbconn.Exec(query, whichConn...)
+	CheckError(err)
 }
 
 func (dbconn *DBConn) Get(destination interface{}, query string, whichConn ...int) error {


### PR DESCRIPTION
These GUCs are set in pg_dump and seem to help prevent potential issues during restore.