### PR TITLE
Add signal handler and cleanup to gpbackup_helper

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -42,7 +42,7 @@ func DoInit() {
 	CleanupGroup.Add(1)
 	SetLogger(utils.InitializeLogging("gpbackup", ""))
 	initializeFlags()
-	InitializeSignalHandler()
+	utils.InitializeSignalHandler(DoCleanup, "backup process", &wasTerminated)
 }
 
 func DoFlagValidation() {

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -348,7 +348,7 @@ var _ = Describe("backup end to end integration tests", func() {
 			output, _ := cmd.CombinedOutput()
 			stdout := string(output)
 
-			Expect(stdout).To(ContainSubstring("Received an interrupt, aborting backup process"))
+			Expect(stdout).To(ContainSubstring("Received a termination signal, aborting backup process"))
 			Expect(stdout).To(ContainSubstring("Cleanup complete"))
 			Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
 
@@ -373,7 +373,7 @@ var _ = Describe("backup end to end integration tests", func() {
 			output, _ := cmd.CombinedOutput()
 			stdout := string(output)
 
-			Expect(stdout).To(ContainSubstring("Received an interrupt, aborting restore process"))
+			Expect(stdout).To(ContainSubstring("Received a termination signal, aborting restore process"))
 			Expect(stdout).To(ContainSubstring("Cleanup complete"))
 			Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
 

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -40,7 +40,7 @@ func DoInit() {
 	CleanupGroup.Add(1)
 	SetLogger(utils.InitializeLogging("gprestore", ""))
 	initializeFlags()
-	InitializeSignalHandler()
+	utils.InitializeSignalHandler(DoCleanup, "restore process", &wasTerminated)
 }
 
 /*
@@ -203,6 +203,7 @@ func restoreData(gucStatements []utils.StatementWithType) {
 		workerPool.Wait()
 	}
 	dataProgressBar.Finish()
+	CheckAgentErrorsOnSegments(globalCluster)
 	logger.Info("Data restore complete")
 }
 
@@ -270,8 +271,8 @@ func DoCleanup() {
 	if backupConfig.SingleDataFile {
 		CleanUpSegmentTOCs(globalCluster)
 		CleanUpHelperFilesOnAllHosts(globalCluster)
+		CleanUpSegmentHelperProcesses(globalCluster)
 		if wasTerminated { // These should all end on their own in a successful restore
-			CleanUpSegmentHelperProcesses(globalCluster)
 			utils.TerminateHangingCopySessions(connection, globalCluster, "gprestore")
 		}
 	}


### PR DESCRIPTION
This prevents COPY from hanging indefinitely if an agent is killed. We also
create an error file if the agent is killed, so that the restore will not
erroneously report success if the agent is killed while restoring the last
table.

Author: Karen Huddleston <khuddleston@pivotal.io>
Author: Jamie McAtamney <jmcatamney@pivotal.io>