### PR TITLE
Back up CREATE DATABASE modifiers

### DIFF
--- a/backup/metadata_globals.go
+++ b/backup/metadata_globals.go
@@ -62,6 +62,12 @@ func PrintCreateDatabaseStatement(metadataFile *utils.FileWithByteCount, toc *ut
 	if db.Encoding != "" {
 		metadataFile.MustPrintf(" ENCODING '%s'", db.Encoding)
 	}
+	if db.Collate != "" {
+		metadataFile.MustPrintf(" LC_COLLATE '%s'", db.Collate)
+	}
+	if db.CType != "" {
+		metadataFile.MustPrintf(" LC_CTYPE '%s'", db.CType)
+	}
 	metadataFile.MustPrintf(";")
 	toc.AddGlobalEntry("", dbname, "DATABASE", start, metadataFile)
 	start = metadataFile.ByteCount

--- a/backup/metadata_globals.go
+++ b/backup/metadata_globals.go
@@ -59,6 +59,9 @@ func PrintCreateDatabaseStatement(metadataFile *utils.FileWithByteCount, toc *ut
 	if db.Tablespace != "pg_default" {
 		metadataFile.MustPrintf(" TABLESPACE %s", db.Tablespace)
 	}
+	if db.Encoding != "" {
+		metadataFile.MustPrintf(" ENCODING '%s'", db.Encoding)
+	}
 	metadataFile.MustPrintf(";")
 	toc.AddGlobalEntry("", dbname, "DATABASE", start, metadataFile)
 	start = metadataFile.ByteCount

--- a/backup/metadata_globals_test.go
+++ b/backup/metadata_globals_test.go
@@ -71,11 +71,11 @@ REVOKE ALL ON DATABASE testdb FROM PUBLIC;
 REVOKE ALL ON DATABASE testdb FROM testrole;
 GRANT TEMPORARY,CONNECT ON DATABASE testdb TO testrole;`)
 		})
-		It("prints a CREATE DATABASE statement with a TABLESPACE and ENCODING", func() {
-			db := backup.Database{Oid: 1, Name: "testdb", Tablespace: "test_tablespace", Encoding: "UTF8"}
+		It("prints a CREATE DATABASE statement with all modifiers", func() {
+			db := backup.Database{Oid: 1, Name: "testdb", Tablespace: "test_tablespace", Encoding: "UTF8", Collate: "en_US.utf-8", CType: "en_US.utf-8"}
 			emptyMetadataMap := backup.MetadataMap{}
 			backup.PrintCreateDatabaseStatement(backupfile, toc, db, emptyMetadataMap)
-			testutils.AssertBufferContents(toc.GlobalEntries, buffer, `CREATE DATABASE testdb TABLESPACE test_tablespace ENCODING 'UTF8';`)
+			testutils.AssertBufferContents(toc.GlobalEntries, buffer, `CREATE DATABASE testdb TABLESPACE test_tablespace ENCODING 'UTF8' LC_COLLATE 'en_US.utf-8' LC_CTYPE 'en_US.utf-8';`)
 		})
 	})
 	Describe("PrintDatabaseGUCs", func() {

--- a/backup/metadata_globals_test.go
+++ b/backup/metadata_globals_test.go
@@ -71,11 +71,11 @@ REVOKE ALL ON DATABASE testdb FROM PUBLIC;
 REVOKE ALL ON DATABASE testdb FROM testrole;
 GRANT TEMPORARY,CONNECT ON DATABASE testdb TO testrole;`)
 		})
