### PR TITLE
Harden gpbackup -single-data-file to handle unexpected pipe removal

### DIFF
--- a/backup/data.go
+++ b/backup/data.go
@@ -47,7 +47,8 @@ func CopyTableOut(connection *utils.DBConn, table Relation, backupFile string) {
 		 */
 		tocFile := globalCluster.GetSegmentTOCFilePath("<SEG_DATA_DIR>", "<SEGID>")
 		helperCommand := fmt.Sprintf("$GPHOME/bin/gpbackup_helper --oid=%d --toc-file=%s --content=<SEGID>", table.Oid, tocFile)
-		copyCommand = fmt.Sprintf("PROGRAM '%s >> %s'", helperCommand, backupFile)
+		checkPipeExistsCommand := fmt.Sprintf("([[ -p %s ]] || (echo \"Pipe not found\">&2; exit 1))", backupFile)
+		copyCommand = fmt.Sprintf("PROGRAM '%s && %s >> %s'", checkPipeExistsCommand, helperCommand, backupFile)
 	} else if usingCompression {
 		copyCommand = fmt.Sprintf("PROGRAM '%s > %s'", compressionProgram.CompressCommand, backupFile)
 	} else {

--- a/backup/data_test.go
+++ b/backup/data_test.go
@@ -74,7 +74,7 @@ var _ = Describe("backup/data tests", func() {
 			backup.SetSingleDataFile(true)
 			utils.SetCompressionParameters(false, utils.Compression{})
 			testTable := backup.Relation{SchemaOid: 2345, Oid: 3456, Schema: "public", Name: "foo", DependsUpon: nil, Inherits: nil}
-			execStr := regexp.QuoteMeta("COPY public.foo TO PROGRAM '$GPHOME/bin/gpbackup_helper --oid=3456 --toc-file=<SEG_DATA_DIR>/gpbackup_<SEGID>_20170101010101_toc.yaml --content=<SEGID> >> <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101' WITH CSV DELIMITER ',' ON SEGMENT IGNORE EXTERNAL PARTITIONS;")
+			execStr := regexp.QuoteMeta(`COPY public.foo TO PROGRAM '([[ -p <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101 ]] || (echo "Pipe not found">&2; exit 1)) && $GPHOME/bin/gpbackup_helper --oid=3456 --toc-file=<SEG_DATA_DIR>/gpbackup_<SEGID>_20170101010101_toc.yaml --content=<SEGID> >> <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101' WITH CSV DELIMITER ',' ON SEGMENT IGNORE EXTERNAL PARTITIONS;`)
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101"
 			backup.CopyTableOut(connection, testTable, filename)

--- a/backup/remote.go
+++ b/backup/remote.go
@@ -32,9 +32,7 @@ func CreateSegmentPipesOnAllHostsForBackup(cluster utils.Cluster) {
 func CleanUpSegmentPipesOnAllHosts(cluster utils.Cluster) {
 	remoteOutput := cluster.GenerateAndExecuteCommand("Cleaning up segment data pipes", func(contentID int) string {
 		pipePath := cluster.GetSegmentPipeFilePath(contentID)
-		scriptPath := cluster.GetSegmentHelperFilePath(contentID, "script")
-		// This cleans up both the pipe itself as well as any gpbackup_helper process associated with it
-		return fmt.Sprintf("set -o pipefail; rm -f %s* && ps ux | grep %s | grep -v grep | awk '{print $2}' | xargs kill -9 || true", pipePath, scriptPath)
+		return fmt.Sprintf("rm -f %s", pipePath)
 	})
 	cluster.CheckClusterError(remoteOutput, "Unable to clean up segment data pipes", func(contentID int) string {
 		return "Unable to clean up segment data pipe"


### PR DESCRIPTION
Previously, if a pipe was removed during gpbackup with -single-data-file, the
backup would continue and report no error. Additionally, the data would end up
getting written to a file, and then removed. The restore would then fail as the
backup was corrupted. Now, we check that the pipe file exists before each
COPY and report an error if it does not exist or is not a pipe.

This adds ~1s per 1k tables to the backup duration.

Author: Chris Hajas <chajas@pivotal.io>