### PR TITLE
Remove segment ToC file if Ctrl-C pressed during data backup

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -304,6 +304,7 @@ func DoCleanup() {
 		if wasTerminated {
 			// It is possible for the COPY command to become orphaned if an agent process is killed
 			utils.TerminateHangingCopySessions(connection, globalFPInfo, "gpbackup")
+			CleanUpSegmentTOCs()
 		}
 	}
 	if globalFPInfo.Timestamp != "" {

--- a/backup/remote.go
+++ b/backup/remote.go
@@ -79,3 +79,12 @@ func MoveSegmentTOCsAndMakeReadOnly() {
 		return fmt.Sprintf("Unable to set permissions on or move file %s", globalFPInfo.GetSegmentTOCFilePath(globalCluster.SegDirMap[contentID], fmt.Sprintf("%d", contentID)))
 	})
 }
+func CleanUpSegmentTOCs() {
+	remoteOutput := globalCluster.GenerateAndExecuteCommand("Cleaning up segment table of contents files", func(contentID int) string {
+		tocFile := globalFPInfo.GetSegmentTOCFilePath(globalCluster.SegDirMap[contentID], fmt.Sprintf("%d", contentID))
+		return fmt.Sprintf("rm -f %s", tocFile)
+	})
+	globalCluster.CheckClusterError(remoteOutput, "Unable to remove segment table of contents files", func(contentID int) string {
+		return fmt.Sprintf("Unable to remove segment table of contents file %s", globalFPInfo.GetSegmentTOCFilePath(globalCluster.SegDirMap[contentID], fmt.Sprintf("%d", contentID)))
+	})
+}

--- a/ci/tasks/scale-tests.yml
+++ b/ci/tasks/scale-tests.yml
@@ -44,7 +44,7 @@ run:
     popd
 
     tar -xvf scale_db1.tgz
-    createdb scaledb
+    createdb scaledb -T template0
 
     psql -f scale_db1.sql -d scaledb -v client_min_messages=error -q
 


### PR DESCRIPTION
Previously, the ToC file in the segment data directory was not removed
if the data backup was interrupted during a single-data-file backup.
Now, we remove the segment ToC file if the backup was interrupted.

Authored-by: Chris Hajas <chajas@pivotal.io