### PR TITLE
Restore indexes, triggers, rules, and constraints for table in table-filtered restore

### DIFF
--- a/backup/metadata_globals_test.go
+++ b/backup/metadata_globals_test.go
@@ -43,14 +43,14 @@ SET default_with_oids = false;`)
 			db := backup.Database{Oid: 1, Name: "testdb", Tablespace: "pg_default"}
 			emptyMetadataMap := backup.MetadataMap{}
 			backup.PrintCreateDatabaseStatement(backupfile, toc, db, emptyMetadataMap)
-			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "testdb", "DATABASE")
+			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "", "testdb", "DATABASE")
 			testutils.AssertBufferContents(toc.GlobalEntries, buffer, `CREATE DATABASE testdb;`)
 		})
 		It("prints a CREATE DATABASE statement for a reserved keyword named database", func() {
 			db := backup.Database{Oid: 1, Name: `"table"`, Tablespace: "pg_default"}
 			emptyMetadataMap := backup.MetadataMap{}
 			backup.PrintCreateDatabaseStatement(backupfile, toc, db, emptyMetadataMap)
-			testutils.ExpectEntry(toc.GlobalEntries, 0, "", `"table"`, "DATABASE")
+			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "", `"table"`, "DATABASE")
 			testutils.AssertBufferContents(toc.GlobalEntries, buffer, `CREATE DATABASE "table";`)
 		})
 		It("prints a CREATE DATABASE statement with privileges, an owner, and a comment", func() {
@@ -88,7 +88,7 @@ GRANT TEMPORARY,CONNECT ON DATABASE testdb TO testrole;`)
 			gucs := []string{defaultOidGUC}
 
 			backup.PrintDatabaseGUCs(backupfile, toc, gucs, dbname)
-			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "testdb", "DATABASE GUC")
+			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "", "testdb", "DATABASE GUC")
 			testutils.AssertBufferContents(toc.GlobalEntries, buffer, `ALTER DATABASE testdb SET default_with_oids TO 'true';`)
 		})
 		It("prints multiple database GUCs", func() {
@@ -109,7 +109,7 @@ GRANT TEMPORARY,CONNECT ON DATABASE testdb TO testrole;`)
 			resQueues := []backup.ResourceQueue{someQueue, maxCostQueue}
 
 			backup.PrintCreateResourceQueueStatements(backupfile, toc, resQueues, emptyResQueueMetadata)
-			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "some_queue", "RESOURCE QUEUE")
+			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "", "some_queue", "RESOURCE QUEUE")
 			testutils.AssertBufferContents(toc.GlobalEntries, buffer,
 				`CREATE RESOURCE QUEUE some_queue WITH (ACTIVE_STATEMENTS=1);`,
 				`CREATE RESOURCE QUEUE "someMaxCostQueue" WITH (MAX_COST=99.9, COST_OVERCOMMIT=TRUE);`)
@@ -154,7 +154,7 @@ COMMENT ON RESOURCE QUEUE "commentQueue" IS 'This is a resource queue comment.';
 			resGroups := []backup.ResourceGroup{someGroup, someGroup2}
 
 			backup.PrintCreateResourceGroupStatements(backupfile, toc, resGroups, emptyResGroupMetadata)
-			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "some_group", "RESOURCE GROUP")
+			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "", "some_group", "RESOURCE GROUP")
 			testutils.AssertBufferContents(toc.GlobalEntries, buffer,
 				`CREATE RESOURCE GROUP some_group WITH (CPU_RATE_LIMIT=10, MEMORY_LIMIT=20, MEMORY_SHARED_QUOTA=25, MEMORY_SPILL_RATIO=30, CONCURRENCY=15);`,
 				`CREATE RESOURCE GROUP some_group2 WITH (CPU_RATE_LIMIT=20, MEMORY_LIMIT=30, MEMORY_SHARED_QUOTA=35, MEMORY_SPILL_RATIO=10, CONCURRENCY=25);`)
@@ -164,7 +164,7 @@ COMMENT ON RESOURCE QUEUE "commentQueue" IS 'This is a resource queue comment.';
 			resGroups := []backup.ResourceGroup{default_group}
 
 			backup.PrintCreateResourceGroupStatements(backupfile, toc, resGroups, emptyResGroupMetadata)
-			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "default_group", "RESOURCE GROUP")
+			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "", "default_group", "RESOURCE GROUP")
 			testutils.AssertBufferContents(toc.GlobalEntries, buffer, `ALTER RESOURCE GROUP default_group SET CPU_RATE_LIMIT 10;`,
 				`ALTER RESOURCE GROUP default_group SET MEMORY_LIMIT 20;`,
 				`ALTER RESOURCE GROUP default_group SET MEMORY_SHARED_QUOTA 25;`,
@@ -230,7 +230,7 @@ COMMENT ON RESOURCE QUEUE "commentQueue" IS 'This is a resource queue comment.';
 			roleMetadataMap := testutils.DefaultMetadataMap("ROLE", false, false, true)
 			backup.PrintCreateRoleStatements(backupfile, toc, []backup.Role{testrole1}, roleMetadataMap)
 
-			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "testrole1", "ROLE")
+			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "", "testrole1", "ROLE")
 			testutils.AssertBufferContents(toc.GlobalEntries, buffer, `CREATE ROLE testrole1;
 ALTER ROLE testrole1 WITH NOSUPERUSER NOINHERIT NOCREATEROLE NOCREATEDB NOLOGIN RESOURCE QUEUE pg_default RESOURCE GROUP default_group;
 
@@ -265,7 +265,7 @@ ALTER ROLE "testRole2" DENY BETWEEN DAY 5 TIME '00:00:00' AND DAY 5 TIME '24:00:
 		roleWithout := backup.RoleMember{Role: "group", Member: "rolewithout", Grantor: "grantor", IsAdmin: false}
 		It("prints a role without ADMIN OPTION", func() {
 			backup.PrintRoleMembershipStatements(backupfile, toc, []backup.RoleMember{roleWithout})
-			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "rolewithout", "ROLE GRANT")
+			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "", "rolewithout", "ROLE GRANT")
 			testutils.AssertBufferContents(toc.GlobalEntries, buffer, `GRANT group TO rolewithout GRANTED BY grantor;`)
 		})
 		It("prints a role WITH ADMIN OPTION", func() {
@@ -284,7 +284,7 @@ ALTER ROLE "testRole2" DENY BETWEEN DAY 5 TIME '00:00:00' AND DAY 5 TIME '24:00:
 		It("prints a basic tablespace", func() {
 			emptyMetadataMap := backup.MetadataMap{}
 			backup.PrintCreateTablespaceStatements(backupfile, toc, []backup.Tablespace{expectedTablespace}, emptyMetadataMap)
-			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "test_tablespace", "TABLESPACE")
+			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "", "test_tablespace", "TABLESPACE")
 			testutils.AssertBufferContents(toc.GlobalEntries, buffer, `CREATE TABLESPACE test_tablespace FILESPACE test_filespace;`)
 		})
 		It("prints a tablespace with privileges, an owner, and a comment", func() {

--- a/backup/postdata.go
+++ b/backup/postdata.go
@@ -17,8 +17,9 @@ func PrintCreateIndexStatements(metadataFile *utils.FileWithByteCount, toc *util
 		if index.Tablespace != "" {
 			metadataFile.MustPrintf("\nALTER INDEX %s SET TABLESPACE %s;", index.Name, index.Tablespace)
 		}
+		tableFQN := utils.MakeFQN(index.OwningSchema, index.OwningTable)
 		PrintObjectMetadata(metadataFile, indexMetadata[index.Oid], index.Name, "INDEX")
-		toc.AddPostdataEntry(index.OwningSchema, index.Name, "INDEX", start, metadataFile)
+		toc.AddPostdataEntry(index.OwningSchema, index.Name, "INDEX", tableFQN, start, metadataFile)
 	}
 }
 
@@ -28,7 +29,7 @@ func PrintCreateRuleStatements(metadataFile *utils.FileWithByteCount, toc *utils
 		metadataFile.MustPrintf("\n\n%s", rule.Def)
 		tableFQN := utils.MakeFQN(rule.OwningSchema, rule.OwningTable)
 		PrintObjectMetadata(metadataFile, ruleMetadata[rule.Oid], rule.Name, "RULE", tableFQN)
-		toc.AddPostdataEntry(rule.OwningSchema, rule.Name, "RULE", start, metadataFile)
+		toc.AddPostdataEntry(rule.OwningSchema, rule.Name, "RULE", tableFQN, start, metadataFile)
 	}
 }
 
