### PR TITLE
Do not attempt to restore session user or current user

### DIFF
--- a/restore/restore.go
+++ b/restore/restore.go
@@ -138,6 +138,7 @@ func restoreGlobal(metadataFilename string) {
 	if *redirect != "" {
 		statements = utils.SubstituteRedirectDatabaseInStatements(statements, backupConfig.DatabaseName, *redirect)
 	}
+	statements = utils.RemoveActiveRole(connection.User, statements)
 	ExecuteRestoreMetadataStatements(statements, "Global objects", nil, utils.PB_VERBOSE, false)
 	gplog.Info("Global database metadata restore complete")
 }

--- a/utils/util_test.go
+++ b/utils/util_test.go
@@ -85,7 +85,7 @@ var _ = Describe("utils/util tests", func() {
 			utils.ValidateFQNs(testStrings)
 		})
 	})
-	Describe("Dbconn.SetDatabaseVersion", func() {
+	Describe("SetDatabaseVersion", func() {
 		BeforeEach(func() {
 			operating.System.Now = func() time.Time { return time.Date(2017, time.January, 1, 1, 1, 1, 1, time.Local) }
 		})


### PR DESCRIPTION
These roles have to exist when you are running gprestore and an error will
occurr if you attempt to restore them as part of the global metadata. We
now get these user values from the database and skip over the roles if
they are in the global metadata.

Authored-by: Karen Huddleston <khuddleston@pivotal.io>