### PR TITLE
Add interrupt handler to gpbackup and gprestore

### DIFF
--- a/backup/data.go
+++ b/backup/data.go
@@ -76,6 +76,14 @@ func BackupDataForAllTables(tables []Relation, tableDefs map[uint32]TableDefinit
 	}
 
 	for _, table := range tables {
+		/*
+		* We break when an interrupt is received and rely on
+		* TerminateHangingCopySessions to kill any COPY statements
+		* in progress if they don't finish on their own.
+		 */
+		if wasTerminated {
+			break
+		}
 		tableDef := tableDefs[table.Oid]
 		isExternal := tableDef.IsExternal
 		if !isExternal {

--- a/backup/global_variables.go
+++ b/backup/global_variables.go
@@ -1,6 +1,10 @@
 package backup
 
-import "github.com/greenplum-db/gpbackup/utils"
+import (
+	"sync"
+
+	"github.com/greenplum-db/gpbackup/utils"
+)
 
 /*
  * This file contains global variables and setter functions for those variables
@@ -18,6 +22,14 @@ var (
 	logger        *utils.Logger
 	objectCounts  map[string]int
 	version       string
+	wasTerminated bool
+
+	/*
+	 * Used for synchronizing DoCleanup.  In DoInit() we increment the group
+	 * and then wait for at least one DoCleanup to finish, either in DoTeardown
+	 * or the signal handler.
+	 */
+	CleanupGroup *sync.WaitGroup
 )
 
 /*

--- a/restore/global_variables.go
+++ b/restore/global_variables.go
@@ -1,6 +1,10 @@
 package restore
 
-import "github.com/greenplum-db/gpbackup/utils"
+import (
+	"sync"
+
+	"github.com/greenplum-db/gpbackup/utils"
+)
 
 /*
  * This file contains global variables and setter functions for those variables
@@ -18,6 +22,14 @@ var (
 	globalTOC     *utils.TOC
 	logger        *utils.Logger
 	version       string
+	wasTerminated bool
+
+	/*
+	 * Used for synchronizing DoCleanup.  In DoInit() we increment the group
+	 * and then wait for at least one DoCleanup to finish, either in DoTeardown
+	 * or the signal handler.
+	 */
+	CleanupGroup *sync.WaitGroup
 )
 
 /*

--- a/utils/report.go
+++ b/utils/report.go
@@ -40,15 +40,14 @@ type Report struct {
 	BackupConfig
 }
 
-func ParseErrorMessage(errStr string) (string, int) {
+func ParseErrorMessage(errStr string) string {
 	if errStr == "" {
-		return "", 0
+		return ""
 	}
 	errLevelStr := "[CRITICAL]:-"
 	headerIndex := strings.Index(errStr, errLevelStr)
 	errMsg := errStr[headerIndex+len(errLevelStr):]
-	exitCode := 1 // TODO: Define different error codes for different kinds of errors
-	return errMsg, exitCode
+	return errMsg
 }
 
 func (report *Report) ConstructBackupParamsStringFromFlags(dataOnly bool, ddlOnly bool, isSchemaFiltered bool, isTableFiltered bool, singleDataFile bool, withStats bool) {


### PR DESCRIPTION
To ensure that the cluster is not left in a bad state if someone aborts a backup
or restore with Ctrl-C, this commit moves cleanup-related functions that were
previously called with defer to a DoCleanup function and sets up a signal handler
goroutine to call DoCleanup and exit if an interrupt is received.  DoTeardown
and several other functions are modified to account for a possible abort in the
middle of the function.

Author: Jamie McAtamney <jmcatamney@pivotal.io>