@@ -38,6 +39,6 @@ func PrintCreateTriggerStatements(metadataFile *utils.FileWithByteCount, toc *ut
 		metadataFile.MustPrintf("\n\n%s;", trigger.Def)
 		tableFQN := utils.MakeFQN(trigger.OwningSchema, trigger.OwningTable)
 		PrintObjectMetadata(metadataFile, triggerMetadata[trigger.Oid], trigger.Name, "TRIGGER", tableFQN)
-		toc.AddPostdataEntry(trigger.OwningSchema, trigger.Name, "TRIGGER", start, metadataFile)
+		toc.AddPostdataEntry(trigger.OwningSchema, trigger.Name, "TRIGGER", tableFQN, start, metadataFile)
 	}
 }

--- a/backup/postdata_test.go
+++ b/backup/postdata_test.go
@@ -16,7 +16,7 @@ var _ = Describe("backup/postdata tests", func() {
 			indexes := []backup.QuerySimpleDefinition{{Oid: 1, Name: "testindex", OwningSchema: "public", OwningTable: "testtable", Tablespace: "", Def: "CREATE INDEX testindex ON public.testtable USING btree(i)"}}
 			emptyMetadataMap := backup.MetadataMap{}
 			backup.PrintCreateIndexStatements(backupfile, toc, indexes, emptyMetadataMap)
-			testutils.ExpectEntry(toc.PostdataEntries, 0, "public", "testindex", "INDEX")
+			testutils.ExpectEntry(toc.PostdataEntries, 0, "public", "public.testtable", "testindex", "INDEX")
 			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE INDEX testindex ON public.testtable USING btree(i);`)
 		})
 		It("can print an index with a tablespace", func() {
@@ -40,7 +40,7 @@ COMMENT ON INDEX testindex IS 'This is an index comment.';`)
 			rules := []backup.QuerySimpleDefinition{{Oid: 1, Name: "testrule", OwningSchema: "public", OwningTable: "testtable", Tablespace: "", Def: "CREATE RULE update_notify AS ON UPDATE TO testtable DO NOTIFY testtable;"}}
 			emptyMetadataMap := backup.MetadataMap{}
 			backup.PrintCreateRuleStatements(backupfile, toc, rules, emptyMetadataMap)
-			testutils.ExpectEntry(toc.PostdataEntries, 0, "public", "testrule", "RULE")
+			testutils.ExpectEntry(toc.PostdataEntries, 0, "public", "public.testtable", "testrule", "RULE")
 			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE RULE update_notify AS ON UPDATE TO testtable DO NOTIFY testtable;`)
 		})
 		It("can print a rule with a comment", func() {
@@ -57,7 +57,7 @@ COMMENT ON RULE testrule ON public.testtable IS 'This is a rule comment.';`)
 			triggers := []backup.QuerySimpleDefinition{{Oid: 1, Name: "testtrigger", OwningSchema: "public", OwningTable: "testtable", Tablespace: "", Def: "CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON testtable FOR EACH STATEMENT EXECUTE PROCEDURE flatfile_update_trigger()"}}
 			emptyMetadataMap := backup.MetadataMap{}
 			backup.PrintCreateTriggerStatements(backupfile, toc, triggers, emptyMetadataMap)
-			testutils.ExpectEntry(toc.PostdataEntries, 0, "public", "testtrigger", "TRIGGER")
+			testutils.ExpectEntry(toc.PostdataEntries, 0, "public", "public.testtable", "testtrigger", "TRIGGER")
 			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON testtable FOR EACH STATEMENT EXECUTE PROCEDURE flatfile_update_trigger();`)
 		})
 		It("can print a trigger with a comment", func() {

--- a/backup/predata_externals.go
+++ b/backup/predata_externals.go
@@ -65,7 +65,7 @@ func PrintExternalTableCreateStatement(metadataFile *utils.FileWithByteCount, to
 	}
 	metadataFile.MustPrintf(";")
 	if toc != nil {
-		toc.AddPredataEntry(table.Schema, table.Name, "TABLE", start, metadataFile)
+		toc.AddPredataEntry(table.Schema, table.Name, "TABLE", "", start, metadataFile)
 	}
 }
 
@@ -243,7 +243,7 @@ func PrintCreateExternalProtocolStatements(metadataFile *utils.FileWithByteCount
 		}
 		metadataFile.MustPrintf("PROTOCOL %s (%s);\n", protocol.Name, strings.Join(protocolFunctions, ", "))
 		PrintObjectMetadata(metadataFile, protoMetadata[protocol.Oid], protocol.Name, "PROTOCOL")
-		toc.AddPredataEntry("", protocol.Name, "PROTOCOL", start, metadataFile)
+		toc.AddPredataEntry("", protocol.Name, "PROTOCOL", "", start, metadataFile)
 	}
 }
 
@@ -278,6 +278,6 @@ func PrintExchangeExternalPartitionStatements(metadataFile *utils.FileWithByteCo
 		}
 		metadataFile.MustPrintf("WITH TABLE %s WITHOUT VALIDATION;", extPartRelationName)
 		metadataFile.MustPrintf("\n\nDROP TABLE %s;", extPartRelationName)
-		toc.AddPredataEntry(externalPartition.ParentSchema, externalPartition.ParentRelationName, "EXCHANGE PARTITION", start, metadataFile)
+		toc.AddPredataEntry(externalPartition.ParentSchema, externalPartition.ParentRelationName, "EXCHANGE PARTITION", "", start, metadataFile)
 	}
 }

--- a/backup/predata_externals_test.go
+++ b/backup/predata_externals_test.go
@@ -99,7 +99,7 @@ var _ = Describe("backup/predata_externals tests", func() {
 			extTableDef.URIs = []string{"file://host:port/path/file"}
 			tableDef.ExtTableDef = extTableDef
 			backup.PrintExternalTableCreateStatement(backupfile, toc, testTable, tableDef)
-			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "tablename", "TABLE")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "tablename", "TABLE")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE READABLE EXTERNAL TABLE public.tablename (
 ) LOCATION (
 	'file://host:port/path/file'
@@ -388,7 +388,7 @@ ENCODING 'UTF-8'`)
 			protos := []backup.ExternalProtocol{protocolUntrustedReadWrite}
 
 			backup.PrintCreateExternalProtocolStatements(backupfile, toc, protos, funcInfoMap, emptyMetadataMap)
