### PR TITLE
Use `make build` instead of `make build_linux` in packaging job

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -717,7 +717,7 @@ jobs:
           pushd $GOPATH/src/github.com/greenplum-db/gpbackup
           make depend
 
-          make build_linux
+          make build
           version=`git describe --tags | perl -pe 's/(.*)-([0-9]*)-(g[0-9a-f]*)/\1+dev.\2.\3/'`
           popd
           echo ${version} > gpbackup_version/version
@@ -725,7 +725,7 @@ jobs:
           # Build s3 plugin
           pushd $GOPATH/src/github.com/greenplum-db/gpbackup-s3-plugin
           make depend
-          make build_linux
+          make build
           popd
 
           # Install dependencies and build ddboost plugin


### PR DESCRIPTION
`make build_linux` places the binary in the current directory instead of
~/go/bin/, which we reference during the packaging job.

Authored-by: Chris Hajas <chajas@pivotal.io>