### PR TITLE
Don't check error for mkfifo command

### DIFF
--- a/helper/helper.go
+++ b/helper/helper.go
@@ -110,7 +110,7 @@ func doBackupAgent() {
 	for i, oid := range oidList {
 		if i < len(oidList)-1 {
 			nextPipe = fmt.Sprintf("%s_%d", *pipeFile, oidList[i+1])
-			createPipe(nextPipe)
+			syscall.Mkfifo(nextPipe, 0777)
 		} else {
 			nextPipe = ""
 		}
@@ -229,7 +229,7 @@ func doRestoreAgent() {
 		log(fmt.Sprintf("Restoring table with oid %d", oid))
 		if i < len(oidList)-1 {
 			nextPipe = fmt.Sprintf("%s_%d", *pipeFile, oidList[i+1])
-			createPipe(nextPipe)
+			syscall.Mkfifo(nextPipe, 0777)
 		} else {
 			nextPipe = ""
 		}
@@ -306,11 +306,6 @@ func getRestorePipeWriter(currentPipe string) (*bufio.Writer, *os.File) {
 /*
  * Shared functions
  */
-
-func createPipe(pipe string) {
-	err := syscall.Mkfifo(pipe, 0777)
-	gplog.FatalOnError(err)
-}
 
 func getOidListFromFile() []int {
 	oidStr, err := operating.System.ReadFile(*oidFile)


### PR DESCRIPTION
Our tests were failing frequently for "file exists" errors with this
command. This should not be a reason for the helper to error out. If the
command errors out and is unable to create the pipe, we should see the
error show up somewhere else, so this check is not very useful.

Authored-by: Karen Huddleston <khuddleston@pivotal.io>