-		It("prints a CREATE DATABASE statement with a TABLESPACE", func() {
-			db := backup.Database{Oid: 1, Name: "testdb", Tablespace: "test_tablespace"}
+		It("prints a CREATE DATABASE statement with a TABLESPACE and ENCODING", func() {
+			db := backup.Database{Oid: 1, Name: "testdb", Tablespace: "test_tablespace", Encoding: "UTF8"}
 			emptyMetadataMap := backup.MetadataMap{}
 			backup.PrintCreateDatabaseStatement(backupfile, toc, db, emptyMetadataMap)
-			testutils.AssertBufferContents(toc.GlobalEntries, buffer, `CREATE DATABASE testdb TABLESPACE test_tablespace;`)
+			testutils.AssertBufferContents(toc.GlobalEntries, buffer, `CREATE DATABASE testdb TABLESPACE test_tablespace ENCODING 'UTF8';`)
 		})
 	})
 	Describe("PrintDatabaseGUCs", func() {

--- a/backup/queries_globals.go
+++ b/backup/queries_globals.go
@@ -31,14 +31,16 @@ type Database struct {
 	Oid        uint32
 	Name       string
 	Tablespace string
+	Encoding   string
 }
 
-func GetDatabaseName(connection *utils.DBConn) Database {
+func GetDatabaseInfo(connection *utils.DBConn) Database {
 	query := fmt.Sprintf(`
 SELECT
 	d.oid,
 	quote_ident(d.datname) AS name,
-	quote_ident(t.spcname) AS tablespace
+	quote_ident(t.spcname) AS tablespace,
+	pg_encoding_to_char(d.encoding) AS encoding
 FROM pg_database d
 JOIN pg_tablespace t
 ON d.dattablespace = t.oid

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -180,7 +180,7 @@ func BackupTablespaces(metadataFile *utils.FileWithByteCount) {
 
 func BackupCreateDatabase(metadataFile *utils.FileWithByteCount) {
 	logger.Verbose("Writing CREATE DATABASE statement to global file")
-	db := GetDatabaseName(connection)
+	db := GetDatabaseInfo(connection)
 	dbMetadata := GetMetadataForObjectType(connection, TYPE_DATABASE)
 	PrintCreateDatabaseStatement(metadataFile, globalTOC, db, dbMetadata)
 }

--- a/integration/metadata_globals_queries_test.go
+++ b/integration/metadata_globals_queries_test.go
@@ -41,7 +41,12 @@ var _ = Describe("backup integration tests", func() {
 
 			result := backup.GetDatabaseInfo(connection)
 
-			testdbExpected := backup.Database{Oid: 0, Name: "testdb", Tablespace: "pg_default", Encoding: "UTF8"}
+			testdbExpected := backup.Database{}
+			if connection.Version.AtLeast("6") {
+				testdbExpected = backup.Database{Oid: 0, Name: "testdb", Tablespace: "pg_default", Encoding: "UTF8", Collate: "en_US.utf-8", CType: "en_US.utf-8"}
+			} else {
+				testdbExpected = backup.Database{Oid: 0, Name: "testdb", Tablespace: "pg_default", Encoding: "UTF8", Collate: "", CType: ""}
+			}
 			testutils.ExpectStructsToMatchExcluding(&testdbExpected, &result, "Oid")
 		})
 	})

--- a/integration/metadata_globals_queries_test.go
+++ b/integration/metadata_globals_queries_test.go
@@ -34,14 +34,14 @@ var _ = Describe("backup integration tests", func() {
 			Expect(results[2]).To(Equal(`SET lc_time TO "C"`))
 		})
 	})
-	Describe("GetDatabaseNames", func() {
-		It("returns a database name struct", func() {
+	Describe("GetDatabaseInfo", func() {
+		It("returns a database info struct", func() {
 			testutils.AssertQueryRuns(connection, "CREATE TABLESPACE test_tablespace FILESPACE test_filespace")
 			defer testutils.AssertQueryRuns(connection, "DROP TABLESPACE test_tablespace")
 
-			result := backup.GetDatabaseName(connection)
+			result := backup.GetDatabaseInfo(connection)
 
-			testdbExpected := backup.Database{Oid: 0, Name: "testdb", Tablespace: "pg_default"}
+			testdbExpected := backup.Database{Oid: 0, Name: "testdb", Tablespace: "pg_default", Encoding: "UTF8"}
 			testutils.ExpectStructsToMatchExcluding(&testdbExpected, &result, "Oid")
 		})
 	})


### PR DESCRIPTION
Back up the database encoding in GPDB 4, 5, and 6.

Back up database locale information in GPDB 6.