-			testutils.ExpectEntry(toc.PredataEntries, 0, "", "s3", "PROTOCOL")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "", "", "s3", "PROTOCOL")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE PROTOCOL s3 (readfunc = public.read_fn_s3, writefunc = public.write_fn_s3);`)
 		})
 		It("prints untrusted protocol with read and validator", func() {

--- a/backup/predata_functions.go
+++ b/backup/predata_functions.go
@@ -25,7 +25,7 @@ func PrintCreateFunctionStatement(metadataFile *utils.FileWithByteCount, toc *ut
 	nameStr := fmt.Sprintf("%s(%s)", funcFQN, funcDef.IdentArgs)
 	nameWithArgs := fmt.Sprintf("%s(%s)", funcDef.Name, funcDef.IdentArgs)
 	PrintObjectMetadata(metadataFile, funcMetadata, nameStr, "FUNCTION")
-	toc.AddPredataEntry(funcDef.Schema, nameWithArgs, "FUNCTION", start, metadataFile)
+	toc.AddPredataEntry(funcDef.Schema, nameWithArgs, "FUNCTION", "", start, metadataFile)
 }
 
 /*
@@ -126,7 +126,7 @@ func PrintCreateAggregateStatements(metadataFile *utils.FileWithByteCount, toc *
 		aggFQN = fmt.Sprintf("%s(%s)", aggFQN, identArgumentsStr)
 		aggWithArgs := fmt.Sprintf("%s(%s)", aggDef.Name, identArgumentsStr)
 		PrintObjectMetadata(metadataFile, aggMetadata[aggDef.Oid], aggFQN, "AGGREGATE")
-		toc.AddPredataEntry(aggDef.Schema, aggWithArgs, "AGGREGATE", start, metadataFile)
+		toc.AddPredataEntry(aggDef.Schema, aggWithArgs, "AGGREGATE", "", start, metadataFile)
 	}
 }
 
@@ -150,7 +150,7 @@ func PrintCreateCastStatements(metadataFile *utils.FileWithByteCount, toc *utils
 		}
 		metadataFile.MustPrintf(";")
 		PrintObjectMetadata(metadataFile, castMetadata[castDef.Oid], castStr, "CAST")
-		toc.AddPredataEntry("pg_catalog", castStr, "CAST", start, metadataFile)
+		toc.AddPredataEntry("pg_catalog", castStr, "CAST", "", start, metadataFile)
 	}
 }
 
@@ -212,7 +212,7 @@ func PrintCreateLanguageStatements(metadataFile *utils.FileWithByteCount, toc *u
 		}
 		PrintObjectMetadata(metadataFile, procLangMetadata[procLang.Oid], procLang.Name, "LANGUAGE")
 		metadataFile.MustPrintln()
-		toc.AddPredataEntry("", procLang.Name, "PROCEDURAL LANGUAGE", start, metadataFile)
+		toc.AddPredataEntry("", procLang.Name, "PROCEDURAL LANGUAGE", "", start, metadataFile)
 	}
 }
 
@@ -228,7 +228,7 @@ func PrintCreateConversionStatements(metadataFile *utils.FileWithByteCount, toc 
 			defaultStr, convFQN, conversion.ForEncoding, conversion.ToEncoding, conversion.ConversionFunction)
 		PrintObjectMetadata(metadataFile, conversionMetadata[conversion.Oid], convFQN, "CONVERSION")
 		metadataFile.MustPrintln()
-		toc.AddPredataEntry(conversion.Schema, conversion.Name, "CONVERSION", start, metadataFile)
+		toc.AddPredataEntry(conversion.Schema, conversion.Name, "CONVERSION", "", start, metadataFile)
 	}
 }
 
@@ -245,7 +245,7 @@ func PrintCreateForeignDataWrapperStatements(metadataFile *utils.FileWithByteCou
 		}
 		metadataFile.MustPrintf(";")
 		PrintObjectMetadata(metadataFile, fdwMetadata[fdw.Oid], fdw.Name, "FOREIGN DATA WRAPPER")
-		toc.AddPredataEntry("", fdw.Name, "FOREIGN DATA WRAPPER", start, metadataFile)
+		toc.AddPredataEntry("", fdw.Name, "FOREIGN DATA WRAPPER", "", start, metadataFile)
 	}
 }
 
@@ -267,7 +267,7 @@ func PrintCreateServerStatements(metadataFile *utils.FileWithByteCount, toc *uti
 
 		//NOTE: We must specify SERVER when creating and dropping, but FOREIGN SERVER when granting and revoking
 		PrintObjectMetadata(metadataFile, serverMetadata[server.Oid], server.Name, "FOREIGN SERVER")
-		toc.AddPredataEntry("", server.Name, "FOREIGN SERVER", start, metadataFile)
+		toc.AddPredataEntry("", server.Name, "FOREIGN SERVER", "", start, metadataFile)
 	}
 }
 
@@ -281,6 +281,6 @@ func PrintCreateUserMappingStatements(metadataFile *utils.FileWithByteCount, toc
 		metadataFile.MustPrintf(";")
 		// User mappings don't have a unique name, so we construct an arbitrary identifier
 		mappingStr := fmt.Sprintf("%s ON %s", mapping.User, mapping.Server)
-		toc.AddPredataEntry("", mappingStr, "USER MAPPING", start, metadataFile)
+		toc.AddPredataEntry("", mappingStr, "USER MAPPING", "", start, metadataFile)
 	}
 }

--- a/backup/predata_functions_test.go
+++ b/backup/predata_functions_test.go
@@ -28,7 +28,7 @@ var _ = Describe("backup/predata_functions tests", func() {
 			})
 			It("prints a function definition for an internal function without a binary path", func() {
 				backup.PrintCreateFunctionStatement(backupfile, toc, funcDef, funcMetadata)
-				testutils.ExpectEntry(toc.PredataEntries, 0, "public", "func_name(integer, integer)", "FUNCTION")
+				testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "func_name(integer, integer)", "FUNCTION")
 				testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE FUNCTION public.func_name(integer, integer) RETURNS integer AS
 $$add_two_ints$$
 LANGUAGE internal;`)
@@ -256,7 +256,7 @@ $_$`)
 
 		It("prints an aggregate definition for an unordered aggregate with no optional specifications", func() {
 			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
-			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "agg_name(integer, integer)", "AGGREGATE")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "agg_name(integer, integer)", "AGGREGATE")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(integer, integer) (
 	SFUNC = public.mysfunc,
 	STYPE = integer
@@ -374,7 +374,7 @@ ALTER AGGREGATE public.agg_name(*) OWNER TO testrole;`)
 		It("prints an explicit cast with a function", func() {
 			castDef := backup.Cast{Oid: 1, SourceTypeFQN: "src", TargetTypeFQN: "dst", FunctionSchema: "public", FunctionName: "cast_func", FunctionArgs: "integer, integer", CastContext: "e"}
 			backup.PrintCreateCastStatements(backupfile, toc, []backup.Cast{castDef}, emptyMetadataMap)
-			testutils.ExpectEntry(toc.PredataEntries, 0, "pg_catalog", "(src AS dst)", "CAST")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "pg_catalog", "", "(src AS dst)", "CAST")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE CAST (src AS dst)
 	WITH FUNCTION public.cast_func(integer, integer);`)
 		})
@@ -466,7 +466,7 @@ COMMENT ON CAST (src AS dst) IS 'This is a cast comment.';`)
 			langs := []backup.ProceduralLanguage{plUntrustedHandlerOnly}
 
 			backup.PrintCreateLanguageStatements(backupfile, toc, langs, funcInfoMap, emptyMetadataMap)
-			testutils.ExpectEntry(toc.PredataEntries, 0, "", "plpythonu", "PROCEDURAL LANGUAGE")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "", "", "plpythonu", "PROCEDURAL LANGUAGE")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE PROCEDURAL LANGUAGE plpythonu;
 ALTER FUNCTION pg_catalog.plpython_call_handler() OWNER TO testrole;`)
 		})
@@ -523,7 +523,7 @@ GRANT ALL ON LANGUAGE plpythonu TO testrole;`)
 		It("prints a non-default conversion", func() {
 			conversions := []backup.Conversion{convOne}
 			backup.PrintCreateConversionStatements(backupfile, toc, conversions, metadataMap)
-			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "conv_one", "CONVERSION")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "conv_one", "CONVERSION")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE CONVERSION public.conv_one FOR 'UTF8' TO 'LATIN1' FROM public.converter;`)
 		})
 		It("prints a default conversion", func() {
@@ -557,27 +557,27 @@ ALTER CONVERSION public.conv_one OWNER TO testrole;`)
 		It("prints a basic foreign data wrapper", func() {
 			foreignDataWrappers := []backup.ForeignDataWrapper{{Oid: 1, Name: "foreigndata"}}
 			backup.PrintCreateForeignDataWrapperStatements(backupfile, toc, foreignDataWrappers, funcInfoMap, backup.MetadataMap{})
-			testutils.ExpectEntry(toc.PredataEntries, 0, "", "foreigndata", "FOREIGN DATA WRAPPER")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "", "", "foreigndata", "FOREIGN DATA WRAPPER")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE FOREIGN DATA WRAPPER foreigndata;`)
 		})
 		It("prints a foreign data wrapper with a validator", func() {
 			foreignDataWrappers := []backup.ForeignDataWrapper{{Name: "foreigndata", Validator: 1}}
 			backup.PrintCreateForeignDataWrapperStatements(backupfile, toc, foreignDataWrappers, funcInfoMap, backup.MetadataMap{})
-			testutils.ExpectEntry(toc.PredataEntries, 0, "", "foreigndata", "FOREIGN DATA WRAPPER")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "", "", "foreigndata", "FOREIGN DATA WRAPPER")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE FOREIGN DATA WRAPPER foreigndata
 	VALIDATOR pg_catalog.postgresql_fdw_validator;`)
 		})
 		It("prints a foreign data wrapper with one option", func() {
 			foreignDataWrappers := []backup.ForeignDataWrapper{{Name: "foreigndata", Options: "debug 'true'"}}
 			backup.PrintCreateForeignDataWrapperStatements(backupfile, toc, foreignDataWrappers, funcInfoMap, backup.MetadataMap{})
-			testutils.ExpectEntry(toc.PredataEntries, 0, "", "foreigndata", "FOREIGN DATA WRAPPER")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "", "", "foreigndata", "FOREIGN DATA WRAPPER")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE FOREIGN DATA WRAPPER foreigndata
 	OPTIONS (debug 'true');`)
 		})
 		It("prints a foreign data wrapper with two options", func() {
 			foreignDataWrappers := []backup.ForeignDataWrapper{{Name: "foreigndata", Options: "debug 'true', host 'localhost'"}}
 			backup.PrintCreateForeignDataWrapperStatements(backupfile, toc, foreignDataWrappers, funcInfoMap, backup.MetadataMap{})
-			testutils.ExpectEntry(toc.PredataEntries, 0, "", "foreigndata", "FOREIGN DATA WRAPPER")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "", "", "foreigndata", "FOREIGN DATA WRAPPER")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE FOREIGN DATA WRAPPER foreigndata
 	OPTIONS (debug 'true', host 'localhost');`)
 		})
