### PR TITLE
Make updates for cluster.Cluster changes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -19,7 +19,7 @@
     "structmatcher",
     "testhelper"
   ]
-  revision = "26097cb0b6c1a5fd473bcea25dddffe2ad492b5a"
+  revision = "e1ff11c5bc81a9412a4cf9484e0131c781fa031e"
 
 [[projects]]
   name = "github.com/inconshreveable/mousetrap"
@@ -195,6 +195,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "e5c978284f2111830cbfbb7e41a35675c998d854b5de743f367caaf06c30321b"
+  inputs-digest = "873ea78f5de4cd978957707dc5c039e4e62c9f5b0ae4d77d9573fda71f767ff2"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -72,7 +72,7 @@ func DoSetup() {
 	segConfig := cluster.MustGetSegmentConfiguration(connection)
 	globalCluster = cluster.NewCluster(segConfig)
 	segPrefix := utils.GetSegPrefix(connection)
-	globalFPInfo = utils.NewFilePathInfo(globalCluster.SegDirMap, *backupDir, timestamp, segPrefix)
+	globalFPInfo = utils.NewFilePathInfo(globalCluster, *backupDir, timestamp, segPrefix)
 	CreateBackupDirectoriesOnAllHosts()
 	globalTOC = &utils.TOC{}
 	globalTOC.InitializeEntryMap()

--- a/backup/global_variables.go
+++ b/backup/global_variables.go
@@ -19,7 +19,7 @@ import (
 var (
 	backupReport  *utils.Report
 	connection    *dbconn.DBConn
-	globalCluster cluster.Cluster
+	globalCluster *cluster.Cluster
 	globalFPInfo  utils.FilePathInfo
 	globalTOC     *utils.TOC
 	objectCounts  map[string]int
@@ -68,7 +68,7 @@ func SetConnection(conn *dbconn.DBConn) {
 	connection = conn
 }
 
-func SetCluster(cluster cluster.Cluster) {
+func SetCluster(cluster *cluster.Cluster) {
 	globalCluster = cluster
 }
 

--- a/restore/data_test.go
+++ b/restore/data_test.go
@@ -53,7 +53,7 @@ var _ = Describe("restore/data tests", func() {
 		localSegOne := cluster.SegConfig{ContentID: 0, Hostname: "localhost", DataDir: "/data/gpseg0"}
 		remoteSegOne := cluster.SegConfig{ContentID: 1, Hostname: "remotehost1", DataDir: "/data/gpseg1"}
 		var (
-			testCluster  cluster.Cluster
+			testCluster  *cluster.Cluster
 			testExecutor *testhelper.TestExecutor
 			testFPInfo   utils.FilePathInfo
 
@@ -66,7 +66,7 @@ var _ = Describe("restore/data tests", func() {
 			testExecutor = &testhelper.TestExecutor{}
 			testCluster = cluster.NewCluster([]cluster.SegConfig{masterSeg, localSegOne, remoteSegOne})
 			testCluster.Executor = testExecutor
-			testFPInfo = utils.NewFilePathInfo(testCluster.SegDirMap, "", "20170101010101", "gpseg")
+			testFPInfo = utils.NewFilePathInfo(testCluster, "", "20170101010101", "gpseg")
 			backup.SetFPInfo(testFPInfo)
 		})
 		AfterEach(func() {

--- a/restore/global_variables.go
+++ b/restore/global_variables.go
@@ -20,7 +20,7 @@ import (
 var (
 	backupConfig     *utils.BackupConfig
 	connection       *dbconn.DBConn
-	globalCluster    cluster.Cluster
+	globalCluster    *cluster.Cluster
 	globalFPInfo     utils.FilePathInfo
 	globalTOC        *utils.TOC
 	pluginConfig     *utils.PluginConfig
@@ -75,7 +75,7 @@ func SetConnection(conn *dbconn.DBConn) {
 	connection = conn
 }
 
-func SetCluster(cluster cluster.Cluster) {
+func SetCluster(cluster *cluster.Cluster) {
 	globalCluster = cluster
 }
 

--- a/restore/remote_test.go
+++ b/restore/remote_test.go
@@ -19,7 +19,7 @@ var _ = Describe("restore/remote tests", func() {
 	localSegOne := cluster.SegConfig{ContentID: 0, Hostname: "localhost", DataDir: "/data/gpseg0"}
 	remoteSegOne := cluster.SegConfig{ContentID: 1, Hostname: "remotehost1", DataDir: "/data/gpseg1"}
 	var (
-		testCluster  cluster.Cluster
+		testCluster  *cluster.Cluster
 		testExecutor *testhelper.TestExecutor
 		testFPInfo   utils.FilePathInfo
 	)
@@ -30,7 +30,7 @@ var _ = Describe("restore/remote tests", func() {
 		testExecutor = &testhelper.TestExecutor{}
 		testCluster = cluster.NewCluster([]cluster.SegConfig{masterSeg, localSegOne, remoteSegOne})
 		testCluster.Executor = testExecutor
-		testFPInfo = utils.NewFilePathInfo(testCluster.SegDirMap, "", "20170101010101", "gpseg")
+		testFPInfo = utils.NewFilePathInfo(testCluster, "", "20170101010101", "gpseg")
 		restore.SetFPInfo(testFPInfo)
 	})
 	Describe("VerifyBackupFileCountOnSegments", func() {

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -78,7 +78,7 @@ func DoSetup() {
 	segConfig := cluster.MustGetSegmentConfiguration(connection)
 	globalCluster = cluster.NewCluster(segConfig)
 	segPrefix := utils.ParseSegPrefix(*backupDir)
-	globalFPInfo = utils.NewFilePathInfo(globalCluster.SegDirMap, *backupDir, *timestamp, segPrefix)
+	globalFPInfo = utils.NewFilePathInfo(globalCluster, *backupDir, *timestamp, segPrefix)
 
 	// Get restore metadata from plugin
 	if *pluginConfigFile != "" {

--- a/testutils/functions.go
+++ b/testutils/functions.go
@@ -45,12 +45,12 @@ func SetupTestCluster() {
 	testCluster := SetDefaultSegmentConfiguration()
 	backup.SetCluster(testCluster)
 	restore.SetCluster(testCluster)
-	testFPInfo := utils.NewFilePathInfo(testCluster.SegDirMap, "", "20170101010101", "gpseg")
+	testFPInfo := utils.NewFilePathInfo(testCluster, "", "20170101010101", "gpseg")
 	backup.SetFPInfo(testFPInfo)
 	restore.SetFPInfo(testFPInfo)
 }
 
-func SetDefaultSegmentConfiguration() cluster.Cluster {
+func SetDefaultSegmentConfiguration() *cluster.Cluster {
 	configMaster := cluster.SegConfig{ContentID: -1, Hostname: "localhost", DataDir: "gpseg-1"}
 	configSegOne := cluster.SegConfig{ContentID: 0, Hostname: "localhost", DataDir: "gpseg0"}
 	configSegTwo := cluster.SegConfig{ContentID: 1, Hostname: "localhost", DataDir: "gpseg1"}

--- a/utils/agent_remote.go
+++ b/utils/agent_remote.go
@@ -14,7 +14,7 @@ import (
  * Functions to run commands on entire cluster during both backup and restore
  */
 
-func CreateFirstSegmentPipeOnAllHosts(oid uint32, c cluster.Cluster, fpInfo FilePathInfo) {
+func CreateFirstSegmentPipeOnAllHosts(oid uint32, c *cluster.Cluster, fpInfo FilePathInfo) {
 	remoteOutput := c.GenerateAndExecuteCommand("Creating segment data pipes", func(contentID int) string {
 		pipeName := fpInfo.GetSegmentPipeFilePath(contentID)
 		pipeName = fmt.Sprintf("%s_%d", pipeName, oid)
@@ -25,7 +25,7 @@ func CreateFirstSegmentPipeOnAllHosts(oid uint32, c cluster.Cluster, fpInfo File
 	})
 }
 
-func WriteOidListToSegments(oidList []string, c cluster.Cluster, fpInfo FilePathInfo) {
+func WriteOidListToSegments(oidList []string, c *cluster.Cluster, fpInfo FilePathInfo) {
 	oidStr := strings.Join(oidList, "\n")
 	remoteOutput := c.GenerateAndExecuteCommand("Writing filtered oid list to segments", func(contentID int) string {
 		oidFile := fpInfo.GetSegmentHelperFilePath(contentID, "oid")
@@ -36,7 +36,7 @@ func WriteOidListToSegments(oidList []string, c cluster.Cluster, fpInfo FilePath
 	})
 }
 
-func VerifyHelperVersionOnSegments(version string, c cluster.Cluster) {
+func VerifyHelperVersionOnSegments(version string, c *cluster.Cluster) {
 	remoteOutput := c.GenerateAndExecuteCommand("Verifying gpbackup_helper version", func(contentID int) string {
 		gphome := operating.System.Getenv("GPHOME")
 		return fmt.Sprintf("%s/bin/gpbackup_helper --version", gphome)
@@ -59,7 +59,7 @@ func VerifyHelperVersionOnSegments(version string, c cluster.Cluster) {
 	}
 }
 
-func StartAgent(c cluster.Cluster, fpInfo FilePathInfo, operation string, pluginConfigFile string, compressStr string) {
+func StartAgent(c *cluster.Cluster, fpInfo FilePathInfo, operation string, pluginConfigFile string, compressStr string) {
 	remoteOutput := c.GenerateAndExecuteCommand("Starting gpbackup_helper agent", func(contentID int) string {
 		tocFile := fpInfo.GetSegmentTOCFilePath(contentID)
 		oidFile := fpInfo.GetSegmentHelperFilePath(contentID, "oid")
@@ -88,7 +88,7 @@ chmod +x %s; (nohup %s > /dev/null 2>&1 &) &`, scriptFile, gphomePath, gphomePat
 	})
 }
 
-func CleanUpHelperFilesOnAllHosts(c cluster.Cluster, fpInfo FilePathInfo) {
+func CleanUpHelperFilesOnAllHosts(c *cluster.Cluster, fpInfo FilePathInfo) {
 	remoteOutput := c.GenerateAndExecuteCommand("Removing oid list and helper script files from segment data directories", func(contentID int) string {
 		errorFile := fmt.Sprintf("%s_error", fpInfo.GetSegmentPipeFilePath(contentID))
 		oidFile := fpInfo.GetSegmentHelperFilePath(contentID, "oid")
@@ -103,7 +103,7 @@ func CleanUpHelperFilesOnAllHosts(c cluster.Cluster, fpInfo FilePathInfo) {
 	}, true)
 }
 
-func CleanUpSegmentHelperProcesses(c cluster.Cluster, fpInfo FilePathInfo, operation string) {
+func CleanUpSegmentHelperProcesses(c *cluster.Cluster, fpInfo FilePathInfo, operation string) {
 	remoteOutput := c.GenerateAndExecuteCommand("Cleaning up segment agent processes", func(contentID int) string {
 		tocFile := fpInfo.GetSegmentTOCFilePath(contentID)
 		procPattern := fmt.Sprintf("gpbackup_helper --%s-agent --toc-file %s", operation, tocFile)

--- a/utils/compression_test.go
+++ b/utils/compression_test.go
@@ -18,7 +18,7 @@ var _ = Describe("utils/compression tests", func() {
 	localSegOne := cluster.SegConfig{ContentID: 0, Hostname: "localhost", DataDir: "/data/gpseg0"}
 	remoteSegOne := cluster.SegConfig{ContentID: 1, Hostname: "remotehost1", DataDir: "/data/gpseg1"}
 	var (
-		testCluster  cluster.Cluster
+		testCluster  *cluster.Cluster
 		testExecutor *testhelper.TestExecutor
 	)
 

--- a/utils/filepath.go
+++ b/utils/filepath.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gp-common-go-libs/operating"
@@ -26,15 +27,15 @@ type FilePathInfo struct {
 	UserSpecifiedSegPrefix string
 }
 
-func NewFilePathInfo(segDirMap map[int]string, userSpecifiedBackupDir string, timestamp string, userSegPrefix string) FilePathInfo {
+func NewFilePathInfo(c *cluster.Cluster, userSpecifiedBackupDir string, timestamp string, userSegPrefix string) FilePathInfo {
 	backupFPInfo := FilePathInfo{}
 	backupFPInfo.PID = os.Getpid()
 	backupFPInfo.UserSpecifiedBackupDir = userSpecifiedBackupDir
 	backupFPInfo.UserSpecifiedSegPrefix = userSegPrefix
 	backupFPInfo.Timestamp = timestamp
 	backupFPInfo.SegDirMap = make(map[int]string)
-	for k, v := range segDirMap {
-		backupFPInfo.SegDirMap[k] = v
+	for content, segment := range c.Segments {
+		backupFPInfo.SegDirMap[content] = segment.DataDir
 	}
 	return backupFPInfo
 }

--- a/utils/filepath_test.go
+++ b/utils/filepath_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/operating"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup/utils"
@@ -13,77 +14,83 @@ import (
 )
 
 var _ = Describe("utils/filepath tests", func() {
+	masterDir := "/data/gpseg-1"
+	segDirOne := "/data/gpseg0"
+	segDirTwo := "/data/gpseg1"
+	var c *cluster.Cluster
+	BeforeEach(func() {
+		c = &cluster.Cluster{
+			Segments: map[int]cluster.SegConfig{
+				-1: {DataDir: masterDir},
+			},
+		}
+	})
 	Describe("Backup Filepath setup and accessors", func() {
-		var segDirMap map[int]string
-		masterDir := "/data/gpseg-1"
-		segDirOne := "/data/gpseg0"
-		segDirTwo := "/data/gpseg1"
 		It("returns content dir for a single-host, single-segment nodes", func() {
-			segDirMap = map[int]string{-1: masterDir, 0: segDirOne}
-			fpInfo := utils.NewFilePathInfo(segDirMap, "", "20170101010101", "gpseg")
+			c.Segments[0] = cluster.SegConfig{DataDir: segDirOne}
+			fpInfo := utils.NewFilePathInfo(c, "", "20170101010101", "gpseg")
 			Expect(len(fpInfo.SegDirMap)).To(Equal(2))
 			Expect(fpInfo.GetDirForContent(-1)).To(Equal("/data/gpseg-1/backups/20170101/20170101010101"))
 			Expect(fpInfo.GetDirForContent(0)).To(Equal("/data/gpseg0/backups/20170101/20170101010101"))
 		})
 		It("sets up the configuration for a single-host, multi-segment fpInfo", func() {
-			segDirMap = map[int]string{-1: masterDir, 0: segDirOne, 1: segDirTwo}
-			fpInfo := utils.NewFilePathInfo(segDirMap, "", "20170101010101", "gpseg")
+			c.Segments[0] = cluster.SegConfig{DataDir: segDirOne}
+			c.Segments[1] = cluster.SegConfig{DataDir: segDirTwo}
+			fpInfo := utils.NewFilePathInfo(c, "", "20170101010101", "gpseg")
 			Expect(len(fpInfo.SegDirMap)).To(Equal(3))
 			Expect(fpInfo.GetDirForContent(-1)).To(Equal("/data/gpseg-1/backups/20170101/20170101010101"))
 			Expect(fpInfo.GetDirForContent(0)).To(Equal("/data/gpseg0/backups/20170101/20170101010101"))
 			Expect(fpInfo.GetDirForContent(1)).To(Equal("/data/gpseg1/backups/20170101/20170101010101"))
 		})
 		It("returns the content directory based on the user specified path", func() {
-			segDirMap = map[int]string{-1: masterDir}
-			fpInfo := utils.NewFilePathInfo(segDirMap, "/foo/bar", "20170101010101", "gpseg")
+			fpInfo := utils.NewFilePathInfo(c, "/foo/bar", "20170101010101", "gpseg")
 			Expect(len(fpInfo.SegDirMap)).To(Equal(1))
 			Expect(fpInfo.GetDirForContent(-1)).To(Equal("/foo/bar/gpseg-1/backups/20170101/20170101010101"))
 		})
 	})
 	Describe("GetTableBackupFilePathForCopyCommand()", func() {
 		It("returns table file path for copy command", func() {
-			fpInfo := utils.NewFilePathInfo(nil, "", "20170101010101", "gpseg")
+			fpInfo := utils.NewFilePathInfo(c, "", "20170101010101", "gpseg")
 			Expect(fpInfo.GetTableBackupFilePathForCopyCommand(1234, false)).To(Equal("<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_1234"))
 		})
 		It("returns table file path for copy command based on user specified path", func() {
-			fpInfo := utils.NewFilePathInfo(nil, "/foo/bar", "20170101010101", "gpseg")
+			fpInfo := utils.NewFilePathInfo(c, "/foo/bar", "20170101010101", "gpseg")
 			Expect(fpInfo.GetTableBackupFilePathForCopyCommand(1234, false)).To(Equal("/foo/bar/gpseg<SEGID>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_1234"))
 		})
 		It("returns table file path for copy command in single-file mode", func() {
-			fpInfo := utils.NewFilePathInfo(nil, "", "20170101010101", "gpseg")
+			fpInfo := utils.NewFilePathInfo(c, "", "20170101010101", "gpseg")
 			Expect(fpInfo.GetTableBackupFilePathForCopyCommand(1234, true)).To(Equal("<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101"))
 		})
 		It("returns table file path for copy command based on user specified path in single-file mode", func() {
-			fpInfo := utils.NewFilePathInfo(nil, "/foo/bar", "20170101010101", "gpseg")
+			fpInfo := utils.NewFilePathInfo(c, "/foo/bar", "20170101010101", "gpseg")
 			Expect(fpInfo.GetTableBackupFilePathForCopyCommand(1234, true)).To(Equal("/foo/bar/gpseg<SEGID>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101"))
 		})
 	})
 	Describe("GetReportFilePath", func() {
 		It("returns report file path", func() {
-			fpInfo := utils.NewFilePathInfo(map[int]string{-1: "/data/gpseg-1"}, "", "20170101010101", "gpseg")
+			fpInfo := utils.NewFilePathInfo(c, "", "20170101010101", "gpseg")
 			Expect(fpInfo.GetBackupReportFilePath()).To(Equal("/data/gpseg-1/backups/20170101/20170101010101/gpbackup_20170101010101_report"))
 		})
 		It("returns report file path based on user specified path", func() {
-			fpInfo := utils.NewFilePathInfo(map[int]string{-1: "/data/gpseg-1"}, "/foo/bar", "20170101010101", "gpseg")
+			fpInfo := utils.NewFilePathInfo(c, "/foo/bar", "20170101010101", "gpseg")
 			Expect(fpInfo.GetBackupReportFilePath()).To(Equal("/foo/bar/gpseg-1/backups/20170101/20170101010101/gpbackup_20170101010101_report"))
 		})
 	})
 	Describe("GetTableBackupFilePath", func() {
-		segDirMap := map[int]string{-1: "/data/gpseg-1"}
 		It("returns table file path", func() {
-			fpInfo := utils.NewFilePathInfo(segDirMap, "", "20170101010101", "gpseg")
+			fpInfo := utils.NewFilePathInfo(c, "", "20170101010101", "gpseg")
 			Expect(fpInfo.GetTableBackupFilePath(-1, 1234, false)).To(Equal("/data/gpseg-1/backups/20170101/20170101010101/gpbackup_-1_20170101010101_1234"))
 		})
 		It("returns table file path based on user specified path", func() {
-			fpInfo := utils.NewFilePathInfo(segDirMap, "/foo/bar", "20170101010101", "gpseg")
+			fpInfo := utils.NewFilePathInfo(c, "/foo/bar", "20170101010101", "gpseg")
 			Expect(fpInfo.GetTableBackupFilePath(-1, 1234, false)).To(Equal("/foo/bar/gpseg-1/backups/20170101/20170101010101/gpbackup_-1_20170101010101_1234"))
 		})
 		It("returns single data file path", func() {
-			fpInfo := utils.NewFilePathInfo(segDirMap, "", "20170101010101", "gpseg")
+			fpInfo := utils.NewFilePathInfo(c, "", "20170101010101", "gpseg")
 			Expect(fpInfo.GetTableBackupFilePath(-1, 1234, true)).To(Equal("/data/gpseg-1/backups/20170101/20170101010101/gpbackup_-1_20170101010101"))
 		})
 		It("returns single data file path based on user specified path", func() {
-			fpInfo := utils.NewFilePathInfo(segDirMap, "/foo/bar", "20170101010101", "gpseg")
+			fpInfo := utils.NewFilePathInfo(c, "/foo/bar", "20170101010101", "gpseg")
 			Expect(fpInfo.GetTableBackupFilePath(-1, 1234, true)).To(Equal("/foo/bar/gpseg-1/backups/20170101/20170101010101/gpbackup_-1_20170101010101"))
 		})
 	})

--- a/utils/plugin.go
+++ b/utils/plugin.go
@@ -56,7 +56,7 @@ func (plugin *PluginConfig) RestoreFile(filenamePath string) {
 	gplog.FatalOnError(err, string(output))
 }
 
-func (plugin *PluginConfig) CheckPluginExistsOnAllHosts(c cluster.Cluster) {
+func (plugin *PluginConfig) CheckPluginExistsOnAllHosts(c *cluster.Cluster) {
 	remoteOutput := c.GenerateAndExecuteCommand("Checking that plugin exists on all hosts", func(contentID int) string {
 		return fmt.Sprintf("source %s/greenplum_path.sh && %s plugin_api_version", operating.System.Getenv("GPHOME"), plugin.ExecutablePath)
 	}, cluster.ON_HOSTS_AND_MASTER)
@@ -81,7 +81,7 @@ func (plugin *PluginConfig) CheckPluginExistsOnAllHosts(c cluster.Cluster) {
 	}
 }
 
-func (plugin *PluginConfig) SetupPluginForBackupOnAllHosts(c cluster.Cluster, configPath string, backupDir string) {
+func (plugin *PluginConfig) SetupPluginForBackupOnAllHosts(c *cluster.Cluster, configPath string, backupDir string) {
 	remoteOutput := c.GenerateAndExecuteCommand("Running plugin setup for backup on all hosts", func(contentID int) string {
 		return fmt.Sprintf("source %s/greenplum_path.sh && %s setup_plugin_for_backup %s %s", operating.System.Getenv("GPHOME"), plugin.ExecutablePath, configPath, backupDir)
 	}, cluster.ON_HOSTS_AND_MASTER)
@@ -90,7 +90,7 @@ func (plugin *PluginConfig) SetupPluginForBackupOnAllHosts(c cluster.Cluster, co
 	})
 }
 
-func (plugin *PluginConfig) SetupPluginForRestoreOnAllHosts(c cluster.Cluster, configPath string, backupDir string) {
+func (plugin *PluginConfig) SetupPluginForRestoreOnAllHosts(c *cluster.Cluster, configPath string, backupDir string) {
 	remoteOutput := c.GenerateAndExecuteCommand("Running plugin setup for restore on all hosts", func(contentID int) string {
 		return fmt.Sprintf("source %s/greenplum_path.sh && %s setup_plugin_for_restore %s %s", operating.System.Getenv("GPHOME"), plugin.ExecutablePath, configPath, backupDir)
 	}, cluster.ON_HOSTS_AND_MASTER)
@@ -99,7 +99,7 @@ func (plugin *PluginConfig) SetupPluginForRestoreOnAllHosts(c cluster.Cluster, c
 	})
 }
 
-func (plugin *PluginConfig) CleanupPluginForBackupOnAllHosts(c cluster.Cluster, configPath string, backupDir string) {
+func (plugin *PluginConfig) CleanupPluginForBackupOnAllHosts(c *cluster.Cluster, configPath string, backupDir string) {
 	remoteOutput := c.GenerateAndExecuteCommand("Running plugin cleanup for backup on all hosts", func(contentID int) string {
 		return fmt.Sprintf("source %s/greenplum_path.sh && %s cleanup_plugin_for_backup %s %s", operating.System.Getenv("GPHOME"), plugin.ExecutablePath, configPath, backupDir)
 	}, cluster.ON_HOSTS_AND_MASTER)
@@ -108,7 +108,7 @@ func (plugin *PluginConfig) CleanupPluginForBackupOnAllHosts(c cluster.Cluster, 
 	}, true)
 }
 
-func (plugin *PluginConfig) CleanupPluginForRestoreOnAllHosts(c cluster.Cluster, configPath string, backupDir string) {
+func (plugin *PluginConfig) CleanupPluginForRestoreOnAllHosts(c *cluster.Cluster, configPath string, backupDir string) {
 	remoteOutput := c.GenerateAndExecuteCommand("Running plugin cleanup for restore on all hosts", func(contentID int) string {
 		return fmt.Sprintf("source %s/greenplum_path.sh && %s cleanup_plugin_for_restore %s %s", operating.System.Getenv("GPHOME"), plugin.ExecutablePath, configPath, backupDir)
 	}, cluster.ON_HOSTS_AND_MASTER)
@@ -117,7 +117,7 @@ func (plugin *PluginConfig) CleanupPluginForRestoreOnAllHosts(c cluster.Cluster,
 	}, true)
 }
 
-func (plugin *PluginConfig) CopyPluginConfigToAllHosts(c cluster.Cluster, configPath string) {
+func (plugin *PluginConfig) CopyPluginConfigToAllHosts(c *cluster.Cluster, configPath string) {
 	remoteOutput := c.GenerateAndExecuteCommand("Copying plugin config to all hosts", func(contentID int) string {
 		return fmt.Sprintf("rsync %s:%s /tmp/.", c.GetHostForContent(-1), configPath)
 	}, cluster.ON_HOSTS_AND_MASTER)
@@ -126,7 +126,7 @@ func (plugin *PluginConfig) CopyPluginConfigToAllHosts(c cluster.Cluster, config
 	})
 }
 
-func (plugin *PluginConfig) BackupSegmentTOCs(c cluster.Cluster, fpInfo FilePathInfo) {
+func (plugin *PluginConfig) BackupSegmentTOCs(c *cluster.Cluster, fpInfo FilePathInfo) {
 	remoteOutput := c.GenerateAndExecuteCommand("Checking that TOC file exists", func(contentID int) string {
 		tocFile := fpInfo.GetSegmentTOCFilePath(contentID)
 		errorFile := fmt.Sprintf("%s_error", fpInfo.GetSegmentPipeFilePath(contentID))
@@ -145,7 +145,7 @@ func (plugin *PluginConfig) BackupSegmentTOCs(c cluster.Cluster, fpInfo FilePath
 	})
 }
 
-func (plugin *PluginConfig) RestoreSegmentTOCs(c cluster.Cluster, fpInfo FilePathInfo) {
+func (plugin *PluginConfig) RestoreSegmentTOCs(c *cluster.Cluster, fpInfo FilePathInfo) {
 	remoteOutput := c.GenerateAndExecuteCommand("Processing segment TOC files with plugin", func(contentID int) string {
 		tocFile := fpInfo.GetSegmentTOCFilePath(contentID)
 		return fmt.Sprintf("mkdir -p %s && source %s/greenplum_path.sh && %s restore_file %s %s", fpInfo.GetDirForContent(contentID), operating.System.Getenv("GPHOME"), plugin.ExecutablePath, plugin.ConfigPath, tocFile)

--- a/utils/report.go
+++ b/utils/report.go
@@ -335,13 +335,13 @@ Content-Disposition: inline
 	return emailHeader + fileContents + emailFooter
 }
 
-func EmailReport(cluster cluster.Cluster, timestamp string, reportFilePath string, utility string) {
+func EmailReport(c *cluster.Cluster, timestamp string, reportFilePath string, utility string) {
 	contactsFilename := "gp_email_contacts.yaml"
 	gphomeFile := fmt.Sprintf("%s/bin/%s", operating.System.Getenv("GPHOME"), contactsFilename)
 	homeFile := fmt.Sprintf("%s/%s", operating.System.Getenv("HOME"), contactsFilename)
-	_, homeErr := cluster.ExecuteLocalCommand(fmt.Sprintf("test -f %s", homeFile))
+	_, homeErr := c.ExecuteLocalCommand(fmt.Sprintf("test -f %s", homeFile))
 	if homeErr != nil {
-		_, gphomeErr := cluster.ExecuteLocalCommand(fmt.Sprintf("test -f %s", gphomeFile))
+		_, gphomeErr := c.ExecuteLocalCommand(fmt.Sprintf("test -f %s", gphomeFile))
 		if gphomeErr != nil {
 			gplog.Info("Found neither %s nor %s", gphomeFile, homeFile)
 			gplog.Info("Email containing %s report %s will not be sent", utility, reportFilePath)
@@ -358,7 +358,7 @@ func EmailReport(cluster cluster.Cluster, timestamp string, reportFilePath strin
 	}
 	message := ConstructEmailMessage(timestamp, contactList, reportFilePath, utility)
 	gplog.Verbose("Sending email report to the following addresses: %s", contactList)
-	output, sendErr := cluster.ExecuteLocalCommand(fmt.Sprintf(`echo "%s" | sendmail -t`, message))
+	output, sendErr := c.ExecuteLocalCommand(fmt.Sprintf(`echo "%s" | sendmail -t`, message))
 	if sendErr != nil {
 		gplog.Warn("Unable to send email report: %s", output)
 	}

--- a/utils/report_test.go
+++ b/utils/report_test.go
@@ -478,7 +478,7 @@ Timestamp Key: 20170101010101`)
 
 		var (
 			testExecutor *testhelper.TestExecutor
-			testCluster  cluster.Cluster
+			testCluster  *cluster.Cluster
 			testFPInfo   utils.FilePathInfo
 			w            *os.File
 			r            *os.File
@@ -486,7 +486,7 @@ Timestamp Key: 20170101010101`)
 		BeforeEach(func() {
 			r, w, _ = os.Pipe()
 			testCluster = testutils.SetDefaultSegmentConfiguration()
-			testFPInfo = utils.NewFilePathInfo(testCluster.SegDirMap, "", "20170101010101", "gpseg")
+			testFPInfo = utils.NewFilePathInfo(testCluster, "", "20170101010101", "gpseg")
 			operating.System.OpenFileRead = func(name string, flag int, perm os.FileMode) (operating.ReadCloserAt, error) { return r, nil }
 			operating.System.ReadFile = func(filename string) ([]byte, error) { return ioutil.ReadAll(r) }
 			operating.System.Hostname = func() (string, error) { return "localhost", nil }


### PR DESCRIPTION
This commit updates source and test code to account for the removal of SegDirMap
from Cluster and NewCluster now returning a *Cluster instead of a Cluster.  The
changes are generally limited to initialization of FilePathInfo and Cluster
objects and the arguments of functions that take Clusters as arguments.

Authored-by: Jamie McAtamney <jmcatamney@pivotal.io>