### PR TITLE
Use Cobra CLI instead of Go flag package

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -22,6 +22,12 @@
   revision = "26097cb0b6c1a5fd473bcea25dddffe2ad492b5a"
 
 [[projects]]
+  name = "github.com/inconshreveable/mousetrap"
+  packages = ["."]
+  revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
+  version = "v1.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/jmoiron/sqlx"
   packages = [
@@ -106,6 +112,18 @@
   version = "v0.8.0"
 
 [[projects]]
+  name = "github.com/spf13/cobra"
+  packages = ["."]
+  revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
+  version = "v0.0.3"
+
+[[projects]]
+  name = "github.com/spf13/pflag"
+  packages = ["."]
+  revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
+  version = "v1.0.1"
+
+[[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = [
@@ -177,6 +195,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5c917dfa592f0ecad7c632440df951cbd9f560994e5c574800ddb0b01064f93b"
+  inputs-digest = "e5c978284f2111830cbfbb7e41a35675c998d854b5de743f367caaf06c30321b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -33,13 +33,13 @@ func initializeFlags(cmd *cobra.Command) {
 	metadataOnly = cmd.Flags().Bool("metadata-only", false, "Only back up metadata, do not back up data")
 	noCompression = cmd.Flags().Bool("no-compression", false, "Disable compression of data files")
 	pluginConfigFile = cmd.Flags().String("plugin-config", "", "The configuration file to use for a plugin")
-	printVersion = cmd.Flags().Bool("version", false, "Print version number and exit")
+	cmd.Flags().Bool("version", false, "Print version number and exit")
 	quiet = cmd.Flags().Bool("quiet", false, "Suppress non-warning, non-error log messages")
 	singleDataFile = cmd.Flags().Bool("single-data-file", false, "Back up all data to a single file instead of one per table")
 	verbose = cmd.Flags().Bool("verbose", false, "Print verbose log messages")
 	withStats = cmd.Flags().Bool("with-stats", false, "Back up query plan statistics")
 
-	cmd.MarkFlagRequired("dbname")
+	_ = cmd.MarkFlagRequired("dbname")
 }
 
 // This function handles setup that can be done before parsing flags.
@@ -52,10 +52,6 @@ func DoInit(cmd *cobra.Command) {
 }
 
 func DoFlagValidation(cmd *cobra.Command) {
-	if *printVersion {
-		fmt.Printf("gpbackup %s\n", version)
-		os.Exit(0)
-	}
 	ValidateFlagCombinations(cmd.Flags())
 	ValidateFlagValues()
 }
@@ -391,4 +387,8 @@ func DoCleanup() {
 	if connection != nil {
 		connection.Close()
 	}
+}
+
+func GetVersion() string {
+	return version
 }

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -56,7 +56,7 @@ func DoFlagValidation(cmd *cobra.Command) {
 		fmt.Printf("gpbackup %s\n", version)
 		os.Exit(0)
 	}
-	ValidateFlagCombinations(cmd)
+	ValidateFlagCombinations(cmd.Flags())
 	ValidateFlagValues()
 }
 

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -38,6 +38,8 @@ func initializeFlags(cmd *cobra.Command) {
 	singleDataFile = cmd.Flags().Bool("single-data-file", false, "Back up all data to a single file instead of one per table")
 	verbose = cmd.Flags().Bool("verbose", false, "Print verbose log messages")
 	withStats = cmd.Flags().Bool("with-stats", false, "Back up query plan statistics")
+
+	cmd.MarkFlagRequired("dbname")
 }
 
 // This function handles setup that can be done before parsing flags.

--- a/backup/backup_suite_test.go
+++ b/backup/backup_suite_test.go
@@ -6,18 +6,17 @@ package backup_test
  */
 
 import (
-	"os/exec"
 	"testing"
 
 	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
+	"github.com/greenplum-db/gpbackup/backup"
 	"github.com/greenplum-db/gpbackup/testutils"
 	"github.com/greenplum-db/gpbackup/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
-	"github.com/onsi/gomega/gexec"
 )
 
 var (
@@ -32,17 +31,6 @@ var (
 	backupfile   *utils.FileWithByteCount
 )
 
-/* This function is a helper function to execute gpbackup and return a session
- * to allow checking its output.
- */
-func gpbackup() *gexec.Session {
-	command := exec.Command(gpbackupPath, "-dbname", "testdb")
-	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
-	Expect(err).ShouldNot(HaveOccurred())
-	<-session.Exited
-	return session
-}
-
 func TestBackup(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "backup tests")
@@ -50,6 +38,10 @@ func TestBackup(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	connection, mock, stdout, stderr, logfile = testutils.SetupTestEnvironment()
+	backup.SetIncludeSchemas([]string{})
+	backup.SetExcludeSchemas([]string{})
+	backup.SetIncludeTables([]string{})
+	backup.SetExcludeTables([]string{})
 })
 
 var _ = BeforeEach(func() {

--- a/backup/backup_suite_test.go
+++ b/backup/backup_suite_test.go
@@ -20,15 +20,14 @@ import (
 )
 
 var (
-	connection   *dbconn.DBConn
-	mock         sqlmock.Sqlmock
-	stdout       *gbytes.Buffer
-	stderr       *gbytes.Buffer
-	logfile      *gbytes.Buffer
-	buffer       = gbytes.NewBuffer()
-	gpbackupPath = ""
-	toc          *utils.TOC
-	backupfile   *utils.FileWithByteCount
+	connection *dbconn.DBConn
+	mock       sqlmock.Sqlmock
+	stdout     *gbytes.Buffer
+	stderr     *gbytes.Buffer
+	logfile    *gbytes.Buffer
+	buffer     = gbytes.NewBuffer()
+	toc        *utils.TOC
+	backupfile *utils.FileWithByteCount
 )
 
 func TestBackup(t *testing.T) {

--- a/backup/global_variables.go
+++ b/backup/global_variables.go
@@ -74,11 +74,11 @@ func SetCluster(cluster cluster.Cluster) {
 }
 
 func SetExcludeSchemas(schemas []string) {
-	*excludeSchemas = schemas
+	excludeSchemas = &schemas
 }
 
 func SetExcludeTables(tables []string) {
-	*excludeTables = tables
+	excludeTables = &tables
 }
 
 func SetFPInfo(fpInfo utils.FilePathInfo) {
@@ -86,11 +86,11 @@ func SetFPInfo(fpInfo utils.FilePathInfo) {
 }
 
 func SetIncludeSchemas(schemas []string) {
-	*includeSchemas = schemas
+	includeSchemas = &schemas
 }
 
 func SetIncludeTables(tables []string) {
-	*includeTables = tables
+	includeTables = &tables
 }
 
 func SetLeafPartitionData(which bool) {

--- a/backup/global_variables.go
+++ b/backup/global_variables.go
@@ -54,7 +54,6 @@ var (
 	metadataOnly      *bool
 	noCompression     *bool
 	pluginConfigFile  *string
-	printVersion      *bool
 	quiet             *bool
 	singleDataFile    *bool
 	verbose           *bool

--- a/backup/global_variables.go
+++ b/backup/global_variables.go
@@ -44,12 +44,12 @@ var (
 	dataOnly          *bool
 	dbname            *string
 	debug             *bool
-	excludeSchemas    utils.ArrayFlags
+	excludeSchemas    *[]string
 	excludeTableFile  *string
-	excludeTables     utils.ArrayFlags
-	includeSchemas    utils.ArrayFlags
+	excludeTables     *[]string
+	includeSchemas    *[]string
 	includeTableFile  *string
-	includeTables     utils.ArrayFlags
+	includeTables     *[]string
 	leafPartitionData *bool
 	metadataOnly      *bool
 	noCompression     *bool
@@ -74,11 +74,11 @@ func SetCluster(cluster cluster.Cluster) {
 }
 
 func SetExcludeSchemas(schemas []string) {
-	excludeSchemas = schemas
+	*excludeSchemas = schemas
 }
 
 func SetExcludeTables(tables []string) {
-	excludeTables = tables
+	*excludeTables = tables
 }
 
 func SetFPInfo(fpInfo utils.FilePathInfo) {
@@ -86,11 +86,11 @@ func SetFPInfo(fpInfo utils.FilePathInfo) {
 }
 
 func SetIncludeSchemas(schemas []string) {
-	includeSchemas = schemas
+	*includeSchemas = schemas
 }
 
 func SetIncludeTables(tables []string) {
-	includeTables = tables
+	*includeTables = tables
 }
 
 func SetLeafPartitionData(which bool) {

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -17,12 +17,12 @@ import (
 
 func tableAndSchemaFilterClause() string {
 	filterClause := SchemaFilterClause("n")
-	if len(excludeTables) > 0 {
-		excludeOids := GetOidsFromTableList(connection, excludeTables)
+	if len(*excludeTables) > 0 {
+		excludeOids := GetOidsFromTableList(connection, *excludeTables)
 		filterClause += fmt.Sprintf("\nAND c.oid NOT IN (%s)", strings.Join(excludeOids, ", "))
 	}
-	if len(includeTables) > 0 {
-		includeOids := GetOidsFromTableList(connection, includeTables)
+	if len(*includeTables) > 0 {
+		includeOids := GetOidsFromTableList(connection, *includeTables)
 		filterClause += fmt.Sprintf("\nAND c.oid IN (%s)", strings.Join(includeOids, ", "))
 	}
 	return filterClause
@@ -40,7 +40,7 @@ WHERE quote_ident(n.nspname) || '.' || quote_ident(c.relname) IN (%s)`, tableLis
 }
 
 func GetAllUserTables(connection *dbconn.DBConn) []Relation {
-	if len(includeTables) > 0 {
+	if len(*includeTables) > 0 {
 		return GetUserTablesWithIncludeFiltering(connection)
 	}
 	return GetUserTables(connection)
@@ -86,7 +86,7 @@ ORDER BY c.oid;`, tableAndSchemaFilterClause(), childPartitionFilter)
 }
 
 func GetUserTablesWithIncludeFiltering(connection *dbconn.DBConn) []Relation {
-	includeOids := GetOidsFromTableList(connection, includeTables)
+	includeOids := GetOidsFromTableList(connection, *includeTables)
 	oidStr := strings.Join(includeOids, ", ")
 	childPartitionFilter := ""
 	if *leafPartitionData {
@@ -506,10 +506,10 @@ ORDER BY n.nspname, c.relname;`, SchemaFilterClause("n"))
 	gplog.FatalOnError(err)
 
 	var tableSet *utils.FilterSet
-	if len(excludeTables) > 0 {
-		tableSet = utils.NewExcludeSet(excludeTables)
-	} else if len(includeTables) > 0 {
-		tableSet = utils.NewIncludeSet(includeTables)
+	if len(*excludeTables) > 0 {
+		tableSet = utils.NewExcludeSet(*excludeTables)
+	} else if len(*includeTables) > 0 {
+		tableSet = utils.NewIncludeSet(*includeTables)
 	} else {
 		return results
 	}

--- a/backup/queries_shared.go
+++ b/backup/queries_shared.go
@@ -210,11 +210,11 @@ func InitializeMetadataParams(connection *dbconn.DBConn) {
 // A list of schemas we don't want to back up, formatted for use in a WHERE clause
 func SchemaFilterClause(namespace string) string {
 	schemaFilterClauseStr := ""
-	if len(includeSchemas) > 0 {
-		schemaFilterClauseStr = fmt.Sprintf("\nAND %s.nspname IN (%s)", namespace, utils.SliceToQuotedString(includeSchemas))
+	if len(*includeSchemas) > 0 {
+		schemaFilterClauseStr = fmt.Sprintf("\nAND %s.nspname IN (%s)", namespace, utils.SliceToQuotedString(*includeSchemas))
 	}
-	if len(excludeSchemas) > 0 {
-		schemaFilterClauseStr = fmt.Sprintf("\nAND %s.nspname NOT IN (%s)", namespace, utils.SliceToQuotedString(excludeSchemas))
+	if len(*excludeSchemas) > 0 {
+		schemaFilterClauseStr = fmt.Sprintf("\nAND %s.nspname NOT IN (%s)", namespace, utils.SliceToQuotedString(*excludeSchemas))
 	}
 	return fmt.Sprintf(`%s.nspname NOT LIKE 'pg_temp_%%' AND %s.nspname NOT LIKE 'pg_toast%%' AND %s.nspname NOT IN ('gp_toolkit', 'information_schema', 'pg_aoseg', 'pg_bitmapindex', 'pg_catalog') %s`, namespace, namespace, namespace, schemaFilterClauseStr)
 }

--- a/backup/validate.go
+++ b/backup/validate.go
@@ -21,7 +21,7 @@ func validateFilterLists() {
 	ValidateFilterTables(connection, *includeTables)
 }
 
-func ValidateFilterSchemas(connection *dbconn.DBConn, schemaList utils.ArrayFlags) {
+func ValidateFilterSchemas(connection *dbconn.DBConn, schemaList []string) {
 	if len(schemaList) > 0 {
 		quotedSchemasStr := utils.SliceToQuotedString(schemaList)
 		query := fmt.Sprintf("SELECT nspname AS string FROM pg_namespace WHERE nspname IN (%s)", quotedSchemasStr)
@@ -37,7 +37,7 @@ func ValidateFilterSchemas(connection *dbconn.DBConn, schemaList utils.ArrayFlag
 	}
 }
 
-func ValidateFilterTables(connection *dbconn.DBConn, tableList utils.ArrayFlags) {
+func ValidateFilterTables(connection *dbconn.DBConn, tableList []string) {
 	if len(tableList) > 0 {
 		utils.ValidateFQNs(tableList)
 		quotedTablesStr := utils.SliceToQuotedString(tableList)
@@ -73,15 +73,16 @@ WHERE quote_ident(n.nspname) || '.' || quote_ident(c.relname) IN (%s)`, quotedTa
 }
 
 func ValidateFlagCombinations(cmd *cobra.Command) {
-	utils.CheckExclusiveFlags(cmd, "debug", "quiet", "verbose")
-	utils.CheckExclusiveFlags(cmd, "data-only", "metadata-only")
-	utils.CheckExclusiveFlags(cmd, "include-schema", "include-table", "include-table-file")
-	utils.CheckExclusiveFlags(cmd, "exclude-schema", "include-schema")
-	utils.CheckExclusiveFlags(cmd, "exclude-schema", "exclude-table", "include-table", "exclude-table-file", "include-table-file")
-	utils.CheckExclusiveFlags(cmd, "exclude-table", "exclude-table-file", "leaf-partition-data")
-	utils.CheckExclusiveFlags(cmd, "metadata-only", "leaf-partition-data")
-	utils.CheckExclusiveFlags(cmd, "metadata-only", "single-data-file")
-	utils.CheckExclusiveFlags(cmd, "no-compression", "compression-level")
+	flags := cmd.Flags()
+	utils.CheckExclusiveFlags(flags, "debug", "quiet", "verbose")
+	utils.CheckExclusiveFlags(flags, "data-only", "metadata-only")
+	utils.CheckExclusiveFlags(flags, "include-schema", "include-table", "include-table-file")
+	utils.CheckExclusiveFlags(flags, "exclude-schema", "include-schema")
+	utils.CheckExclusiveFlags(flags, "exclude-schema", "exclude-table", "include-table", "exclude-table-file", "include-table-file")
+	utils.CheckExclusiveFlags(flags, "exclude-table", "exclude-table-file", "leaf-partition-data")
+	utils.CheckExclusiveFlags(flags, "metadata-only", "leaf-partition-data")
+	utils.CheckExclusiveFlags(flags, "metadata-only", "single-data-file")
+	utils.CheckExclusiveFlags(flags, "no-compression", "compression-level")
 	if *pluginConfigFile != "" && !(*singleDataFile || *metadataOnly) {
 		gplog.Fatal(errors.Errorf("--plugin-config must be specified with either --single-data-file or --metadata-only"), "")
 	}

--- a/backup/validate.go
+++ b/backup/validate.go
@@ -7,7 +7,7 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 /*
@@ -72,8 +72,7 @@ WHERE quote_ident(n.nspname) || '.' || quote_ident(c.relname) IN (%s)`, quotedTa
 	}
 }
 
-func ValidateFlagCombinations(cmd *cobra.Command) {
-	flags := cmd.Flags()
+func ValidateFlagCombinations(flags *pflag.FlagSet) {
 	utils.CheckExclusiveFlags(flags, "debug", "quiet", "verbose")
 	utils.CheckExclusiveFlags(flags, "data-only", "metadata-only")
 	utils.CheckExclusiveFlags(flags, "include-schema", "include-table", "include-table-file")

--- a/backup/validate.go
+++ b/backup/validate.go
@@ -73,8 +73,6 @@ WHERE quote_ident(n.nspname) || '.' || quote_ident(c.relname) IN (%s)`, quotedTa
 }
 
 func ValidateFlagCombinations(cmd *cobra.Command) {
-	utils.CheckMandatoryFlags(cmd, "dbname")
-
 	utils.CheckExclusiveFlags(cmd, "debug", "quiet", "verbose")
 	utils.CheckExclusiveFlags(cmd, "data-only", "metadata-only")
 	utils.CheckExclusiveFlags(cmd, "include-schema", "include-table", "include-table-file")

--- a/backup/validate.go
+++ b/backup/validate.go
@@ -7,6 +7,7 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 )
 
 /*
@@ -14,10 +15,10 @@ import (
  */
 
 func validateFilterLists() {
-	ValidateFilterSchemas(connection, excludeSchemas)
-	ValidateFilterSchemas(connection, includeSchemas)
-	ValidateFilterTables(connection, excludeTables)
-	ValidateFilterTables(connection, includeTables)
+	ValidateFilterSchemas(connection, *excludeSchemas)
+	ValidateFilterSchemas(connection, *includeSchemas)
+	ValidateFilterTables(connection, *excludeTables)
+	ValidateFilterTables(connection, *includeTables)
 }
 
 func ValidateFilterSchemas(connection *dbconn.DBConn, schemaList utils.ArrayFlags) {
@@ -71,18 +72,18 @@ WHERE quote_ident(n.nspname) || '.' || quote_ident(c.relname) IN (%s)`, quotedTa
 	}
 }
 
-func ValidateFlagCombinations() {
-	utils.CheckMandatoryFlags("dbname")
+func ValidateFlagCombinations(cmd *cobra.Command) {
+	utils.CheckMandatoryFlags(cmd, "dbname")
 
-	utils.CheckExclusiveFlags("debug", "quiet", "verbose")
-	utils.CheckExclusiveFlags("data-only", "metadata-only")
-	utils.CheckExclusiveFlags("include-schema", "include-table", "include-table-file")
-	utils.CheckExclusiveFlags("exclude-schema", "include-schema")
-	utils.CheckExclusiveFlags("exclude-schema", "exclude-table", "include-table", "exclude-table-file", "include-table-file")
-	utils.CheckExclusiveFlags("exclude-table", "exclude-table-file", "leaf-partition-data")
-	utils.CheckExclusiveFlags("metadata-only", "leaf-partition-data")
-	utils.CheckExclusiveFlags("metadata-only", "single-data-file")
-	utils.CheckExclusiveFlags("no-compression", "compression-level")
+	utils.CheckExclusiveFlags(cmd, "debug", "quiet", "verbose")
+	utils.CheckExclusiveFlags(cmd, "data-only", "metadata-only")
+	utils.CheckExclusiveFlags(cmd, "include-schema", "include-table", "include-table-file")
+	utils.CheckExclusiveFlags(cmd, "exclude-schema", "include-schema")
+	utils.CheckExclusiveFlags(cmd, "exclude-schema", "exclude-table", "include-table", "exclude-table-file", "include-table-file")
+	utils.CheckExclusiveFlags(cmd, "exclude-table", "exclude-table-file", "leaf-partition-data")
+	utils.CheckExclusiveFlags(cmd, "metadata-only", "leaf-partition-data")
+	utils.CheckExclusiveFlags(cmd, "metadata-only", "single-data-file")
+	utils.CheckExclusiveFlags(cmd, "no-compression", "compression-level")
 	if *pluginConfigFile != "" && !(*singleDataFile || *metadataOnly) {
 		gplog.Fatal(errors.Errorf("--plugin-config must be specified with either --single-data-file or --metadata-only"), "")
 	}

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -72,19 +72,19 @@ func InitializeBackupReport() {
 		BackupConfig: config,
 	}
 	utils.InitializeCompressionParameters(!*noCompression, *compressionLevel)
-	isIncludeSchemaFiltered := len(includeSchemas) > 0
-	isIncludeTableFiltered := len(includeTables) > 0
-	isExcludeSchemaFiltered := len(excludeSchemas) > 0
-	isExcludeTableFiltered := len(excludeTables) > 0
+	isIncludeSchemaFiltered := len(*includeSchemas) > 0
+	isIncludeTableFiltered := len(*includeTables) > 0
+	isExcludeSchemaFiltered := len(*excludeSchemas) > 0
+	isExcludeTableFiltered := len(*excludeTables) > 0
 	backupReport.SetBackupParamsFromFlags(*dataOnly, *metadataOnly, "", isIncludeSchemaFiltered, isIncludeTableFiltered, isExcludeSchemaFiltered, isExcludeTableFiltered, *singleDataFile, *withStats)
 }
 
 func InitializeFilterLists() {
 	if *excludeTableFile != "" {
-		excludeTables = iohelper.MustReadLinesFromFile(*excludeTableFile)
+		*excludeTables = iohelper.MustReadLinesFromFile(*excludeTableFile)
 	}
 	if *includeTableFile != "" {
-		includeTables = iohelper.MustReadLinesFromFile(*includeTableFile)
+		*includeTables = iohelper.MustReadLinesFromFile(*includeTableFile)
 	}
 }
 
@@ -110,13 +110,13 @@ func RetrieveAndProcessTables() ([]Relation, []Relation, map[uint32]TableDefinit
 	 * We expand the includeTables list to include parent and leaf partitions that may not have been
 	 * specified by the user but are used in the backup for metadata or data.
 	 */
-	userPassedIncludeTables := includeTables
-	if len(includeTables) > 0 {
+	userPassedIncludeTables := *includeTables
+	if len(*includeTables) > 0 {
 		expandedIncludeTables := make([]string, 0)
 		for _, table := range tables {
 			expandedIncludeTables = append(expandedIncludeTables, table.FQN())
 		}
-		includeTables = expandedIncludeTables
+		*includeTables = expandedIncludeTables
 	}
 	tableDefs := ConstructDefinitionsForTables(connection, tables)
 	metadataTables, dataTables := SplitTablesByPartitionType(tables, tableDefs, userPassedIncludeTables)

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -500,7 +500,6 @@ var _ = Describe("backup end to end integration tests", func() {
 
 			os.RemoveAll(backupdir)
 		})
-
 		It("runs example_plugin.sh with plugin_test_bench", func() {
 			pluginsDir := fmt.Sprintf("%s/go/src/github.com/greenplum-db/gpbackup/plugins", os.Getenv("HOME"))
 			copyPluginToAllHosts(backupConn, fmt.Sprintf("%s/example_plugin.sh", pluginsDir))
@@ -511,6 +510,22 @@ var _ = Describe("backup end to end integration tests", func() {
 			}
 
 			os.RemoveAll("/tmp/plugin_dest")
+		})
+		It("runs gpbackup with --version flag", func() {
+			output, err := exec.Command(gpbackupPath, "--version").CombinedOutput()
+			if err != nil {
+				fmt.Printf("%s", output)
+				Fail(fmt.Sprintf("%v", err))
+			}
+			Expect(string(output)).To(MatchRegexp(`gpbackup version \w+`))
+		})
+		It("runs gprestore with --version flag", func() {
+			output, err := exec.Command(gprestorePath, "--version").CombinedOutput()
+			if err != nil {
+				fmt.Printf("%s", output)
+				Fail(fmt.Sprintf("%v", err))
+			}
+			Expect(string(output)).To(MatchRegexp(`gprestore version \w+`))
 		})
 
 	})

--- a/gpbackup.go
+++ b/gpbackup.go
@@ -4,9 +4,9 @@ package main
 
 import (
 	"os"
-	"regexp"
 
 	. "github.com/greenplum-db/gpbackup/backup"
+	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -21,19 +21,9 @@ func main() {
 			DoSetup()
 			DoBackup()
 		}}
-	rootCmd.SetArgs(handleSingleDashes(os.Args[1:]))
+	rootCmd.SetArgs(utils.HandleSingleDashes(os.Args[1:]))
 	DoInit(rootCmd)
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(2)
 	}
-}
-
-func handleSingleDashes(args []string) []string {
-	r, _ := regexp.Compile(`^-(\w{2,})`)
-	var newArgs []string
-	for _, arg := range args {
-		newArg := r.ReplaceAllString(arg, "--$1")
-		newArgs = append(newArgs, newArg)
-	}
-	return newArgs
 }

--- a/gpbackup.go
+++ b/gpbackup.go
@@ -3,13 +3,39 @@
 package main
 
 import (
+	"os"
+	"regexp"
+
 	. "github.com/greenplum-db/gpbackup/backup"
+	"github.com/spf13/cobra"
 )
 
 func main() {
-	defer DoTeardown()
-	DoInit()
-	DoFlagValidation()
-	DoSetup()
-	DoBackup()
+	var rootCmd = &cobra.Command{
+		Use:   "gpbackup",
+		Short: "gpbackup is parallel backup utility for Greenplum",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			defer DoTeardown()
+			DoFlagValidation(cmd)
+			DoSetup()
+			DoBackup()
+		}}
+	rootCmd.SetArgs(handleSingleDashes(os.Args[1:]))
+	DoInit(rootCmd)
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(2)
+	}
+
+}
+
+func handleSingleDashes(args []string) []string {
+	r, _ := regexp.Compile(`^-(\w{2,})`)
+	var newArgs []string
+	for _, arg := range args {
+		newArg := r.ReplaceAllString(arg, "--$1")
+		newArgs = append(newArgs, newArg)
+	}
+
+	return newArgs
 }

--- a/gpbackup.go
+++ b/gpbackup.go
@@ -13,7 +13,7 @@ import (
 func main() {
 	var rootCmd = &cobra.Command{
 		Use:   "gpbackup",
-		Short: "gpbackup is parallel backup utility for Greenplum",
+		Short: "gpbackup is the parallel backup utility for Greenplum",
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			defer DoTeardown()
@@ -26,7 +26,6 @@ func main() {
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(2)
 	}
-
 }
 
 func handleSingleDashes(args []string) []string {
@@ -36,6 +35,5 @@ func handleSingleDashes(args []string) []string {
 		newArg := r.ReplaceAllString(arg, "--$1")
 		newArgs = append(newArgs, newArg)
 	}
-
 	return newArgs
 }

--- a/gpbackup.go
+++ b/gpbackup.go
@@ -12,9 +12,10 @@ import (
 
 func main() {
 	var rootCmd = &cobra.Command{
-		Use:   "gpbackup",
-		Short: "gpbackup is the parallel backup utility for Greenplum",
-		Args:  cobra.NoArgs,
+		Use:     "gpbackup",
+		Short:   "gpbackup is the parallel backup utility for Greenplum",
+		Args:    cobra.NoArgs,
+		Version: GetVersion(),
 		Run: func(cmd *cobra.Command, args []string) {
 			defer DoTeardown()
 			DoFlagValidation(cmd)

--- a/gprestore.go
+++ b/gprestore.go
@@ -4,9 +4,9 @@ package main
 
 import (
 	"os"
-	"regexp"
 
 	. "github.com/greenplum-db/gpbackup/restore"
+	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -21,19 +21,9 @@ func main() {
 			DoSetup()
 			DoRestore()
 		}}
-	rootCmd.SetArgs(handleSingleDashes(os.Args[1:]))
+	rootCmd.SetArgs(utils.HandleSingleDashes(os.Args[1:]))
 	DoInit(rootCmd)
 	if err := rootCmd.Execute(); err != nil {
 		os.Exit(2)
 	}
-}
-
-func handleSingleDashes(args []string) []string {
-	r, _ := regexp.Compile(`^-(\w{2,})`)
-	var newArgs []string
-	for _, arg := range args {
-		newArg := r.ReplaceAllString(arg, "--$1")
-		newArgs = append(newArgs, newArg)
-	}
-	return newArgs
 }

--- a/gprestore.go
+++ b/gprestore.go
@@ -12,9 +12,10 @@ import (
 
 func main() {
 	var rootCmd = &cobra.Command{
-		Use:   "gprestore",
-		Short: "gprestore is the parallel restore utility for Greenplum",
-		Args:  cobra.NoArgs,
+		Use:     "gprestore",
+		Short:   "gprestore is the parallel restore utility for Greenplum",
+		Args:    cobra.NoArgs,
+		Version: GetVersion(),
 		Run: func(cmd *cobra.Command, args []string) {
 			defer DoTeardown()
 			DoValidation(cmd)

--- a/gprestore.go
+++ b/gprestore.go
@@ -3,13 +3,37 @@
 package main
 
 import (
+	"os"
+	"regexp"
+
 	. "github.com/greenplum-db/gpbackup/restore"
+	"github.com/spf13/cobra"
 )
 
 func main() {
-	defer DoTeardown()
-	DoInit()
-	DoValidation()
-	DoSetup()
-	DoRestore()
+	var rootCmd = &cobra.Command{
+		Use:   "gprestore",
+		Short: "gprestore is the parallel restore utility for Greenplum",
+		Args:  cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			defer DoTeardown()
+			DoValidation(cmd)
+			DoSetup()
+			DoRestore()
+		}}
+	rootCmd.SetArgs(handleSingleDashes(os.Args[1:]))
+	DoInit(rootCmd)
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(2)
+	}
+}
+
+func handleSingleDashes(args []string) []string {
+	r, _ := regexp.Compile(`^-(\w{2,})`)
+	var newArgs []string
+	for _, arg := range args {
+		newArg := r.ReplaceAllString(arg, "--$1")
+		newArgs = append(newArgs, newArg)
+	}
+	return newArgs
 }

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -72,6 +72,7 @@ var _ = BeforeSuite(func() {
 
 var _ = BeforeEach(func() {
 	buffer = bytes.NewBuffer([]byte(""))
+	backup.SetExcludeSchemas([]string{})
 	backup.SetIncludeSchemas([]string{})
 	backup.SetExcludeTables([]string{})
 	backup.SetIncludeTables([]string{})

--- a/restore/global_variables.go
+++ b/restore/global_variables.go
@@ -55,7 +55,6 @@ var (
 	numJobs          *int
 	onErrorContinue  *bool
 	pluginConfigFile *string
-	printVersion     *bool
 	quiet            *bool
 	redirect         *string
 	restoreGlobals   *bool

--- a/restore/global_variables.go
+++ b/restore/global_variables.go
@@ -45,13 +45,12 @@ var (
 	createDB         *bool
 	dataOnly         *bool
 	debug            *bool
-	excludeSchemas   utils.ArrayFlags
+	excludeSchemas   *[]string
 	excludeTableFile *string
-	excludeTables    utils.ArrayFlags
-	includeSchemas   utils.ArrayFlags
+	excludeTables    *[]string
+	includeSchemas   *[]string
 	includeTableFile *string
-	includeTables    utils.ArrayFlags
-	metadataOnly     *bool
+	includeTables    *[]string
 	numJobs          *int
 	onErrorContinue  *bool
 	pluginConfigFile *string

--- a/restore/global_variables.go
+++ b/restore/global_variables.go
@@ -51,6 +51,7 @@ var (
 	includeSchemas   *[]string
 	includeTableFile *string
 	includeTables    *[]string
+	metadataOnly     *bool
 	numJobs          *int
 	onErrorContinue  *bool
 	pluginConfigFile *string

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -35,14 +35,15 @@ func initializeFlags(cmd *cobra.Command) {
 	numJobs = cmd.Flags().Int("jobs", 1, "Number of parallel connections to use when restoring table data and post-data")
 	onErrorContinue = cmd.Flags().Bool("on-error-continue", false, "Log errors and continue restore, instead of exiting on first error")
 	pluginConfigFile = cmd.Flags().String("plugin-config", "", "The configuration file to use for a plugin")
-	printVersion = cmd.Flags().Bool("version", false, "Print version number and exit")
+	cmd.Flags().Bool("version", false, "Print version number and exit")
 	quiet = cmd.Flags().Bool("quiet", false, "Suppress non-warning, non-error log messages")
 	redirect = cmd.Flags().String("redirect-db", "", "Restore to the specified database instead of the database that was backed up")
 	restoreGlobals = cmd.Flags().Bool("with-globals", false, "Restore global metadata")
 	timestamp = cmd.Flags().String("timestamp", "", "The timestamp to be restored, in the format YYYYMMDDHHMMSS")
 	verbose = cmd.Flags().Bool("verbose", false, "Print verbose log messages")
 	withStats = cmd.Flags().Bool("with-stats", false, "Restore query plan statistics")
-	cmd.MarkFlagRequired("timestamp")
+
+	_ = cmd.MarkFlagRequired("timestamp")
 }
 
 // This function handles setup that can be done before parsing flags.
@@ -59,10 +60,6 @@ func DoInit(cmd *cobra.Command) {
 * It should only validate; initialization with any sort of side effects should go in DoInit or DoSetup.
  */
 func DoValidation(cmd *cobra.Command) {
-	if *printVersion {
-		fmt.Printf("gprestore %s\n", version)
-		os.Exit(0)
-	}
 	ValidateFlagCombinations(cmd.Flags())
 	utils.ValidateFullPath(*backupDir)
 	utils.ValidateFullPath(*pluginConfigFile)
@@ -344,4 +341,8 @@ func DoCleanup() {
 	if connection != nil {
 		connection.Close()
 	}
+}
+
+func GetVersion() string {
+	return version
 }

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -63,7 +63,7 @@ func DoValidation(cmd *cobra.Command) {
 		fmt.Printf("gprestore %s\n", version)
 		os.Exit(0)
 	}
-	ValidateFlagCombinations(cmd)
+	ValidateFlagCombinations(cmd.Flags())
 	utils.ValidateFullPath(*backupDir)
 	utils.ValidateFullPath(*pluginConfigFile)
 	if !utils.IsValidTimestamp(*timestamp) {

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -42,6 +42,7 @@ func initializeFlags(cmd *cobra.Command) {
 	timestamp = cmd.Flags().String("timestamp", "", "The timestamp to be restored, in the format YYYYMMDDHHMMSS")
 	verbose = cmd.Flags().Bool("verbose", false, "Print verbose log messages")
 	withStats = cmd.Flags().Bool("with-stats", false, "Restore query plan statistics")
+	cmd.MarkFlagRequired("timestamp")
 }
 
 // This function handles setup that can be done before parsing flags.

--- a/restore/validate.go
+++ b/restore/validate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 )
 
 /*
@@ -16,8 +17,8 @@ import (
  */
 
 func validateFilterListsInBackupSet() {
-	ValidateFilterSchemasInBackupSet(includeSchemas)
-	ValidateFilterTablesInBackupSet(includeTables)
+	ValidateFilterSchemasInBackupSet(*includeSchemas)
+	ValidateFilterTablesInBackupSet(*includeTables)
 }
 
 func ValidateFilterSchemasInBackupSet(schemaList utils.ArrayFlags) {
@@ -160,14 +161,14 @@ func validateBackupFlagPluginCombinations() {
 	}
 }
 
-func ValidateFlagCombinations() {
-	//	utils.CheckMandatoryFlags("timestamp")
-	// utils.CheckExclusiveFlags("data-only", "with-globals")
-	// utils.CheckExclusiveFlags("data-only", "create-db")
-	// utils.CheckExclusiveFlags("debug", "quiet", "verbose")
-	// utils.CheckExclusiveFlags("include-schema", "include-table", "include-table-file")
-	// utils.CheckExclusiveFlags("exclude-schema", "include-schema")
-	// utils.CheckExclusiveFlags("exclude-schema", "exclude-table", "include-table", "exclude-table-file", "include-table-file")
-	// utils.CheckExclusiveFlags("exclude-table", "exclude-table-file", "leaf-partition-data")
-	// utils.CheckExclusiveFlags("metadata-only", "data-only")
+func ValidateFlagCombinations(cmd *cobra.Command) {
+	utils.CheckMandatoryFlags(cmd, "timestamp")
+	utils.CheckExclusiveFlags(cmd, "data-only", "with-globals")
+	utils.CheckExclusiveFlags(cmd, "data-only", "create-db")
+	utils.CheckExclusiveFlags(cmd, "debug", "quiet", "verbose")
+	utils.CheckExclusiveFlags(cmd, "include-schema", "include-table", "include-table-file")
+	utils.CheckExclusiveFlags(cmd, "exclude-schema", "include-schema")
+	utils.CheckExclusiveFlags(cmd, "exclude-schema", "exclude-table", "include-table", "exclude-table-file", "include-table-file")
+	utils.CheckExclusiveFlags(cmd, "exclude-table", "exclude-table-file", "leaf-partition-data")
+	utils.CheckExclusiveFlags(cmd, "metadata-only", "data-only")
 }

--- a/restore/validate.go
+++ b/restore/validate.go
@@ -9,7 +9,7 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 /*
@@ -161,8 +161,7 @@ func validateBackupFlagPluginCombinations() {
 	}
 }
 
-func ValidateFlagCombinations(cmd *cobra.Command) {
-	flags := cmd.Flags()
+func ValidateFlagCombinations(flags *pflag.FlagSet) {
 	utils.CheckExclusiveFlags(flags, "data-only", "with-globals")
 	utils.CheckExclusiveFlags(flags, "data-only", "create-db")
 	utils.CheckExclusiveFlags(flags, "debug", "quiet", "verbose")

--- a/restore/validate.go
+++ b/restore/validate.go
@@ -161,13 +161,13 @@ func validateBackupFlagPluginCombinations() {
 }
 
 func ValidateFlagCombinations() {
-	utils.CheckMandatoryFlags("timestamp")
-	utils.CheckExclusiveFlags("data-only", "with-globals")
-	utils.CheckExclusiveFlags("data-only", "create-db")
-	utils.CheckExclusiveFlags("debug", "quiet", "verbose")
-	utils.CheckExclusiveFlags("include-schema", "include-table", "include-table-file")
-	utils.CheckExclusiveFlags("exclude-schema", "include-schema")
-	utils.CheckExclusiveFlags("exclude-schema", "exclude-table", "include-table", "exclude-table-file", "include-table-file")
-	utils.CheckExclusiveFlags("exclude-table", "exclude-table-file", "leaf-partition-data")
-	utils.CheckExclusiveFlags("metadata-only", "data-only")
+	//	utils.CheckMandatoryFlags("timestamp")
+	// utils.CheckExclusiveFlags("data-only", "with-globals")
+	// utils.CheckExclusiveFlags("data-only", "create-db")
+	// utils.CheckExclusiveFlags("debug", "quiet", "verbose")
+	// utils.CheckExclusiveFlags("include-schema", "include-table", "include-table-file")
+	// utils.CheckExclusiveFlags("exclude-schema", "include-schema")
+	// utils.CheckExclusiveFlags("exclude-schema", "exclude-table", "include-table", "exclude-table-file", "include-table-file")
+	// utils.CheckExclusiveFlags("exclude-table", "exclude-table-file", "leaf-partition-data")
+	// utils.CheckExclusiveFlags("metadata-only", "data-only")
 }

--- a/restore/validate.go
+++ b/restore/validate.go
@@ -21,7 +21,7 @@ func validateFilterListsInBackupSet() {
 	ValidateFilterTablesInBackupSet(*includeTables)
 }
 
-func ValidateFilterSchemasInBackupSet(schemaList utils.ArrayFlags) {
+func ValidateFilterSchemasInBackupSet(schemaList []string) {
 	schemaMap := make(map[string]bool, len(schemaList))
 	for _, schema := range schemaList {
 		schemaMap[schema] = true
@@ -59,7 +59,7 @@ func ValidateFilterSchemasInBackupSet(schemaList utils.ArrayFlags) {
 	gplog.Fatal(errors.Errorf("Could not find the following schema(s) in the backup set: %s", strings.Join(keys, ", ")), "")
 }
 
-func ValidateFilterTablesInRestoreDatabase(connection *dbconn.DBConn, tableList utils.ArrayFlags) {
+func ValidateFilterTablesInRestoreDatabase(connection *dbconn.DBConn, tableList []string) {
 	if len(tableList) > 0 {
 		utils.ValidateFQNs(tableList)
 		quotedTablesStr := utils.SliceToQuotedString(tableList)
@@ -76,7 +76,7 @@ WHERE quote_ident(n.nspname) || '.' || quote_ident(c.relname) IN (%s)`, quotedTa
 	}
 }
 
-func ValidateFilterTablesInBackupSet(tableList utils.ArrayFlags) {
+func ValidateFilterTablesInBackupSet(tableList []string) {
 	tableMap := make(map[string]bool, len(tableList))
 	for _, table := range tableList {
 		tableMap[table] = true
@@ -162,13 +162,13 @@ func validateBackupFlagPluginCombinations() {
 }
 
 func ValidateFlagCombinations(cmd *cobra.Command) {
-	utils.CheckMandatoryFlags(cmd, "timestamp")
-	utils.CheckExclusiveFlags(cmd, "data-only", "with-globals")
-	utils.CheckExclusiveFlags(cmd, "data-only", "create-db")
-	utils.CheckExclusiveFlags(cmd, "debug", "quiet", "verbose")
-	utils.CheckExclusiveFlags(cmd, "include-schema", "include-table", "include-table-file")
-	utils.CheckExclusiveFlags(cmd, "exclude-schema", "include-schema")
-	utils.CheckExclusiveFlags(cmd, "exclude-schema", "exclude-table", "include-table", "exclude-table-file", "include-table-file")
-	utils.CheckExclusiveFlags(cmd, "exclude-table", "exclude-table-file", "leaf-partition-data")
-	utils.CheckExclusiveFlags(cmd, "metadata-only", "data-only")
+	flags := cmd.Flags()
+	utils.CheckExclusiveFlags(flags, "data-only", "with-globals")
+	utils.CheckExclusiveFlags(flags, "data-only", "create-db")
+	utils.CheckExclusiveFlags(flags, "debug", "quiet", "verbose")
+	utils.CheckExclusiveFlags(flags, "include-schema", "include-table", "include-table-file")
+	utils.CheckExclusiveFlags(flags, "exclude-schema", "include-schema")
+	utils.CheckExclusiveFlags(flags, "exclude-schema", "exclude-table", "include-table", "exclude-table-file", "include-table-file")
+	utils.CheckExclusiveFlags(flags, "exclude-table", "exclude-table-file", "leaf-partition-data")
+	utils.CheckExclusiveFlags(flags, "metadata-only", "data-only")
 }

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -63,10 +63,10 @@ func InitializeBackupConfig() {
 
 func InitializeFilterLists() {
 	if *excludeTableFile != "" {
-		excludeTables = iohelper.MustReadLinesFromFile(*excludeTableFile)
+		*excludeTables = iohelper.MustReadLinesFromFile(*excludeTableFile)
 	}
 	if *includeTableFile != "" {
-		includeTables = iohelper.MustReadLinesFromFile(*includeTableFile)
+		*includeTables = iohelper.MustReadLinesFromFile(*includeTableFile)
 	}
 }
 
@@ -117,12 +117,12 @@ func GetRestoreMetadataStatements(section string, filename string, includeObject
 	if len(includeObjectTypes) > 0 || len(excludeObjectTypes) > 0 || filterSchemas || filterTables {
 		var inSchemas, exSchemas, inTables, exTables []string
 		if filterSchemas {
-			inSchemas = includeSchemas
-			exSchemas = excludeSchemas
+			inSchemas = *includeSchemas
+			exSchemas = *excludeSchemas
 		}
 		if filterTables {
-			inTables = includeTables
-			exTables = excludeTables
+			inTables = *includeTables
+			exTables = *excludeTables
 		}
 		statements = globalTOC.GetSQLStatementForObjectTypes(section, metadataFile, includeObjectTypes, excludeObjectTypes, inSchemas, exSchemas, inTables, exTables)
 	} else {

--- a/utils/flag.go
+++ b/utils/flag.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/pkg/errors"
-	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 /*
@@ -18,27 +18,16 @@ import (
  */
 
 // At most one of the flags passed to this function may be set
-func CheckExclusiveFlags(cmd *cobra.Command, flagNames ...string) {
+func CheckExclusiveFlags(flags *pflag.FlagSet, flagNames ...string) {
 	numSet := 0
 	for _, name := range flagNames {
-		if cmd.Flags().Changed(name) {
+		if flags.Changed(name) {
 			numSet++
 		}
 	}
 	if numSet > 1 {
 		gplog.Fatal(errors.Errorf("The following flags may not be specified together: %s", strings.Join(flagNames, ", ")), "")
 	}
-}
-
-type ArrayFlags []string
-
-func (i *ArrayFlags) String() string {
-	return strings.Join(*i, ", ")
-}
-
-func (i *ArrayFlags) Set(value string) error {
-	*i = append(*i, value)
-	return nil
 }
 
 /*

--- a/utils/flag.go
+++ b/utils/flag.go
@@ -43,3 +43,17 @@ func IsValidTimestamp(timestamp string) bool {
 	timestampFormat := regexp.MustCompile(`^([0-9]{14})$`)
 	return timestampFormat.MatchString(timestamp)
 }
+
+/*
+ * Convert arguements that contain a single dash to double dashes for backward
+ * compatibility.
+ */
+func HandleSingleDashes(args []string) []string {
+	r, _ := regexp.Compile(`^-(\w{2,})`)
+	var newArgs []string
+	for _, arg := range args {
+		newArg := r.ReplaceAllString(arg, "--$1")
+		newArgs = append(newArgs, newArg)
+	}
+	return newArgs
+}

--- a/utils/flag.go
+++ b/utils/flag.go
@@ -45,7 +45,7 @@ func IsValidTimestamp(timestamp string) bool {
 }
 
 /*
- * Convert arguements that contain a single dash to double dashes for backward
+ * Convert arguments that contain a single dash to double dashes for backward
  * compatibility.
  */
 func HandleSingleDashes(args []string) []string {

--- a/utils/flag.go
+++ b/utils/flag.go
@@ -17,15 +17,6 @@ import (
  * Functions for validating whether flags are set and in what combination
  */
 
-// Each flag passed to this function must be set
-func CheckMandatoryFlags(cmd *cobra.Command, flagNames ...string) {
-	for _, name := range flagNames {
-		if !cmd.Flags().Changed(name) {
-			gplog.Fatal(errors.Errorf("Flag %s must be set", name), "")
-		}
-	}
-}
-
 // At most one of the flags passed to this function may be set
 func CheckExclusiveFlags(cmd *cobra.Command, flagNames ...string) {
 	numSet := 0

--- a/utils/flag.go
+++ b/utils/flag.go
@@ -5,38 +5,32 @@ package utils
  */
 
 import (
-	"flag"
 	"regexp"
 	"strings"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
 )
 
 /*
  * Functions for validating whether flags are set and in what combination
  */
 
-func FlagIsSet(f *flag.Flag) bool {
-	return (*f).Value.String() != (*f).DefValue
-}
-
 // Each flag passed to this function must be set
-func CheckMandatoryFlags(flagNames ...string) {
+func CheckMandatoryFlags(cmd *cobra.Command, flagNames ...string) {
 	for _, name := range flagNames {
-		f := flag.Lookup(name)
-		if f == nil || !FlagIsSet(f) {
+		if !cmd.Flags().Changed(name) {
 			gplog.Fatal(errors.Errorf("Flag %s must be set", name), "")
 		}
 	}
 }
 
 // At most one of the flags passed to this function may be set
-func CheckExclusiveFlags(flagNames ...string) {
+func CheckExclusiveFlags(cmd *cobra.Command, flagNames ...string) {
 	numSet := 0
 	for _, name := range flagNames {
-		f := flag.Lookup(name)
-		if f != nil && FlagIsSet(f) {
+		if cmd.Flags().Changed(name) {
 			numSet++
 		}
 	}

--- a/utils/flag_test.go
+++ b/utils/flag_test.go
@@ -40,17 +40,6 @@ var _ = Describe("utils/flag tests", func() {
 			_ = flag.Bool("boolFlag", false, "This is a sample bool flag.")
 			_ = flag.Int("intFlag", 0, "This is a sample int flag.")
 		})
-		Context("CheckMandatoryFlags", func() {
-			It("does not panic if a mandatory flag is set", func() {
-				flag.CommandLine.Parse([]string{"-stringFlag", "foo"})
-				utils.CheckMandatoryFlags("stringFlag")
-			})
-			It("panics if a mandatory flag is not set", func() {
-				flag.CommandLine.Parse([]string{})
-				defer testhelper.ShouldPanicWithMessage("Flag stringFlag must be set")
-				utils.CheckMandatoryFlags("stringFlag")
-			})
-		})
 		Context("CheckExclusiveFlags", func() {
 			It("does not panic if no flags in the argument list are set", func() {
 				flag.CommandLine.Parse([]string{})

--- a/utils/flag_test.go
+++ b/utils/flag_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup/utils"
+	"github.com/spf13/pflag"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -34,29 +35,30 @@ var _ = Describe("utils/flag tests", func() {
 		})
 	})
 	Context("Flag parsing functions ", func() {
+		var flagSet *pflag.FlagSet
 		BeforeEach(func() {
-			flag.CommandLine = flag.NewFlagSet("", flag.ContinueOnError)
-			_ = flag.String("stringFlag", "", "This is a sample string flag.")
-			_ = flag.Bool("boolFlag", false, "This is a sample bool flag.")
-			_ = flag.Int("intFlag", 0, "This is a sample int flag.")
+			flagSet = pflag.NewFlagSet("testFlags", pflag.ContinueOnError)
+			_ = flagSet.String("stringFlag", "", "This is a sample string flag.")
+			_ = flagSet.Bool("boolFlag", false, "This is a sample bool flag.")
+			_ = flagSet.Int("intFlag", 0, "This is a sample int flag.")
 		})
 		Context("CheckExclusiveFlags", func() {
 			It("does not panic if no flags in the argument list are set", func() {
 				flag.CommandLine.Parse([]string{})
-				utils.CheckExclusiveFlags("stringFlag", "boolFlag")
+				utils.CheckExclusiveFlags(flagSet, "boolFlag")
 			})
 			It("does not panic if one flags in the argument list is set", func() {
-				flag.CommandLine.Parse([]string{"-stringFlag", "foo"})
-				utils.CheckExclusiveFlags("stringFlag", "boolFlag")
+				flagSet.Parse([]string{"--stringFlag", "foo"})
+				utils.CheckExclusiveFlags(flagSet, "boolFlag")
 			})
 			It("does not panic if one flags in the argument list is set with flags not in the set", func() {
-				flag.CommandLine.Parse([]string{"-stringFlag", "foo", "-intFlag", "42"})
-				utils.CheckExclusiveFlags("stringFlag", "boolFlag")
+				flagSet.Parse([]string{"--stringFlag", "foo", "--intFlag", "42"})
+				utils.CheckExclusiveFlags(flagSet, "boolFlag")
 			})
 			It("panics if two or more flags in the argument list are set", func() {
-				flag.CommandLine.Parse([]string{"-stringFlag", "foo", "-boolFlag"})
+				flagSet.Parse([]string{"--stringFlag", "foo", "--boolFlag"})
 				defer testhelper.ShouldPanicWithMessage("The following flags may not be specified together: stringFlag, boolFlag")
-				utils.CheckExclusiveFlags("stringFlag", "boolFlag")
+				utils.CheckExclusiveFlags(flagSet, "stringFlag", "boolFlag")
 			})
 		})
 	})

--- a/utils/flag_test.go
+++ b/utils/flag_test.go
@@ -61,5 +61,23 @@ var _ = Describe("utils/flag tests", func() {
 				utils.CheckExclusiveFlags(flagSet, "stringFlag", "boolFlag")
 			})
 		})
+		Context("HandleSingleDashes", func() {
+			It("replaces single dash at beginning of command", func() {
+				result := utils.HandleSingleDashes([]string{"-some_flag", "some_argument"})
+				Expect(result).To(Equal([]string{"--some_flag", "some_argument"}))
+			})
+			It("does not replace single dashes inside command", func() {
+				result := utils.HandleSingleDashes([]string{"-some-flag", "some_argument"})
+				Expect(result).To(Equal([]string{"--some-flag", "some_argument"}))
+			})
+			It("does not replace double dashes", func() {
+				result := utils.HandleSingleDashes([]string{"--some_flag", "some_argument"})
+				Expect(result).To(Equal([]string{"--some_flag", "some_argument"}))
+			})
+			It("does not replace dash for single character flag", func() {
+				result := utils.HandleSingleDashes([]string{"-s", "some_argument"})
+				Expect(result).To(Equal([]string{"-s", "some_argument"}))
+			})
+		})
 	})
 })


### PR DESCRIPTION
This set of commits migrates the gpbackup and gprestore utilities to use Cobra (https://github.com/spf13/cobra), which supports POSIX-compliant flags and allows us to support more complex CLI features in the future. We continue to support single dashes for flags (-flag) for backwards compatibility. This set of commits only changes the help UI, there is no change in functionality of the utilities.

I did not modify gpbackup_helper in this PR, as it is not user facing. However, we can also migrate it to use Cobra if we want.

New help UI:
```
gpbackup is the parallel backup utility for Greenplum

Usage:
  gpbackup [flags]

Flags:
      --backup-dir string           The absolute path of the directory to which all backup files will be written
      --compression-level int       Level of compression to use during data backup. Valid values are between 1 and 9.
      --data-only                   Only back up data, do not back up metadata
      --dbname string               The database to be backed up
      --debug                       Print verbose and debug log messages
      --exclude-schema strings      Back up all metadata except objects in the specified schema(s). --exclude-schema can be specified multiple times.
      --exclude-table strings       Back up all metadata except the specified table(s). --exclude-table can be specified multiple times.
      --exclude-table-file string   A file containing a list of fully-qualified tables to be excluded from the backup
      --help                        Help for gpbackup
```