@@ -586,14 +586,14 @@ ALTER CONVERSION public.conv_one OWNER TO testrole;`)
 		It("prints a basic foreign server", func() {
 			foreignServers := []backup.ForeignServer{{Oid: 1, Name: "foreignserver", ForeignDataWrapper: "foreignwrapper"}}
 			backup.PrintCreateServerStatements(backupfile, toc, foreignServers, backup.MetadataMap{})
-			testutils.ExpectEntry(toc.PredataEntries, 0, "", "foreignserver", "FOREIGN SERVER")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "", "", "foreignserver", "FOREIGN SERVER")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE SERVER foreignserver
 	FOREIGN DATA WRAPPER foreignwrapper;`)
 		})
 		It("prints a foreign server with one option", func() {
 			foreignServers := []backup.ForeignServer{{Oid: 1, Name: "foreignserver", ForeignDataWrapper: "foreignwrapper", Options: "host 'localhost'"}}
 			backup.PrintCreateServerStatements(backupfile, toc, foreignServers, backup.MetadataMap{})
-			testutils.ExpectEntry(toc.PredataEntries, 0, "", "foreignserver", "FOREIGN SERVER")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "", "", "foreignserver", "FOREIGN SERVER")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE SERVER foreignserver
 	FOREIGN DATA WRAPPER foreignwrapper
 	OPTIONS (host 'localhost');`)
@@ -601,7 +601,7 @@ ALTER CONVERSION public.conv_one OWNER TO testrole;`)
 		It("prints a foreign server with two options", func() {
 			foreignServers := []backup.ForeignServer{{Oid: 1, Name: "foreignserver", ForeignDataWrapper: "foreignwrapper", Options: "host 'localhost', dbname 'testdb'"}}
 			backup.PrintCreateServerStatements(backupfile, toc, foreignServers, backup.MetadataMap{})
-			testutils.ExpectEntry(toc.PredataEntries, 0, "", "foreignserver", "FOREIGN SERVER")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "", "", "foreignserver", "FOREIGN SERVER")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE SERVER foreignserver
 	FOREIGN DATA WRAPPER foreignwrapper
 	OPTIONS (host 'localhost', dbname 'testdb');`)
@@ -609,7 +609,7 @@ ALTER CONVERSION public.conv_one OWNER TO testrole;`)
 		It("prints a foreign server with type and version", func() {
 			foreignServers := []backup.ForeignServer{{Oid: 1, Name: "foreignserver", Type: "server type", Version: "server version", ForeignDataWrapper: "foreignwrapper"}}
 			backup.PrintCreateServerStatements(backupfile, toc, foreignServers, backup.MetadataMap{})
-			testutils.ExpectEntry(toc.PredataEntries, 0, "", "foreignserver", "FOREIGN SERVER")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "", "", "foreignserver", "FOREIGN SERVER")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE SERVER foreignserver
 	TYPE 'server type'
 	VERSION 'server version'
@@ -620,14 +620,14 @@ ALTER CONVERSION public.conv_one OWNER TO testrole;`)
 		It("prints a basic user mapping", func() {
 			userMappings := []backup.UserMapping{{Oid: 1, User: "testrole", Server: "foreignserver"}}
 			backup.PrintCreateUserMappingStatements(backupfile, toc, userMappings)
-			testutils.ExpectEntry(toc.PredataEntries, 0, "", "testrole ON foreignserver", "USER MAPPING")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "", "", "testrole ON foreignserver", "USER MAPPING")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE USER MAPPING FOR testrole
 	SERVER foreignserver;`)
 		})
 		It("prints a user mapping with one option", func() {
 			userMappings := []backup.UserMapping{{Oid: 1, User: "testrole", Server: "foreignserver", Options: "host 'localhost'"}}
 			backup.PrintCreateUserMappingStatements(backupfile, toc, userMappings)
-			testutils.ExpectEntry(toc.PredataEntries, 0, "", "testrole ON foreignserver", "USER MAPPING")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "", "", "testrole ON foreignserver", "USER MAPPING")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE USER MAPPING FOR testrole
 	SERVER foreignserver
 	OPTIONS (host 'localhost');`)
@@ -635,7 +635,7 @@ ALTER CONVERSION public.conv_one OWNER TO testrole;`)
 		It("prints a user mapping with two options", func() {
 			userMappings := []backup.UserMapping{{Oid: 1, User: "testrole", Server: "foreignserver", Options: "host 'localhost', dbname 'testdb'"}}
 			backup.PrintCreateUserMappingStatements(backupfile, toc, userMappings)
-			testutils.ExpectEntry(toc.PredataEntries, 0, "", "testrole ON foreignserver", "USER MAPPING")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "", "", "testrole ON foreignserver", "USER MAPPING")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE USER MAPPING FOR testrole
 	SERVER foreignserver
 	OPTIONS (host 'localhost', dbname 'testdb');`)

--- a/backup/predata_operators.go
+++ b/backup/predata_operators.go
@@ -56,7 +56,7 @@ CREATE OPERATOR %s (
 );`, operatorFQN, operator.Procedure, strings.Join(optionalFields, ",\n\t"))
 		operatorStr := fmt.Sprintf("%s (%s, %s)", operatorFQN, leftArg, rightArg)
 		PrintObjectMetadata(metadataFile, operatorMetadata[operator.Oid], operatorStr, "OPERATOR")
-		toc.AddPredataEntry(operator.Schema, operator.Name, "OPERATOR", start, metadataFile)
+		toc.AddPredataEntry(operator.Schema, operator.Name, "OPERATOR", "", start, metadataFile)
 	}
 }
 
@@ -71,7 +71,7 @@ func PrintCreateOperatorFamilyStatements(metadataFile *utils.FileWithByteCount, 
 		operatorFamilyStr := fmt.Sprintf("%s USING %s", operatorFamilyFQN, operatorFamily.IndexMethod)
 		metadataFile.MustPrintf("\n\nCREATE OPERATOR FAMILY %s;", operatorFamilyStr)
 		PrintObjectMetadata(metadataFile, operatorFamilyMetadata[operatorFamily.Oid], operatorFamilyStr, "OPERATOR FAMILY")
-		toc.AddPredataEntry(operatorFamily.Schema, operatorFamily.Name, "OPERATOR FAMILY", start, metadataFile)
+		toc.AddPredataEntry(operatorFamily.Schema, operatorFamily.Name, "OPERATOR FAMILY", "", start, metadataFile)
 	}
 }
 
@@ -116,6 +116,6 @@ func PrintCreateOperatorClassStatements(metadataFile *utils.FileWithByteCount, t
 
 		operatorClassStr := fmt.Sprintf("%s USING %s", operatorClassFQN, operatorClass.IndexMethod)
 		PrintObjectMetadata(metadataFile, operatorClassMetadata[operatorClass.Oid], operatorClassStr, "OPERATOR CLASS")
-		toc.AddPredataEntry(operatorClass.Schema, operatorClass.Name, "OPERATOR CLASS", start, metadataFile)
+		toc.AddPredataEntry(operatorClass.Schema, operatorClass.Name, "OPERATOR CLASS", "", start, metadataFile)
 	}
 }

--- a/backup/predata_operators_test.go
+++ b/backup/predata_operators_test.go
@@ -17,7 +17,7 @@ var _ = Describe("backup/predata_operators tests", func() {
 
 			backup.PrintCreateOperatorStatements(backupfile, toc, []backup.Operator{operator}, backup.MetadataMap{})
 
-			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "##", "OPERATOR")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "##", "OPERATOR")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE OPERATOR public.## (
 	PROCEDURE = public.path_inter,
 	LEFTARG = public.path,
@@ -89,7 +89,7 @@ ALTER OPERATOR public.## (NONE, public."PATH") OWNER TO testrole;`)
 
 			backup.PrintCreateOperatorFamilyStatements(backupfile, toc, []backup.OperatorFamily{operatorFamily}, backup.MetadataMap{})
 
-			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "testfam", "OPERATOR FAMILY")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "testfam", "OPERATOR FAMILY")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE OPERATOR FAMILY public.testfam USING hash;`)
 		})
 		It("prints an operator family with an owner and comment", func() {
@@ -113,7 +113,7 @@ ALTER OPERATOR FAMILY public.testfam USING hash OWNER TO testrole;`)
 
 			backup.PrintCreateOperatorClassStatements(backupfile, toc, []backup.OperatorClass{operatorClass}, backup.MetadataMap{})
 
