### PR TITLE
Add support for backing up extensions

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -137,6 +137,9 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Relation, tab
 	logger.Info("Writing pre-data metadata")
 
 	BackupSchemas(metadataFile)
+	if len(includeSchemas) == 0 && connection.Version.AtLeast("5") {
+		BackupExtensions(metadataFile)
+	}
 
 	procLangs := GetProceduralLanguages(connection)
 	langFuncs, otherFuncs, functionMetadata := RetrieveFunctions(procLangs)

--- a/backup/predata_functions.go
+++ b/backup/predata_functions.go
@@ -167,6 +167,15 @@ func PrintCreateCastStatements(metadataFile *utils.FileWithByteCount, toc *utils
 	}
 }
 
+func PrintCreateExtensionStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, extensionDefs []Extension, extensionMetadata MetadataMap) {
+	for _, extensionDef := range extensionDefs {
+		start := metadataFile.ByteCount
+		metadataFile.MustPrintf("\n\nSET search_path=%s,pg_catalog;\nCREATE EXTENSION IF NOT EXISTS %s WITH SCHEMA %s;\nSET search_path=pg_catalog;", extensionDef.Schema, extensionDef.Name, extensionDef.Schema)
+		PrintObjectMetadata(metadataFile, extensionMetadata[extensionDef.Oid], extensionDef.Name, "EXTENSION")
+		toc.AddPredataEntry("", extensionDef.Name, "EXTENSION", "", start, metadataFile)
+	}
+}
+
 /*
  * This function separates out functions related to procedural languages from
  * any other functions, so that language-related functions can be backed up before

--- a/backup/predata_functions_test.go
+++ b/backup/predata_functions_test.go
@@ -451,6 +451,26 @@ AS ASSIGNMENT;`)
 COMMENT ON CAST (src AS dst) IS 'This is a cast comment.';`)
 		})
 	})
+	Describe("PrintCreateExtensionStatement", func() {
+		emptyMetadataMap := backup.MetadataMap{}
+		It("prints a create extension statement", func() {
+			extensionDef := backup.Extension{Oid: 1, Name: "extension1", Schema: "schema1"}
+			backup.PrintCreateExtensionStatements(backupfile, toc, []backup.Extension{extensionDef}, emptyMetadataMap)
+			testutils.AssertBufferContents(toc.PredataEntries, buffer, `SET search_path=schema1,pg_catalog;
+CREATE EXTENSION IF NOT EXISTS extension1 WITH SCHEMA schema1;
+SET search_path=pg_catalog;`)
+		})
+		It("prints a create extension statement with a comment", func() {
+			extensionDef := backup.Extension{Oid: 1, Name: "extension1", Schema: "schema1"}
+			extensionMetadataMap := testutils.DefaultMetadataMap("EXTENSION", false, false, true)
+			backup.PrintCreateExtensionStatements(backupfile, toc, []backup.Extension{extensionDef}, extensionMetadataMap)
+			testutils.AssertBufferContents(toc.PredataEntries, buffer, `SET search_path=schema1,pg_catalog;
+CREATE EXTENSION IF NOT EXISTS extension1 WITH SCHEMA schema1;
+SET search_path=pg_catalog;
+
+COMMENT ON EXTENSION extension1 IS 'This is an extension comment.';`)
+		})
+	})
 	Describe("ExtractLanguageFunctions", func() {
 		customLang := backup.ProceduralLanguage{Oid: 1, Name: "custom_language", Owner: "testrole", IsPl: true, PlTrusted: true, Handler: 3, Inline: 4, Validator: 5}
 		procLangs := []backup.ProceduralLanguage{customLang}

--- a/backup/queries_operators.go
+++ b/backup/queries_operators.go
@@ -61,7 +61,8 @@ SELECT
 	oprcanhash AS canhash
 FROM pg_operator o
 JOIN pg_namespace n on n.oid = o.oprnamespace
-WHERE %s AND oprcode != 0`, SchemaFilterClause("n"))
+WHERE %s AND oprcode != 0
+AND o.oid NOT IN (select objid from pg_depend where deptype = 'e')`, SchemaFilterClause("n"))
 
 	var err error
 	if connection.Version.Before("5") {
@@ -95,7 +96,8 @@ SELECT
 	(SELECT quote_ident(amname) FROM pg_am WHERE oid = opfmethod) AS indexMethod
 FROM pg_opfamily o
 JOIN pg_namespace n on n.oid = o.opfnamespace
-WHERE %s`, SchemaFilterClause("n"))
+WHERE %s
+AND o.oid NOT IN (select objid from pg_depend where deptype = 'e')`, SchemaFilterClause("n"))
 	err := connection.Select(&results, query)
 	utils.CheckError(err)
 	return results
@@ -153,7 +155,8 @@ FROM pg_catalog.pg_opclass c
 LEFT JOIN pg_catalog.pg_opfamily f ON f.oid = opcfamily
 JOIN pg_catalog.pg_namespace cls_ns ON cls_ns.oid = opcnamespace
 JOIN pg_catalog.pg_namespace fam_ns ON fam_ns.oid = opfnamespace
-WHERE %s`, SchemaFilterClause("cls_ns"))
+WHERE %s
+AND c.oid NOT IN (select objid from pg_depend where deptype = 'e')`, SchemaFilterClause("cls_ns"))
 
 	var err error
 	if connection.Version.Before("5") {

--- a/backup/queries_shared.go
+++ b/backup/queries_shared.go
@@ -39,6 +39,7 @@ SELECT
 	quote_ident(nspname) AS name
 FROM pg_namespace n
 WHERE %s
+AND oid NOT IN (select objid from pg_depend where deptype = 'e')
 ORDER BY name;`, SchemaFilterClause("n"))
 
 	results := make([]Schema, 0)
@@ -143,6 +144,7 @@ var (
 	TYPE_CONSTRAINT         MetadataQueryParams
 	TYPE_CONVERSION         MetadataQueryParams
 	TYPE_DATABASE           MetadataQueryParams
+	TYPE_EXTENSION          MetadataQueryParams
 	TYPE_FOREIGNDATAWRAPPER MetadataQueryParams
 	TYPE_FOREIGNSERVER      MetadataQueryParams
 	TYPE_FUNCTION           MetadataQueryParams
@@ -173,6 +175,7 @@ func InitializeMetadataParams(connection *utils.DBConn) {
 	TYPE_CONSTRAINT = MetadataQueryParams{NameField: "conname", SchemaField: "connamespace", OidField: "oid", CatalogTable: "pg_constraint"}
 	TYPE_CONVERSION = MetadataQueryParams{NameField: "conname", OidField: "oid", SchemaField: "connamespace", OwnerField: "conowner", CatalogTable: "pg_conversion"}
 	TYPE_DATABASE = MetadataQueryParams{NameField: "datname", ACLField: "datacl", OwnerField: "datdba", CatalogTable: "pg_database", Shared: true}
+	TYPE_EXTENSION = MetadataQueryParams{NameField: "extname", OidField: "oid", CatalogTable: "pg_extension"}
 	TYPE_FOREIGNDATAWRAPPER = MetadataQueryParams{NameField: "fdwname", ACLField: "fdwacl", OwnerField: "fdwowner", CatalogTable: "pg_foreign_data_wrapper"}
 	TYPE_FOREIGNSERVER = MetadataQueryParams{NameField: "srvname", ACLField: "srvacl", OwnerField: "srvowner", CatalogTable: "pg_foreign_server"}
 	TYPE_FUNCTION = MetadataQueryParams{NameField: "proname", SchemaField: "pronamespace", ACLField: "proacl", OwnerField: "proowner", CatalogTable: "pg_proc"}

--- a/backup/queries_textsearch.go
+++ b/backup/queries_textsearch.go
@@ -39,6 +39,7 @@ SELECT
 FROM pg_ts_parser p
 JOIN pg_namespace n ON n.oid = p.prsnamespace
 WHERE %s
+AND p.oid NOT IN (select objid from pg_depend where deptype = 'e')
 ORDER BY prsname;`, SchemaFilterClause("n"))
 
 	results := make([]TextSearchParser, 0)
@@ -66,6 +67,7 @@ SELECT
 FROM pg_ts_template p
 JOIN pg_namespace n ON n.oid = p.tmplnamespace
 WHERE %s
+AND p.oid NOT IN (select objid from pg_depend where deptype = 'e')
 ORDER BY tmplname;`, SchemaFilterClause("n"))
 
 	results := make([]TextSearchTemplate, 0)
@@ -95,6 +97,7 @@ JOIN pg_ts_template t ON t.oid = d.dicttemplate
 JOIN pg_namespace tmpl_ns ON tmpl_ns.oid = t.tmplnamespace
 JOIN pg_namespace dict_ns ON dict_ns.oid = d.dictnamespace
 WHERE %s
+AND d.oid NOT IN (select objid from pg_depend where deptype = 'e')
 ORDER BY dictname;`, SchemaFilterClause("dict_ns"))
 
 	results := make([]TextSearchDictionary, 0)
@@ -124,6 +127,7 @@ JOIN pg_ts_parser p ON p.oid = c.cfgparser
 JOIN pg_namespace cfg_ns ON cfg_ns.oid = c.cfgnamespace
 JOIN pg_namespace prs_ns ON prs_ns.oid = prsnamespace
 WHERE %s
+AND c.oid NOT IN (select objid from pg_depend where deptype = 'e')
 ORDER BY cfgname;`, SchemaFilterClause("cfg_ns"))
 
 	results := make([]struct {

--- a/backup/queries_types.go
+++ b/backup/queries_types.go
@@ -65,6 +65,7 @@ GROUP BY %s`, selectClause, groupBy)
 	 */
 	tableTypesClause := fmt.Sprintf(`
 %s
+AND t.oid NOT IN (select objid from pg_depend where deptype = 'e')
 JOIN pg_class c ON t.typrelid = c.oid AND c.relkind IN ('r', 'S', 'v')
 GROUP BY %s
 UNION ALL
@@ -246,6 +247,7 @@ JOIN pg_namespace n ON t.typnamespace = n.oid
 JOIN pg_type b ON t.typbasetype = b.oid
 WHERE %s
 AND t.typtype = 'd'
+AND t.oid NOT IN (select objid from pg_depend where deptype = 'e')
 ORDER BY n.nspname, t.typname;`, SchemaFilterClause("n"))
 
 	results := make([]Type, 0)
