### PR TITLE
CI: deprecate CCP remote state path convention

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -65,7 +65,7 @@ resources:
       secret_access_key: {{tf-machine-secret-access-key}}
       region_name: {{aws-region}}
       bucket: gpdb5-pipeline-dynamic-terraform
-      bucket_path: {{tf-bucket-path}}
+      bucket_path: clusters/
 
 - name: boostfs_terraform
   type: terraform
@@ -78,7 +78,7 @@ resources:
       secret_access_key: {{gpdb4-tf-machine-secret-access-key}}
       region_name: {{aws-region}}
       bucket: pivotal-pa-toolsmiths-pipeline-dynamic-terraform
-      bucket_path: {{tf-bucket-path}}
+      bucket_path: clusters/
 
 - name: scale_schema
   type: s3
@@ -394,13 +394,13 @@ ccp_gen_cluster_default_params_anchor: &ccp_gen_cluster_default_params
   AWS_SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
   AWS_DEFAULT_REGION: {{aws-region}}
   BUCKET_NAME: gpdb5-pipeline-dynamic-terraform
-  BUCKET_PATH: {{tf-bucket-path}}
+  BUCKET_PATH: clusters/
 
 boostfs_ccp_gen_cluster_default_params_anchor: &boostfs_ccp_gen_cluster_default_params
   AWS_ACCESS_KEY_ID: {{gpdb4-tf-machine-access-key-id}}
   AWS_SECRET_ACCESS_KEY: {{gpdb4-tf-machine-secret-access-key}}
   AWS_DEFAULT_REGION: {{aws-region}}
-  BUCKET_PATH: {{tf-bucket-path}}
+  BUCKET_PATH: clusters/
   BUCKET_NAME: pivotal-pa-toolsmiths-pipeline-dynamic-terraform
 
 ccp_destroy_anchor: &ccp_destroy
@@ -446,7 +446,7 @@ set_failed_anchor: &set_failed
         AWS_ACCESS_KEY_ID: {{tf-machine-access-key-id}}
         AWS_SECRET_ACCESS_KEY: {{tf-machine-secret-access-key}}
         AWS_DEFAULT_REGION: {{tf-machine-region}}
-        BUCKET_PATH: {{tf-bucket-path}}
+        BUCKET_PATH: clusters/
         BUCKET_NAME: {{tf-bucket-name}}
 
 boostfs_debug_sleep_anchor: &boostfs_debug_sleep


### PR DESCRIPTION
Going forward any pipeline with a terraform resource should specify a
BUCKET_PATH of `clusters/`.

As a static value it can be hardcoded in place of being an interpolated
value from a secrets file.  The key `tf-bucket-path` in any secrets yaml
files is now deprecated and should be removed.

We are dropping the convention where we had teams place their clusters'
tfstate files in a path. In the past this convention was necessary, but
now that we are tagging the clusters with much richer metadata, this
convention is no longer strictly necessary.

Balanced against the need for keeping the bucket organized was the
possibility of two clusters attempting to register their AWS public key
with the same name.  This collision came as a result of the mismatch in
scope.  The terraform resource that provisioned the clusters, and
selected names is only looking in the path given for name collisions,
but the names for AWS keys has to be unique for the account.

By collapsing all of the clusters into an account wide bucket, we will
rely on the terraform resource to check for name conflicts going
forward.

Addresses bug: https://www.pivotaltracker.com/story/show/153928527

Signed-off-by: Jim Doty <jdoty@pivotal.io>