### PR TITLE
Signal code cleanup

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -301,7 +301,8 @@ func DoCleanup() {
 	if *singleDataFile {
 		CleanUpSegmentPipesOnAllHosts()
 		CleanUpSegmentTailProcesses()
-		if wasTerminated { // These should all end on their own in a successful backup
+		if wasTerminated {
+			// It is possible for the COPY command to become orphaned if an agent process is killed
 			utils.TerminateHangingCopySessions(connection, globalFPInfo, "gpbackup")
 		}
 	}

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -2,8 +2,6 @@ package backup
 
 import (
 	"fmt"
-	"os"
-	"os/signal"
 	"strings"
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
@@ -40,20 +38,6 @@ func InitializeConnection() {
 	InitializeMetadataParams(connection)
 	connection.MustBegin()
 	SetSessionGUCs()
-}
-
-func InitializeSignalHandler() {
-	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan, os.Interrupt)
-	go func() {
-		for range signalChan {
-			fmt.Println() // Add newline after "^C" is printed
-			gplog.Warn("Received an interrupt, aborting backup process")
-			wasTerminated = true
-			DoCleanup()
-			os.Exit(2)
-		}
-	}()
 }
 
 func SetSessionGUCs() {

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -2,8 +2,6 @@ package restore
 
 import (
 	"fmt"
-	"os"
-	"os/signal"
 	"strings"
 
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
@@ -54,20 +52,6 @@ SET default_with_oids = off;
 	for i := 0; i < connection.NumConns; i++ {
 		connection.MustExec(setupQuery, i)
 	}
-}
-
-func InitializeSignalHandler() {
-	signalChan := make(chan os.Signal, 1)
-	signal.Notify(signalChan, os.Interrupt)
-	go func() {
-		for range signalChan {
-			fmt.Println() // Add newline after "^C" is printed
-			gplog.Warn("Received an interrupt, aborting restore process")
-			wasTerminated = true
-			DoCleanup()
-			os.Exit(2)
-		}
-	}()
 }
 
 func InitializeBackupConfig() {

--- a/utils/util.go
+++ b/utils/util.go
@@ -84,7 +84,8 @@ FROM pg_stat_activity
 WHERE application_name = '%s'
 AND current_query LIKE '%%%s%%'
 AND procpid <> pg_backend_pid()`, appName, copyFileName)
-	connection.MustExec(query)
+	// We don't check the error as the connection may have finished or been previously terminated
+	connection.Exec(query)
 }
 
 func SetDatabaseVersion(connection *dbconn.DBConn) {


### PR DESCRIPTION
Previously, a "current transaction is aborted" error would sometimes occur
during cleanup if ctrl-C was pressed during the data portion of a
single-data-file backup. Now, we ignore SQL errors during cleanup.