### PR TITLE
Fully qualify error tables in CREATE EXTERNAL TABLE statements

### DIFF
--- a/backup/predata_externals.go
+++ b/backup/predata_externals.go
@@ -40,7 +40,8 @@ type ExternalTableDefinition struct {
 	Command         string
 	RejectLimit     int
 	RejectLimitType string
-	ErrTable        string
+	ErrTableName    string
+	ErrTableSchema  string
 	Encoding        string
 	Writable        bool
 	URIs            []string
@@ -191,10 +192,11 @@ func PrintExternalTableStatements(metadataFile *utils.FileWithByteCount, table R
 		 * If an external table is created using LOG ERRORS instead of LOG ERRORS INTO [tablename],
 		 * the value of pg_exttable.fmterrtbl will match the table's own name.
 		 */
-		if extTableDef.ErrTable == table.Name {
+		errTableFQN := utils.MakeFQN(extTableDef.ErrTableSchema, extTableDef.ErrTableName)
+		if errTableFQN == table.ToString() {
 			metadataFile.MustPrintf("\nLOG ERRORS")
-		} else if extTableDef.ErrTable != "" {
-			metadataFile.MustPrintf("\nLOG ERRORS INTO %s", extTableDef.ErrTable)
+		} else if extTableDef.ErrTableName != "" {
+			metadataFile.MustPrintf("\nLOG ERRORS INTO %s", errTableFQN)
 		}
 		if extTableDef.RejectLimit != 0 {
 			metadataFile.MustPrintf("\nSEGMENT REJECT LIMIT %d ", extTableDef.RejectLimit)

--- a/backup/predata_externals_test.go
+++ b/backup/predata_externals_test.go
@@ -297,17 +297,19 @@ FORMAT 'text'
 ENCODING 'UTF-8'`)
 			})
 			It("prints a CREATE block for a table using error logging with an error table", func() {
-				extTableDef.ErrTable = "error_table"
+				extTableDef.ErrTableName = "error_table"
+				extTableDef.ErrTableSchema = "error_table_schema"
 				backup.PrintExternalTableStatements(backupfile, testTable, extTableDef)
 				testhelper.ExpectRegexp(buffer, `LOCATION (
 	'file://host:port/path/file'
 )
 FORMAT 'text'
 ENCODING 'UTF-8'
-LOG ERRORS INTO error_table`)
+LOG ERRORS INTO error_table_schema.error_table`)
 			})
 			It("prints a CREATE block for a table using error logging without an error table", func() {
-				extTableDef.ErrTable = "tablename"
+				extTableDef.ErrTableName = "tablename"
+				extTableDef.ErrTableSchema = "public"
 				backup.PrintExternalTableStatements(backupfile, testTable, extTableDef)
 				testhelper.ExpectRegexp(buffer, `LOCATION (
 	'file://host:port/path/file'
@@ -339,7 +341,8 @@ ENCODING 'UTF-8'
 SEGMENT REJECT LIMIT 2 PERCENT`)
 			})
 			It("prints a CREATE block for a table with error logging and a row-based reject limit", func() {
-				extTableDef.ErrTable = "tablename"
+				extTableDef.ErrTableName = "tablename"
+				extTableDef.ErrTableSchema = "public"
 				extTableDef.RejectLimit = 2
 				extTableDef.RejectLimitType = "r"
 				backup.PrintExternalTableStatements(backupfile, testTable, extTableDef)

--- a/backup/predata_relations_test.go
+++ b/backup/predata_relations_test.go
@@ -32,7 +32,7 @@ var _ = Describe("backup/predata_relations tests", func() {
 	partDefEmpty := ""
 	partTemplateDefEmpty := ""
 	colDefsEmpty := []backup.ColumnDefinition{}
-	extTableEmpty := backup.ExternalTableDefinition{Oid: 0, Type: -2, Protocol: -2, Location: "", ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "", Options: "", Command: "", RejectLimit: 0, RejectLimitType: "", ErrTable: "", Encoding: "UTF-8", Writable: false, URIs: nil}
+	extTableEmpty := backup.ExternalTableDefinition{Oid: 0, Type: -2, Protocol: -2, Location: "", ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "", Options: "", Command: "", RejectLimit: 0, RejectLimitType: "", ErrTableName: "", ErrTableSchema: "", Encoding: "UTF-8", Writable: false, URIs: nil}
 
 	partDef := `PARTITION BY LIST(gender)
 	(

--- a/backup/queries_externals.go
+++ b/backup/queries_externals.go
@@ -26,7 +26,7 @@ SELECT
 	coalesce(rejectlimit, 0) AS rejectlimit,
 	coalesce(rejectlimittype, '') AS rejectlimittype,
 	coalesce(quote_ident(c.relname),'') AS errtablename,
-	coalesce((SELECT quote_ident(nspname) FROM pg_namespace WHERE oid = relnamespace), '') AS errtableschema,
+	coalesce((SELECT quote_ident(nspname) FROM pg_namespace n WHERE n.oid = c.relnamespace), '') AS errtableschema,
 	pg_encoding_to_char(encoding) AS encoding,
 	writable
 FROM pg_exttable e LEFT JOIN pg_class c ON (e.fmterrtbl = c.oid);`, execOptions, execOptions)
@@ -47,7 +47,7 @@ SELECT
 	coalesce(rejectlimit, 0) AS rejectlimit,
 	coalesce(rejectlimittype, '') AS rejectlimittype,
 	coalesce(quote_ident(c.relname),'') AS errtablename,
-	coalesce((SELECT quote_ident(nspname) FROM pg_namespace WHERE oid = relnamespace), '') AS errtableschema,
+	coalesce((SELECT quote_ident(nspname) FROM pg_namespace n WHERE n.oid = c.relnamespace), '') AS errtableschema,
 	pg_encoding_to_char(encoding) AS encoding,
 	writable
 FROM pg_exttable e LEFT JOIN pg_class c ON (e.fmterrtbl = c.oid);`
@@ -68,7 +68,7 @@ SELECT
 	coalesce(rejectlimit, 0) AS rejectlimit,
 	coalesce(rejectlimittype, '') AS rejectlimittype,
 	CASE WHEN logerrors = 'false' THEN '' ELSE quote_ident(c.relname) END AS errtablename,
-  CASE WHEN logerrors = 'false' THEN '' ELSE coalesce((SELECT quote_ident(nspname) FROM pg_namespace WHERE oid = relnamespace), '') END AS errtableschema,
+  CASE WHEN logerrors = 'false' THEN '' ELSE coalesce((SELECT quote_ident(nspname) FROM pg_namespace n WHERE n.oid = c.relnamespace), '') END AS errtableschema,
 	pg_encoding_to_char(encoding) AS encoding,
 	writable
 FROM pg_exttable e LEFT JOIN pg_class c ON (e.reloid = c.oid);`

--- a/backup/queries_externals.go
+++ b/backup/queries_externals.go
@@ -25,10 +25,11 @@ SELECT
 	coalesce(command, '') AS command,
 	coalesce(rejectlimit, 0) AS rejectlimit,
 	coalesce(rejectlimittype, '') AS rejectlimittype,
-	coalesce((SELECT relname FROM pg_class WHERE oid = fmterrtbl), '') AS errtable,
+	coalesce(quote_ident(c.relname),'') AS errtablename,
+	coalesce((SELECT quote_ident(nspname) FROM pg_namespace WHERE oid = relnamespace), '') AS errtableschema,
 	pg_encoding_to_char(encoding) AS encoding,
 	writable
-FROM pg_exttable;`, execOptions, execOptions)
+FROM pg_exttable e LEFT JOIN pg_class c ON (e.fmterrtbl = c.oid);`, execOptions, execOptions)
 
 	version5query := `
 SELECT
@@ -45,10 +46,11 @@ SELECT
 	coalesce(command, '') AS command,
 	coalesce(rejectlimit, 0) AS rejectlimit,
 	coalesce(rejectlimittype, '') AS rejectlimittype,
-	coalesce((SELECT relname FROM pg_class WHERE oid = fmterrtbl), '') AS errtable,
+	coalesce(quote_ident(c.relname),'') AS errtablename,
+	coalesce((SELECT quote_ident(nspname) FROM pg_namespace WHERE oid = relnamespace), '') AS errtableschema,
 	pg_encoding_to_char(encoding) AS encoding,
 	writable
-FROM pg_exttable;`
+FROM pg_exttable e LEFT JOIN pg_class c ON (e.fmterrtbl = c.oid);`
 
 	query := `
 SELECT
@@ -65,10 +67,11 @@ SELECT
 	coalesce(command, '') AS command,
 	coalesce(rejectlimit, 0) AS rejectlimit,
 	coalesce(rejectlimittype, '') AS rejectlimittype,
-	CASE WHEN logerrors = 'false' THEN '' ELSE coalesce((SELECT relname FROM pg_class WHERE oid = reloid), '') END AS errtable,
+	CASE WHEN logerrors = 'false' THEN '' ELSE quote_ident(c.relname) END AS errtablename,
+  CASE WHEN logerrors = 'false' THEN '' ELSE coalesce((SELECT quote_ident(nspname) FROM pg_namespace WHERE oid = relnamespace), '') END AS errtableschema,
 	pg_encoding_to_char(encoding) AS encoding,
 	writable
-FROM pg_exttable;`
+FROM pg_exttable e LEFT JOIN pg_class c ON (e.reloid = c.oid);`
 
 	results := make([]ExternalTableDefinition, 0)
 	var err error

--- a/integration/predata_externals_create_test.go
+++ b/integration/predata_externals_create_test.go
@@ -25,7 +25,7 @@ var _ = Describe("backup integration create statement tests", func() {
 		BeforeEach(func() {
 			extTable = backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: backup.FILE, Location: "file://tmp/ext_table_file",
 				ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "delimiter '	' null '\\N' escape '\\'",
-				Options: "", Command: "", RejectLimit: 0, RejectLimitType: "", ErrTable: "", Encoding: "UTF8",
+				Options: "", Command: "", RejectLimit: 0, RejectLimitType: "", ErrTableName: "", ErrTableSchema: "", Encoding: "UTF8",
 				Writable: false, URIs: []string{"file://tmp/ext_table_file"}}
 			testTable = backup.BasicRelation("public", "testtable")
 			tableDef = backup.TableDefinition{IsExternal: true}
@@ -39,7 +39,8 @@ var _ = Describe("backup integration create statement tests", func() {
 		It("creates a READABLE EXTERNAL table", func() {
 			extTable.Type = backup.READABLE
 			extTable.Writable = false
-			extTable.ErrTable = "testtable"
+			extTable.ErrTableName = "testtable"
+			extTable.ErrTableSchema = "public"
 			extTable.RejectLimit = 2
 			extTable.RejectLimitType = "r"
 			tableDef.ExtTableDef = extTable
@@ -59,7 +60,8 @@ var _ = Describe("backup integration create statement tests", func() {
 			testutils.SkipIfNot4(connection)
 			extTable.Type = backup.READABLE
 			extTable.Writable = false
-			extTable.ErrTable = "err_table"
+			extTable.ErrTableName = "err_table"
+			extTable.ErrTableSchema = "public"
 			extTable.RejectLimit = 2
 			extTable.RejectLimitType = "r"
 			tableDef.ExtTableDef = extTable

--- a/integration/predata_externals_queries_test.go
+++ b/integration/predata_externals_queries_test.go
@@ -26,7 +26,7 @@ FORMAT 'TEXT'`)
 
 			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: "file://tmp/myfile.txt",
 				ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "delimiter '	' null '\\N' escape '\\'",
-				Options: "", Command: "", RejectLimit: 0, RejectLimitType: "", ErrTable: "", Encoding: "UTF8",
+				Options: "", Command: "", RejectLimit: 0, RejectLimitType: "", ErrTableName: "", ErrTableSchema: "", Encoding: "UTF8",
 				Writable: false, URIs: []string{"file://tmp/myfile.txt"}}
 			structmatcher.ExpectStructsToMatchExcluding(&extTable, &result, "Oid")
 		})
@@ -44,7 +44,7 @@ FORMAT 'TEXT'`)
 
 			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: "",
 				ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "delimiter '	' null '\\N' escape '\\'",
-				Options: "", Command: "hostname", RejectLimit: 0, RejectLimitType: "", ErrTable: "", Encoding: "UTF8",
+				Options: "", Command: "hostname", RejectLimit: 0, RejectLimitType: "", ErrTableName: "", ErrTableSchema: "", Encoding: "UTF8",
 				Writable: false, URIs: nil}
 
 			structmatcher.ExpectStructsToMatchExcluding(&extTable, &result, "Oid")
@@ -64,7 +64,7 @@ SEGMENT REJECT LIMIT 10 PERCENT
 
 			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: "file://tmp/myfile.txt",
 				ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "delimiter '	' null '\\N' escape '\\'",
-				Options: "", Command: "", RejectLimit: 10, RejectLimitType: "p", ErrTable: "ext_table", Encoding: "UTF8",
+				Options: "", Command: "", RejectLimit: 10, RejectLimitType: "p", ErrTableName: "ext_table", ErrTableSchema: "public", Encoding: "UTF8",
 				Writable: false, URIs: []string{"file://tmp/myfile.txt"}}
 
 			structmatcher.ExpectStructsToMatchExcluding(&extTable, &result, "Oid")
@@ -86,7 +86,7 @@ SEGMENT REJECT LIMIT 10 PERCENT
 
 			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: "file://tmp/myfile.txt",
 				ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "delimiter '	' null '\\N' escape '\\'",
-				Options: "foo 'bar'", Command: "", RejectLimit: 10, RejectLimitType: "p", ErrTable: "ext_table", Encoding: "UTF8",
+				Options: "foo 'bar'", Command: "", RejectLimit: 10, RejectLimitType: "p", ErrTableName: "ext_table", ErrTableSchema: "public", Encoding: "UTF8",
 				Writable: false, URIs: []string{"file://tmp/myfile.txt"}}
 
 			structmatcher.ExpectStructsToMatchExcluding(&extTable, &result, "Oid")

--- a/integration/predata_relations_create_test.go
+++ b/integration/predata_relations_create_test.go
@@ -69,7 +69,7 @@ SET SUBPARTITION TEMPLATE  ` + `
 			emptyACL = []backup.ACL{}
 		)
 		BeforeEach(func() {
-			extTableEmpty = backup.ExternalTableDefinition{Oid: 0, Type: -2, Protocol: -2, Location: "", ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "", Options: "", Command: "", RejectLimit: 0, RejectLimitType: "", ErrTable: "", Encoding: "UTF-8", Writable: false, URIs: nil}
+			extTableEmpty = backup.ExternalTableDefinition{Oid: 0, Type: -2, Protocol: -2, Location: "", ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "", Options: "", Command: "", RejectLimit: 0, RejectLimitType: "", ErrTableName: "", ErrTableSchema: "", Encoding: "UTF-8", Writable: false, URIs: nil}
 			testTable = backup.BasicRelation("public", "testtable")
 			tableDef = backup.TableDefinition{DistPolicy: "DISTRIBUTED RANDOMLY", ExtTableDef: extTableEmpty}
 			tableDefs = map[uint32]backup.TableDefinition{}
@@ -257,7 +257,7 @@ SET SUBPARTITION TEMPLATE  ` + `
 	})
 	Describe("PrintPostCreateTableStatements", func() {
 		var (
-			extTableEmpty = backup.ExternalTableDefinition{Oid: 0, Type: -2, Protocol: -2, Location: "", ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "", Options: "", Command: "", RejectLimit: 0, RejectLimitType: "", ErrTable: "", Encoding: "UTF-8", Writable: false, URIs: nil}
+			extTableEmpty = backup.ExternalTableDefinition{Oid: 0, Type: -2, Protocol: -2, Location: "", ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "", Options: "", Command: "", RejectLimit: 0, RejectLimitType: "", ErrTableName: "", ErrTableSchema: "", Encoding: "UTF-8", Writable: false, URIs: nil}
 			testTable     = backup.BasicRelation("public", "testtable")
 			tableRow      = backup.ColumnDefinition{Oid: 0, Num: 1, Name: "i", NotNull: false, HasDefault: false, Type: "integer", Encoding: "", StatTarget: -1, StorageType: "", DefaultVal: "", Comment: "", ACL: []backup.ACL{}}
 			tableMetadata backup.ObjectMetadata


### PR DESCRIPTION
Previously, the error table was not fully qualified, causing gprestore to
attempt to put the table in pg_catalog. Now, we fully qualify the error
table. Additionally, we now properly quote the error table.

Authored-by: Chris Hajas <chajas@pivotal.io>