### PR TITLE
Do not back up plpgsql

### DIFF
--- a/backup/predata_functions_test.go
+++ b/backup/predata_functions_test.go
@@ -502,12 +502,12 @@ COMMENT ON EXTENSION extension1 IS 'This is an extension comment.';`)
 	})
 	Describe("PrintCreateLanguageStatements", func() {
 		plUntrustedHandlerOnly := backup.ProceduralLanguage{Oid: 1, Name: "plpythonu", Owner: "testrole", IsPl: true, PlTrusted: false, Handler: 4, Inline: 0, Validator: 0}
-		plAllFields := backup.ProceduralLanguage{Oid: 1, Name: "plpgsql", Owner: "testrole", IsPl: true, PlTrusted: true, Handler: 1, Inline: 2, Validator: 3}
+		plAllFields := backup.ProceduralLanguage{Oid: 1, Name: "plperl", Owner: "testrole", IsPl: true, PlTrusted: true, Handler: 1, Inline: 2, Validator: 3}
 		plComment := backup.ProceduralLanguage{Oid: 1, Name: "plpythonu", Owner: "testrole", IsPl: true, PlTrusted: false, Handler: 4, Inline: 0, Validator: 0}
 		funcInfoMap := map[uint32]backup.FunctionInfo{
-			1: {QualifiedName: "pg_catalog.plpgsql_call_handler", Arguments: "", IsInternal: true},
-			2: {QualifiedName: "pg_catalog.plpgsql_inline_handler", Arguments: "internal", IsInternal: true},
-			3: {QualifiedName: "pg_catalog.plpgsql_validator", Arguments: "oid", IsInternal: true},
+			1: {QualifiedName: "pg_catalog.plperl_call_handler", Arguments: "", IsInternal: true},
+			2: {QualifiedName: "pg_catalog.plperl_inline_handler", Arguments: "internal", IsInternal: true},
+			3: {QualifiedName: "pg_catalog.plperl_validator", Arguments: "oid", IsInternal: true},
 			4: {QualifiedName: "pg_catalog.plpython_call_handler", Arguments: "", IsInternal: true},
 		}
 		emptyMetadataMap := backup.MetadataMap{}
@@ -524,20 +524,20 @@ ALTER FUNCTION pg_catalog.plpython_call_handler() OWNER TO testrole;`)
 			langs := []backup.ProceduralLanguage{plAllFields}
 
 			backup.PrintCreateLanguageStatements(backupfile, toc, langs, funcInfoMap, emptyMetadataMap)