-			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "testclass", "OPERATOR CLASS")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "testclass", "OPERATOR CLASS")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE OPERATOR CLASS public.testclass
 	FOR TYPE uuid USING hash AS
 	STORAGE uuid;`)

--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -189,7 +189,7 @@ func PrintCreateTableStatement(metadataFile *utils.FileWithByteCount, toc *utils
 		PrintRegularTableCreateStatement(metadataFile, nil, table, tableDef)
 	}
 	PrintPostCreateTableStatements(metadataFile, table, tableDef, tableMetadata)
-	toc.AddPredataEntry(table.Schema, table.Name, "TABLE", start, metadataFile)
+	toc.AddPredataEntry(table.Schema, table.Name, "TABLE", "", start, metadataFile)
 }
 
 func PrintRegularTableCreateStatement(metadataFile *utils.FileWithByteCount, toc *utils.TOC, table Relation, tableDef TableDefinition) {
@@ -217,7 +217,7 @@ func PrintRegularTableCreateStatement(metadataFile *utils.FileWithByteCount, toc
 	}
 	printAlterColumnStatements(metadataFile, table, tableDef.ColumnDefs)
 	if toc != nil {
-		toc.AddPredataEntry(table.Schema, table.Name, "TABLE", start, metadataFile)
+		toc.AddPredataEntry(table.Schema, table.Name, "TABLE", "", start, metadataFile)
 	}
 }
 
@@ -319,7 +319,7 @@ func PrintCreateSequenceStatements(metadataFile *utils.FileWithByteCount, toc *u
 		metadataFile.MustPrintf("\n\nSELECT pg_catalog.setval('%s', %d, %v);\n", seqFQN, sequence.LastVal, sequence.IsCalled)
 
 		PrintObjectMetadata(metadataFile, sequenceMetadata[sequence.Oid], seqFQN, "SEQUENCE")
-		toc.AddPredataEntry(sequence.Relation.Schema, sequence.Relation.Name, "SEQUENCE", start, metadataFile)
+		toc.AddPredataEntry(sequence.Relation.Schema, sequence.Relation.Name, "SEQUENCE", "", start, metadataFile)
 	}
 }
 
@@ -330,7 +330,7 @@ func PrintAlterSequenceStatements(metadataFile *utils.FileWithByteCount, toc *ut
 		if owningColumn, hasColumnOwner := sequenceColumnOwners[seqFQN]; hasColumnOwner {
 			start := metadataFile.ByteCount
 			metadataFile.MustPrintf("\n\nALTER SEQUENCE %s OWNED BY %s;\n", seqFQN, owningColumn)
-			toc.AddPredataEntry(sequence.Relation.Schema, sequence.Relation.Name, "SEQUENCE OWNER", start, metadataFile)
+			toc.AddPredataEntry(sequence.Relation.Schema, sequence.Relation.Name, "SEQUENCE OWNER", "", start, metadataFile)
 		}
 	}
 }
@@ -341,6 +341,6 @@ func PrintCreateViewStatements(metadataFile *utils.FileWithByteCount, toc *utils
 		viewFQN := utils.MakeFQN(view.Schema, view.Name)
 		metadataFile.MustPrintf("\n\nCREATE VIEW %s AS %s\n", viewFQN, view.Definition)
 		PrintObjectMetadata(metadataFile, viewMetadata[view.Oid], viewFQN, "VIEW")
-		toc.AddPredataEntry(view.Schema, view.Name, "VIEW", start, metadataFile)
+		toc.AddPredataEntry(view.Schema, view.Name, "VIEW", "", start, metadataFile)
 	}
 }

--- a/backup/predata_relations_test.go
+++ b/backup/predata_relations_test.go
@@ -61,7 +61,7 @@ SET SUBPARTITION TEMPLATE
 
 			tableDef.IsExternal = false
 			backup.PrintCreateTableStatement(backupfile, toc, testTable, tableDef, tableMetadata)
-			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "tablename", "TABLE")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "tablename", "TABLE")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TABLE public.tablename (
 ) DISTRIBUTED RANDOMLY;
 
@@ -499,7 +499,7 @@ COMMENT ON COLUMN public.tablename.j IS 'This is another column comment.';`)
 		It("can print a sequence with all default options", func() {
 			sequences := []backup.Sequence{seqDefault}
 			backup.PrintCreateSequenceStatements(backupfile, toc, sequences, emptySequenceMetadataMap)
-			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "seq_name", "SEQUENCE")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "seq_name", "SEQUENCE")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE SEQUENCE public.seq_name
 	INCREMENT BY 1
 	NO MAXVALUE
@@ -640,7 +640,7 @@ GRANT SELECT,USAGE ON SEQUENCE public.seq_name TO testrole WITH GRANT OPTION;`)
 			viewTwo := backup.View{Oid: 1, Schema: "shamwow", Name: "shazam", Definition: "SELECT count(*) FROM pg_tables;", DependsUpon: []string{}}
 			viewMetadataMap := backup.MetadataMap{}
 			backup.PrintCreateViewStatements(backupfile, toc, []backup.View{viewOne, viewTwo}, viewMetadataMap)
-			testutils.ExpectEntry(toc.PredataEntries, 0, "public", `"WowZa"`, "VIEW")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", `"WowZa"`, "VIEW")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer,
 				`CREATE VIEW public."WowZa" AS SELECT rolname FROM pg_role;`,
 				`CREATE VIEW shamwow.shazam AS SELECT count(*) FROM pg_tables;`)
@@ -677,7 +677,7 @@ GRANT ALL ON shamwow.shazam TO testrole;`)
 		It("can print an ALTER SEQUENCE statement for a sequence with an owning column", func() {
 			sequences := []backup.Sequence{seqDefault}
 			backup.PrintAlterSequenceStatements(backupfile, toc, sequences, columnOwnerMap)
-			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "seq_name", "SEQUENCE OWNER")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "seq_name", "SEQUENCE OWNER")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `ALTER SEQUENCE public.seq_name OWNED BY tablename.col_one;`)
 		})
 	})

--- a/backup/predata_shared.go
+++ b/backup/predata_shared.go
@@ -69,7 +69,7 @@ func PrintConstraintStatements(metadataFile *utils.FileWithByteCount, toc *utils
 		}
 		metadataFile.MustPrintf(alterStr, objStr, constraint.OwningObject, constraint.Name, constraint.ConDef)
 		PrintObjectMetadata(metadataFile, conMetadata[constraint.Oid], constraint.Name, "CONSTRAINT", constraint.OwningObject)
-		toc.AddPredataEntry(constraint.Schema, constraint.Name, "CONSTRAINT", start, metadataFile)
+		toc.AddPredataEntry(constraint.Schema, constraint.Name, "CONSTRAINT", constraint.OwningObject, start, metadataFile)
 	}
 }
 
@@ -81,7 +81,7 @@ func PrintCreateSchemaStatements(backupfile *utils.FileWithByteCount, toc *utils
 			backupfile.MustPrintf("\nCREATE SCHEMA %s;", schema.Name)
 		}
 		PrintObjectMetadata(backupfile, schemaMetadata[schema.Oid], schema.Name, "SCHEMA")
-		toc.AddPredataEntry(schema.Name, schema.Name, "SCHEMA", start, backupfile)
+		toc.AddPredataEntry(schema.Name, schema.Name, "SCHEMA", "", start, backupfile)
 	}
 }
 

