### PR TITLE
Disable comment on resource queue tests temporarily

### DIFF
--- a/integration/metadata_globals_create_test.go
+++ b/integration/metadata_globals_create_test.go
@@ -35,7 +35,7 @@ var _ = Describe("backup integration create statement tests", func() {
 		})
 	})
 	Describe("PrintCreateResourceQueueStatements", func() {
-		It("creates a basic resource queue with a comment", func() {
+		PIt("creates a basic resource queue with a comment", func() {
 			basicQueue := backup.ResourceQueue{Oid: 1, Name: `"basicQueue"`, ActiveStatements: -1, MaxCost: "32.80", CostOvercommit: false, MinCost: "0.00", Priority: "medium", MemoryLimit: "-1"}
 			resQueueMetadataMap := testutils.DefaultMetadataMap("RESOURCE QUEUE", false, false, true)
 			resQueueMetadata := resQueueMetadataMap[1]

--- a/integration/predata_shared_queries_test.go
+++ b/integration/predata_shared_queries_test.go
@@ -927,7 +927,7 @@ LANGUAGE SQL`)
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
-			It("returns a slice of default metadata for a resource queue", func() {
+			PIt("returns a slice of default metadata for a resource queue", func() {
 				resultMetadataMap := backup.GetCommentsForObjectType(connection, backup.TYPE_RESOURCEQUEUE)
 				numResQueues := len(resultMetadataMap)
 


### PR DESCRIPTION
This is currently not working in master. These tests will be enabled
once it is fixed.

Authored-by: Chris Hajas <chajas@pivotal.io>