### PR TITLE
Fix ordering and syntax when dumping procedural languages

### DIFF
--- a/backup/predata_functions.go
+++ b/backup/predata_functions.go
@@ -190,7 +190,7 @@ func ExtractLanguageFunctions(funcDefs []Function, procLangs []ProceduralLanguag
 	isLangFuncMap := make(map[uint32]bool, 0)
 	for _, procLang := range procLangs {
 		for _, funcDef := range funcDefs {
-			isLangFuncMap[funcDef.Oid] = (funcDef.Oid == procLang.Handler ||
+			isLangFuncMap[funcDef.Oid] = (isLangFuncMap[funcDef.Oid] || funcDef.Oid == procLang.Handler ||
 				funcDef.Oid == procLang.Inline ||
 				funcDef.Oid == procLang.Validator)
 		}

--- a/backup/predata_functions_test.go
+++ b/backup/predata_functions_test.go
@@ -518,14 +518,14 @@ COMMENT ON EXTENSION extension1 IS 'This is an extension comment.';`)
 
 			backup.PrintCreateLanguageStatements(backupfile, toc, langs, funcInfoMap, emptyMetadataMap)
 			testutils.ExpectEntry(toc.PredataEntries, 0, "", "", "plpythonu", "PROCEDURAL LANGUAGE")
-			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE PROCEDURAL LANGUAGE plpythonu;
+			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE PROCEDURAL LANGUAGE plpythonu HANDLER pg_catalog.plpython_call_handler;
 ALTER FUNCTION pg_catalog.plpython_call_handler() OWNER TO testrole;`)
 		})
 		It("prints trusted language with handler, inline, and validator", func() {
 			langs := []backup.ProceduralLanguage{plAllFields}
 
 			backup.PrintCreateLanguageStatements(backupfile, toc, langs, funcInfoMap, emptyMetadataMap)
-			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TRUSTED PROCEDURAL LANGUAGE plperl;
+			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TRUSTED PROCEDURAL LANGUAGE plperl HANDLER pg_catalog.plperl_call_handler INLINE pg_catalog.plperl_inline_handler VALIDATOR pg_catalog.plperl_validator;
 ALTER FUNCTION pg_catalog.plperl_call_handler() OWNER TO testrole;
 ALTER FUNCTION pg_catalog.plperl_inline_handler(internal) OWNER TO testrole;
 ALTER FUNCTION pg_catalog.plperl_validator(oid) OWNER TO testrole;`)
@@ -534,8 +534,8 @@ ALTER FUNCTION pg_catalog.plperl_validator(oid) OWNER TO testrole;`)
 			langs := []backup.ProceduralLanguage{plUntrustedHandlerOnly, plAllFields}
 
 			backup.PrintCreateLanguageStatements(backupfile, toc, langs, funcInfoMap, emptyMetadataMap)
-			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE PROCEDURAL LANGUAGE plpythonu;
-ALTER FUNCTION pg_catalog.plpython_call_handler() OWNER TO testrole;`, `CREATE TRUSTED PROCEDURAL LANGUAGE plperl;
+			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE PROCEDURAL LANGUAGE plpythonu HANDLER pg_catalog.plpython_call_handler;
+ALTER FUNCTION pg_catalog.plpython_call_handler() OWNER TO testrole;`, `CREATE TRUSTED PROCEDURAL LANGUAGE plperl HANDLER pg_catalog.plperl_call_handler INLINE pg_catalog.plperl_inline_handler VALIDATOR pg_catalog.plperl_validator;
 ALTER FUNCTION pg_catalog.plperl_call_handler() OWNER TO testrole;
 ALTER FUNCTION pg_catalog.plperl_inline_handler(internal) OWNER TO testrole;
 ALTER FUNCTION pg_catalog.plperl_validator(oid) OWNER TO testrole;`)
@@ -545,7 +545,7 @@ ALTER FUNCTION pg_catalog.plperl_validator(oid) OWNER TO testrole;`)
 			langMetadataMap := testutils.DefaultMetadataMap("LANGUAGE", true, true, true)
 
 			backup.PrintCreateLanguageStatements(backupfile, toc, langs, funcInfoMap, langMetadataMap)
-			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE PROCEDURAL LANGUAGE plpythonu;
+			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE PROCEDURAL LANGUAGE plpythonu HANDLER pg_catalog.plpython_call_handler;
 ALTER FUNCTION pg_catalog.plpython_call_handler() OWNER TO testrole;
 
 COMMENT ON LANGUAGE plpythonu IS 'This is a language comment.';

--- a/backup/predata_functions_test.go
+++ b/backup/predata_functions_test.go
@@ -473,8 +473,9 @@ COMMENT ON EXTENSION extension1 IS 'This is an extension comment.';`)
 		})
 	})
 	Describe("ExtractLanguageFunctions", func() {
-		customLang := backup.ProceduralLanguage{Oid: 1, Name: "custom_language", Owner: "testrole", IsPl: true, PlTrusted: true, Handler: 3, Inline: 4, Validator: 5}
-		procLangs := []backup.ProceduralLanguage{customLang}
+		customLang1 := backup.ProceduralLanguage{Oid: 1, Name: "custom_language", Owner: "testrole", IsPl: true, PlTrusted: true, Handler: 3, Inline: 4, Validator: 5}
+		customLang2 := backup.ProceduralLanguage{Oid: 2, Name: "custom_language2", Owner: "testrole", IsPl: true, PlTrusted: true, Handler: 5, Inline: 6, Validator: 7}
+		procLangs := []backup.ProceduralLanguage{customLang1, customLang2}
 		langFunc := backup.Function{Oid: 3, Name: "custom_handler"}
 		nonLangFunc := backup.Function{Oid: 2, Name: "random_function"}
 		It("handles a case where all functions are language-associated functions", func() {


### PR DESCRIPTION
These commits fix two issues:

1) The ExtractLanguageFunctions logic overwrote a function's value
if multiple languages existed in the database, resulting in the function not
getting dumped before the language and causing errors during restore.

2) While some languages such as plpython and plperl do not require
parameters such as HANDLER, INLINE, and VALIDATOR to be specified
in the CREATE syntax, languages not present in pg_pltempate
such as java do.  We now dump these parameters in all cases,
though they will be ignored if language is in pg_pltemplate.

Authored-by: Chris Hajas <chajas@pivotal.io>