### PR TITLE
 Allow concurrent gprestores of same timestamp

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -70,7 +70,7 @@ func DoSetup() {
 	segConfig := utils.GetSegmentConfiguration(connection)
 	segPrefix := utils.GetSegPrefix(connection)
 	globalCluster = utils.NewCluster(segConfig, *backupDir, timestamp, segPrefix)
-	globalCluster.CreateBackupDirectoriesOnAllHosts()
+	CreateBackupDirectoriesOnAllHosts(globalCluster)
 	globalTOC = &utils.TOC{}
 	globalTOC.InitializeEntryMap()
 }
@@ -203,7 +203,7 @@ func backupData(tables []Relation, tableDefs map[uint32]TableDefinition) {
 	BackupData(tables, tableDefs)
 	AddTableDataEntriesToTOC(tables, tableDefs)
 	if *singleDataFile {
-		globalCluster.MoveSegmentTOCsAndMakeReadOnly()
+		MoveSegmentTOCsAndMakeReadOnly(globalCluster)
 	}
 	logger.Info("Data backup complete")
 }

--- a/backup/remote.go
+++ b/backup/remote.go
@@ -1,0 +1,78 @@
+package backup
+
+import (
+	"fmt"
+
+	"github.com/greenplum-db/gpbackup/utils"
+)
+
+/*
+ * Functions to run commands on entire cluster during backup
+ */
+
+func CreateBackupDirectoriesOnAllHosts(cluster utils.Cluster) {
+	remoteOutput := cluster.GenerateAndExecuteCommand("Creating backup directories", func(contentID int) string {
+		return fmt.Sprintf("mkdir -p %s", cluster.GetDirForContent(contentID))
+	}, true)
+	cluster.CheckClusterError(remoteOutput, "Unable to create backup directories", func(contentID int) string {
+		return fmt.Sprintf("Unable to create backup directory %s", cluster.GetDirForContent(contentID))
+	})
+}
+
+func CreateSegmentPipesOnAllHostsForBackup(cluster utils.Cluster) {
+	remoteOutput := cluster.GenerateAndExecuteCommand("Creating segment data pipes", func(contentID int) string {
+		pipeName := cluster.GetSegmentPipeFilePath(contentID)
+		return fmt.Sprintf("mkfifo %s", pipeName)
+	})
+	cluster.CheckClusterError(remoteOutput, "Unable to create segment data pipes", func(contentID int) string {
+		return "Unable to create segment data pipe"
+	})
+}
+
+func CleanUpSegmentPipesOnAllHosts(cluster utils.Cluster) {
+	remoteOutput := cluster.GenerateAndExecuteCommand("Cleaning up segment data pipes", func(contentID int) string {
+		pipePath := cluster.GetSegmentPipeFilePath(contentID)
+		scriptPath := cluster.GetSegmentHelperFilePath(contentID, "script")
+		// This cleans up both the pipe itself as well as any gpbackup_helper process associated with it
+		return fmt.Sprintf("set -o pipefail; rm -f %s* && ps ux | grep %s | grep -v grep | awk '{print $2}' | xargs kill -9 || true", pipePath, scriptPath)
+	})
+	cluster.CheckClusterError(remoteOutput, "Unable to clean up segment data pipes", func(contentID int) string {
+		return "Unable to clean up segment data pipe"
+	})
+}
+
+func ReadFromSegmentPipes(cluster utils.Cluster) {
+	remoteOutput := cluster.GenerateAndExecuteCommand("Reading from segment data pipes", func(contentID int) string {
+		usingCompression, compressionProgram := utils.GetCompressionParameters()
+		pipeFile := cluster.GetSegmentPipeFilePath(contentID)
+		compress := compressionProgram.CompressCommand
+		backupFile := cluster.GetTableBackupFilePath(contentID, 0, true)
+		if usingCompression {
+			return fmt.Sprintf("set -o pipefail; nohup tail -n +1 -f %s | %s > %s &", pipeFile, compress, backupFile)
+		}
+		return fmt.Sprintf("nohup tail -n +1 -f %s > %s &", pipeFile, backupFile)
+	})
+	cluster.CheckClusterError(remoteOutput, "Unable to read from segment data pipes", func(contentID int) string {
+		return "Unable to read from segment data pipe"
+	})
+}
+
+func CleanUpSegmentTailProcesses(cluster utils.Cluster) {
+	remoteOutput := cluster.GenerateAndExecuteCommand("Cleaning up segment tail processes", func(contentID int) string {
+		filePattern := fmt.Sprintf("gpbackup_%d_%s", contentID, cluster.Timestamp) // Matches pipe name for backup and file name for restore
+		return fmt.Sprintf(`ps ux | grep "tail -n +1 -f" | grep "%s" | grep -v "grep" | awk '{print $2}' | xargs kill -9`, filePattern)
+	})
+	cluster.CheckClusterError(remoteOutput, "Unable to clean up tail processes", func(contentID int) string {
+		return "Unable to clean up tail process"
+	})
+}
+
+func MoveSegmentTOCsAndMakeReadOnly(cluster utils.Cluster) {
+	remoteOutput := cluster.GenerateAndExecuteCommand("Setting permissions on segment table of contents files and moving to backup directories", func(contentID int) string {
+		tocFile := cluster.GetSegmentTOCFilePath(cluster.SegDirMap[contentID], fmt.Sprintf("%d", contentID))
+		return fmt.Sprintf("chmod 444 %s; mv %s %s/.", tocFile, tocFile, cluster.GetDirForContent(contentID))
+	})
+	cluster.CheckClusterError(remoteOutput, "Unable to set permissions on or move segment table of contents files", func(contentID int) string {
+		return fmt.Sprintf("Unable to set permissions on or move file %s", cluster.GetSegmentTOCFilePath(cluster.SegDirMap[contentID], fmt.Sprintf("%d", contentID)))
+	})
+}