--- a/backup/predata_shared_test.go
+++ b/backup/predata_shared_test.go
@@ -45,7 +45,7 @@ var _ = Describe("backup/predata_shared tests", func() {
 				constraints := []backup.Constraint{uniqueOne}
 				constraintMetadataMap := testutils.DefaultMetadataMap("CONSTRAINT", false, false, true)
 				backup.PrintConstraintStatements(backupfile, toc, constraints, constraintMetadataMap)
-				testutils.ExpectEntry(toc.PredataEntries, 0, "", "tablename_i_key", "CONSTRAINT")
+				testutils.ExpectEntry(toc.PredataEntries, 0, "", "public.tablename", "tablename_i_key", "CONSTRAINT")
 				testutils.AssertBufferContents(toc.PredataEntries, buffer, `ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_i_key UNIQUE (i);
 
 
@@ -149,7 +149,7 @@ COMMENT ON CONSTRAINT tablename_i_key ON public.tablename IS 'This is a constrai
 			emptyMetadataMap := backup.MetadataMap{}
 
 			backup.PrintCreateSchemaStatements(backupfile, toc, schemas, emptyMetadataMap)
-			testutils.ExpectEntry(toc.PredataEntries, 0, "schemaname", "schemaname", "SCHEMA")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "schemaname", "", "schemaname", "SCHEMA")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, "CREATE SCHEMA schemaname;")
 		})
 		It("can print a schema with privileges, an owner, and a comment", func() {

--- a/backup/predata_textsearch.go
+++ b/backup/predata_textsearch.go
@@ -30,7 +30,7 @@ func PrintCreateTextSearchParserStatements(metadataFile *utils.FileWithByteCount
 		}
 		metadataFile.MustPrintf("\n);")
 		PrintObjectMetadata(metadataFile, parserMetadata[parser.Oid], parserFQN, "TEXT SEARCH PARSER")
-		toc.AddPredataEntry(parser.Schema, parser.Name, "TEXT SEARCH PARSER", start, metadataFile)
+		toc.AddPredataEntry(parser.Schema, parser.Name, "TEXT SEARCH PARSER", "", start, metadataFile)
 	}
 }
 
@@ -45,7 +45,7 @@ func PrintCreateTextSearchTemplateStatements(metadataFile *utils.FileWithByteCou
 		metadataFile.MustPrintf("\n\tLEXIZE = %s", template.LexizeFunc)
 		metadataFile.MustPrintf("\n);")
 		PrintObjectMetadata(metadataFile, templateMetadata[template.Oid], templateFQN, "TEXT SEARCH TEMPLATE")
-		toc.AddPredataEntry(template.Schema, template.Name, "TEXT SEARCH TEMPLATE", start, metadataFile)
+		toc.AddPredataEntry(template.Schema, template.Name, "TEXT SEARCH TEMPLATE", "", start, metadataFile)
 	}
 }
 
@@ -60,7 +60,7 @@ func PrintCreateTextSearchDictionaryStatements(metadataFile *utils.FileWithByteC
 		}
 		metadataFile.MustPrintf("\n);")
 		PrintObjectMetadata(metadataFile, dictionaryMetadata[dictionary.Oid], dictionaryFQN, "TEXT SEARCH DICTIONARY")
-		toc.AddPredataEntry(dictionary.Schema, dictionary.Name, "TEXT SEARCH DICTIONARY", start, metadataFile)
+		toc.AddPredataEntry(dictionary.Schema, dictionary.Name, "TEXT SEARCH DICTIONARY", "", start, metadataFile)
 	}
 }
 
@@ -82,6 +82,6 @@ func PrintCreateTextSearchConfigurationStatements(metadataFile *utils.FileWithBy
 			metadataFile.MustPrintf("\n\tADD MAPPING FOR \"%s\" WITH %s;", token, strings.Join(dicts, ", "))
 		}
 		PrintObjectMetadata(metadataFile, configurationMetadata[configuration.Oid], configurationFQN, "TEXT SEARCH CONFIGURATION")
-		toc.AddPredataEntry(configuration.Schema, configuration.Name, "TEXT SEARCH CONFIGURATION", start, metadataFile)
+		toc.AddPredataEntry(configuration.Schema, configuration.Name, "TEXT SEARCH CONFIGURATION", "", start, metadataFile)
 	}
 }

--- a/backup/predata_textsearch_test.go
+++ b/backup/predata_textsearch_test.go
@@ -15,7 +15,7 @@ var _ = Describe("backup/predata_textsearch tests", func() {
 		It("prints a basic text search parser", func() {
 			parsers := []backup.TextSearchParser{{Oid: 0, Schema: "public", Name: "testparser", StartFunc: "start_func", TokenFunc: "token_func", EndFunc: "end_func", LexTypesFunc: "lextypes_func"}}
 			backup.PrintCreateTextSearchParserStatements(backupfile, toc, parsers, backup.MetadataMap{})
-			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "testparser", "TEXT SEARCH PARSER")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "testparser", "TEXT SEARCH PARSER")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TEXT SEARCH PARSER public.testparser (
 	START = start_func,
 	GETTOKEN = token_func,
@@ -43,7 +43,7 @@ COMMENT ON TEXT SEARCH PARSER public.testparser IS 'This is a text search parser
 			templates := []backup.TextSearchTemplate{{Oid: 1, Schema: "public", Name: "testtemplate", InitFunc: "dsimple_init", LexizeFunc: "dsimple_lexize"}}
 			metadataMap := testutils.DefaultMetadataMap("TEXT SEARCH TEMPLATE", false, false, true)
 			backup.PrintCreateTextSearchTemplateStatements(backupfile, toc, templates, metadataMap)
-			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "testtemplate", "TEXT SEARCH TEMPLATE")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "testtemplate", "TEXT SEARCH TEMPLATE")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TEXT SEARCH TEMPLATE public.testtemplate (
 	INIT = dsimple_init,
 	LEXIZE = dsimple_lexize
@@ -57,7 +57,7 @@ COMMENT ON TEXT SEARCH TEMPLATE public.testtemplate IS 'This is a text search te
 			dictionaries := []backup.TextSearchDictionary{{Oid: 1, Schema: "public", Name: "testdictionary", Template: "testschema.snowball", InitOption: "language = 'russian', stopwords = 'russian'"}}
 			metadataMap := testutils.DefaultMetadataMap("TEXT SEARCH DICTIONARY", false, true, true)
 			backup.PrintCreateTextSearchDictionaryStatements(backupfile, toc, dictionaries, metadataMap)
-			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "testdictionary", "TEXT SEARCH DICTIONARY")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "testdictionary", "TEXT SEARCH DICTIONARY")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TEXT SEARCH DICTIONARY public.testdictionary (
 	TEMPLATE = testschema.snowball,
 	language = 'russian', stopwords = 'russian'
@@ -82,7 +82,7 @@ ALTER TEXT SEARCH DICTIONARY public.testdictionary OWNER TO testrole;`)
 			configurations := []backup.TextSearchConfiguration{{Oid: 1, Schema: "public", Name: "testconfiguration", Parser: `pg_catalog."default"`, TokenToDicts: tokenToDicts}}
 			metadataMap := testutils.DefaultMetadataMap("TEXT SEARCH CONFIGURATION", false, true, true)
 			backup.PrintCreateTextSearchConfigurationStatements(backupfile, toc, configurations, metadataMap)
-			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "testconfiguration", "TEXT SEARCH CONFIGURATION")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "testconfiguration", "TEXT SEARCH CONFIGURATION")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TEXT SEARCH CONFIGURATION public.testconfiguration (
 	PARSER = pg_catalog."default"
 );

--- a/backup/predata_types.go
+++ b/backup/predata_types.go
@@ -26,7 +26,7 @@ func PrintCreateShellTypeStatements(metadataFile *utils.FileWithByteCount, toc *
 		if typ.Type == "b" || typ.Type == "p" {
 			typeFQN := utils.MakeFQN(typ.Schema, typ.Name)
 			metadataFile.MustPrintf("CREATE TYPE %s;\n", typeFQN)
-			toc.AddPredataEntry(typ.Schema, typ.Name, "TYPE", start, metadataFile)
+			toc.AddPredataEntry(typ.Schema, typ.Name, "TYPE", "", start, metadataFile)
 			start = metadataFile.ByteCount
 		}
 	}
@@ -47,7 +47,7 @@ func PrintCreateDomainStatement(metadataFile *utils.FileWithByteCount, toc *util
 	}
 	metadataFile.MustPrintln(";")
 	PrintObjectMetadata(metadataFile, typeMetadata, typeFQN, "DOMAIN")
-	toc.AddPredataEntry(domain.Schema, domain.Name, "DOMAIN", start, metadataFile)
+	toc.AddPredataEntry(domain.Schema, domain.Name, "DOMAIN", "", start, metadataFile)
 }
 
 func PrintCreateBaseTypeStatement(metadataFile *utils.FileWithByteCount, toc *utils.TOC, base Type, typeMetadata ObjectMetadata) {
@@ -110,7 +110,7 @@ func PrintCreateBaseTypeStatement(metadataFile *utils.FileWithByteCount, toc *ut
 	}
 	metadataFile.MustPrintln("\n);")
 	PrintObjectMetadata(metadataFile, typeMetadata, typeFQN, "TYPE")
-	toc.AddPredataEntry(base.Schema, base.Name, "TYPE", start, metadataFile)
+	toc.AddPredataEntry(base.Schema, base.Name, "TYPE", "", start, metadataFile)
 }
 
 func PrintCreateCompositeTypeStatement(metadataFile *utils.FileWithByteCount, toc *utils.TOC, composite Type, typeMetadata ObjectMetadata) {
@@ -120,7 +120,7 @@ func PrintCreateCompositeTypeStatement(metadataFile *utils.FileWithByteCount, to
 	metadataFile.MustPrintln(strings.Join(composite.Attributes, ",\n"))
 	metadataFile.MustPrintf(");")
 	PrintObjectMetadata(metadataFile, typeMetadata, typeFQN, "TYPE")
-	toc.AddPredataEntry(composite.Schema, composite.Name, "TYPE", start, metadataFile)
+	toc.AddPredataEntry(composite.Schema, composite.Name, "TYPE", "", start, metadataFile)
 }
 
 func PrintCreateEnumTypeStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, enums []Type, typeMetadata MetadataMap) {
@@ -129,6 +129,6 @@ func PrintCreateEnumTypeStatements(metadataFile *utils.FileWithByteCount, toc *u
 		typeFQN := utils.MakeFQN(enum.Schema, enum.Name)
 		metadataFile.MustPrintf("\n\nCREATE TYPE %s AS ENUM (\n\t%s\n);\n", typeFQN, enum.EnumLabels)
 		PrintObjectMetadata(metadataFile, typeMetadata[enum.Oid], typeFQN, "TYPE")
-		toc.AddPredataEntry(enum.Schema, enum.Name, "TYPE", start, metadataFile)
+		toc.AddPredataEntry(enum.Schema, enum.Name, "TYPE", "", start, metadataFile)
 	}
 }

