### PR TITLE
Clean up extra logging if user interrupts backup or restore

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -132,10 +132,17 @@ func backupGlobal(metadataFile *utils.FileWithByteCount) {
 		BackupRoles(metadataFile)
 		BackupRoleGrants(metadataFile)
 	}
-	gplog.Info("Global database metadata backup complete")
+	if wasTerminated {
+		gplog.Info("Global database metadata backup incomplete")
+	} else {
+		gplog.Info("Global database metadata backup complete")
+	}
 }
 
 func backupPredata(metadataFile *utils.FileWithByteCount, tables []Relation, tableDefs map[uint32]TableDefinition) {
+	if wasTerminated {
+		return
+	}
 	gplog.Info("Writing pre-data metadata")
 
 	BackupSchemas(metadataFile)
@@ -192,10 +199,17 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Relation, tab
 	BackupCasts(metadataFile)
 	BackupViews(metadataFile, relationMetadata)
 	BackupConstraints(metadataFile, constraints, conMetadata)
-	gplog.Info("Pre-data metadata backup complete")
+	if wasTerminated {
+		gplog.Info("Pre-data metadata backup incomplete")
+	} else {
+		gplog.Info("Pre-data metadata backup complete")
+	}
 }
 
 func backupTablePredata(metadataFile *utils.FileWithByteCount, tables []Relation, tableDefs map[uint32]TableDefinition) {
+	if wasTerminated {
+		return
+	}
 	gplog.Info("Writing table metadata")
 
 	relationMetadata := GetMetadataForObjectType(connection, TYPE_RELATION)
@@ -214,25 +228,43 @@ func backupData(tables []Relation, tableDefs map[uint32]TableDefinition) {
 	if *singleDataFile {
 		MoveSegmentTOCsAndMakeReadOnly()
 	}
-	gplog.Info("Data backup complete")
+	if wasTerminated {
+		gplog.Info("Data backup incomplete")
+	} else {
+		gplog.Info("Data backup complete")
+	}
 }
 
 func backupPostdata(metadataFile *utils.FileWithByteCount) {
+	if wasTerminated {
+		return
+	}
 	gplog.Info("Writing post-data metadata")
 
 	BackupIndexes(metadataFile)
 	BackupRules(metadataFile)
 	BackupTriggers(metadataFile)
-	gplog.Info("Post-data metadata backup complete")
+	if wasTerminated {
+		gplog.Info("Post-data metadata backup incomplete")
+	} else {
+		gplog.Info("Post-data metadata backup complete")
+	}
 }
 
 func backupStatistics(tables []Relation) {
+	if wasTerminated {
+		return
+	}
 	statisticsFilename := globalFPInfo.GetStatisticsFilePath()
 	gplog.Info("Writing query planner statistics to %s", statisticsFilename)
 	statisticsFile := utils.NewFileWithByteCountFromFile(statisticsFilename)
 	defer statisticsFile.Close()
 	BackupStatistics(statisticsFile, tables)
-	gplog.Info("Query planner statistics backup complete")
+	if wasTerminated {
+		gplog.Info("Query planner statistics backup incomplete")
+	} else {
+		gplog.Info("Query planner statistics backup complete")
+	}
 }
 
 func DoTeardown() {

--- a/backup/data.go
+++ b/backup/data.go
@@ -11,6 +11,7 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gpbackup/utils"
+	pb "gopkg.in/cheggaaa/pb.v1"
 )
 
 var (
@@ -88,6 +89,7 @@ func BackupDataForAllTables(tables []Relation, tableDefs map[uint32]TableDefinit
 		* in progress if they don't finish on their own.
 		 */
 		if wasTerminated {
+			dataProgressBar.(*pb.ProgressBar).NotPrint = true
 			break
 		}
 		tableDef := tableDefs[table.Oid]

--- a/restore/parallel.go
+++ b/restore/parallel.go
@@ -44,6 +44,9 @@ func ExecuteStatements(statements []utils.StatementWithType, progressBar utils.P
 	if !executeInParallel {
 		connNum := connection.ValidateConnNum(whichConn...)
 		for _, statement := range statements {
+			if wasTerminated {
+				return
+			}
 			numErrors += executeStatement(statement, showProgressBar, connNum)
 			progressBar.Increment()
 		}

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gpbackup/utils"
+	pb "gopkg.in/cheggaaa/pb.v1"
 
 	"github.com/pkg/errors"
 )
@@ -144,6 +145,9 @@ func restoreGlobal(metadataFilename string) {
 }
 
 func restorePredata(metadataFilename string) {
+	if wasTerminated {
+		return
+	}
 	gplog.Info("Restoring pre-data metadata")
 
 	schemaStatements := GetRestoreMetadataStatements("predata", metadataFilename, []string{"SCHEMA"}, []string{}, includeSchemas, []string{})
@@ -160,6 +164,9 @@ func restorePredata(metadataFilename string) {
 }
 
 func restoreData(gucStatements []utils.StatementWithType) {
+	if wasTerminated {
+		return
+	}
 	gplog.Info("Restoring data")
 	filteredMasterDataEntries := globalTOC.GetDataEntriesMatching(includeSchemas, includeTables)
 	if backupConfig.SingleDataFile {
@@ -184,7 +191,8 @@ func restoreData(gucStatements []utils.StatementWithType) {
 	if connection.NumConns == 1 {
 		for i, entry := range filteredMasterDataEntries {
 			if wasTerminated {
-				break
+				dataProgressBar.(*pb.ProgressBar).NotPrint = true
+				return
 			}
 			restoreSingleTableData(entry, uint32(i)+1, totalTables, 0)
 			dataProgressBar.Increment()
@@ -228,6 +236,9 @@ func restoreData(gucStatements []utils.StatementWithType) {
 }
 
 func restorePostdata(metadataFilename string) {
+	if wasTerminated {
+		return
+	}
 	gplog.Info("Restoring post-data metadata")
 	statements := GetRestoreMetadataStatements("postdata", metadataFilename, []string{}, []string{}, includeSchemas, includeTables)
 	firstBatch, secondBatch := BatchPostdataStatements(statements)
@@ -240,6 +251,9 @@ func restorePostdata(metadataFilename string) {
 }
 
 func restoreStatistics() {
+	if wasTerminated {
+		return
+	}
 	statisticsFilename := globalFPInfo.GetStatisticsFilePath()
 	gplog.Info("Restoring query planner statistics from %s", statisticsFilename)
 	statements := GetRestoreMetadataStatements("statistics", statisticsFilename, []string{}, []string{}, includeSchemas, []string{})


### PR DESCRIPTION
This commit adds guards to prevent misleading logging. Additionally, it
cleans up some extra progress bars that are printed if the user exits
the utility.

Authored-by: Chris Hajas <chajas@pivotal.io>