### PR TITLE
Split end_to_end test containing all sql objects based on GPDB version

### DIFF
--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -348,10 +348,13 @@ var _ = Describe("backup end to end integration tests", func() {
 		})
 		It("runs gpbackup and gprestore on database with all objects", func() {
 			testhelper.AssertQueryRuns(backupConn, "DROP SCHEMA IF EXISTS schema2 CASCADE; DROP SCHEMA public CASCADE; CREATE SCHEMA public; DROP PROCEDURAL LANGUAGE IF EXISTS plpythonu;")
-			/* We do not check the error code since there are some objects we
-			 * expect to fail during creation between DB versions
-			 */
-			exec.Command("psql", "-d", "testdb", "-f", "all_objects.sql", "-q")
+			testutils.ExecuteSQLFile(backupConn, "gpdb4_objects.sql")
+			if backupConn.Version.AtLeast("5") {
+				testutils.ExecuteSQLFile(backupConn, "gpdb5_objects.sql")
+			}
+			if backupConn.Version.AtLeast("6") {
+				testutils.ExecuteSQLFile(backupConn, "gpdb6_objects.sql")
+			}
 			timestamp := gpbackup(gpbackupPath)
 			gprestore(gprestorePath, timestamp, "-redirect-db", "restoredb")
 

--- a/end_to_end/gpdb4_objects.sql
+++ b/end_to_end/gpdb4_objects.sql
@@ -1,6 +1,3 @@
---
--- Greenplum Database database dump
---
 
 SET statement_timeout = 0;
 SET client_encoding = 'UTF8';
@@ -10,29 +7,19 @@ SET client_min_messages = warning;
 
 SET default_with_oids = false;
 
---
---
 
 CREATE SCHEMA schema2;
 
-
-
---
---
 
 CREATE PROCEDURAL LANGUAGE plpythonu;
 
 
 SET search_path = public, pg_catalog;
 
---
---
 
 CREATE TYPE base_type;
 
 
---
---
 
 CREATE FUNCTION base_fn_in(cstring) RETURNS base_type
     AS $$boolin$$
@@ -40,17 +27,11 @@ CREATE FUNCTION base_fn_in(cstring) RETURNS base_type
 
 
 
---
---
 
 CREATE FUNCTION base_fn_out(base_type) RETURNS cstring
     AS $$boolout$$
     LANGUAGE internal NO SQL;
 
-
-
---
---
 
 CREATE TYPE base_type (
     INTERNALLENGTH = variable,
@@ -61,31 +42,12 @@ CREATE TYPE base_type (
 );
 
 
-
---
---
-
 CREATE TYPE composite_type AS (
 	name integer,
 	name1 integer,
 	name2 text
 );
 
-
-
---
---
-
-CREATE TYPE enum_type AS ENUM (
-    '750582',
-    '750583',
-    '750584'
-);
-
-
-
---
---
 
 CREATE FUNCTION casttoint(text) RETURNS integer
     AS $_$
@@ -94,20 +56,12 @@ $_$
     LANGUAGE sql IMMUTABLE STRICT CONTAINS SQL;
 
 
-
---
---
-
-CREATE FUNCTION dup(integer DEFAULT 42, OUT f1 integer, OUT f2 text) RETURNS record
+CREATE FUNCTION dup(integer, OUT f1 integer, OUT f2 text) RETURNS record
     AS $_$
 SELECT $1, CAST($1 AS text) || ' is text'
 $_$
     LANGUAGE sql CONTAINS SQL;
 
-
-
---
---
 
 CREATE FUNCTION mypre_accum(numeric, numeric) RETURNS numeric
     AS $_$
@@ -116,20 +70,12 @@ $_$
     LANGUAGE sql IMMUTABLE STRICT CONTAINS SQL;
 
 
-
---
---
-
 CREATE FUNCTION mysfunc_accum(numeric, numeric, numeric) RETURNS numeric
     AS $_$
 select $1 + $2 + $3
 $_$
     LANGUAGE sql IMMUTABLE STRICT CONTAINS SQL;
 
-
-
---
---
 
 CREATE FUNCTION plusone(x text) RETURNS text
     AS $$
@@ -140,37 +86,6 @@ $$
     LANGUAGE plpgsql NO SQL;
 
 
-
---
---
-
-CREATE FUNCTION plusone(x character varying) RETURNS character varying
-    AS $$
-BEGIN
-    RETURN x || 'a';
-END;
-$$
-    LANGUAGE plpgsql NO SQL
-    SET standard_conforming_strings TO 'on'
-    SET client_min_messages TO 'notice'
-    SET search_path TO public;
-
-
-
---
---
-
-CREATE FUNCTION return_enum_as_array(anyenum, anyelement, anyelement) RETURNS TABLE(ae anyenum, aa anyarray)
-    AS $_$
-SELECT $1, array[$2, $3]
-$_$
-    LANGUAGE sql STABLE CONTAINS SQL;
-
-
-
---
---
-
 CREATE AGGREGATE agg_prefunc(numeric, numeric) (
     SFUNC = mysfunc_accum,
     STYPE = numeric,
@@ -179,10 +94,6 @@ CREATE AGGREGATE agg_prefunc(numeric, numeric) (
 );
 
 
-
---
---
-
 CREATE AGGREGATE agg_test(integer) (
     SFUNC = int4xor,
     STYPE = integer,
@@ -190,49 +101,27 @@ CREATE AGGREGATE agg_test(integer) (
 );
 
 
-
---
---
-
 CREATE OPERATOR #### (
     PROCEDURE = numeric_fac,
     LEFTARG = bigint
 );
 
 
-
---
---
-
 CREATE OPERATOR CLASS test_op_class
-    FOR TYPE uuid USING hash AS
-    STORAGE uuid;
+    FOR TYPE _int4 USING hash AS
+    STORAGE _int4;
 
-
-
---
---
-
-CREATE OPERATOR FAMILY testfam USING gist;
-
-
-
---
---
 
 CREATE OPERATOR CLASS testclass
-    FOR TYPE uuid USING gist FAMILY testfam AS
-    OPERATOR 1 =(uuid,uuid) RECHECK ,
-    OPERATOR 2 <(uuid,uuid) ,
-    FUNCTION 1 abs(integer) ,
-    FUNCTION 2 int4out(integer);
-
+	FOR TYPE int USING gist AS
+	OPERATOR 1 = RECHECK,
+	OPERATOR 2 < ,
+	FUNCTION 1 abs(integer),
+	FUNCTION 2 int4out(integer);
 
 
 SET default_tablespace = '';
 
---
---
 
 CREATE TABLE bar (
     i integer NOT NULL,
@@ -243,15 +132,10 @@ CREATE TABLE bar (
 
 
 
---
---
 
 COPY bar (i, j, k, l) FROM stdin;
 \.
 
-
---
---
 
 CREATE TABLE foo (
     k text,
@@ -260,16 +144,9 @@ CREATE TABLE foo (
 ) DISTRIBUTED RANDOMLY;
 
 
-
---
---
-
 COPY foo (k, i, j) FROM stdin;
 \.
 
-
---
---
 
 CREATE TABLE foo2 (
     k text,
@@ -278,18 +155,12 @@ CREATE TABLE foo2 (
 INHERITS (foo) DISTRIBUTED RANDOMLY;
 
 
-
---
---
-
 COPY foo2 (k, i, j, l) FROM stdin;
 \.
 
 
 SET search_path = schema2, pg_catalog;
 
---
---
 
 CREATE TABLE foo3 (
     m double precision
@@ -300,8 +171,6 @@ INHERITS (public.foo2) DISTRIBUTED RANDOMLY;
 
 SET search_path = public, pg_catalog;
 
---
---
 
 CREATE TABLE foo4 (
     n integer
@@ -309,16 +178,10 @@ CREATE TABLE foo4 (
 INHERITS (schema2.foo3) DISTRIBUTED RANDOMLY;
 
 
-
---
---
-
 COPY foo4 (k, i, j, l, m, n) FROM stdin;
 \.
 
 
---
---
 
 CREATE TABLE gpcrondump_history (
     rec_date timestamp without time zone,
@@ -332,33 +195,23 @@ CREATE TABLE gpcrondump_history (
 ) DISTRIBUTED BY (rec_date);
 
 
-
---
---
-
 COPY gpcrondump_history (rec_date, start_time, end_time, options, dump_key, dump_exit_status, script_exit_status, exit_text) FROM stdin;
 \.
 
 
 SET search_path = schema2, pg_catalog;
 
---
---
 
 COPY foo3 (k, i, j, l, m) FROM stdin;
 \.
 
 
---
---
 
 CREATE TABLE noatts (
 ) DISTRIBUTED RANDOMLY;
 
 
 
---
---
 
 COPY noatts  FROM stdin;
 \.
@@ -366,8 +219,6 @@ COPY noatts  FROM stdin;
 
 SET search_path = public, pg_catalog;
 
---
---
 
 CREATE TABLE pk_table (
     a integer NOT NULL
@@ -375,15 +226,11 @@ CREATE TABLE pk_table (
 
 
 
---
---
 
 COPY pk_table (a) FROM stdin;
 \.
 
 
---
---
 
 CREATE TABLE reference_table (
     a integer,
@@ -392,8 +239,6 @@ CREATE TABLE reference_table (
 
 
 
---
---
 
 COPY reference_table (a, b) FROM stdin;
 \.
@@ -401,8 +246,6 @@ COPY reference_table (a, b) FROM stdin;
 
 SET search_path = schema2, pg_catalog;
 
---
---
 
 CREATE TABLE prime (
     i integer NOT NULL,
@@ -411,8 +254,6 @@ CREATE TABLE prime (
 
 
 
---
---
 
 COPY prime (i, j) FROM stdin;
 \.
@@ -420,8 +261,6 @@ COPY prime (i, j) FROM stdin;
 
 SET search_path = public, pg_catalog;
 
---
---
 
 CREATE TABLE rule_table1 (
     i integer
@@ -429,33 +268,13 @@ CREATE TABLE rule_table1 (
 
 
 
---
---
 
 COPY rule_table1 (i) FROM stdin;
 \.
 
 
-SET search_path = pg_catalog;
-
---
--- Name: CAST (text AS integer); Type: CAST; Schema: pg_catalog; Owner: 
---
-
-CREATE CAST (text AS integer) WITH FUNCTION public.casttoint(text) AS ASSIGNMENT;
-
-
---
--- Name: CAST (text AS integer); Type: COMMENT; Schema: -; Owner: 
---
-
-COMMENT ON CAST (text AS integer) IS 'sample cast';
-
-
 SET search_path = public, pg_catalog;
 
---
---
 
 CREATE TABLE trigger_table1 (
     i integer
@@ -463,24 +282,16 @@ CREATE TABLE trigger_table1 (
 
 
 
---
---
 
 COPY trigger_table1 (i) FROM stdin;
 \.
 
 
---
---
 
 CREATE TABLE uniq (
     i integer
 ) DISTRIBUTED BY (i);
 
-
-
---
---
 
 COPY uniq (i) FROM stdin;
 \.
@@ -488,8 +299,6 @@ COPY uniq (i) FROM stdin;
 
 SET search_path = schema2, pg_catalog;
 
---
---
 
 CREATE TABLE with_multiple_check (
     a integer,
@@ -498,58 +307,22 @@ CREATE TABLE with_multiple_check (
 ) DISTRIBUTED BY (a);
 
 
-
---
---
-
 COPY with_multiple_check (a, b) FROM stdin;
 \.
 
 
 SET search_path = public, pg_catalog;
 
---
---
 
 CREATE CONVERSION testconv FOR 'LATIN1' TO 'MULE_INTERNAL' FROM latin1_to_mic;
 
 
-
---
---
-
-CREATE TEXT SEARCH DICTIONARY testdictionary (
-    TEMPLATE = pg_catalog.snowball,
-    language = 'russian', stopwords = 'russian' );
-
-
-
---
---
-
-CREATE TEXT SEARCH CONFIGURATION testconfiguration (
-    PARSER = pg_catalog."default" );
-
-
-
---
--- Name: testtemplate; Type: TEXT SEARCH TEMPLATE; Schema: public; Owner: 
---
-
-CREATE TEXT SEARCH TEMPLATE testtemplate (
-    LEXIZE = dsimple_lexize );
-
-
---
---
 
 CREATE VIEW test_view AS
     SELECT pk_table.a FROM pk_table;
 
 
 
---
---
 
 CREATE VIEW view_view AS
     SELECT test_view.a FROM test_view;
@@ -558,8 +331,6 @@ CREATE VIEW view_view AS
 
 SET search_path = schema2, pg_catalog;
 
---
---
 
 CREATE SEQUENCE seq_one
     START WITH 3
@@ -569,41 +340,19 @@ CREATE SEQUENCE seq_one
     CACHE 1;
 
 
-
---
---
-
 ALTER SEQUENCE seq_one OWNED BY prime.j;
 
-
---
---
 
 SELECT pg_catalog.setval('seq_one', 3, false);
 
 
 SET search_path = public, pg_catalog;
 
---
--- Name: testparser; Type: TEXT SEARCH PARSER; Schema: public; Owner: 
---
-
-CREATE TEXT SEARCH PARSER testparser (
-    START = prsd_start,
-    GETTOKEN = prsd_nexttoken,
-    END = prsd_end,
-    LEXTYPES = prsd_lextype );
-
-
---
---
 
 ALTER TABLE ONLY pk_table
     ADD CONSTRAINT pk_table_pkey PRIMARY KEY (a);
 
 
---
---
 
 ALTER TABLE ONLY uniq
     ADD CONSTRAINT uniq_i_key UNIQUE (i);
@@ -611,8 +360,6 @@ ALTER TABLE ONLY uniq
 
 SET search_path = schema2, pg_catalog;
 
---
---
 
 ALTER TABLE ONLY prime
     ADD CONSTRAINT prime_pkey PRIMARY KEY (i);
@@ -620,42 +367,23 @@ ALTER TABLE ONLY prime
 
 SET search_path = public, pg_catalog;
 
---
---
 
 CREATE INDEX simple_table_idx1 ON foo4 USING btree (n);
 
 
---
---
 
 CREATE RULE double_insert AS ON INSERT TO rule_table1 DO INSERT INTO rule_table1 VALUES (1);
 
 
---
---
-
 CREATE TRIGGER sync_trigger_table1
     AFTER INSERT OR DELETE OR UPDATE ON trigger_table1
     FOR EACH STATEMENT
-    EXECUTE PROCEDURE flatfile_update_trigger();
+    EXECUTE PROCEDURE "RI_FKey_check_ins"();
 
-
---
---
 
 ALTER TABLE ONLY reference_table
     ADD CONSTRAINT reference_table_b_fkey FOREIGN KEY (b) REFERENCES pk_table(a);
 
 
---
---
-
 REVOKE ALL ON SCHEMA public FROM PUBLIC;
 GRANT ALL ON SCHEMA public TO PUBLIC;
-
-
---
--- Greenplum Database database dump complete
---
-

--- a/end_to_end/gpdb5_objects.sql
+++ b/end_to_end/gpdb5_objects.sql
@@ -1,0 +1,67 @@
+SET statement_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+
+SET default_with_oids = false;
+SET search_path = public, pg_catalog;
+
+
+CREATE TYPE enum_type AS ENUM (
+    '750582',
+    '750583',
+    '750584'
+);
+
+
+CREATE FUNCTION plusone(x character varying) RETURNS character varying
+    AS $$
+BEGIN
+    RETURN x || 'a';
+END;
+$$
+    LANGUAGE plpgsql NO SQL
+    SET standard_conforming_strings TO 'on'
+    SET client_min_messages TO 'notice'
+    SET search_path TO public;
+
+
+CREATE FUNCTION return_enum_as_array(anyenum, anyelement, anyelement) RETURNS TABLE(ae anyenum, aa anyarray)
+    AS $_$
+SELECT $1, array[$2, $3]
+$_$
+    LANGUAGE sql STABLE CONTAINS SQL;
+
+
+
+SET default_tablespace = '';
+
+
+CREATE CAST (text AS integer) WITH FUNCTION public.casttoint(text) AS ASSIGNMENT;
+
+
+COMMENT ON CAST (text AS integer) IS 'sample cast';
+
+
+
+CREATE TEXT SEARCH DICTIONARY testdictionary (
+    TEMPLATE = pg_catalog.snowball,
+    language = 'russian', stopwords = 'russian' );
+
+
+CREATE TEXT SEARCH CONFIGURATION testconfiguration (
+    PARSER = pg_catalog."default" );
+
+
+CREATE TEXT SEARCH TEMPLATE testtemplate (
+    LEXIZE = dsimple_lexize );
+
+
+
+CREATE TEXT SEARCH PARSER testparser (
+    START = prsd_start,
+    GETTOKEN = prsd_nexttoken,
+    END = prsd_end,
+    LEXTYPES = prsd_lextype );
+

--- a/end_to_end/gpdb6_objects.sql
+++ b/end_to_end/gpdb6_objects.sql
@@ -1,0 +1,30 @@
+SET statement_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SET check_function_bodies = false;
+SET client_min_messages = warning;
+
+SET search_path = public, pg_catalog;
+
+SET default_with_oids = false;
+
+
+CREATE TYPE employee_type AS (
+	name text,
+	salary numeric
+);
+
+
+CREATE FUNCTION add(integer, integer) RETURNS integer
+    LANGUAGE sql WINDOW CONTAINS SQL
+    AS $_$SELECT $1 + $2$_$;
+
+
+CREATE FUNCTION mleast(VARIADIC arr numeric[]) RETURNS numeric
+    LANGUAGE sql CONTAINS SQL
+    AS $_$
+    SELECT min($1[i]) FROM generate_subscripts($1, 1) g(i);
+$_$;
+
+
+CREATE FOREIGN DATA WRAPPER fdw;


### PR DESCRIPTION
Previously, a single sql file containing all possible objects was run on
all GPDB versions. Now, we have separate sql files for objects and syntax
introduced in newer GPDB versions.

Authored-by: Chris Hajas <chajas@pivotal.io>