### PR TITLE
Fix procedural language test due to 9.1 merge

### DIFF
--- a/integration/predata_functions_queries_test.go
+++ b/integration/predata_functions_queries_test.go
@@ -439,10 +439,13 @@ LANGUAGE SQL`)
 
 			pythonHandlerOid := testutils.OidFromObjectName(connection, "pg_catalog", "plpython_call_handler", backup.TYPE_FUNCTION)
 
-			expectedPlpythonInfo := backup.ProceduralLanguage{Oid: 1, Name: "plpythonu", Owner: "testrole", IsPl: true, PlTrusted: false, Handler: pythonHandlerOid, Inline: 0}
+			expectedPlpythonInfo := backup.ProceduralLanguage{Oid: 1, Name: "plpythonu", Owner: "testrole", IsPl: true, PlTrusted: false, Handler: pythonHandlerOid, Inline: 0, Validator: 0}
 			if connection.Version.AtLeast("5") {
 				pythonInlineOid := testutils.OidFromObjectName(connection, "pg_catalog", "plpython_inline_handler", backup.TYPE_FUNCTION)
 				expectedPlpythonInfo.Inline = pythonInlineOid
+			}
+			if connection.Version.AtLeast("6") {
+				expectedPlpythonInfo.Validator = testutils.OidFromObjectName(connection, "pg_catalog", "plpython_validator", backup.TYPE_FUNCTION)
 			}
 
 			resultProcLangs := backup.GetProceduralLanguages(connection)


### PR DESCRIPTION
In postgres 9.1, the plpythonu language has a validator function, thus
we must check for this function in our test.

Authored-by: Chris Hajas <chajas@pivotal.io>