### PR TITLE
Ensure passing tests before release job in pipeline

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -501,11 +501,7 @@ jobs:
     - get: gpbackup
       passed:
        - units
-       - scale-master
-       - scale-43-stable
-       - scale-5x-stable
        - integrations-GPDB5
-       - integrations-master
        - integrations-GPDB4.3
        - integrations-GPDB5-sles
        - test_package_conan

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -496,6 +496,19 @@ jobs:
   - aggregate:
     - get: gpbackup_tagged_src
       trigger: true
+    # While the resource is not used, it ensures only releasing if
+    #  tests are passing
+    - get: gpbackup
+      passed:
+       - units
+       - scale-master
+       - scale-43-stable
+       - scale-5x-stable
+       - integrations-GPDB5
+       - integrations-master
+       - integrations-GPDB4.3
+       - integrations-GPDB5-sles
+       - test_package_conan
   - task: compile_gpbackup
     config:
       platform: linux


### PR DESCRIPTION
This helps with understanding the pipeline when looking at it with the idea that tests are first and they block the final action which in this case is release. A tag in the source will still trigger the release job, but it will now require every test before it to be green as well.

@khuddlefish @chrishajas 