--- a/backup/remote_test.go
+++ b/backup/remote_test.go
@@ -1,0 +1,63 @@
+package backup_test
+
+import (
+	"os/user"
+
+	"github.com/greenplum-db/gpbackup/backup"
+	"github.com/greenplum-db/gpbackup/testutils"
+	"github.com/greenplum-db/gpbackup/utils"
+	"github.com/pkg/errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("backup/remote tests", func() {
+	masterSeg := utils.SegConfig{ContentID: -1, Hostname: "localhost", DataDir: "/data/gpseg-1"}
+	localSegOne := utils.SegConfig{ContentID: 0, Hostname: "localhost", DataDir: "/data/gpseg0"}
+	remoteSegOne := utils.SegConfig{ContentID: 1, Hostname: "remotehost1", DataDir: "/data/gpseg1"}
+	var (
+		testCluster  utils.Cluster
+		testExecutor *testutils.TestExecutor
+	)
+
+	BeforeEach(func() {
+		utils.System.CurrentUser = func() (*user.User, error) { return &user.User{Username: "testUser", HomeDir: "testDir"}, nil }
+		utils.System.Hostname = func() (string, error) { return "testHost", nil }
+		testExecutor = &testutils.TestExecutor{}
+		testCluster = utils.NewCluster([]utils.SegConfig{masterSeg, localSegOne, remoteSegOne}, "", "20170101010101", "gpseg")
+		testCluster.Executor = testExecutor
+	})
+	Describe("CreateBackupDirectoriesOnAllHosts", func() {
+		It("successfully creates all directories", func() {
+			testExecutor.ClusterOutput = &utils.RemoteOutput{
+				NumErrors: 0,
+			}
+			backup.CreateBackupDirectoriesOnAllHosts(testCluster)
+			Expect((*testExecutor).NumExecutions).To(Equal(1))
+		})
+		It("panics if it cannot create all directories", func() {
+			testExecutor.ClusterOutput = &utils.RemoteOutput{
+				NumErrors: 2,
+				Errors: map[int]error{
+					0: errors.Errorf("exit status 1"),
+					1: errors.Errorf("exit status 1"),
+				},
+			}
+			testCluster.Executor = testExecutor
+			defer testutils.ShouldPanicWithMessage("Unable to create backup directories on 2 segments")
+			backup.CreateBackupDirectoriesOnAllHosts(testCluster)
+		})
+		It("panics if it cannot create some directories", func() {
+			testExecutor.ClusterOutput = &utils.RemoteOutput{
+				NumErrors: 1,
+				Errors: map[int]error{
+					1: errors.Errorf("exit status 1"),
+				},
+			}
+			testCluster.Executor = testExecutor
+			defer testutils.ShouldPanicWithMessage("Unable to create backup directories on 1 segment")
+			backup.CreateBackupDirectoriesOnAllHosts(testCluster)
+		})
+	})
+})

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -461,7 +461,7 @@ func BackupTriggers(metadataFile *utils.FileWithByteCount) {
 
 func BackupData(tables []Relation, tableDefs map[uint32]TableDefinition) {
 	if *singleDataFile {
-		globalCluster.CreateSegmentPipesOnAllHosts()
+		globalCluster.CreateSegmentPipesOnAllHostsForBackup()
 		defer globalCluster.CleanUpSegmentPipesOnAllHosts()
 		globalCluster.ReadFromSegmentPipes()
 		defer globalCluster.CleanUpSegmentTailProcesses()

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -461,10 +461,10 @@ func BackupTriggers(metadataFile *utils.FileWithByteCount) {
 
 func BackupData(tables []Relation, tableDefs map[uint32]TableDefinition) {
 	if *singleDataFile {
-		globalCluster.CreateSegmentPipesOnAllHostsForBackup()
-		defer globalCluster.CleanUpSegmentPipesOnAllHosts()
-		globalCluster.ReadFromSegmentPipes()
-		defer globalCluster.CleanUpSegmentTailProcesses()
+		CreateSegmentPipesOnAllHostsForBackup(globalCluster)
+		defer CleanUpSegmentPipesOnAllHosts(globalCluster)
+		ReadFromSegmentPipes(globalCluster)
+		defer CleanUpSegmentTailProcesses(globalCluster)
 	}
 	BackupDataForAllTables(tables, tableDefs)
 }

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -92,7 +92,7 @@ var _ = AfterSuite(func() {
 })
 
 func setupTestFilespace(cluster utils.Cluster) {
-	cluster.CreateBackupDirectoriesOnAllHosts()
+	backup.CreateBackupDirectoriesOnAllHosts(cluster)
 	// Construct a filespace config like the one that gpfilespace generates
 	filespaceConfigQuery := `COPY (SELECT hostname || ':' || dbid || ':/tmp/test_dir/' || preferred_role || content FROM gp_segment_configuration AS subselect) TO '/tmp/temp_filespace_config';`
 	testutils.AssertQueryRuns(connection, filespaceConfigQuery)

--- a/restore/remote.go
+++ b/restore/remote.go
@@ -1,0 +1,181 @@
+package restore
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/greenplum-db/gpbackup/utils"
+	"github.com/pkg/errors"
+)
+
+/*
+ * Functions to run commands on entire cluster during restore
+ */
+
+func VerifyBackupDirectoriesExistOnAllHosts(cluster utils.Cluster) {
+	remoteOutput := cluster.GenerateAndExecuteCommand("Verifying backup directories exist", func(contentID int) string {
+		return fmt.Sprintf("test -d %s", cluster.GetDirForContent(contentID))
+	}, true)
+	cluster.CheckClusterError(remoteOutput, "Backup directories missing or inaccessible", func(contentID int) string {
+		return fmt.Sprintf("Backup directory %s missing or inaccessible", cluster.GetDirForContent(contentID))
+	})
+}
+
+func CreateSegmentPipesOnAllHostsForRestore(cluster utils.Cluster, oid uint32) {
+	remoteOutput := cluster.GenerateAndExecuteCommand("Creating segment data pipes", func(contentID int) string {
+		pipeName := cluster.GetSegmentPipeFilePathWithPID(contentID)
+		pipeName = fmt.Sprintf("%s_%d", pipeName, oid)
+		return fmt.Sprintf("mkfifo %s", pipeName)
+	})
+	cluster.CheckClusterError(remoteOutput, "Unable to create segment data pipes", func(contentID int) string {
+		return "Unable to create segment data pipe"
+	})
+}
+
+func WriteToSegmentPipes(cluster utils.Cluster) {
+	remoteOutput := cluster.GenerateAndExecuteCommand("Writing to segment data pipes", func(contentID int) string {
+		tocFile := cluster.GetSegmentTOCFilePathWithPID(cluster.SegDirMap[contentID], fmt.Sprintf("%d", contentID))
+		oidFile := cluster.GetSegmentHelperFilePath(contentID, "oid")
+		scriptFile := cluster.GetSegmentHelperFilePath(contentID, "script")
+		pipeFile := cluster.GetSegmentPipeFilePathWithPID(contentID)
+		backupFile := cluster.GetTableBackupFilePath(contentID, 0, true)
+		gphomePath := utils.System.Getenv("GPHOME")
+		return fmt.Sprintf(`cat << HEREDOC > %s
+#!/bin/bash
+%s/bin/gpbackup_helper --restore-agent --toc-file %s --oid-file %s --pipe-file %s --data-file %s --content %d
+HEREDOC
+
+chmod +x %s; (nohup %s > /dev/null 2>&1 &) &`, scriptFile, gphomePath, tocFile, oidFile, pipeFile, backupFile, contentID, scriptFile, scriptFile)
+	})
+	cluster.CheckClusterError(remoteOutput, "Unable to write to segment data pipes", func(contentID int) string {
+		return fmt.Sprintf("Unable to write to data pipe for segment %d on host %s", contentID, cluster.GetHostForContent(contentID))
+	})
+}
+
+func WriteOidListToSegments(cluster utils.Cluster, filteredEntries []utils.MasterDataEntry) {
+	filteredOids := make([]string, len(filteredEntries))
+	for i, entry := range filteredEntries {
+		filteredOids[i] = fmt.Sprintf("%d", entry.Oid)
+	}
+	oidStr := strings.Join(filteredOids, "\n")
+	remoteOutput := cluster.GenerateAndExecuteCommand("Writing filtered oid list to segments", func(contentID int) string {
+		oidFile := cluster.GetSegmentHelperFilePath(contentID, "oid")
+		return fmt.Sprintf(`echo "%s" > %s`, oidStr, oidFile)
+	})
+	cluster.CheckClusterError(remoteOutput, "Unable to write oid list to segments", func(contentID int) string {
+		return fmt.Sprintf("Unable to write oid list for segment %d on host %s", contentID, cluster.GetHostForContent(contentID))
+	})
+}
+
+func CleanUpHelperFilesOnAllHosts(cluster utils.Cluster) {
+	remoteOutput := cluster.GenerateAndExecuteCommand("Removing oid list and helper script files from segment data directories", func(contentID int) string {
+		oidFile := cluster.GetSegmentHelperFilePath(contentID, "oid")
+		scriptFile := cluster.GetSegmentHelperFilePath(contentID, "script")
+		return fmt.Sprintf("rm %s && rm %s", oidFile, scriptFile)
+	})
+	errMsg := fmt.Sprintf("Unable to remove segment helper file(s). See %s for a complete list of segments with errors and remove manually.",
+		logger.GetLogFilePath())
+	cluster.CheckClusterError(remoteOutput, errMsg, func(contentID int) string {
+		tocFile := cluster.GetSegmentTOCFilePathWithPID(cluster.SegDirMap[contentID], fmt.Sprintf("%d", contentID))
+		return fmt.Sprintf("Unable to remove helper file %s on segment %d on host %s", tocFile, contentID, cluster.GetHostForContent(contentID))
+	}, true)
+}
+
+func CopySegmentTOCs(cluster utils.Cluster) {
+	remoteOutput := cluster.GenerateAndExecuteCommand("Copying segment table of contents files from backup directories", func(contentID int) string {
+		tocFile := cluster.GetSegmentTOCFilePathWithPID(cluster.SegDirMap[contentID], fmt.Sprintf("%d", contentID))
+		tocFilename := fmt.Sprintf("gpbackup_%d_%s_toc.yaml", contentID, cluster.Timestamp)
+		return fmt.Sprintf("cp -f %s/%s %s", cluster.GetDirForContent(contentID), tocFilename, tocFile)
+	})
+	cluster.CheckClusterError(remoteOutput, "Unable to copy segment table of contents files from backup directories", func(contentID int) string {
+		return fmt.Sprintf("Unable to copy segment table of contents file to %s", cluster.GetSegmentTOCFilePathWithPID(cluster.SegDirMap[contentID], fmt.Sprintf("%d", contentID)))
+	})
+}
+
+func VerifyBackupFileCountOnSegments(cluster utils.Cluster, fileCount int) {
+	remoteOutput := cluster.GenerateAndExecuteCommand("Verifying backup file count", func(contentID int) string {
+		return fmt.Sprintf("find %s -type f | wc -l", cluster.GetDirForContent(contentID))
+	})
+	cluster.CheckClusterError(remoteOutput, "Could not verify backup file count", func(contentID int) string {
+		return "Could not verify backup file count"
+	})
+
+	s := ""
+	if fileCount != 1 {
+		s = "s"
+	}
+	numIncorrect := 0
+	for contentID := range remoteOutput.Stdouts {
+		numFound, _ := strconv.Atoi(strings.TrimSpace(remoteOutput.Stdouts[contentID]))
+		if numFound != fileCount {
+			logger.Verbose("Expected to find %d file%s on segment %d on host %s, but found %d instead.", fileCount, s, contentID, cluster.GetHostForContent(contentID), numFound)
+			numIncorrect++
+		}
+	}
+	if numIncorrect > 0 {
+		utils.LogFatalClusterError("Found incorrect number of backup files", numIncorrect)
+	}
+}
+
+func VerifyHelperVersionOnSegments(cluster utils.Cluster, version string) {
+	remoteOutput := cluster.GenerateAndExecuteCommand("Verifying gpbackup_helper version", func(contentID int) string {
+		gphome := utils.System.Getenv("GPHOME")
+		return fmt.Sprintf("%s/bin/gpbackup_helper --version", gphome)
+	})
+	cluster.CheckClusterError(remoteOutput, "Could not verify gpbackup_helper version", func(contentID int) string {
+		return "Could not verify gpbackup_helper version"
+	})
+
+	numIncorrect := 0
+	for contentID := range remoteOutput.Stdouts {
+		segVersion := strings.TrimSpace(remoteOutput.Stdouts[contentID])
+		segVersion = strings.Split(segVersion, " ")[1] // Format is "gpbackup_helper [version string]"
+		if segVersion != version {
+			logger.Verbose("Version mismatch for gpbackup_helper on segment %d on host %s: Expected version %s, found version %s.", contentID, cluster.GetHostForContent(contentID), version, segVersion)
+			numIncorrect++
+		}
+	}
+	if numIncorrect > 0 {
+		utils.LogFatalClusterError("The version of gpbackup_helper must match the version of gprestore, but found gpbackup_helper binaries with invalid version", numIncorrect)
+	}
+}
+
+func CleanUpSegmentTOCs(cluster utils.Cluster) {
+	remoteOutput := cluster.GenerateAndExecuteCommand("Removing segment table of contents files from segment data directories", func(contentID int) string {
+		tocFile := cluster.GetSegmentTOCFilePathWithPID(cluster.SegDirMap[contentID], fmt.Sprintf("%d", contentID))
+		return fmt.Sprintf("rm %s", tocFile)
+	})
+	errMsg := fmt.Sprintf("Unable to remove segment table of contents file(s). See %s for a complete list of segments with errors and remove manually.",
+		logger.GetLogFilePath())
+	cluster.CheckClusterError(remoteOutput, errMsg, func(contentID int) string {
+		tocFile := cluster.GetSegmentTOCFilePathWithPID(cluster.SegDirMap[contentID], fmt.Sprintf("%d", contentID))
+		return fmt.Sprintf("Unable to remove table of contents file %s on segment %d on host %s", tocFile, contentID, cluster.GetHostForContent(contentID))
+	}, true)
+}
+
+func VerifyMetadataFilePaths(cluster utils.Cluster, dataOnly bool, withStats bool) {
+	filetypes := []string{"config", "table of contents"}
+	if !dataOnly {
+		filetypes = append(filetypes, "metadata")
+	}
+	missing := false
+	for _, filetype := range filetypes {
+		filepath := cluster.GetBackupFilePath(filetype)
+		if !utils.FileExistsAndIsReadable(filepath) {
+			missing = true
+			logger.Error("Cannot access %s file %s", filetype, filepath)
+		}
+	}
+	if withStats {
+		filepath := cluster.GetStatisticsFilePath()
+		if !utils.FileExistsAndIsReadable(filepath) {
+			missing = true
+			logger.Error("Cannot access statistics file %s", filepath)
+			logger.Error(`Note that the "-with-stats" flag must be passed to gpbackup to generate a statistics file.`)
+		}
+	}
+	if missing {
+		logger.Fatal(errors.Errorf("One or more metadata files do not exist or are not readable."), "Cannot proceed with restore")
+	}
+}

--- a/restore/remote_test.go
+++ b/restore/remote_test.go
@@ -1,0 +1,104 @@
+package restore_test
+
+import (
+	"os/user"
+
+	"github.com/greenplum-db/gpbackup/restore"
+	"github.com/greenplum-db/gpbackup/testutils"
+	"github.com/greenplum-db/gpbackup/utils"
+	"github.com/pkg/errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("restore/remote tests", func() {
+	masterSeg := utils.SegConfig{ContentID: -1, Hostname: "localhost", DataDir: "/data/gpseg-1"}
+	localSegOne := utils.SegConfig{ContentID: 0, Hostname: "localhost", DataDir: "/data/gpseg0"}
+	remoteSegOne := utils.SegConfig{ContentID: 1, Hostname: "remotehost1", DataDir: "/data/gpseg1"}
+	var (
+		testCluster  utils.Cluster
+		testExecutor *testutils.TestExecutor
+	)
+
+	BeforeEach(func() {
+		utils.System.CurrentUser = func() (*user.User, error) { return &user.User{Username: "testUser", HomeDir: "testDir"}, nil }
+		utils.System.Hostname = func() (string, error) { return "testHost", nil }
+		testExecutor = &testutils.TestExecutor{}
+		testCluster = utils.NewCluster([]utils.SegConfig{masterSeg, localSegOne, remoteSegOne}, "", "20170101010101", "gpseg")
+		testCluster.Executor = testExecutor
+	})
+	Describe("VerifyBackupFileCountOnSegments", func() {
+		It("successfully verifies all backup file counts", func() {
+			testExecutor.ClusterOutput = &utils.RemoteOutput{
+				NumErrors: 0,
+			}
+			restore.VerifyBackupFileCountOnSegments(testCluster, 2)
+			Expect((*testExecutor).NumExecutions).To(Equal(1))
+		})
+		It("panics if backup file counts do not match on all segments", func() {
+			testExecutor.ClusterOutput = &utils.RemoteOutput{
+				Stdouts: map[int]string{
+					0: "1",
+					1: "1",
+				},
+			}
+			testCluster.Executor = testExecutor
+			defer testutils.ShouldPanicWithMessage("Found incorrect number of backup files on 2 segments")
+			restore.VerifyBackupFileCountOnSegments(testCluster, 2)
+		})
+		It("panics if backup file counts do not match on some segments", func() {
+			testExecutor.ClusterOutput = &utils.RemoteOutput{
+				Stdouts: map[int]string{
+					1: "1",
+				},
+			}
+			testCluster.Executor = testExecutor
+			defer testutils.ShouldPanicWithMessage("Found incorrect number of backup files on 1 segment")
+			restore.VerifyBackupFileCountOnSegments(testCluster, 2)
+		})
+		It("panics if it cannot verify some backup file counts", func() {
+			testExecutor.ClusterOutput = &utils.RemoteOutput{
+				NumErrors: 1,
+				Errors: map[int]error{
+					1: errors.Errorf("exit status 1"),
+				},
+			}
+			testCluster.Executor = testExecutor
+			defer testutils.ShouldPanicWithMessage("Could not verify backup file count on 1 segment")
+			restore.VerifyBackupFileCountOnSegments(testCluster, 2)
+		})
+	})
+	Describe("VerifyBackupDirectoriesExistOnAllHosts", func() {
+		It("successfully verifies all directories", func() {
+			testExecutor.ClusterOutput = &utils.RemoteOutput{
+				NumErrors: 0,
+			}
+			restore.VerifyBackupDirectoriesExistOnAllHosts(testCluster)
+			Expect((*testExecutor).NumExecutions).To(Equal(1))
+		})
+		It("panics if it cannot verify all directories", func() {
+			testExecutor.ClusterOutput = &utils.RemoteOutput{
+				NumErrors: 2,
+				Errors: map[int]error{
+					0: errors.Errorf("exit status 1"),
+					1: errors.Errorf("exit status 1"),
+				},
+			}
+			testCluster.Executor = testExecutor
+			defer testutils.ShouldPanicWithMessage("Backup directories missing or inaccessible on 2 segments")
+			restore.VerifyBackupDirectoriesExistOnAllHosts(testCluster)
+		})
+		It("panics if it cannot verify some directories", func() {
+			testExecutor.ClusterOutput = &utils.RemoteOutput{
+				NumErrors: 1,
+				Errors: map[int]error{
+					1: errors.Errorf("exit status 1"),
+				},
+			}
+			testCluster.Executor = testExecutor
+			defer testutils.ShouldPanicWithMessage("Backup directories missing or inaccessible on 1 segment")
+			restore.VerifyBackupDirectoriesExistOnAllHosts(testCluster)
+		})
+	})
+})

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -102,7 +102,7 @@ func DoRestore() {
 		if !backupConfig.SingleDataFile {
 			backupFileCount = len(globalTOC.DataEntries)
 		}
-		globalCluster.VerifyBackupFileCountOnSegments(backupFileCount)
+		VerifyBackupFileCountOnSegments(globalCluster, backupFileCount)
 		restoreData(gucStatements)
 	}
 
@@ -149,14 +149,14 @@ func restoreData(gucStatements []utils.StatementWithType) {
 	filteredMasterDataEntries := globalTOC.GetDataEntriesMatching(includeSchemas, includeTables)
 	if backupConfig.SingleDataFile {
 		logger.Verbose("Initializing pipes and gpbackup_helper on segments for single data file restore")
-		globalCluster.VerifyHelperVersionOnSegments(version)
-		globalCluster.CopySegmentTOCs()
-		defer globalCluster.CleanUpSegmentTOCs()
-		globalCluster.WriteOidListToSegments(filteredMasterDataEntries)
-		defer globalCluster.CleanUpHelperFilesOnAllHosts()
+		VerifyHelperVersionOnSegments(globalCluster, version)
+		CopySegmentTOCs(globalCluster)
+		defer CleanUpSegmentTOCs(globalCluster)
+		WriteOidListToSegments(globalCluster, filteredMasterDataEntries)
+		defer CleanUpHelperFilesOnAllHosts(globalCluster)
 		firstOid := filteredMasterDataEntries[0].Oid
-		globalCluster.CreateSegmentPipesOnAllHostsForRestore(firstOid)
-		globalCluster.WriteToSegmentPipes()
+		CreateSegmentPipesOnAllHostsForRestore(globalCluster, firstOid)
+		WriteToSegmentPipes(globalCluster)
 	}
 
 	totalTables := len(filteredMasterDataEntries)

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -155,7 +155,7 @@ func restoreData(gucStatements []utils.StatementWithType) {
 		globalCluster.WriteOidListToSegments(filteredMasterDataEntries)
 		defer globalCluster.CleanUpHelperFilesOnAllHosts()
 		firstOid := filteredMasterDataEntries[0].Oid
-		globalCluster.CreateSegmentPipesOnAllHosts(firstOid)
+		globalCluster.CreateSegmentPipesOnAllHostsForRestore(firstOid)
 		globalCluster.WriteToSegmentPipes()
 	}
 

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -61,11 +61,11 @@ func DoPostgresValidation() {
 	segConfig := utils.GetSegmentConfiguration(connection)
 	globalCluster = utils.NewCluster(segConfig, *backupDir, *timestamp, "")
 	globalCluster.UserSpecifiedSegPrefix = utils.ParseSegPrefix(*backupDir)
-	globalCluster.VerifyBackupDirectoriesExistOnAllHosts()
+	VerifyBackupDirectoriesExistOnAllHosts(globalCluster)
 
 	InitializeBackupConfig()
 	ValidateBackupFlagCombinations()
-	globalCluster.VerifyMetadataFilePaths(backupConfig.DataOnly, *withStats)
+	VerifyMetadataFilePaths(globalCluster, backupConfig.DataOnly, *withStats)
 
 	tocFilename := globalCluster.GetTOCFilePath()
 	globalTOC = utils.NewTOC(tocFilename)

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -1,6 +1,8 @@
 package restore
 
 import (
+	"fmt"
+
 	"github.com/greenplum-db/gpbackup/utils"
 )
 
@@ -144,7 +146,7 @@ func restoreSingleTableData(entry utils.MasterDataEntry, tableNum uint32, totalT
 	}
 	backupFile := ""
 	if backupConfig.SingleDataFile {
-		backupFile = globalCluster.GetSegmentPipePathForCopyCommand()
+		backupFile = fmt.Sprintf("%s_%d", globalCluster.GetSegmentPipePathForCopyCommand(), globalCluster.PID)
 	} else {
 		backupFile = globalCluster.GetTableBackupFilePathForCopyCommand(entry.Oid, backupConfig.SingleDataFile)
 	}

--- a/utils/compression.go
+++ b/utils/compression.go
@@ -1,0 +1,35 @@
+package utils
+
+import "fmt"
+
+var (
+	usingCompression   = true
+	compressionProgram Compression
+)
+
+type Compression struct {
+	Name              string
+	CompressCommand   string
+	DecompressCommand string
+	Extension         string
+}
+
+func InitializeCompressionParameters(compress bool, compressionLevel int) {
+	usingCompression = compress
+	compressCommand := ""
+	if compressionLevel == 0 {
+		compressCommand = "gzip -c -1"
+	} else {
+		compressCommand = fmt.Sprintf("gzip -c -%d", compressionLevel)
+	}
+	compressionProgram = Compression{Name: "gzip", CompressCommand: compressCommand, DecompressCommand: "gzip -d -c", Extension: ".gz"}
+}
+
+func GetCompressionParameters() (bool, Compression) {
+	return usingCompression, compressionProgram
+}
+
+func SetCompressionParameters(compress bool, compression Compression) {
+	usingCompression = compress
+	compressionProgram = compression
+}

--- a/utils/compression_test.go
+++ b/utils/compression_test.go
@@ -1,0 +1,74 @@
+package utils_test
+
+import (
+	"os/user"
+
+	"github.com/greenplum-db/gpbackup/testutils"
+	"github.com/greenplum-db/gpbackup/utils"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("utils/compression tests", func() {
+	masterSeg := utils.SegConfig{ContentID: -1, Hostname: "localhost", DataDir: "/data/gpseg-1"}
+	localSegOne := utils.SegConfig{ContentID: 0, Hostname: "localhost", DataDir: "/data/gpseg0"}
+	remoteSegOne := utils.SegConfig{ContentID: 1, Hostname: "remotehost1", DataDir: "/data/gpseg1"}
+	var (
+		testCluster  utils.Cluster
+		testExecutor *testutils.TestExecutor
+	)
+
+	BeforeEach(func() {
+		utils.System.CurrentUser = func() (*user.User, error) { return &user.User{Username: "testUser", HomeDir: "testDir"}, nil }
+		utils.System.Hostname = func() (string, error) { return "testHost", nil }
+		testExecutor = &testutils.TestExecutor{}
+		testCluster = utils.NewCluster([]utils.SegConfig{masterSeg, localSegOne, remoteSegOne}, "", "20170101010101", "gpseg")
+		testCluster.Executor = testExecutor
+	})
+
+	Describe("InitializeCompressionParameters", func() {
+		It("initializes properly when passed no compression", func() {
+			useCompress, compression := utils.GetCompressionParameters()
+			defer utils.SetCompressionParameters(useCompress, compression)
+			expectedCompress := utils.Compression{
+				Name:              "gzip",
+				CompressCommand:   "gzip -c -3",
+				DecompressCommand: "gzip -d -c",
+				Extension:         ".gz",
+			}
+			utils.InitializeCompressionParameters(false, 3)
+			resultUseCompress, resultCompression := utils.GetCompressionParameters()
+			Expect(resultUseCompress).To(BeFalse())
+			testutils.ExpectStructsToMatch(&expectedCompress, &resultCompression)
+		})
+		It("initializes properly when passed compression", func() {
+			useCompress, compression := utils.GetCompressionParameters()
+			defer utils.SetCompressionParameters(useCompress, compression)
+			expectedCompress := utils.Compression{
+				Name:              "gzip",
+				CompressCommand:   "gzip -c -7",
+				DecompressCommand: "gzip -d -c",
+				Extension:         ".gz",
+			}
+			utils.InitializeCompressionParameters(true, 7)
+			resultUseCompress, resultCompression := utils.GetCompressionParameters()
+			Expect(resultUseCompress).To(BeTrue())
+			testutils.ExpectStructsToMatch(&expectedCompress, &resultCompression)
+		})
+		It("uses default gzip command when passed compression level 0", func() {
+			useCompress, compression := utils.GetCompressionParameters()
+			defer utils.SetCompressionParameters(useCompress, compression)
+			expectedCompress := utils.Compression{
+				Name:              "gzip",
+				CompressCommand:   "gzip -c -1",
+				DecompressCommand: "gzip -d -c",
+				Extension:         ".gz",
+			}
+			utils.InitializeCompressionParameters(true, 0)
+			resultUseCompress, resultCompression := utils.GetCompressionParameters()
+			Expect(resultUseCompress).To(BeTrue())
+			testutils.ExpectStructsToMatch(&expectedCompress, &resultCompression)
+		})
+	})
+})


### PR DESCRIPTION
Previously, multiple gprestores of the same timestamp on a backup taken
with -single-data-file would cause the restores to interfere with each
other as they would share the same temporary file/pipe names. Now, we
add the PID of the gprestore program to these temproary file/pipe names.
