### PR TITLE
Add errcheck linter

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -388,7 +388,7 @@ func DoCleanup() {
 			}
 		}
 		timestampLockFile := fmt.Sprintf("/tmp/%s.lck", globalFPInfo.Timestamp)
-		os.Remove(timestampLockFile) // Don't check error, as DoTeardown may have removed it already
+		_ = os.Remove(timestampLockFile) // Don't check error, as DoTeardown may have removed it already
 	}
 	if connection != nil {
 		connection.Close()

--- a/gometalinter.config
+++ b/gometalinter.config
@@ -1,6 +1,6 @@
 {
   "DisableAll": true,
-  "Enable": ["golint", "vet", "varcheck", "unparam"],
+  "Enable": ["golint", "vet", "varcheck", "unparam", "errcheck"],
   "Exclude": [
     "should have comment",
     "comment on exported",

--- a/restore/data.go
+++ b/restore/data.go
@@ -33,7 +33,8 @@ func CopyTableIn(connection *dbconn.DBConn, tableName string, tableAttributes st
 	if err != nil {
 		gplog.Fatal(err, "Error loading data into table %s", tableName)
 	}
-	numRows, _ := result.RowsAffected()
+	numRows, err := result.RowsAffected()
+	gplog.FatalOnError(err)
 	return numRows
 }
 

--- a/utils/io.go
+++ b/utils/io.go
@@ -105,9 +105,10 @@ func NewFileWithByteCountFromFile(filename string) *FileWithByteCount {
 
 func (file *FileWithByteCount) Close() {
 	if file.closer != nil {
-		file.closer.Close()
+		_ = file.closer.Close()
 		if file.Filename != "" {
-			operating.System.Chmod(file.Filename, 0444)
+			err := operating.System.Chmod(file.Filename, 0444)
+			gplog.FatalOnError(err)
 		}
 	}
 }

--- a/utils/plugin.go
+++ b/utils/plugin.go
@@ -43,7 +43,8 @@ func (plugin *PluginConfig) BackupFile(filenamePath string, noFatal ...bool) {
 			gplog.Fatal(err, string(output))
 		}
 	}
-	operating.System.Chmod(filenamePath, 0755)
+	err = operating.System.Chmod(filenamePath, 0755)
+	gplog.FatalOnError(err)
 }
 
 func (plugin *PluginConfig) RestoreFile(filenamePath string) {

--- a/utils/report.go
+++ b/utils/report.go
@@ -134,15 +134,15 @@ func ReadConfigFile(filename string) *BackupConfig {
 
 func (report *Report) WriteConfigFile(configFilename string) {
 	configFile := iohelper.MustOpenFileForWriting(configFilename)
-	defer operating.System.Chmod(configFilename, 0444)
 	config := report.BackupConfig
 	configContents, _ := yaml.Marshal(config)
 	MustPrintBytes(configFile, configContents)
+	err := operating.System.Chmod(configFilename, 0444)
+	gplog.FatalOnError(err)
 }
 
 func (report *Report) WriteBackupReportFile(reportFilename string, timestamp string, objectCounts map[string]int, errMsg string) {
 	reportFile := iohelper.MustOpenFileForWriting(reportFilename)
-	defer operating.System.Chmod(reportFilename, 0444)
 	reportFileTemplate := `Greenplum Database Backup Report
 
 Timestamp Key: %s
@@ -178,11 +178,12 @@ Backup Status: %s
 		backupStatus, dbSizeStr)
 
 	PrintObjectCounts(reportFile, objectCounts)
+	err := operating.System.Chmod(reportFilename, 0444)
+	gplog.FatalOnError(err)
 }
 
 func WriteRestoreReportFile(reportFilename string, backupTimestamp string, startTimestamp string, connection *dbconn.DBConn, restoreVersion string, errMsg string) {
 	reportFile := iohelper.MustOpenFileForWriting(reportFilename)
-	defer operating.System.Chmod(reportFilename, 0444)
 	reportFileTemplate := `Greenplum Database Restore Report
 
 Timestamp Key: %s
@@ -212,7 +213,8 @@ Restore Status: %s`
 		backupTimestamp, connection.Version.VersionString, restoreVersion,
 		connection.DBName, gprestoreCommandLine,
 		start, end, duration, restoreStatus)
-
+	err := operating.System.Chmod(reportFilename, 0444)
+	gplog.FatalOnError(err)
 }
 
 func GetDurationInfo(timestamp string, endTime time.Time) (string, string, string) {

--- a/utils/report_test.go
+++ b/utils/report_test.go
@@ -61,6 +61,10 @@ Data File Format: Single Data File Per Segment`,
 			operating.System.Now = func() time.Time {
 				return time.Date(2017, 1, 1, 5, 4, 3, 2, time.Local)
 			}
+			operating.System.Chmod = func(name string, mode os.FileMode) error {
+				return nil
+			}
+
 		})
 
 		It("writes a report for a successful backup", func() {
@@ -166,6 +170,10 @@ types                        1000`))
 			operating.System.Now = func() time.Time {
 				return time.Date(2017, 1, 1, 5, 4, 3, 2, time.Local)
 			}
+			operating.System.Chmod = func(name string, mode os.FileMode) error {
+				return nil
+			}
+
 		})
 		AfterEach(func() {
 			gplog.SetErrorCode(0)

--- a/utils/toc.go
+++ b/utils/toc.go
@@ -65,17 +65,21 @@ func NewSegmentTOC(filename string) *SegmentTOC {
 }
 
 func (toc *TOC) WriteToFileAndMakeReadOnly(filename string) {
-	defer operating.System.Chmod(filename, 0444)
 	tocFile := iohelper.MustOpenFileForWriting(filename)
-	tocContents, _ := yaml.Marshal(toc)
+	tocContents, err := yaml.Marshal(toc)
+	gplog.FatalOnError(err)
 	MustPrintBytes(tocFile, tocContents)
+	err = operating.System.Chmod(filename, 0444)
+	gplog.FatalOnError(err)
 }
 
 func (toc *SegmentTOC) WriteToFileAndMakeReadOnly(filename string) {
-	defer operating.System.Chmod(filename, 0444)
 	tocFile := iohelper.MustOpenFileForWriting(filename)
-	tocContents, _ := yaml.Marshal(toc)
+	tocContents, err := yaml.Marshal(toc)
+	gplog.FatalOnError(err)
 	MustPrintBytes(tocFile, tocContents)
+	err = operating.System.Chmod(filename, 0444)
+	gplog.FatalOnError(err)
 }
 
 type StatementWithType struct {

--- a/utils/util.go
+++ b/utils/util.go
@@ -91,7 +91,7 @@ WHERE application_name = '%s'
 AND current_query LIKE '%%%s%%'
 AND procpid <> pg_backend_pid()`, appName, copyFileName)
 	// We don't check the error as the connection may have finished or been previously terminated
-	connection.Exec(query)
+	_, _ = connection.Exec(query)
 }
 
 func SetDatabaseVersion(connection *dbconn.DBConn) {


### PR DESCRIPTION
This linter ensures that we check the error on functions that return an
error. This will help prevent bugs where we assume that a function such
as Chmod or Open is successful, but forget to check that no error is
returned.

In cases where we do intentionally want to ignore the error, we will now
need to assign it to an empty identifier, such as _ = os.Chmod().

Authored-by: Chris Hajas <chajas@pivotal.io>