--- a/backup/predata_types_test.go
+++ b/backup/predata_types_test.go
@@ -23,7 +23,7 @@ var _ = Describe("backup/predata_types tests", func() {
 
 		It("prints an enum type with multiple attributes", func() {
 			backup.PrintCreateEnumTypeStatements(backupfile, toc, []backup.Type{enumOne}, typeMetadataMap)
-			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "enum_type", "TYPE")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "enum_type", "TYPE")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TYPE public.enum_type AS ENUM (
 	'bar',
 	'baz',
@@ -54,7 +54,7 @@ ALTER TYPE public.enum_type OWNER TO testrole;`)
 		It("prints a composite type with one attribute", func() {
 			compType.Attributes = oneAtt
 			backup.PrintCreateCompositeTypeStatement(backupfile, toc, compType, typeMetadata)
-			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "composite_type", "TYPE")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "composite_type", "TYPE")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TYPE public.composite_type AS (
 	foo integer
 );`)
@@ -92,7 +92,7 @@ ALTER TYPE public.composite_type OWNER TO testrole;`)
 
 		It("prints a base type with no optional arguments", func() {
 			backup.PrintCreateBaseTypeStatement(backupfile, toc, baseSimple, typeMetadata)
-			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "base_type", "TYPE")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "base_type", "TYPE")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TYPE public.base_type (
 	INPUT = input_fn,
 	OUTPUT = output_fn
@@ -164,8 +164,8 @@ ALTER TYPE public.composite_type OWNER TO testrole;`)
 		enumOne := backup.Type{Oid: 1, Schema: "public", Name: "enum_type", Type: "e", EnumLabels: "'bar',\n\t'baz',\n\t'foo'"}
 		It("prints shell type for only a base type", func() {
 			backup.PrintCreateShellTypeStatements(backupfile, toc, []backup.Type{baseOne, baseTwo, compOne, compTwo, enumOne})
-			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "base_type1", "TYPE")
-			testutils.ExpectEntry(toc.PredataEntries, 1, "public", "base_type2", "TYPE")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "base_type1", "TYPE")
+			testutils.ExpectEntry(toc.PredataEntries, 1, "public", "", "base_type2", "TYPE")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, "CREATE TYPE public.base_type1;", "CREATE TYPE public.base_type2;")
 		})
 	})
@@ -181,7 +181,7 @@ ALTER TYPE public.composite_type OWNER TO testrole;`)
 		domainTwo.BaseType = "varchar"
 		It("prints a basic domain with a constraint", func() {
 			backup.PrintCreateDomainStatement(backupfile, toc, domainOne, emptyMetadata, checkConstraint)
-			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "domain1", "DOMAIN")
+			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "domain1", "DOMAIN")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE DOMAIN public.domain1 AS numeric DEFAULT 4 NOT NULL
 	CONSTRAINT domain1_check CHECK (VALUE > 2);`)
 		})

--- a/backup/statistics_test.go
+++ b/backup/statistics_test.go
@@ -22,7 +22,7 @@ var _ = Describe("backup/statistics tests", func() {
 			tupleStats = backup.TupleStatistic{Schema: "testschema", Table: "testtable"}
 			attStats = []backup.AttributeStatistic{}
 			backup.PrintStatisticsStatementsForTable(backupfile, toc, tableTestTable, attStats, tupleStats)
-			testutils.ExpectEntry(toc.StatisticsEntries, 0, "testschema", "testtable", "STATISTICS")
+			testutils.ExpectEntry(toc.StatisticsEntries, 0, "testschema", "", "testtable", "STATISTICS")
 			testutils.AssertBufferContents(toc.StatisticsEntries, buffer, `UPDATE pg_class
 SET
 	relpages = 0::int,
@@ -39,7 +39,7 @@ AND relnamespace = 0;`)
 					Width: 10, Distinct: .5, Kind1: 20, Operator1: 10, Numbers1: pq.StringArray([]string{"1", "2", "3"}), Values1: pq.StringArray([]string{"4", "5", "6"})},
 			}
 			backup.PrintStatisticsStatementsForTable(backupfile, toc, tableTestTable, attStats, tupleStats)