-			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TRUSTED PROCEDURAL LANGUAGE plpgsql;
-ALTER FUNCTION pg_catalog.plpgsql_call_handler() OWNER TO testrole;
-ALTER FUNCTION pg_catalog.plpgsql_inline_handler(internal) OWNER TO testrole;
-ALTER FUNCTION pg_catalog.plpgsql_validator(oid) OWNER TO testrole;`)
+			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TRUSTED PROCEDURAL LANGUAGE plperl;
+ALTER FUNCTION pg_catalog.plperl_call_handler() OWNER TO testrole;
+ALTER FUNCTION pg_catalog.plperl_inline_handler(internal) OWNER TO testrole;
+ALTER FUNCTION pg_catalog.plperl_validator(oid) OWNER TO testrole;`)
 		})
 		It("prints multiple create language statements", func() {
 			langs := []backup.ProceduralLanguage{plUntrustedHandlerOnly, plAllFields}
 
 			backup.PrintCreateLanguageStatements(backupfile, toc, langs, funcInfoMap, emptyMetadataMap)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE PROCEDURAL LANGUAGE plpythonu;
-ALTER FUNCTION pg_catalog.plpython_call_handler() OWNER TO testrole;`, `CREATE TRUSTED PROCEDURAL LANGUAGE plpgsql;
-ALTER FUNCTION pg_catalog.plpgsql_call_handler() OWNER TO testrole;
-ALTER FUNCTION pg_catalog.plpgsql_inline_handler(internal) OWNER TO testrole;
-ALTER FUNCTION pg_catalog.plpgsql_validator(oid) OWNER TO testrole;`)
+ALTER FUNCTION pg_catalog.plpython_call_handler() OWNER TO testrole;`, `CREATE TRUSTED PROCEDURAL LANGUAGE plperl;
+ALTER FUNCTION pg_catalog.plperl_call_handler() OWNER TO testrole;
+ALTER FUNCTION pg_catalog.plperl_inline_handler(internal) OWNER TO testrole;
+ALTER FUNCTION pg_catalog.plperl_validator(oid) OWNER TO testrole;`)
 		})
 		It("prints a language with privileges, an owner, and a comment", func() {
 			langs := []backup.ProceduralLanguage{plComment}

--- a/backup/queries_functions.go
+++ b/backup/queries_functions.go
@@ -514,7 +514,8 @@ SELECT
 	0 AS laninline,
 	l.lanvalidator::regprocedure::oid
 FROM pg_language l
-WHERE l.lanispl='t';
+WHERE l.lanispl='t'
+AND l.lanname != 'plpgsql';
 `
 	query := `
 SELECT
@@ -528,6 +529,7 @@ SELECT
 	l.lanvalidator::regprocedure::oid
 FROM pg_language l
 WHERE l.lanispl='t'
+AND l.lanname != 'plpgsql'
 AND l.oid NOT IN (select objid from pg_depend where deptype = 'e');`
 	var err error
 	if connection.Version.Before("5") {

--- a/integration/predata_functions_queries_test.go
+++ b/integration/predata_functions_queries_test.go
@@ -437,16 +437,8 @@ LANGUAGE SQL`)
 			testhelper.AssertQueryRuns(connection, "CREATE LANGUAGE plpythonu")
 			defer testhelper.AssertQueryRuns(connection, "DROP LANGUAGE plpythonu")
 
-			pgsqlHandlerOid := testutils.OidFromObjectName(connection, "pg_catalog", "plpgsql_call_handler", backup.TYPE_FUNCTION)
-			pgsqlValidatorOid := testutils.OidFromObjectName(connection, "pg_catalog", "plpgsql_validator", backup.TYPE_FUNCTION)
-
 			pythonHandlerOid := testutils.OidFromObjectName(connection, "pg_catalog", "plpython_call_handler", backup.TYPE_FUNCTION)
 
-			expectedPlpgsqlInfo := backup.ProceduralLanguage{Oid: 0, Name: "plpgsql", Owner: "testrole", IsPl: true, PlTrusted: true, Handler: pgsqlHandlerOid, Inline: 0, Validator: pgsqlValidatorOid}
-			if connection.Version.AtLeast("5") {
-				pgsqlInlineOid := testutils.OidFromObjectName(connection, "pg_catalog", "plpgsql_inline_handler", backup.TYPE_FUNCTION)
-				expectedPlpgsqlInfo.Inline = pgsqlInlineOid
-			}
 			expectedPlpythonInfo := backup.ProceduralLanguage{Oid: 1, Name: "plpythonu", Owner: "testrole", IsPl: true, PlTrusted: false, Handler: pythonHandlerOid, Inline: 0}
 			if connection.Version.AtLeast("5") {
 				pythonInlineOid := testutils.OidFromObjectName(connection, "pg_catalog", "plpython_inline_handler", backup.TYPE_FUNCTION)
@@ -455,9 +447,8 @@ LANGUAGE SQL`)
 
 			resultProcLangs := backup.GetProceduralLanguages(connection)
 
-			Expect(len(resultProcLangs)).To(Equal(2))
-			structmatcher.ExpectStructsToMatchExcluding(&expectedPlpgsqlInfo, &resultProcLangs[0], "Oid", "Owner")
-			structmatcher.ExpectStructsToMatchExcluding(&expectedPlpythonInfo, &resultProcLangs[1], "Oid", "Owner")
+			Expect(len(resultProcLangs)).To(Equal(1))
+			structmatcher.ExpectStructsToMatchExcluding(&expectedPlpythonInfo, &resultProcLangs[0], "Oid", "Owner")
 		})
 	})
 	Describe("GetConversions", func() {


### PR DESCRIPTION
This language is always in the database so it is not useful to back it
up or restore it. pg_dump excludes it so we will behave the same.

Authored-by: Karen Huddleston <khuddleston@pivotal.io>