### PR TITLE
Move hardcoded session GUCs from backup file to gprestore

### DIFF
--- a/backup/metadata_globals.go
+++ b/backup/metadata_globals.go
@@ -14,42 +14,12 @@ import (
  * such as roles and database configuration.
  */
 
-/*
- * Session GUCs are printed to global, predata, and postdata files so we
- * will use the correct settings when the files are run during restore
- */
 func PrintSessionGUCs(metadataFile *utils.FileWithByteCount, toc *utils.TOC, gucs SessionGUCs) {
-	printUniversalSessionGUCs(metadataFile, toc, gucs)
-	if connection.Version.Before("5") {
-		print4OnlySessionGUCs(metadataFile, toc)
-	}
-}
-
-func printUniversalSessionGUCs(metadataFile *utils.FileWithByteCount, toc *utils.TOC, gucs SessionGUCs) {
 	start := metadataFile.ByteCount
-	metadataFile.MustPrintf(`SET statement_timeout = 0;
-SET check_function_bodies = false;
-SET client_min_messages = error;
+	metadataFile.MustPrintf(`
 SET client_encoding = '%s';
-SET standard_conforming_strings = on;
-SET default_with_oids = %s;
-`, gucs.ClientEncoding, gucs.DefaultWithOids)
+`, gucs.ClientEncoding)
 	toc.AddGlobalEntry("", "", "SESSION GUCS", start, metadataFile)
-}
-
-/*
- * We print GPDB4-specific GUCs separately, with a different TOC entry type, so
- * that we can easily ignore them when restoring to a GPDB5 cluster.
- */
-func print4OnlySessionGUCs(metadataFile *utils.FileWithByteCount, toc *utils.TOC) {
-	start := metadataFile.ByteCount
-	/*
-	 * We always want to turn off strict XML parsing for restore, regardless of
-	 * its current value.
-	 */
-	metadataFile.MustPrintf(`SET gp_strict_xml_parse = off;
-`)
-	toc.AddGlobalEntry("", "", "GPDB4 SESSION GUCS", start, metadataFile)
 }
 
 func PrintCreateDatabaseStatement(metadataFile *utils.FileWithByteCount, toc *utils.TOC, db Database, dbMetadata MetadataMap) {

--- a/backup/metadata_globals_test.go
+++ b/backup/metadata_globals_test.go
@@ -12,30 +12,13 @@ var _ = Describe("backup/metadata_globals tests", func() {
 		toc, backupfile = testutils.InitializeTestTOC(buffer, "global")
 	})
 	Describe("PrintSessionGUCs", func() {
-		It("prints session GUCs for GPDB4", func() {
+		It("prints session GUCs", func() {
 			testutils.SetDBVersion(connection, "4.3.0")
-			gucs := backup.SessionGUCs{ClientEncoding: "UTF8", DefaultWithOids: "false"}
+			gucs := backup.SessionGUCs{ClientEncoding: "UTF8"}
 
 			backup.PrintSessionGUCs(backupfile, toc, gucs)
-			testutils.ExpectRegexp(buffer, `SET statement_timeout = 0;
-SET check_function_bodies = false;
-SET client_min_messages = error;
-SET client_encoding = 'UTF8';
-SET standard_conforming_strings = on;
-SET default_with_oids = false;
-SET gp_strict_xml_parse = off;`)
-		})
-		It("prints session GUCs for GPDB5", func() {
-			testutils.SetDBVersion(connection, "5.0.0")
-			gucs := backup.SessionGUCs{ClientEncoding: "UTF8", DefaultWithOids: "false"}
-
-			backup.PrintSessionGUCs(backupfile, toc, gucs)
-			testutils.ExpectRegexp(buffer, `SET statement_timeout = 0;
-SET check_function_bodies = false;
-SET client_min_messages = error;
-SET client_encoding = 'UTF8';
-SET standard_conforming_strings = on;
-SET default_with_oids = false;`)
+			testutils.ExpectRegexp(buffer, `SET client_encoding = 'UTF8';
+`)
 		})
 	})
 	Describe("PrintCreateDatabaseStatement", func() {

--- a/backup/queries_globals.go
+++ b/backup/queries_globals.go
@@ -12,17 +12,13 @@ import (
 )
 
 type SessionGUCs struct {
-	ClientEncoding  string `db:"client_encoding"`
-	DefaultWithOids string `db:"default_with_oids"`
+	ClientEncoding string `db:"client_encoding"`
 }
 
 func GetSessionGUCs(connection *utils.DBConn) SessionGUCs {
 	result := SessionGUCs{}
 	query := "SHOW client_encoding;"
 	err := connection.Get(&result, query)
-	utils.CheckError(err)
-	query = "SHOW default_with_oids;"
-	err = connection.Get(&result, query)
 	utils.CheckError(err)
 	return result
 }

--- a/integration/metadata_globals_queries_test.go
+++ b/integration/metadata_globals_queries_test.go
@@ -17,7 +17,6 @@ var _ = Describe("backup integration tests", func() {
 			 */
 			results := backup.GetSessionGUCs(connection)
 			Expect(results.ClientEncoding).To(Equal("UTF8"))
-			Expect(results.DefaultWithOids).To(Equal("off"))
 		})
 	})
 	Describe("GetDatabaseGUCs", func() {

--- a/integration/predata_shared_create_test.go
+++ b/integration/predata_shared_create_test.go
@@ -160,7 +160,7 @@ PARTITION BY RANGE (year)
 		})
 	})
 	Describe("GUC-printing functions", func() {
-		gucs := backup.SessionGUCs{ClientEncoding: "UTF8", DefaultWithOids: "off"}
+		gucs := backup.SessionGUCs{ClientEncoding: "UTF8"}
 		Describe("PrintSessionGUCs", func() {
 			It("prints the default session GUCs", func() {
 				backup.PrintSessionGUCs(backupfile, toc, gucs)

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -119,7 +119,7 @@ func DoRestore() {
 }
 
 func createDatabase(metadataFilename string) {
-	objectTypes := []string{"SESSION GUCS", "GPDB4 SESSION GUCS", "DATABASE GUC", "DATABASE", "DATABASE METADATA"}
+	objectTypes := []string{"SESSION GUCS", "DATABASE GUC", "DATABASE", "DATABASE METADATA"}
 	logger.Info("Creating database")
 	statements := GetRestoreMetadataStatements("global", metadataFilename, objectTypes, []string{}, []string{})
 	if *redirect != "" {
@@ -130,7 +130,7 @@ func createDatabase(metadataFilename string) {
 }
 
 func restoreGlobal(metadataFilename string) {
-	objectTypes := []string{"SESSION GUCS", "GPDB4 SESSION GUCS", "DATABASE GUC", "DATABASE METADATA", "RESOURCE QUEUE", "RESOURCE GROUP", "ROLE", "ROLE GRANT", "TABLESPACE"}
+	objectTypes := []string{"SESSION GUCS", "DATABASE GUC", "DATABASE METADATA", "RESOURCE QUEUE", "RESOURCE GROUP", "ROLE", "ROLE GRANT", "TABLESPACE"}
 	logger.Info("Restoring global metadata")
 	statements := GetRestoreMetadataStatements("global", metadataFilename, objectTypes, []string{}, []string{})
 	if *redirect != "" {


### PR DESCRIPTION
Previously, we generated statements in the backup file for hardcoded GUCs
that should be set during restore. Now, we simply execute those statements
on the restore side.

Additionally, we now hardcode the default_with_oids GUC to false.

Authored-by: Chris Hajas <chajas@pivotal.io>