-			testutils.ExpectEntry(toc.StatisticsEntries, 0, "testschema", "testtable", "STATISTICS")
+			testutils.ExpectEntry(toc.StatisticsEntries, 0, "testschema", "", "testtable", "STATISTICS")
 			testutils.AssertBufferContents(toc.StatisticsEntries, buffer, `UPDATE pg_class
 SET
 	relpages = 0::int,

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -196,7 +196,7 @@ func restoreData(gucStatements []utils.StatementWithType) {
 
 func restorePostdata(metadataFilename string) {
 	logger.Info("Restoring post-data metadata")
-	statements := GetRestoreMetadataStatements("postdata", metadataFilename, []string{}, includeSchemas, []string{})
+	statements := GetRestoreMetadataStatements("postdata", metadataFilename, []string{}, includeSchemas, includeTables)
 	ExecuteRestoreMetadataStatements(statements, "Post-data objects", utils.PB_VERBOSE, false)
 	logger.Info("Post-data metadata restore complete")
 }

--- a/restore/validate_test.go
+++ b/restore/validate_test.go
@@ -53,13 +53,13 @@ var _ = Describe("restore/validate tests", func() {
 		BeforeEach(func() {
 			toc, backupfile = testutils.InitializeTestTOC(buffer, "predata")
 			backupfile.ByteCount = table1Len
-			toc.AddPredataEntry("schema1", "table1", "TABLE", 0, backupfile)
+			toc.AddPredataEntry("schema1", "table1", "", "TABLE", 0, backupfile)
 			toc.AddMasterDataEntry("schema1", "table1", 1, "(i)")
 			backupfile.ByteCount += table2Len
-			toc.AddPredataEntry("schema2", "table2", "TABLE", table1Len, backupfile)
+			toc.AddPredataEntry("schema2", "table2", "TABLE", "", table1Len, backupfile)
 			toc.AddMasterDataEntry("schema2", "table2", 2, "(j)")
 			backupfile.ByteCount += sequenceLen
-			toc.AddPredataEntry("schema", "somesequence", "SEQUENCE", table1Len+table2Len, backupfile)
+			toc.AddPredataEntry("schema", "somesequence", "SEQUENCE", "", table1Len+table2Len, backupfile)
 			restore.SetTOC(toc)
 		})
 		It("schema exists in normal backup", func() {
@@ -124,13 +124,13 @@ var _ = Describe("restore/validate tests", func() {
 		BeforeEach(func() {
 			toc, backupfile = testutils.InitializeTestTOC(buffer, "predata")
 			backupfile.ByteCount = table1Len
-			toc.AddPredataEntry("schema1", "table1", "TABLE", 0, backupfile)
+			toc.AddPredataEntry("schema1", "table1", "TABLE", "", 0, backupfile)
 			toc.AddMasterDataEntry("schema1", "table1", 1, "(i)")
 			backupfile.ByteCount += table2Len
-			toc.AddPredataEntry("schema2", "table2", "TABLE", table1Len, backupfile)
+			toc.AddPredataEntry("schema2", "table2", "TABLE", "", table1Len, backupfile)
 			toc.AddMasterDataEntry("schema2", "table2", 2, "(j)")
 			backupfile.ByteCount += sequenceLen
-			toc.AddPredataEntry("schema1", "somesequence", "SEQUENCE", table1Len+table2Len, backupfile)
+			toc.AddPredataEntry("schema1", "somesequence", "SEQUENCE", "", table1Len+table2Len, backupfile)
 			restore.SetTOC(toc)
 		})
 		It("table exists in normal backup", func() {

--- a/testutils/functions.go
+++ b/testutils/functions.go
@@ -300,9 +300,9 @@ func AssertBufferContents(entries []utils.MetadataEntry, buffer *gbytes.Buffer, 
 	}
 }
 
-func ExpectEntry(entries []utils.MetadataEntry, index int, schema, name, objectType string) {
+func ExpectEntry(entries []utils.MetadataEntry, index int, schema, referenceObject, name, objectType string) {
 	Expect(len(entries)).To(BeNumerically(">", index))
-	ExpectStructsToMatchExcluding(entries[index], utils.MetadataEntry{Schema: schema, Name: name, ObjectType: objectType, StartByte: 0, EndByte: 0}, "StartByte", "EndByte")
+	ExpectStructsToMatchExcluding(entries[index], utils.MetadataEntry{Schema: schema, Name: name, ObjectType: objectType, ReferenceObject: referenceObject, StartByte: 0, EndByte: 0}, "StartByte", "EndByte")
 }
 
 func ExpectPathToExist(path string) {

--- a/utils/toc_test.go
+++ b/utils/toc_test.go
@@ -30,7 +30,7 @@ var _ = Describe("utils/toc tests", func() {
 	Context("GetSqlStatementForObjectTypes", func() {
 		It("returns statement for a single object type", func() {
 			backupfile.ByteCount = commentLen + createLen
-			toc.AddMetadataEntry("", "somedatabase", "DATABASE", commentLen, backupfile, "global")
+			toc.AddMetadataEntry("", "somedatabase", "DATABASE", "", commentLen, backupfile, "global")
 
 			metadataFile := bytes.NewReader([]byte(comment.Statement + create.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, []string{"DATABASE"}, []string{}, []string{})
@@ -39,11 +39,11 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns statement for multiple object types", func() {
 			backupfile.ByteCount = commentLen + createLen
-			toc.AddMetadataEntry("", "somedatabase", "DATABASE", commentLen, backupfile, "global")
+			toc.AddMetadataEntry("", "somedatabase", "DATABASE", "", commentLen, backupfile, "global")
 			backupfile.ByteCount += role1Len
-			toc.AddMetadataEntry("", "somerole1", "ROLE", commentLen+createLen, backupfile, "global")
+			toc.AddMetadataEntry("", "somerole1", "ROLE", "", commentLen+createLen, backupfile, "global")
 			backupfile.ByteCount += role2Len
-			toc.AddMetadataEntry("", "somerole2", "ROLE", commentLen+createLen+role1Len, backupfile, "global")
+			toc.AddMetadataEntry("", "somerole2", "ROLE", "", commentLen+createLen+role1Len, backupfile, "global")
 
 			metadataFile := bytes.NewReader([]byte(comment.Statement + create.Statement + role1.Statement + role2.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, []string{"DATABASE", "ROLE"}, []string{}, []string{})
@@ -52,7 +52,7 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns empty statement when no object types are found", func() {
 			backupfile.ByteCount = commentLen + createLen
-			toc.AddMetadataEntry("", "somedatabase", "DATABASE", commentLen, backupfile, "global")
+			toc.AddMetadataEntry("", "somedatabase", "DATABASE", "", commentLen, backupfile, "global")
 
 			metadataFile := bytes.NewReader([]byte(comment.Statement + create.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, []string{"TABLE"}, []string{}, []string{})
@@ -61,11 +61,11 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns statement for a single object type with matching schema", func() {
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntry("schema", "table1", "TABLE", 0, backupfile, "global")
+			toc.AddMetadataEntry("schema", "table1", "TABLE", "", 0, backupfile, "global")
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntry("schema2", "table2", "TABLE", table1Len, backupfile, "global")
+			toc.AddMetadataEntry("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
 			backupfile.ByteCount += sequenceLen
-			toc.AddMetadataEntry("schema", "somesequence", "SEQUENCE", table1Len+table2Len, backupfile, "global")
+			toc.AddMetadataEntry("schema", "somesequence", "SEQUENCE", "", table1Len+table2Len, backupfile, "global")
 
 			metadataFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, []string{"TABLE"}, []string{"schema"}, []string{})
@@ -74,11 +74,11 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns statement for any object type with matching schema", func() {
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntry("schema", "table1", "TABLE", 0, backupfile, "global")
+			toc.AddMetadataEntry("schema", "table1", "TABLE", "", 0, backupfile, "global")
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntry("schema2", "table2", "TABLE", table1Len, backupfile, "global")
+			toc.AddMetadataEntry("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
 			backupfile.ByteCount += sequenceLen
-			toc.AddMetadataEntry("schema", "somesequence", "SEQUENCE", table1Len+table2Len, backupfile, "global")
+			toc.AddMetadataEntry("schema", "somesequence", "SEQUENCE", "", table1Len+table2Len, backupfile, "global")
 
 			metadataFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, []string{}, []string{"schema"}, []string{})
@@ -87,24 +87,39 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns statement for any object type with matching table", func() {
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntry("schema", "table1", "TABLE", 0, backupfile, "global")
+			toc.AddMetadataEntry("schema", "table1", "TABLE", "", 0, backupfile, "global")
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntry("schema2", "table2", "TABLE", table1Len, backupfile, "global")
+			toc.AddMetadataEntry("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
 			backupfile.ByteCount += sequenceLen
-			toc.AddMetadataEntry("schema", "somesequence", "SEQUENCE", table1Len+table2Len, backupfile, "global")
+			toc.AddMetadataEntry("schema", "somesequence", "SEQUENCE", "", table1Len+table2Len, backupfile, "global")
 
 			metadataFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, []string{}, []string{}, []string{"schema.table1"})
 
 			Expect(statements).To(Equal([]utils.StatementWithType{table1}))
 		})
+
+		It("returns statement for any object type with matching reference object", func() {
+			backupfile.ByteCount = table1Len
+			toc.AddMetadataEntry("schema", "table1", "INDEX", "", 0, backupfile, "global")
+			backupfile.ByteCount += table2Len
+			toc.AddMetadataEntry("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
+			backupfile.ByteCount += sequenceLen
+			toc.AddMetadataEntry("schema", "somesequence", "SEQUENCE", "schema.tablefoo", table1Len+table2Len, backupfile, "global")
+
+			metadataFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement))
+			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, []string{}, []string{}, []string{"schema.tablefoo"})
+
+			Expect(statements).To(Equal([]utils.StatementWithType{sequence}))
+
+		})
 		It("returns no statements for a non-table object with matching name from table list", func() {
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntry("schema", "table1", "TABLE", 0, backupfile, "global")
+			toc.AddMetadataEntry("schema", "table1", "TABLE", "", 0, backupfile, "global")
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntry("schema2", "table2", "TABLE", table1Len, backupfile, "global")
+			toc.AddMetadataEntry("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
 			backupfile.ByteCount += sequenceLen
-			toc.AddMetadataEntry("schema", "somesequence", "SEQUENCE", table1Len+table2Len, backupfile, "global")
+			toc.AddMetadataEntry("schema", "somesequence", "SEQUENCE", "", table1Len+table2Len, backupfile, "global")
 
 			metadataFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, []string{}, []string{}, []string{"schema.somesequence"})
@@ -138,7 +153,7 @@ var _ = Describe("utils/toc tests", func() {
 	Context("GetAllSqlStatements", func() {
 		It("returns statement for a single object type", func() {
 			backupfile.ByteCount = createLen
-			toc.AddMetadataEntry("", "somedatabase", "DATABASE", 0, backupfile, "global")
+			toc.AddMetadataEntry("", "somedatabase", "DATABASE", "", 0, backupfile, "global")
 
 			metadataFile := bytes.NewReader([]byte(create.Statement))
 			statements := toc.GetAllSQLStatements("global", metadataFile)
@@ -147,11 +162,11 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns statement for a multiple object types", func() {
 			backupfile.ByteCount = createLen
-			toc.AddMetadataEntry("", "somedatabase", "DATABASE", 0, backupfile, "global")
+			toc.AddMetadataEntry("", "somedatabase", "DATABASE", "", 0, backupfile, "global")
 			backupfile.ByteCount += role1Len
-			toc.AddMetadataEntry("", "somerole1", "ROLE", createLen, backupfile, "global")
+			toc.AddMetadataEntry("", "somerole1", "ROLE", "", createLen, backupfile, "global")
 			backupfile.ByteCount += role2Len
-			toc.AddMetadataEntry("", "somerole2", "ROLE", createLen+role1Len, backupfile, "global")
+			toc.AddMetadataEntry("", "somerole2", "ROLE", "", createLen+role1Len, backupfile, "global")
 
 			metadataFile := bytes.NewReader([]byte(create.Statement + role1.Statement + role2.Statement))
 			statements := toc.GetAllSQLStatements("global", metadataFile)


### PR DESCRIPTION
This adds a ReferenceObject entry in the TOC to associate an object with a table (or other object) for use in restore.

Author: Chris Hajas <chajas@pivotal.io>