@@ -269,6 +271,7 @@ LEFT JOIN (
 	) e ON t.oid = e.enumtypid
 WHERE %s
 AND t.typtype = 'e'
+AND t.oid NOT IN (select objid from pg_depend where deptype = 'e')
 ORDER BY n.nspname, t.typname;`, SchemaFilterClause("n"))
 
 	results := make([]Type, 0)
@@ -288,6 +291,7 @@ FROM pg_type t
 JOIN pg_namespace n ON t.typnamespace = n.oid
 WHERE %s
 AND t.typtype = 'p'
+AND t.oid NOT IN (select objid from pg_depend where deptype = 'e')
 ORDER BY n.nspname, t.typname;`, SchemaFilterClause("n"))
 
 	results := make([]Type, 0)

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -428,6 +428,14 @@ func BackupCasts(metadataFile *utils.FileWithByteCount) {
 	PrintCreateCastStatements(metadataFile, globalTOC, casts, castMetadata)
 }
 
+func BackupExtensions(metadataFile *utils.FileWithByteCount) {
+	logger.Verbose("Writing CREATE EXTENSIONS statements to metadata file")
+	extensions := GetExtensions(connection)
+	objectCounts["Extensions"] = len(extensions)
+	extensionMetadata := GetCommentsForObjectType(connection, TYPE_EXTENSION)
+	PrintCreateExtensionStatements(metadataFile, globalTOC, extensions, extensionMetadata)
+}
+
 func BackupViews(metadataFile *utils.FileWithByteCount, relationMetadata MetadataMap) {
 	logger.Verbose("Writing CREATE VIEW statements to metadata file")
 	views := GetViews(connection)

--- a/integration/predata_functions_queries_test.go
+++ b/integration/predata_functions_queries_test.go
@@ -415,6 +415,21 @@ LANGUAGE SQL`)
 			testutils.ExpectStructsToMatchExcluding(&castDef, &results[0], "Oid")
 		})
 	})
+	Describe("GetExtensions", func() {
+		It("returns a slice of extension", func() {
+			testutils.SkipIf4(connection)
+			testutils.AssertQueryRuns(connection, "CREATE EXTENSION plperl")
+			defer testutils.AssertQueryRuns(connection, "DROP EXTENSION plperl")
+
+			results := backup.GetExtensions(connection)
+
+			Expect(len(results)).To(Equal(1))
+
+			extensionDef := backup.Extension{Oid: 0, Name: "plperl", Schema: "pg_catalog"}
+			testutils.ExpectStructsToMatchExcluding(&extensionDef, &results[0], "Oid")
+
+		})
+	})
 	Describe("GetProceduralLanguages", func() {
 		It("returns a slice of procedural languages", func() {
 			testutils.AssertQueryRuns(connection, "CREATE LANGUAGE plpythonu")

--- a/integration/predata_shared_queries_test.go
+++ b/integration/predata_shared_queries_test.go
@@ -975,6 +975,22 @@ LANGUAGE SQL`)
 				resultMetadata := resultMetadataMap[oid]
 				testutils.ExpectStructsToMatch(&templateMetadata, &resultMetadata)
 			})
+			It("returns a slice of default metadata for an extension", func() {
+				testutils.SkipIf4(connection)
+				extensionMetadataMap := testutils.DefaultMetadataMap("EXTENSION", false, false, true)
+				extensionMetadata := extensionMetadataMap[1]
+
+				testutils.AssertQueryRuns(connection, "CREATE EXTENSION plperl;")
+				defer testutils.AssertQueryRuns(connection, "DROP EXTENSION plperl")
+				testutils.AssertQueryRuns(connection, "COMMENT ON EXTENSION plperl IS 'This is an extension comment.'")
+
+				oid := testutils.OidFromObjectName(connection, "", "plperl", backup.TYPE_EXTENSION)
+				resultMetadataMap := backup.GetCommentsForObjectType(connection, backup.TYPE_EXTENSION)
+
+				Expect(len(resultMetadataMap)).To(Equal(1))
+				resultMetadata := resultMetadataMap[oid]
+				testutils.ExpectStructsToMatch(&extensionMetadata, &resultMetadata)
+			})
 		})
 		Context("comments for objects in a specific schema", func() {
 			It("returns a slice of default metadata for an index in a specific schema", func() {


### PR DESCRIPTION
An extra clause to exclude objects that are part of an extension was added to each query. The total metadata backup time did not show any noticeable increase due to the addition of this clause. This clause is also included in queries on GPDB4 for simplicity, but extensions are only backed up/restored in GPDB5 or later.

Author: Chris Hajas <chajas@pivotal.io>