### PR TITLE
Fully qualify index in ALTER INDEX and COMMENT ON INDEX statements

### DIFF
--- a/backup/postdata.go
+++ b/backup/postdata.go
@@ -14,14 +14,15 @@ func PrintCreateIndexStatements(metadataFile *utils.FileWithByteCount, toc *util
 	for _, index := range indexes {
 		start := metadataFile.ByteCount
 		metadataFile.MustPrintf("\n\n%s;", index.Def)
+		indexFQN := utils.MakeFQN(index.OwningSchema, index.Name)
 		if index.Tablespace != "" {
-			metadataFile.MustPrintf("\nALTER INDEX %s SET TABLESPACE %s;", index.Name, index.Tablespace)
+			metadataFile.MustPrintf("\nALTER INDEX %s SET TABLESPACE %s;", indexFQN, index.Tablespace)
 		}
 		tableFQN := utils.MakeFQN(index.OwningSchema, index.OwningTable)
 		if index.IsClustered {
 			metadataFile.MustPrintf("\nALTER TABLE %s CLUSTER ON %s;", tableFQN, index.Name)
 		}
-		PrintObjectMetadata(metadataFile, indexMetadata[index.Oid], index.Name, "INDEX")
+		PrintObjectMetadata(metadataFile, indexMetadata[index.Oid], indexFQN, "INDEX")
 		toc.AddPostdataEntry(index.OwningSchema, index.Name, "INDEX", tableFQN, start, metadataFile)
 	}
 }

--- a/backup/postdata_test.go
+++ b/backup/postdata_test.go
@@ -32,7 +32,7 @@ ALTER TABLE public.testtable CLUSTER ON testindex;`)
 			emptyMetadataMap := backup.MetadataMap{}
 			backup.PrintCreateIndexStatements(backupfile, toc, indexes, emptyMetadataMap)
 			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE INDEX testindex ON public.testtable USING btree(i);
-ALTER INDEX testindex SET TABLESPACE test_tablespace;`)
+ALTER INDEX public.testindex SET TABLESPACE test_tablespace;`)
 		})
 		It("can print an index with a comment", func() {
 			indexes := []backup.IndexDefinition{{Oid: 1, Name: "testindex", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE INDEX testindex ON public.testtable USING btree(i)"}}
@@ -40,7 +40,7 @@ ALTER INDEX testindex SET TABLESPACE test_tablespace;`)
 			backup.PrintCreateIndexStatements(backupfile, toc, indexes, indexMetadataMap)
 			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE INDEX testindex ON public.testtable USING btree(i);
 
-COMMENT ON INDEX testindex IS 'This is an index comment.';`)
+COMMENT ON INDEX public.testindex IS 'This is an index comment.';`)
 		})
 	})
 	Context("PrintCreateRuleStatements", func() {

--- a/backup/predata_types.go
+++ b/backup/predata_types.go
@@ -147,7 +147,7 @@ func PrintCreateCollationStatements(metadataFile *utils.FileWithByteCount, toc *
 		collationFQN := utils.MakeFQN(collation.Schema, collation.Name)
 		start := metadataFile.ByteCount
 		metadataFile.MustPrintf("\nCREATE COLLATION %s (LC_COLLATE = '%s', LC_CTYPE = '%s');", collationFQN, collation.Collate, collation.Ctype)
-		PrintObjectMetadata(metadataFile, collationMetadata[collation.Oid], collation.Name, "COLLATION")
+		PrintObjectMetadata(metadataFile, collationMetadata[collation.Oid], collationFQN, "COLLATION")
 		toc.AddPredataEntry(collation.Schema, collation.Name, "COLLATION", "", start, metadataFile)
 	}
 }

--- a/backup/predata_types_test.go
+++ b/backup/predata_types_test.go
@@ -219,10 +219,10 @@ ALTER DOMAIN public.domain2 OWNER TO testrole;`)
 			backup.PrintCreateCollationStatements(backupfile, toc, []backup.Collation{collation}, collationMetadataMap)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE COLLATION schema1.collation1 (LC_COLLATE = 'collate1', LC_CTYPE = 'ctype1');
 
-COMMENT ON COLLATION collation1 IS 'This is a collation comment.';
+COMMENT ON COLLATION schema1.collation1 IS 'This is a collation comment.';
 
 
-ALTER COLLATION collation1 OWNER TO testrole;`)
+ALTER COLLATION schema1.collation1 OWNER TO testrole;`)
 		})
 	})
 })

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -54,6 +54,7 @@ var _ = BeforeSuite(func() {
 	testhelper.AssertQueryRuns(connection, "ALTER SCHEMA public OWNER TO anothertestrole")
 	testhelper.AssertQueryRuns(connection, "DROP PROTOCOL IF EXISTS gphdfs")
 	testhelper.AssertQueryRuns(connection, `SET standard_conforming_strings TO "on"`)
+	testhelper.AssertQueryRuns(connection, `SET search_path=pg_catalog`)
 	if connection.Version.AtLeast("6") {
 		// Drop plpgsql extension to not interfere in extension tests
 		testhelper.AssertQueryRuns(connection, "DROP EXTENSION plpgsql CASCADE")

--- a/integration/postdata_create_test.go
+++ b/integration/postdata_create_test.go
@@ -22,12 +22,12 @@ var _ = Describe("backup integration create statement tests", func() {
 			indexMetadataMap = backup.MetadataMap{}
 		})
 		It("creates a basic index", func() {
-			indexes := []backup.IndexDefinition{{Oid: 0, Name: "index1", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE INDEX index1 ON testtable USING btree (i)"}}
+			indexes := []backup.IndexDefinition{{Oid: 0, Name: "index1", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE INDEX index1 ON public.testtable USING btree (i)"}}
 			backup.PrintCreateIndexStatements(backupfile, toc, indexes, indexMetadataMap)
 
 			//Create table whose columns we can index
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE testtable(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE testtable")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.testtable(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.testtable")
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
 
@@ -36,12 +36,12 @@ var _ = Describe("backup integration create statement tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&resultIndexes[0], &indexes[0], "Oid")
 		})
 		It("creates an index used for clustering", func() {
-			indexes := []backup.IndexDefinition{{Oid: 0, Name: "index1", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE INDEX index1 ON testtable USING btree (i)", IsClustered: true}}
+			indexes := []backup.IndexDefinition{{Oid: 0, Name: "index1", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE INDEX index1 ON public.testtable USING btree (i)", IsClustered: true}}
 			backup.PrintCreateIndexStatements(backupfile, toc, indexes, indexMetadataMap)
 
 			//Create table whose columns we can index
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE testtable(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE testtable")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.testtable(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.testtable")
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
 
@@ -50,14 +50,14 @@ var _ = Describe("backup integration create statement tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&resultIndexes[0], &indexes[0], "Oid")
 		})
 		It("creates an index with a comment", func() {
-			indexes := []backup.IndexDefinition{{Oid: 1, Name: "index1", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE INDEX index1 ON testtable USING btree (i)"}}
+			indexes := []backup.IndexDefinition{{Oid: 1, Name: "index1", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE INDEX index1 ON public.testtable USING btree (i)"}}
 			indexMetadataMap = testutils.DefaultMetadataMap("INDEX", false, false, true)
 			indexMetadata := indexMetadataMap[1]
 			backup.PrintCreateIndexStatements(backupfile, toc, indexes, indexMetadataMap)
 
 			//Create table whose columns we can index
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE testtable(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE testtable")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.testtable(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.testtable")
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
 
@@ -76,12 +76,12 @@ var _ = Describe("backup integration create statement tests", func() {
 				testhelper.AssertQueryRuns(connection, "CREATE TABLESPACE test_tablespace LOCATION '/tmp/test_dir'")
 			}
 			defer testhelper.AssertQueryRuns(connection, "DROP TABLESPACE test_tablespace")
-			indexes := []backup.IndexDefinition{{Oid: 0, Name: "index1", OwningSchema: "public", OwningTable: "testtable", Tablespace: "test_tablespace", Def: "CREATE INDEX index1 ON testtable USING btree (i)"}}
+			indexes := []backup.IndexDefinition{{Oid: 0, Name: "index1", OwningSchema: "public", OwningTable: "testtable", Tablespace: "test_tablespace", Def: "CREATE INDEX index1 ON public.testtable USING btree (i)"}}
 			backup.PrintCreateIndexStatements(backupfile, toc, indexes, indexMetadataMap)
 
 			//Create table whose columns we can index
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE testtable(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE testtable")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.testtable(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.testtable")
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
 
@@ -98,11 +98,11 @@ var _ = Describe("backup integration create statement tests", func() {
 			ruleMetadataMap = backup.MetadataMap{}
 		})
 		It("creates a basic rule", func() {
-			rules := []backup.QuerySimpleDefinition{{Oid: 0, Name: "update_notify", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE RULE update_notify AS ON UPDATE TO testtable DO NOTIFY testtable;"}}
+			rules := []backup.QuerySimpleDefinition{{Oid: 0, Name: "update_notify", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE RULE update_notify AS ON UPDATE TO public.testtable DO NOTIFY testtable;"}}
 			backup.PrintCreateRuleStatements(backupfile, toc, rules, ruleMetadataMap)
 
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE testtable(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE testtable")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.testtable(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.testtable")
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
 
@@ -111,13 +111,13 @@ var _ = Describe("backup integration create statement tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&resultRules[0], &rules[0], "Oid")
 		})
 		It("creates a rule with a comment", func() {
-			rules := []backup.QuerySimpleDefinition{{Oid: 1, Name: "update_notify", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE RULE update_notify AS ON UPDATE TO testtable DO NOTIFY testtable;"}}
+			rules := []backup.QuerySimpleDefinition{{Oid: 1, Name: "update_notify", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE RULE update_notify AS ON UPDATE TO public.testtable DO NOTIFY testtable;"}}
 			ruleMetadataMap = testutils.DefaultMetadataMap("RULE", false, false, true)
 			ruleMetadata := ruleMetadataMap[1]
 			backup.PrintCreateRuleStatements(backupfile, toc, rules, ruleMetadataMap)
 
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE testtable(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE testtable")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.testtable(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.testtable")
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
 
@@ -138,11 +138,11 @@ var _ = Describe("backup integration create statement tests", func() {
 			triggerMetadataMap = backup.MetadataMap{}
 		})
 		It("creates a basic trigger", func() {
-			triggers := []backup.QuerySimpleDefinition{{Oid: 0, Name: "sync_testtable", OwningSchema: "public", OwningTable: "testtable", Def: `CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON testtable FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}}
+			triggers := []backup.QuerySimpleDefinition{{Oid: 0, Name: "sync_testtable", OwningSchema: "public", OwningTable: "testtable", Def: `CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON public.testtable FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}}
 			backup.PrintCreateTriggerStatements(backupfile, toc, triggers, triggerMetadataMap)
 
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE testtable(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE testtable")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.testtable(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.testtable")
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
 
@@ -151,13 +151,13 @@ var _ = Describe("backup integration create statement tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&resultTriggers[0], &triggers[0], "Oid")
 		})
 		It("creates a trigger with a comment", func() {
-			triggers := []backup.QuerySimpleDefinition{{Oid: 1, Name: "sync_testtable", OwningSchema: "public", OwningTable: "testtable", Def: `CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON testtable FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}}
+			triggers := []backup.QuerySimpleDefinition{{Oid: 1, Name: "sync_testtable", OwningSchema: "public", OwningTable: "testtable", Def: `CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON public.testtable FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}}
 			triggerMetadataMap = testutils.DefaultMetadataMap("RULE", false, false, true)
 			triggerMetadata := triggerMetadataMap[1]
 			backup.PrintCreateTriggerStatements(backupfile, toc, triggers, triggerMetadataMap)
 
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE testtable(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE testtable")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.testtable(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.testtable")
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
 

--- a/integration/postdata_queries_test.go
+++ b/integration/postdata_queries_test.go
@@ -13,16 +13,16 @@ import (
 var _ = Describe("backup integration tests", func() {
 	Describe("ConstructImplicitIndexNames", func() {
 		It("returns an empty map if there are no implicit indexes", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE simple_table(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE simple_table")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.simple_table(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.simple_table")
 
 			indexNameSet := backup.ConstructImplicitIndexNames(connection)
 
 			Expect(indexNameSet.Length()).To(Equal(0))
 		})
 		It("returns a map of all implicit indexes", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE simple_table(i int UNIQUE)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE simple_table")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.simple_table(i int UNIQUE)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.simple_table")
 
 			indexNameSet := backup.ConstructImplicitIndexNames(connection)
 
@@ -32,23 +32,23 @@ var _ = Describe("backup integration tests", func() {
 	})
 	Describe("GetIndex", func() {
 		It("returns no slice when no index exists", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE simple_table(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE simple_table")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.simple_table(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.simple_table")
 
 			results := backup.GetIndexes(connection)
 
 			Expect(len(results)).To(Equal(0))
 		})
 		It("returns a slice of multiple indexes", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE simple_table(i int, j int, k int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE simple_table")
-			testhelper.AssertQueryRuns(connection, "CREATE INDEX simple_table_idx1 ON simple_table(i)")
-			defer testhelper.AssertQueryRuns(connection, "DROP INDEX simple_table_idx1")
-			testhelper.AssertQueryRuns(connection, "CREATE INDEX simple_table_idx2 ON simple_table(j)")
-			defer testhelper.AssertQueryRuns(connection, "DROP INDEX simple_table_idx2")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.simple_table(i int, j int, k int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.simple_table")
+			testhelper.AssertQueryRuns(connection, "CREATE INDEX simple_table_idx1 ON public.simple_table(i)")
+			defer testhelper.AssertQueryRuns(connection, "DROP INDEX public.simple_table_idx1")
+			testhelper.AssertQueryRuns(connection, "CREATE INDEX simple_table_idx2 ON public.simple_table(j)")
+			defer testhelper.AssertQueryRuns(connection, "DROP INDEX public.simple_table_idx2")
 
-			index1 := backup.IndexDefinition{Oid: 0, Name: "simple_table_idx1", OwningSchema: "public", OwningTable: "simple_table", Def: "CREATE INDEX simple_table_idx1 ON simple_table USING btree (i)"}
-			index2 := backup.IndexDefinition{Oid: 1, Name: "simple_table_idx2", OwningSchema: "public", OwningTable: "simple_table", Def: "CREATE INDEX simple_table_idx2 ON simple_table USING btree (j)"}
+			index1 := backup.IndexDefinition{Oid: 0, Name: "simple_table_idx1", OwningSchema: "public", OwningTable: "simple_table", Def: "CREATE INDEX simple_table_idx1 ON public.simple_table USING btree (i)"}
+			index2 := backup.IndexDefinition{Oid: 1, Name: "simple_table_idx2", OwningSchema: "public", OwningTable: "simple_table", Def: "CREATE INDEX simple_table_idx2 ON public.simple_table USING btree (j)"}
 
 			results := backup.GetIndexes(connection)
 
@@ -60,14 +60,14 @@ var _ = Describe("backup integration tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&index2, &results[1], "Oid")
 		})
 		It("returns a slice of multiple indexes, excluding implicit indexes", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE simple_table(i int, j int, k int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE simple_table CASCADE")
-			testhelper.AssertQueryRuns(connection, "ALTER TABLE simple_table ADD CONSTRAINT test_constraint UNIQUE (i, k)")
-			testhelper.AssertQueryRuns(connection, "CREATE INDEX simple_table_idx1 ON simple_table(i)")
-			testhelper.AssertQueryRuns(connection, "CREATE INDEX simple_table_idx2 ON simple_table(j)")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.simple_table(i int, j int, k int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.simple_table CASCADE")
+			testhelper.AssertQueryRuns(connection, "ALTER TABLE public.simple_table ADD CONSTRAINT test_constraint UNIQUE (i, k)")
+			testhelper.AssertQueryRuns(connection, "CREATE INDEX simple_table_idx1 ON public.simple_table(i)")
+			testhelper.AssertQueryRuns(connection, "CREATE INDEX simple_table_idx2 ON public.simple_table(j)")
 
-			index1 := backup.IndexDefinition{Oid: 0, Name: "simple_table_idx1", OwningSchema: "public", OwningTable: "simple_table", Def: "CREATE INDEX simple_table_idx1 ON simple_table USING btree (i)"}
-			index2 := backup.IndexDefinition{Oid: 1, Name: "simple_table_idx2", OwningSchema: "public", OwningTable: "simple_table", Def: "CREATE INDEX simple_table_idx2 ON simple_table USING btree (j)"}
+			index1 := backup.IndexDefinition{Oid: 0, Name: "simple_table_idx1", OwningSchema: "public", OwningTable: "simple_table", Def: "CREATE INDEX simple_table_idx1 ON public.simple_table USING btree (i)"}
+			index2 := backup.IndexDefinition{Oid: 1, Name: "simple_table_idx2", OwningSchema: "public", OwningTable: "simple_table", Def: "CREATE INDEX simple_table_idx2 ON public.simple_table USING btree (j)"}
 
 			results := backup.GetIndexes(connection)
 
@@ -76,18 +76,18 @@ var _ = Describe("backup integration tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&index2, &results[1], "Oid")
 		})
 		It("returns a slice of indexes for only partition parent tables", func() {
-			testhelper.AssertQueryRuns(connection, `CREATE TABLE part (id int, date date, amt decimal(10,2)) DISTRIBUTED BY (id)
+			testhelper.AssertQueryRuns(connection, `CREATE TABLE public.part (id int, date date, amt decimal(10,2)) DISTRIBUTED BY (id)
 PARTITION BY RANGE (date)
       (PARTITION Jan08 START (date '2008-01-01') INCLUSIVE ,
       PARTITION Feb08 START (date '2008-02-01') INCLUSIVE ,
       PARTITION Mar08 START (date '2008-03-01') INCLUSIVE
       END (date '2008-04-01') EXCLUSIVE);
 `)
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE part")
-			testhelper.AssertQueryRuns(connection, "CREATE INDEX part_idx ON part(id)")
-			defer testhelper.AssertQueryRuns(connection, "DROP INDEX part_idx")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.part")
+			testhelper.AssertQueryRuns(connection, "CREATE INDEX part_idx ON public.part(id)")
+			defer testhelper.AssertQueryRuns(connection, "DROP INDEX public.part_idx")
 
-			index1 := backup.IndexDefinition{Oid: 0, Name: "part_idx", OwningSchema: "public", OwningTable: "part", Def: "CREATE INDEX part_idx ON part USING btree (id)"}
+			index1 := backup.IndexDefinition{Oid: 0, Name: "part_idx", OwningSchema: "public", OwningTable: "part", Def: "CREATE INDEX part_idx ON public.part USING btree (id)"}
 
 			results := backup.GetIndexes(connection)
 
@@ -101,12 +101,12 @@ PARTITION BY RANGE (date)
 				testhelper.AssertQueryRuns(connection, "CREATE TABLESPACE test_tablespace LOCATION '/tmp/test_dir'")
 			}
 			defer testhelper.AssertQueryRuns(connection, "DROP TABLESPACE test_tablespace")
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE simple_table(i int, j int, k int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE simple_table")
-			testhelper.AssertQueryRuns(connection, "CREATE INDEX simple_table_idx ON simple_table(i) TABLESPACE test_tablespace")
-			defer testhelper.AssertQueryRuns(connection, "DROP INDEX simple_table_idx")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.simple_table(i int, j int, k int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.simple_table")
+			testhelper.AssertQueryRuns(connection, "CREATE INDEX simple_table_idx ON public.simple_table(i) TABLESPACE test_tablespace")
+			defer testhelper.AssertQueryRuns(connection, "DROP INDEX public.simple_table_idx")
 
-			index1 := backup.IndexDefinition{Oid: 0, Name: "simple_table_idx", OwningSchema: "public", OwningTable: "simple_table", Tablespace: "test_tablespace", Def: "CREATE INDEX simple_table_idx ON simple_table USING btree (i)"}
+			index1 := backup.IndexDefinition{Oid: 0, Name: "simple_table_idx", OwningSchema: "public", OwningTable: "simple_table", Tablespace: "test_tablespace", Def: "CREATE INDEX simple_table_idx ON public.simple_table USING btree (i)"}
 
 			results := backup.GetIndexes(connection)
 
@@ -116,10 +116,10 @@ PARTITION BY RANGE (date)
 			structmatcher.ExpectStructsToMatchExcluding(&index1, &results[0], "Oid")
 		})
 		It("returns a slice for an index in specific schema", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE simple_table(i int, j int, k int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE simple_table")
-			testhelper.AssertQueryRuns(connection, "CREATE INDEX simple_table_idx1 ON simple_table(i)")
-			defer testhelper.AssertQueryRuns(connection, "DROP INDEX simple_table_idx1")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.simple_table(i int, j int, k int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.simple_table")
+			testhelper.AssertQueryRuns(connection, "CREATE INDEX simple_table_idx1 ON public.simple_table(i)")
+			defer testhelper.AssertQueryRuns(connection, "DROP INDEX public.simple_table_idx1")
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, "CREATE TABLE testschema.simple_table(i int, j int, k int)")
@@ -138,10 +138,10 @@ PARTITION BY RANGE (date)
 			structmatcher.ExpectStructsToMatchExcluding(&index1, &results[0], "Oid")
 		})
 		It("returns a slice of indexes belonging to filtered tables", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE simple_table(i int, j int, k int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE simple_table")
-			testhelper.AssertQueryRuns(connection, "CREATE INDEX simple_table_idx1 ON simple_table(i)")
-			defer testhelper.AssertQueryRuns(connection, "DROP INDEX simple_table_idx1")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.simple_table(i int, j int, k int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.simple_table")
+			testhelper.AssertQueryRuns(connection, "CREATE INDEX simple_table_idx1 ON public.simple_table(i)")
+			defer testhelper.AssertQueryRuns(connection, "DROP INDEX public.simple_table_idx1")
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, "CREATE TABLE testschema.simple_table(i int, j int, k int)")
@@ -160,13 +160,13 @@ PARTITION BY RANGE (date)
 			structmatcher.ExpectStructsToMatchExcluding(&index1, &results[0], "Oid")
 		})
 		It("returns a slice for an index used for clustering", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE simple_table(i int, j int, k int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE simple_table")
-			testhelper.AssertQueryRuns(connection, "CREATE INDEX simple_table_idx1 ON simple_table(i)")
-			defer testhelper.AssertQueryRuns(connection, "DROP INDEX simple_table_idx1")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.simple_table(i int, j int, k int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.simple_table")
+			testhelper.AssertQueryRuns(connection, "CREATE INDEX simple_table_idx1 ON public.simple_table(i)")
+			defer testhelper.AssertQueryRuns(connection, "DROP INDEX public.simple_table_idx1")
 			testhelper.AssertQueryRuns(connection, "ALTER TABLE public.simple_table CLUSTER ON simple_table_idx1")
 
-			index1 := backup.IndexDefinition{Oid: 0, Name: "simple_table_idx1", OwningSchema: "public", OwningTable: "simple_table", Def: "CREATE INDEX simple_table_idx1 ON simple_table USING btree (i)", IsClustered: true}
+			index1 := backup.IndexDefinition{Oid: 0, Name: "simple_table_idx1", OwningSchema: "public", OwningTable: "simple_table", Def: "CREATE INDEX simple_table_idx1 ON public.simple_table USING btree (i)", IsClustered: true}
 
 			results := backup.GetIndexes(connection)
 
@@ -183,18 +183,18 @@ PARTITION BY RANGE (date)
 			Expect(len(results)).To(Equal(0))
 		})
 		It("returns a slice of multiple rules", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE rule_table1(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE rule_table1")
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE rule_table2(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE rule_table2")
-			testhelper.AssertQueryRuns(connection, "CREATE RULE double_insert AS ON INSERT TO rule_table1 DO INSERT INTO rule_table2 (i) VALUES (1)")
-			defer testhelper.AssertQueryRuns(connection, "DROP RULE double_insert ON rule_table1")
-			testhelper.AssertQueryRuns(connection, "CREATE RULE update_notify AS ON UPDATE TO rule_table1 DO NOTIFY rule_table1")
-			defer testhelper.AssertQueryRuns(connection, "DROP RULE update_notify ON rule_table1")
-			testhelper.AssertQueryRuns(connection, "COMMENT ON RULE update_notify ON rule_table1 IS 'This is a rule comment.'")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.rule_table1(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.rule_table1")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.rule_table2(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.rule_table2")
+			testhelper.AssertQueryRuns(connection, "CREATE RULE double_insert AS ON INSERT TO public.rule_table1 DO INSERT INTO public.rule_table2 (i) VALUES (1)")
+			defer testhelper.AssertQueryRuns(connection, "DROP RULE double_insert ON public.rule_table1")
+			testhelper.AssertQueryRuns(connection, "CREATE RULE update_notify AS ON UPDATE TO public.rule_table1 DO NOTIFY rule_table1")
+			defer testhelper.AssertQueryRuns(connection, "DROP RULE update_notify ON public.rule_table1")
+			testhelper.AssertQueryRuns(connection, "COMMENT ON RULE update_notify ON public.rule_table1 IS 'This is a rule comment.'")
 
-			rule1 := backup.QuerySimpleDefinition{Oid: 0, Name: "double_insert", OwningSchema: "public", OwningTable: "rule_table1", Def: "CREATE RULE double_insert AS ON INSERT TO rule_table1 DO INSERT INTO rule_table2 (i) VALUES (1);"}
-			rule2 := backup.QuerySimpleDefinition{Oid: 1, Name: "update_notify", OwningSchema: "public", OwningTable: "rule_table1", Def: "CREATE RULE update_notify AS ON UPDATE TO rule_table1 DO NOTIFY rule_table1;"}
+			rule1 := backup.QuerySimpleDefinition{Oid: 0, Name: "double_insert", OwningSchema: "public", OwningTable: "rule_table1", Def: "CREATE RULE double_insert AS ON INSERT TO public.rule_table1 DO INSERT INTO public.rule_table2 (i) VALUES (1);"}
+			rule2 := backup.QuerySimpleDefinition{Oid: 1, Name: "update_notify", OwningSchema: "public", OwningTable: "rule_table1", Def: "CREATE RULE update_notify AS ON UPDATE TO public.rule_table1 DO NOTIFY rule_table1;"}
 
 			results := backup.GetRules(connection)
 
@@ -203,10 +203,10 @@ PARTITION BY RANGE (date)
 			structmatcher.ExpectStructsToMatchExcluding(&rule2, &results[1], "Oid")
 		})
 		It("returns a slice of rules for a specific schema", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE rule_table1(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE rule_table1")
-			testhelper.AssertQueryRuns(connection, "CREATE RULE double_insert AS ON INSERT TO rule_table1 DO INSERT INTO rule_table1 (i) VALUES (1)")
-			defer testhelper.AssertQueryRuns(connection, "DROP RULE double_insert ON rule_table1")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.rule_table1(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.rule_table1")
+			testhelper.AssertQueryRuns(connection, "CREATE RULE double_insert AS ON INSERT TO public.rule_table1 DO INSERT INTO public.rule_table1 (i) VALUES (1)")
+			defer testhelper.AssertQueryRuns(connection, "DROP RULE double_insert ON public.rule_table1")
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, "CREATE TABLE testschema.rule_table1(i int)")
@@ -223,10 +223,10 @@ PARTITION BY RANGE (date)
 			structmatcher.ExpectStructsToMatchExcluding(&rule1, &results[0], "Oid")
 		})
 		It("returns a slice of rules belonging to filtered tables", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE rule_table1(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE rule_table1")
-			testhelper.AssertQueryRuns(connection, "CREATE RULE double_insert AS ON INSERT TO rule_table1 DO INSERT INTO rule_table1 (i) VALUES (1)")
-			defer testhelper.AssertQueryRuns(connection, "DROP RULE double_insert ON rule_table1")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.rule_table1(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.rule_table1")
+			testhelper.AssertQueryRuns(connection, "CREATE RULE double_insert AS ON INSERT TO public.rule_table1 DO INSERT INTO public.rule_table1 (i) VALUES (1)")
+			defer testhelper.AssertQueryRuns(connection, "DROP RULE double_insert ON public.rule_table1")
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, "CREATE TABLE testschema.rule_table1(i int)")
@@ -250,18 +250,18 @@ PARTITION BY RANGE (date)
 			Expect(len(results)).To(Equal(0))
 		})
 		It("returns a slice of multiple triggers", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE trigger_table1(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE trigger_table1")
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE trigger_table2(j int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE trigger_table2")
-			testhelper.AssertQueryRuns(connection, `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`)
-			defer testhelper.AssertQueryRuns(connection, "DROP TRIGGER sync_trigger_table1 ON trigger_table1")
-			testhelper.AssertQueryRuns(connection, `CREATE TRIGGER sync_trigger_table2 AFTER INSERT OR DELETE OR UPDATE ON trigger_table2 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`)
-			defer testhelper.AssertQueryRuns(connection, "DROP TRIGGER sync_trigger_table2 ON trigger_table2")
-			testhelper.AssertQueryRuns(connection, "COMMENT ON TRIGGER sync_trigger_table2 ON trigger_table2 IS 'This is a trigger comment.'")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.trigger_table1(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.trigger_table1")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.trigger_table2(j int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.trigger_table2")
+			testhelper.AssertQueryRuns(connection, `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`)
+			defer testhelper.AssertQueryRuns(connection, "DROP TRIGGER sync_trigger_table1 ON public.trigger_table1")
+			testhelper.AssertQueryRuns(connection, `CREATE TRIGGER sync_trigger_table2 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table2 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`)
+			defer testhelper.AssertQueryRuns(connection, "DROP TRIGGER sync_trigger_table2 ON public.trigger_table2")
+			testhelper.AssertQueryRuns(connection, "COMMENT ON TRIGGER sync_trigger_table2 ON public.trigger_table2 IS 'This is a trigger comment.'")
 
-			trigger1 := backup.QuerySimpleDefinition{Oid: 0, Name: "sync_trigger_table1", OwningSchema: "public", OwningTable: "trigger_table1", Def: `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}
-			trigger2 := backup.QuerySimpleDefinition{Oid: 1, Name: "sync_trigger_table2", OwningSchema: "public", OwningTable: "trigger_table2", Def: `CREATE TRIGGER sync_trigger_table2 AFTER INSERT OR DELETE OR UPDATE ON trigger_table2 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}
+			trigger1 := backup.QuerySimpleDefinition{Oid: 0, Name: "sync_trigger_table1", OwningSchema: "public", OwningTable: "trigger_table1", Def: `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}
+			trigger2 := backup.QuerySimpleDefinition{Oid: 1, Name: "sync_trigger_table2", OwningSchema: "public", OwningTable: "trigger_table2", Def: `CREATE TRIGGER sync_trigger_table2 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table2 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}
 
 			results := backup.GetTriggers(connection)
 
@@ -270,21 +270,21 @@ PARTITION BY RANGE (date)
 			structmatcher.ExpectStructsToMatchExcluding(&trigger2, &results[1], "Oid")
 		})
 		It("does not include constraint triggers", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE trigger_table1(i int PRIMARY KEY)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE trigger_table1")
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE trigger_table2(j int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE trigger_table2")
-			testhelper.AssertQueryRuns(connection, "ALTER TABLE trigger_table2 ADD CONSTRAINT fkc FOREIGN KEY (j) REFERENCES trigger_table1 (i) ON UPDATE RESTRICT ON DELETE RESTRICT")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.trigger_table1(i int PRIMARY KEY)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.trigger_table1")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.trigger_table2(j int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.trigger_table2")
+			testhelper.AssertQueryRuns(connection, "ALTER TABLE public.trigger_table2 ADD CONSTRAINT fkc FOREIGN KEY (j) REFERENCES public.trigger_table1 (i) ON UPDATE RESTRICT ON DELETE RESTRICT")
 
 			results := backup.GetTriggers(connection)
 
 			Expect(len(results)).To(Equal(0))
 		})
 		It("returns a slice of triggers for a specific schema", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE trigger_table1(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE trigger_table1")
-			testhelper.AssertQueryRuns(connection, `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`)
-			defer testhelper.AssertQueryRuns(connection, "DROP TRIGGER sync_trigger_table1 ON trigger_table1")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.trigger_table1(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.trigger_table1")
+			testhelper.AssertQueryRuns(connection, `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`)
+			defer testhelper.AssertQueryRuns(connection, "DROP TRIGGER sync_trigger_table1 ON public.trigger_table1")
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, "CREATE TABLE testschema.trigger_table1(i int)")
@@ -301,10 +301,10 @@ PARTITION BY RANGE (date)
 			structmatcher.ExpectStructsToMatchExcluding(&trigger1, &results[0], "Oid")
 		})
 		It("returns a slice of triggers belonging to filtered tables", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE trigger_table1(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE trigger_table1")
-			testhelper.AssertQueryRuns(connection, `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`)
-			defer testhelper.AssertQueryRuns(connection, "DROP TRIGGER sync_trigger_table1 ON trigger_table1")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.trigger_table1(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.trigger_table1")
+			testhelper.AssertQueryRuns(connection, `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`)
+			defer testhelper.AssertQueryRuns(connection, "DROP TRIGGER sync_trigger_table1 ON public.trigger_table1")
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, "CREATE TABLE testschema.trigger_table1(i int)")

--- a/integration/predata_externals_create_test.go
+++ b/integration/predata_externals_create_test.go
@@ -33,8 +33,8 @@ var _ = Describe("backup integration create statement tests", func() {
 		})
 		AfterEach(func() {
 			os.Remove("/tmp/ext_table_file")
-			testhelper.AssertQueryRuns(connection, "DROP EXTERNAL TABLE testtable")
-			testhelper.AssertQueryRuns(connection, "DROP TABLE IF EXISTS err_table")
+			testhelper.AssertQueryRuns(connection, "DROP EXTERNAL TABLE public.testtable")
+			testhelper.AssertQueryRuns(connection, "DROP TABLE IF EXISTS public.err_table")
 		})
 		It("creates a READABLE EXTERNAL table", func() {
 			extTable.Type = backup.READABLE
@@ -113,8 +113,8 @@ var _ = Describe("backup integration create statement tests", func() {
 
 			backup.PrintCreateExternalProtocolStatements(backupfile, toc, externalProtocols, funcInfoMap, protoMetadataMap)
 
-			testhelper.AssertQueryRuns(connection, "CREATE OR REPLACE FUNCTION read_from_s3() RETURNS integer AS '$libdir/gps3ext.so', 's3_import' LANGUAGE C STABLE;")
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION read_from_s3()")
+			testhelper.AssertQueryRuns(connection, "CREATE OR REPLACE FUNCTION public.read_from_s3() RETURNS integer AS '$libdir/gps3ext.so', 's3_import' LANGUAGE C STABLE;")
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.read_from_s3()")
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
 			defer testhelper.AssertQueryRuns(connection, "DROP PROTOCOL s3_read")
@@ -129,8 +129,8 @@ var _ = Describe("backup integration create statement tests", func() {
 
 			backup.PrintCreateExternalProtocolStatements(backupfile, toc, externalProtocols, funcInfoMap, emptyMetadataMap)
 
-			testhelper.AssertQueryRuns(connection, "CREATE OR REPLACE FUNCTION write_to_s3() RETURNS integer AS '$libdir/gps3ext.so', 's3_export' LANGUAGE C STABLE;")
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION write_to_s3()")
+			testhelper.AssertQueryRuns(connection, "CREATE OR REPLACE FUNCTION public.write_to_s3() RETURNS integer AS '$libdir/gps3ext.so', 's3_export' LANGUAGE C STABLE;")
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.write_to_s3()")
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
 			defer testhelper.AssertQueryRuns(connection, "DROP PROTOCOL s3_write")
@@ -145,11 +145,11 @@ var _ = Describe("backup integration create statement tests", func() {
 
 			backup.PrintCreateExternalProtocolStatements(backupfile, toc, externalProtocols, funcInfoMap, emptyMetadataMap)
 
-			testhelper.AssertQueryRuns(connection, "CREATE OR REPLACE FUNCTION read_from_s3() RETURNS integer AS '$libdir/gps3ext.so', 's3_import' LANGUAGE C STABLE;")
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION read_from_s3()")
+			testhelper.AssertQueryRuns(connection, "CREATE OR REPLACE FUNCTION public.read_from_s3() RETURNS integer AS '$libdir/gps3ext.so', 's3_import' LANGUAGE C STABLE;")
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.read_from_s3()")
 
-			testhelper.AssertQueryRuns(connection, "CREATE OR REPLACE FUNCTION write_to_s3() RETURNS integer AS '$libdir/gps3ext.so', 's3_export' LANGUAGE C STABLE;")
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION write_to_s3()")
+			testhelper.AssertQueryRuns(connection, "CREATE OR REPLACE FUNCTION public.write_to_s3() RETURNS integer AS '$libdir/gps3ext.so', 's3_export' LANGUAGE C STABLE;")
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.write_to_s3()")
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
 			defer testhelper.AssertQueryRuns(connection, "DROP PROTOCOL s3_read_write")
@@ -167,7 +167,7 @@ var _ = Describe("backup integration create statement tests", func() {
 		}
 		emptyPartInfoMap := make(map[uint32]backup.PartitionInfo, 0)
 		AfterEach(func() {
-			testhelper.AssertQueryRuns(connection, "DROP TABLE part_tbl")
+			testhelper.AssertQueryRuns(connection, "DROP TABLE public.part_tbl")
 		})
 		It("writes an alter statement for a named list partition", func() {
 			externalPartition := backup.PartitionInfo{
@@ -182,14 +182,14 @@ var _ = Describe("backup integration create statement tests", func() {
 				IsExternal:             true,
 			}
 			testhelper.AssertQueryRuns(connection, `
-CREATE TABLE part_tbl (id int, gender char(1))
+CREATE TABLE public.part_tbl (id int, gender char(1))
 DISTRIBUTED BY (id)
 PARTITION BY LIST (gender)
 ( PARTITION girls VALUES ('F'),
   PARTITION boys VALUES ('M'),
   DEFAULT PARTITION other );`)
 			testhelper.AssertQueryRuns(connection, `
-CREATE EXTERNAL WEB TABLE part_tbl_ext_part_ (like part_tbl_1_prt_girls)
+CREATE EXTERNAL WEB TABLE public.part_tbl_ext_part_ (like public.part_tbl_1_prt_girls)
 EXECUTE 'echo -e "2\n1"' on host
 FORMAT 'csv';`)
 			externalPartitions := []backup.PartitionInfo{externalPartition}
@@ -215,12 +215,12 @@ FORMAT 'csv';`)
 				IsExternal:             true,
 			}
 			testhelper.AssertQueryRuns(connection, `
-CREATE TABLE part_tbl (a int)
+CREATE TABLE public.part_tbl (a int)
 DISTRIBUTED BY (a)
 PARTITION BY RANGE (a)
 (start(1) end(3) every(1));`)
 			testhelper.AssertQueryRuns(connection, `
-CREATE EXTERNAL WEB TABLE part_tbl_ext_part_ (like part_tbl_1_prt_1)
+CREATE EXTERNAL WEB TABLE public.part_tbl_ext_part_ (like public.part_tbl_1_prt_1)
 EXECUTE 'echo -e "2\n1"' on host
 FORMAT 'csv';`)
 			externalPartitions := []backup.PartitionInfo{externalPartition}
@@ -258,7 +258,7 @@ FORMAT 'csv';`)
 				IsExternal:             false,
 			}
 			testhelper.AssertQueryRuns(connection, `
-CREATE TABLE part_tbl (a int,b date,c text,d int)
+CREATE TABLE public.part_tbl (a int,b date,c text,d int)
 DISTRIBUTED BY (a)
 PARTITION BY RANGE (b)
 SUBPARTITION BY LIST (c)
@@ -273,7 +273,7 @@ SUBPARTITION eur values ('eur'))
                   END (date '2017-01-01') EXCLUSIVE);
 `)
 
-			testhelper.AssertQueryRuns(connection, `CREATE EXTERNAL TABLE part_tbl_ext_part_ (a int,b date,c text,d int) LOCATION ('gpfdist://127.0.0.1/apj') FORMAT 'text';`)
+			testhelper.AssertQueryRuns(connection, `CREATE EXTERNAL TABLE public.part_tbl_ext_part_ (a int,b date,c text,d int) LOCATION ('gpfdist://127.0.0.1/apj') FORMAT 'text';`)
 			partInfoMap := map[uint32]backup.PartitionInfo{externalPartitionParent.PartitionRuleOid: externalPartitionParent}
 			externalPartitions := []backup.PartitionInfo{externalPartition}
 
@@ -321,7 +321,7 @@ SUBPARTITION eur values ('eur'))
 				IsExternal:             false,
 			}
 			testhelper.AssertQueryRuns(connection, `
-CREATE TABLE part_tbl (id int, year int, month int, day int, region text)
+CREATE TABLE public.part_tbl (id int, year int, month int, day int, region text)
 DISTRIBUTED BY (id)
 PARTITION BY RANGE (year)
     SUBPARTITION BY RANGE (month)
@@ -336,7 +336,7 @@ PARTITION BY RANGE (year)
 ( START (2002) END (2005) EVERY (1));
 `)
 
-			testhelper.AssertQueryRuns(connection, `CREATE EXTERNAL TABLE part_tbl_ext_part_ (like part_tbl_1_prt_3_2_prt_1_3_prt_europe) LOCATION ('gpfdist://127.0.0.1/apj') FORMAT 'text';`)
+			testhelper.AssertQueryRuns(connection, `CREATE EXTERNAL TABLE public.part_tbl_ext_part_ (like public.part_tbl_1_prt_3_2_prt_1_3_prt_europe) LOCATION ('gpfdist://127.0.0.1/apj') FORMAT 'text';`)
 			partInfoMap := map[uint32]backup.PartitionInfo{externalPartitionParent1.PartitionRuleOid: externalPartitionParent1, externalPartitionParent2.PartitionRuleOid: externalPartitionParent2}
 			externalPartitions := []backup.PartitionInfo{externalPartition}
 

--- a/integration/predata_externals_queries_test.go
+++ b/integration/predata_externals_queries_test.go
@@ -13,12 +13,12 @@ import (
 var _ = Describe("backup integration tests", func() {
 	Describe("GetExternalTableDefinitions", func() {
 		It("returns a slice for a basic external table definition", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE simple_table(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE simple_table")
-			testhelper.AssertQueryRuns(connection, `CREATE READABLE EXTERNAL TABLE ext_table(i int)
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.simple_table(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.simple_table")
+			testhelper.AssertQueryRuns(connection, `CREATE READABLE EXTERNAL TABLE public.ext_table(i int)
 LOCATION ('file://tmp/myfile.txt')
 FORMAT 'TEXT'`)
-			defer testhelper.AssertQueryRuns(connection, "DROP EXTERNAL TABLE ext_table")
+			defer testhelper.AssertQueryRuns(connection, "DROP EXTERNAL TABLE public.ext_table")
 			oid := testutils.OidFromObjectName(connection, "public", "ext_table", backup.TYPE_RELATION)
 
 			results := backup.GetExternalTableDefinitions(connection)
@@ -31,12 +31,12 @@ FORMAT 'TEXT'`)
 			structmatcher.ExpectStructsToMatchExcluding(&extTable, &result, "Oid")
 		})
 		It("returns a slice for a basic external web table definition", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE simple_table(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE simple_table")
-			testhelper.AssertQueryRuns(connection, `CREATE READABLE EXTERNAL WEB TABLE ext_table(i int)
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.simple_table(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.simple_table")
+			testhelper.AssertQueryRuns(connection, `CREATE READABLE EXTERNAL WEB TABLE public.ext_table(i int)
 EXECUTE 'hostname'
 FORMAT 'TEXT'`)
-			defer testhelper.AssertQueryRuns(connection, "DROP EXTERNAL WEB TABLE ext_table")
+			defer testhelper.AssertQueryRuns(connection, "DROP EXTERNAL WEB TABLE public.ext_table")
 			oid := testutils.OidFromObjectName(connection, "public", "ext_table", backup.TYPE_RELATION)
 
 			results := backup.GetExternalTableDefinitions(connection)
@@ -50,13 +50,13 @@ FORMAT 'TEXT'`)
 			structmatcher.ExpectStructsToMatchExcluding(&extTable, &result, "Oid")
 		})
 		It("returns a slice for a complex external table definition", func() {
-			testhelper.AssertQueryRuns(connection, `CREATE READABLE EXTERNAL TABLE ext_table(i int)
+			testhelper.AssertQueryRuns(connection, `CREATE READABLE EXTERNAL TABLE public.ext_table(i int)
 LOCATION ('file://tmp/myfile.txt')
 FORMAT 'TEXT'
 LOG ERRORS
 SEGMENT REJECT LIMIT 10 PERCENT
 `)
-			defer testhelper.AssertQueryRuns(connection, "DROP EXTERNAL TABLE ext_table")
+			defer testhelper.AssertQueryRuns(connection, "DROP EXTERNAL TABLE public.ext_table")
 			oid := testutils.OidFromObjectName(connection, "public", "ext_table", backup.TYPE_RELATION)
 
 			results := backup.GetExternalTableDefinitions(connection)
@@ -71,14 +71,14 @@ SEGMENT REJECT LIMIT 10 PERCENT
 		})
 		It("returns a slice for a complex external table definition with options", func() {
 			testutils.SkipIfBefore5(connection)
-			testhelper.AssertQueryRuns(connection, `CREATE READABLE EXTERNAL TABLE ext_table(i int)
+			testhelper.AssertQueryRuns(connection, `CREATE READABLE EXTERNAL TABLE public.ext_table(i int)
 LOCATION ('file://tmp/myfile.txt')
 FORMAT 'TEXT'
 OPTIONS (foo 'bar')
 LOG ERRORS
 SEGMENT REJECT LIMIT 10 PERCENT
 `)
-			defer testhelper.AssertQueryRuns(connection, "DROP EXTERNAL TABLE ext_table")
+			defer testhelper.AssertQueryRuns(connection, "DROP EXTERNAL TABLE public.ext_table")
 			oid := testutils.OidFromObjectName(connection, "public", "ext_table", backup.TYPE_RELATION)
 
 			results := backup.GetExternalTableDefinitions(connection)
@@ -94,11 +94,11 @@ SEGMENT REJECT LIMIT 10 PERCENT
 	})
 	Describe("GetExternalProtocols", func() {
 		It("returns a slice for a protocol", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE OR REPLACE FUNCTION write_to_s3() RETURNS integer AS '$libdir/gps3ext.so', 's3_export' LANGUAGE C STABLE;")
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION write_to_s3()")
-			testhelper.AssertQueryRuns(connection, "CREATE OR REPLACE FUNCTION read_from_s3() RETURNS integer AS '$libdir/gps3ext.so', 's3_import' LANGUAGE C STABLE;")
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION read_from_s3()")
-			testhelper.AssertQueryRuns(connection, "CREATE PROTOCOL s3 (writefunc = write_to_s3, readfunc = read_from_s3);")
+			testhelper.AssertQueryRuns(connection, "CREATE OR REPLACE FUNCTION public.write_to_s3() RETURNS integer AS '$libdir/gps3ext.so', 's3_export' LANGUAGE C STABLE;")
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.write_to_s3()")
+			testhelper.AssertQueryRuns(connection, "CREATE OR REPLACE FUNCTION public.read_from_s3() RETURNS integer AS '$libdir/gps3ext.so', 's3_import' LANGUAGE C STABLE;")
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.read_from_s3()")
+			testhelper.AssertQueryRuns(connection, "CREATE PROTOCOL s3 (writefunc = public.write_to_s3, readfunc = public.read_from_s3);")
 			defer testhelper.AssertQueryRuns(connection, "DROP PROTOCOL s3")
 
 			readFunctionOid := testutils.OidFromObjectName(connection, "public", "read_from_s3", backup.TYPE_FUNCTION)
@@ -114,19 +114,19 @@ SEGMENT REJECT LIMIT 10 PERCENT
 	})
 	Describe("GetExternalPartitionInfo", func() {
 		AfterEach(func() {
-			testhelper.AssertQueryRuns(connection, "DROP TABLE part_tbl")
-			testhelper.AssertQueryRuns(connection, "DROP TABLE part_tbl_ext_part_")
+			testhelper.AssertQueryRuns(connection, "DROP TABLE public.part_tbl")
+			testhelper.AssertQueryRuns(connection, "DROP TABLE public.part_tbl_ext_part_")
 		})
 		It("returns a slice of external partition info for a named list partition", func() {
 			testhelper.AssertQueryRuns(connection, `
-CREATE TABLE part_tbl (id int, gender char(1))
+CREATE TABLE public.part_tbl (id int, gender char(1))
 DISTRIBUTED BY (id)
 PARTITION BY LIST (gender)
 ( PARTITION girls VALUES ('F'),
   PARTITION boys VALUES ('M'),
   DEFAULT PARTITION other );`)
 			testhelper.AssertQueryRuns(connection, `
-CREATE EXTERNAL WEB TABLE part_tbl_ext_part_ (like part_tbl_1_prt_girls)
+CREATE EXTERNAL WEB TABLE public.part_tbl_ext_part_ (like public.part_tbl_1_prt_girls)
 EXECUTE 'echo -e "2\n1"' on host
 FORMAT 'csv';`)
 			testhelper.AssertQueryRuns(connection, `ALTER TABLE public.part_tbl EXCHANGE PARTITION girls WITH TABLE public.part_tbl_ext_part_ WITHOUT VALIDATION;`)
@@ -150,12 +150,12 @@ FORMAT 'csv';`)
 		})
 		It("returns a slice of external partition info for an unnamed range partition", func() {
 			testhelper.AssertQueryRuns(connection, `
-CREATE TABLE part_tbl (a int)
+CREATE TABLE public.part_tbl (a int)
 DISTRIBUTED BY (a)
 PARTITION BY RANGE (a)
 (start(1) end(3) every(1));`)
 			testhelper.AssertQueryRuns(connection, `
-CREATE EXTERNAL WEB TABLE part_tbl_ext_part_ (like part_tbl_1_prt_1)
+CREATE EXTERNAL WEB TABLE public.part_tbl_ext_part_ (like public.part_tbl_1_prt_1)
 EXECUTE 'echo -e "2\n1"' on host
 FORMAT 'csv';`)
 			testhelper.AssertQueryRuns(connection, `ALTER TABLE public.part_tbl EXCHANGE PARTITION FOR (RANK(1)) WITH TABLE public.part_tbl_ext_part_ WITHOUT VALIDATION;`)
@@ -180,7 +180,7 @@ FORMAT 'csv';`)
 		It("returns a slice of info for a two level partition", func() {
 			testutils.SkipIfBefore5(connection)
 			testhelper.AssertQueryRuns(connection, `
-CREATE TABLE part_tbl (a int,b date,c text,d int)
+CREATE TABLE public.part_tbl (a int,b date,c text,d int)
 DISTRIBUTED BY (a)
 PARTITION BY RANGE (b)
 SUBPARTITION BY LIST (c)
@@ -195,7 +195,7 @@ SUBPARTITION eur values ('eur'))
                   END (date '2017-01-01') EXCLUSIVE);
 `)
 
-			testhelper.AssertQueryRuns(connection, `CREATE EXTERNAL TABLE part_tbl_ext_part_ (a int,b date,c text,d int) LOCATION ('gpfdist://127.0.0.1/apj') FORMAT 'text';`)
+			testhelper.AssertQueryRuns(connection, `CREATE EXTERNAL TABLE public.part_tbl_ext_part_ (a int,b date,c text,d int) LOCATION ('gpfdist://127.0.0.1/apj') FORMAT 'text';`)
 			testhelper.AssertQueryRuns(connection, `ALTER TABLE public.part_tbl ALTER PARTITION Dec16 EXCHANGE PARTITION apj WITH TABLE public.part_tbl_ext_part_ WITHOUT VALIDATION;`)
 
 			resultExtPartitions, _ := backup.GetExternalPartitionInfo(connection)
@@ -217,7 +217,7 @@ SUBPARTITION eur values ('eur'))
 		It("returns a slice of info for a three level partition", func() {
 			testutils.SkipIfBefore5(connection)
 			testhelper.AssertQueryRuns(connection, `
-CREATE TABLE part_tbl (id int, year int, month int, day int, region text)
+CREATE TABLE public.part_tbl (id int, year int, month int, day int, region text)
 DISTRIBUTED BY (id)
 PARTITION BY RANGE (year)
     SUBPARTITION BY RANGE (month)
@@ -232,7 +232,7 @@ PARTITION BY RANGE (year)
 ( START (2002) END (2005) EVERY (1));
 `)
 
-			testhelper.AssertQueryRuns(connection, `CREATE EXTERNAL TABLE part_tbl_ext_part_ (like part_tbl_1_prt_3_2_prt_1_3_prt_europe) LOCATION ('gpfdist://127.0.0.1/apj') FORMAT 'text';`)
+			testhelper.AssertQueryRuns(connection, `CREATE EXTERNAL TABLE public.part_tbl_ext_part_ (like public.part_tbl_1_prt_3_2_prt_1_3_prt_europe) LOCATION ('gpfdist://127.0.0.1/apj') FORMAT 'text';`)
 			testhelper.AssertQueryRuns(connection, `ALTER TABLE public.part_tbl ALTER PARTITION FOR (RANK(3)) ALTER PARTITION FOR (RANK(1)) EXCHANGE PARTITION europe WITH TABLE public.part_tbl_ext_part_ WITHOUT VALIDATION;`)
 
 			resultExtPartitions, _ := backup.GetExternalPartitionInfo(connection)

--- a/integration/predata_functions_create_test.go
+++ b/integration/predata_functions_create_test.go
@@ -30,7 +30,7 @@ var _ = Describe("backup integration create statement tests", func() {
 				backup.PrintCreateFunctionStatement(backupfile, toc, addFunction, funcMetadata)
 
 				testhelper.AssertQueryRuns(connection, buffer.String())
-				defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION add(integer, integer)")
+				defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.add(integer, integer)")
 
 				resultFunctions := backup.GetFunctionsAllVersions(connection)
 
@@ -47,7 +47,7 @@ var _ = Describe("backup integration create statement tests", func() {
 				backup.PrintCreateFunctionStatement(backupfile, toc, appendFunction, funcMetadata)
 
 				testhelper.AssertQueryRuns(connection, buffer.String())
-				defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION append(integer, integer)")
+				defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.append(integer, integer)")
 
 				resultFunctions := backup.GetFunctionsAllVersions(connection)
 
@@ -64,7 +64,7 @@ var _ = Describe("backup integration create statement tests", func() {
 				backup.PrintCreateFunctionStatement(backupfile, toc, dupFunction, funcMetadata)
 
 				testhelper.AssertQueryRuns(connection, buffer.String())
-				defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION dup(integer)")
+				defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.dup(integer)")
 
 				resultFunctions := backup.GetFunctionsAllVersions(connection)
 
@@ -88,7 +88,7 @@ var _ = Describe("backup integration create statement tests", func() {
 				backup.PrintCreateFunctionStatement(backupfile, toc, addFunction, funcMetadata)
 
 				testhelper.AssertQueryRuns(connection, buffer.String())
-				defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION add(integer, integer)")
+				defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.add(integer, integer)")
 
 				resultFunctions := backup.GetFunctionsAllVersions(connection)
 
@@ -107,7 +107,7 @@ var _ = Describe("backup integration create statement tests", func() {
 				backup.PrintCreateFunctionStatement(backupfile, toc, appendFunction, funcMetadata)
 
 				testhelper.AssertQueryRuns(connection, buffer.String())
-				defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION append(integer, integer)")
+				defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.append(integer, integer)")
 
 				resultFunctions := backup.GetFunctionsAllVersions(connection)
 
@@ -126,7 +126,7 @@ var _ = Describe("backup integration create statement tests", func() {
 				backup.PrintCreateFunctionStatement(backupfile, toc, dupFunction, funcMetadata)
 
 				testhelper.AssertQueryRuns(connection, buffer.String())
-				defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION dup(integer)")
+				defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.dup(integer)")
 
 				resultFunctions := backup.GetFunctionsAllVersions(connection)
 
@@ -150,7 +150,7 @@ var _ = Describe("backup integration create statement tests", func() {
 				backup.PrintCreateFunctionStatement(backupfile, toc, windowFunction, funcMetadata)
 
 				testhelper.AssertQueryRuns(connection, buffer.String())
-				defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION add(integer, integer)")
+				defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.add(integer, integer)")
 
 				resultFunctions := backup.GetFunctionsAllVersions(connection)
 
@@ -168,7 +168,7 @@ var _ = Describe("backup integration create statement tests", func() {
 				backup.PrintCreateFunctionStatement(backupfile, toc, segmentFunction, funcMetadata)
 
 				testhelper.AssertQueryRuns(connection, buffer.String())
-				defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION add(integer, integer)")
+				defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.add(integer, integer)")
 
 				resultFunctions := backup.GetFunctionsAllVersions(connection)
 
@@ -198,7 +198,7 @@ var _ = Describe("backup integration create statement tests", func() {
 		BeforeEach(func() {
 			//Run queries to set up the database state so we can successfully create an aggregate
 			testhelper.AssertQueryRuns(connection, `
-			CREATE FUNCTION mysfunc_accum(numeric, numeric, numeric)
+			CREATE FUNCTION public.mysfunc_accum(numeric, numeric, numeric)
 			   RETURNS numeric
 			   AS 'select $1 + $2 + $3'
 			   LANGUAGE SQL
@@ -206,7 +206,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			   RETURNS NULL ON NULL INPUT;
 			`)
 			testhelper.AssertQueryRuns(connection, `
-			CREATE FUNCTION mypre_accum(numeric, numeric)
+			CREATE FUNCTION public.mypre_accum(numeric, numeric)
 			   RETURNS numeric
 			   AS 'select $1 + $2'
 			   LANGUAGE SQL
@@ -215,14 +215,14 @@ var _ = Describe("backup integration create statement tests", func() {
 			`)
 		})
 		AfterEach(func() {
-			testhelper.AssertQueryRuns(connection, "DROP FUNCTION mysfunc_accum(numeric, numeric, numeric)")
-			testhelper.AssertQueryRuns(connection, "DROP FUNCTION mypre_accum(numeric, numeric)")
+			testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.mysfunc_accum(numeric, numeric, numeric)")
+			testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.mypre_accum(numeric, numeric)")
 		})
 		It("creates a basic aggregate", func() {
 			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{basicAggregateDef}, funcInfoMap, emptyMetadataMap)
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
-			defer testhelper.AssertQueryRuns(connection, "DROP AGGREGATE agg_prefunc(numeric, numeric)")
+			defer testhelper.AssertQueryRuns(connection, "DROP AGGREGATE public.agg_prefunc(numeric, numeric)")
 
 			resultAggregates := backup.GetAggregates(connection)
 			Expect(len(resultAggregates)).To(Equal(1))
@@ -234,7 +234,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{basicAggregateDef}, funcInfoMap, aggMetadataMap)
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
-			defer testhelper.AssertQueryRuns(connection, "DROP AGGREGATE agg_prefunc(numeric, numeric)")
+			defer testhelper.AssertQueryRuns(connection, "DROP AGGREGATE public.agg_prefunc(numeric, numeric)")
 
 			oid := testutils.OidFromObjectName(connection, "", "agg_prefunc", backup.TYPE_AGGREGATE)
 			resultAggregates := backup.GetAggregates(connection)
@@ -250,7 +250,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{complexAggregateDef}, funcInfoMap, emptyMetadataMap)
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
-			defer testhelper.AssertQueryRuns(connection, `DROP AGGREGATE agg_hypo_ord(VARIADIC "any" ORDER BY VARIADIC "any")`)
+			defer testhelper.AssertQueryRuns(connection, `DROP AGGREGATE public.agg_hypo_ord(VARIADIC "any" ORDER BY VARIADIC "any")`)
 			resultAggregates := backup.GetAggregates(connection)
 
 			Expect(len(resultAggregates)).To(Equal(1))
@@ -267,8 +267,8 @@ var _ = Describe("backup integration create statement tests", func() {
 		It("prints a basic cast with a function", func() {
 			castDef := backup.Cast{Oid: 0, SourceTypeFQN: "pg_catalog.money", TargetTypeFQN: "pg_catalog.text", FunctionSchema: "public", FunctionName: "money_to_text", FunctionArgs: "money", CastContext: "a", CastMethod: "f"}
 
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION money_to_text(money) RETURNS TEXT AS $$ SELECT textin(cash_out($1)) $$ LANGUAGE SQL;")
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION money_to_text(money)")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.money_to_text(money) RETURNS TEXT AS $$ SELECT textin(cash_out($1)) $$ LANGUAGE SQL;")
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.money_to_text(money)")
 
 			backup.PrintCreateCastStatements(backupfile, toc, []backup.Cast{castDef}, castMetadataMap)
 			defer testhelper.AssertQueryRuns(connection, "DROP CAST (money AS text)")
@@ -282,10 +282,10 @@ var _ = Describe("backup integration create statement tests", func() {
 		It("prints a basic cast without a function", func() {
 			castDef := backup.Cast{Oid: 0, SourceTypeFQN: "pg_catalog.text", TargetTypeFQN: "public.casttesttype", FunctionSchema: "", FunctionName: "", FunctionArgs: "", CastContext: "i", CastMethod: "b"}
 
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION cast_in(cstring) RETURNS casttesttype AS $$textin$$ LANGUAGE internal STRICT NO SQL")
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION cast_out(casttesttype) RETURNS cstring AS $$textout$$ LANGUAGE internal STRICT NO SQL")
-			testhelper.AssertQueryRuns(connection, "CREATE TYPE casttesttype (INTERNALLENGTH = variable, INPUT = cast_in, OUTPUT = cast_out)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TYPE casttesttype CASCADE")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.cast_in(cstring) RETURNS public.casttesttype AS $$textin$$ LANGUAGE internal STRICT NO SQL")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.cast_out(public.casttesttype) RETURNS cstring AS $$textout$$ LANGUAGE internal STRICT NO SQL")
+			testhelper.AssertQueryRuns(connection, "CREATE TYPE public.casttesttype (INTERNALLENGTH = variable, INPUT = public.cast_in, OUTPUT = public.cast_out)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TYPE public.casttesttype CASCADE")
 
 			backup.PrintCreateCastStatements(backupfile, toc, []backup.Cast{castDef}, castMetadataMap)
 			defer testhelper.AssertQueryRuns(connection, "DROP CAST (text AS public.casttesttype)")
@@ -301,8 +301,8 @@ var _ = Describe("backup integration create statement tests", func() {
 			castMetadataMap = testutils.DefaultMetadataMap("CAST", false, false, true)
 			castMetadata := castMetadataMap[1]
 
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION money_to_text(money) RETURNS TEXT AS $$ SELECT textin(cash_out($1)) $$ LANGUAGE SQL;")
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION money_to_text(money)")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.money_to_text(money) RETURNS TEXT AS $$ SELECT textin(cash_out($1)) $$ LANGUAGE SQL;")
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.money_to_text(money)")
 
 			backup.PrintCreateCastStatements(backupfile, toc, []backup.Cast{castDef}, castMetadataMap)
 			defer testhelper.AssertQueryRuns(connection, "DROP CAST (money AS text)")
@@ -319,11 +319,11 @@ var _ = Describe("backup integration create statement tests", func() {
 		It("prints an inout cast ", func() {
 			testutils.SkipIfBefore6(connection)
 			castDef := backup.Cast{Oid: 0, SourceTypeFQN: `pg_catalog."varchar"`, TargetTypeFQN: "public.custom_numeric", FunctionSchema: "", FunctionName: "", FunctionArgs: "", CastContext: "a", CastMethod: "i"}
-			testhelper.AssertQueryRuns(connection, "CREATE TYPE custom_numeric AS (i numeric)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TYPE custom_numeric")
+			testhelper.AssertQueryRuns(connection, "CREATE TYPE public.custom_numeric AS (i numeric)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TYPE public.custom_numeric")
 
 			backup.PrintCreateCastStatements(backupfile, toc, []backup.Cast{castDef}, castMetadataMap)
-			defer testhelper.AssertQueryRuns(connection, "DROP CAST (varchar AS custom_numeric)")
+			defer testhelper.AssertQueryRuns(connection, "DROP CAST (varchar AS public.custom_numeric)")
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
 
@@ -378,7 +378,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			backup.PrintCreateExtensionStatements(backupfile, toc, extensions, extensionMetadataMap)
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
-			defer testhelper.AssertQueryRuns(connection, "DROP EXTENSION plperl; SET search_path=public,pg_catalog")
+			defer testhelper.AssertQueryRuns(connection, "DROP EXTENSION plperl; SET search_path=pg_catalog")
 
 			resultExtensions := backup.GetExtensions(connection)
 			resultMetadataMap := backup.GetCommentsForObjectType(connection, backup.TYPE_EXTENSION)
@@ -402,8 +402,8 @@ var _ = Describe("backup integration create statement tests", func() {
 			backup.PrintCreateConversionStatements(backupfile, toc, conversions, convMetadataMap)
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
-			defer testhelper.AssertQueryRuns(connection, "DROP CONVERSION conv_one")
-			defer testhelper.AssertQueryRuns(connection, "DROP CONVERSION conv_two")
+			defer testhelper.AssertQueryRuns(connection, "DROP CONVERSION public.conv_one")
+			defer testhelper.AssertQueryRuns(connection, "DROP CONVERSION public.conv_two")
 
 			resultConversions := backup.GetConversions(connection)
 			resultMetadataMap := backup.GetMetadataForObjectType(connection, backup.TYPE_CONVERSION)

--- a/integration/predata_functions_queries_test.go
+++ b/integration/predata_functions_queries_test.go
@@ -15,12 +15,12 @@ var _ = Describe("backup integration tests", func() {
 			testutils.SkipIfBefore5(connection)
 		})
 		It("returns a slice of functions", func() {
-			testhelper.AssertQueryRuns(connection, `CREATE FUNCTION add(integer, integer) RETURNS integer
+			testhelper.AssertQueryRuns(connection, `CREATE FUNCTION public.add(integer, integer) RETURNS integer
 AS 'SELECT $1 + $2'
 LANGUAGE SQL`)
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION add(integer, integer)")
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.add(integer, integer)")
 			testhelper.AssertQueryRuns(connection, `
-CREATE FUNCTION append(integer, integer) RETURNS SETOF record
+CREATE FUNCTION public.append(integer, integer) RETURNS SETOF record
 AS 'SELECT ($1, $2)'
 LANGUAGE SQL
 SECURITY DEFINER
@@ -31,8 +31,8 @@ ROWS 200
 SET search_path = pg_temp
 MODIFIES SQL DATA
 `)
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION append(integer, integer)")
-			testhelper.AssertQueryRuns(connection, "COMMENT ON FUNCTION append(integer, integer) IS 'this is a function comment'")
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.append(integer, integer)")
+			testhelper.AssertQueryRuns(connection, "COMMENT ON FUNCTION public.append(integer, integer) IS 'this is a function comment'")
 
 			results := backup.GetFunctionsMaster(connection)
 
@@ -52,10 +52,10 @@ MODIFIES SQL DATA
 			structmatcher.ExpectStructsToMatchExcluding(&results[1], &appendFunction, "Oid")
 		})
 		It("returns a slice of functions in a specific schema", func() {
-			testhelper.AssertQueryRuns(connection, `CREATE FUNCTION add(integer, integer) RETURNS integer
+			testhelper.AssertQueryRuns(connection, `CREATE FUNCTION public.add(integer, integer) RETURNS integer
 AS 'SELECT $1 + $2'
 LANGUAGE SQL`)
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION add(integer, integer)")
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.add(integer, integer)")
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, `CREATE FUNCTION testschema.add(integer, integer) RETURNS integer
@@ -76,10 +76,10 @@ LANGUAGE SQL`)
 		})
 		It("returns a window function", func() {
 			testutils.SkipIfBefore6(connection)
-			testhelper.AssertQueryRuns(connection, `CREATE FUNCTION add(integer, integer) RETURNS integer
+			testhelper.AssertQueryRuns(connection, `CREATE FUNCTION public.add(integer, integer) RETURNS integer
 AS 'SELECT $1 + $2'
 LANGUAGE SQL WINDOW`)
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION add(integer, integer)")
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.add(integer, integer)")
 
 			results := backup.GetFunctionsMaster(connection)
 
@@ -94,16 +94,16 @@ LANGUAGE SQL WINDOW`)
 		})
 		It("returns a function to execute on master and all segments", func() {
 			testutils.SkipIfBefore6(connection)
-			testhelper.AssertQueryRuns(connection, `CREATE FUNCTION srf_on_master(integer, integer) RETURNS integer
+			testhelper.AssertQueryRuns(connection, `CREATE FUNCTION public.srf_on_master(integer, integer) RETURNS integer
 AS 'SELECT $1 + $2'
 LANGUAGE SQL WINDOW
 EXECUTE ON MASTER;`)
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION srf_on_master(integer, integer)")
-			testhelper.AssertQueryRuns(connection, `CREATE FUNCTION srf_on_all_segments(integer, integer) RETURNS integer
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.srf_on_master(integer, integer)")
+			testhelper.AssertQueryRuns(connection, `CREATE FUNCTION public.srf_on_all_segments(integer, integer) RETURNS integer
 AS 'SELECT $1 + $2'
 LANGUAGE SQL WINDOW
 EXECUTE ON ALL SEGMENTS;`)
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION srf_on_all_segments(integer, integer)")
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.srf_on_all_segments(integer, integer)")
 
 			results := backup.GetFunctionsMaster(connection)
 
@@ -128,22 +128,22 @@ EXECUTE ON ALL SEGMENTS;`)
 			testutils.SkipIfNot4(connection)
 		})
 		It("returns a slice of functions", func() {
-			testhelper.AssertQueryRuns(connection, `CREATE FUNCTION add(numeric, integer) RETURNS numeric
+			testhelper.AssertQueryRuns(connection, `CREATE FUNCTION public.add(numeric, integer) RETURNS numeric
 AS 'SELECT $1 + $2'
 LANGUAGE SQL`)
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION add(numeric, integer)")
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.add(numeric, integer)")
 			testhelper.AssertQueryRuns(connection, `
-CREATE FUNCTION append(float, integer) RETURNS SETOF record
+CREATE FUNCTION public.append(float, integer) RETURNS SETOF record
 AS 'SELECT ($1, $2)'
 LANGUAGE SQL
 SECURITY DEFINER
 STRICT
 STABLE
 `)
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION append(float, integer)")
-			testhelper.AssertQueryRuns(connection, "COMMENT ON FUNCTION append(float, integer) IS 'this is a function comment'")
-			testhelper.AssertQueryRuns(connection, `CREATE FUNCTION "specChar"(t text, "precision" double precision) RETURNS double precision AS $$BEGIN RETURN precision + 1; END;$$ LANGUAGE PLPGSQL;`)
-			defer testhelper.AssertQueryRuns(connection, `DROP FUNCTION "specChar"(text, double precision)`)
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.append(float, integer)")
+			testhelper.AssertQueryRuns(connection, "COMMENT ON FUNCTION public.append(float, integer) IS 'this is a function comment'")
+			testhelper.AssertQueryRuns(connection, `CREATE FUNCTION public."specChar"(t text, "precision" double precision) RETURNS double precision AS $$BEGIN RETURN precision + 1; END;$$ LANGUAGE PLPGSQL;`)
+			defer testhelper.AssertQueryRuns(connection, `DROP FUNCTION public."specChar"(text, double precision)`)
 
 			results := backup.GetFunctions4(connection)
 
@@ -166,10 +166,10 @@ STABLE
 			structmatcher.ExpectStructsToMatchExcluding(&results[2], &specCharFunction, "Oid")
 		})
 		It("returns a slice of functions in a specific schema", func() {
-			testhelper.AssertQueryRuns(connection, `CREATE FUNCTION add(numeric, integer) RETURNS numeric
+			testhelper.AssertQueryRuns(connection, `CREATE FUNCTION public.add(numeric, integer) RETURNS numeric
 AS 'SELECT $1 + $2'
 LANGUAGE SQL`)
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION add(numeric, integer)")
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.add(numeric, integer)")
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, `CREATE FUNCTION testschema.add(float, integer) RETURNS float
@@ -191,31 +191,31 @@ LANGUAGE SQL`)
 	Describe("GetAggregates", func() {
 		It("returns a slice of aggregates", func() {
 			testhelper.AssertQueryRuns(connection, `
-CREATE FUNCTION mysfunc_accum(numeric, numeric, numeric)
+CREATE FUNCTION public.mysfunc_accum(numeric, numeric, numeric)
    RETURNS numeric
    AS 'select $1 + $2 + $3'
    LANGUAGE SQL
    IMMUTABLE
    RETURNS NULL ON NULL INPUT;
 `)
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION mysfunc_accum(numeric, numeric, numeric)")
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.mysfunc_accum(numeric, numeric, numeric)")
 			testhelper.AssertQueryRuns(connection, `
-CREATE FUNCTION mypre_accum(numeric, numeric)
+CREATE FUNCTION public.mypre_accum(numeric, numeric)
    RETURNS numeric
    AS 'select $1 + $2'
    LANGUAGE SQL
    IMMUTABLE
    RETURNS NULL ON NULL INPUT;
 `)
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION mypre_accum(numeric, numeric)")
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.mypre_accum(numeric, numeric)")
 			testhelper.AssertQueryRuns(connection, `
-CREATE AGGREGATE agg_prefunc(numeric, numeric) (
-	SFUNC = mysfunc_accum,
+CREATE AGGREGATE public.agg_prefunc(numeric, numeric) (
+	SFUNC = public.mysfunc_accum,
 	STYPE = numeric,
-	PREFUNC = mypre_accum,
+	PREFUNC = public.mypre_accum,
 	INITCOND = 0 );
 `)
-			defer testhelper.AssertQueryRuns(connection, "DROP AGGREGATE agg_prefunc(numeric, numeric)")
+			defer testhelper.AssertQueryRuns(connection, "DROP AGGREGATE public.agg_prefunc(numeric, numeric)")
 
 			transitionOid := testutils.OidFromObjectName(connection, "public", "mysfunc_accum", backup.TYPE_FUNCTION)
 			prelimOid := testutils.OidFromObjectName(connection, "public", "mypre_accum", backup.TYPE_FUNCTION)
@@ -233,38 +233,38 @@ CREATE AGGREGATE agg_prefunc(numeric, numeric) (
 		})
 		It("returns a slice of aggregates in a specific schema", func() {
 			testhelper.AssertQueryRuns(connection, `
-CREATE FUNCTION mysfunc_accum(numeric, numeric, numeric)
+CREATE FUNCTION public.mysfunc_accum(numeric, numeric, numeric)
    RETURNS numeric
    AS 'select $1 + $2 + $3'
    LANGUAGE SQL
    IMMUTABLE
    RETURNS NULL ON NULL INPUT;
 `)
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION mysfunc_accum(numeric, numeric, numeric)")
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.mysfunc_accum(numeric, numeric, numeric)")
 			testhelper.AssertQueryRuns(connection, `
-CREATE FUNCTION mypre_accum(numeric, numeric)
+CREATE FUNCTION public.mypre_accum(numeric, numeric)
    RETURNS numeric
    AS 'select $1 + $2'
    LANGUAGE SQL
    IMMUTABLE
    RETURNS NULL ON NULL INPUT;
 `)
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION mypre_accum(numeric, numeric)")
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.mypre_accum(numeric, numeric)")
 			testhelper.AssertQueryRuns(connection, `
-CREATE AGGREGATE agg_prefunc(numeric, numeric) (
-	SFUNC = mysfunc_accum,
+CREATE AGGREGATE public.agg_prefunc(numeric, numeric) (
+	SFUNC = public.mysfunc_accum,
 	STYPE = numeric,
-	PREFUNC = mypre_accum,
+	PREFUNC = public.mypre_accum,
 	INITCOND = 0 );
 `)
-			defer testhelper.AssertQueryRuns(connection, "DROP AGGREGATE agg_prefunc(numeric, numeric)")
+			defer testhelper.AssertQueryRuns(connection, "DROP AGGREGATE public.agg_prefunc(numeric, numeric)")
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, `
 CREATE AGGREGATE testschema.agg_prefunc(numeric, numeric) (
-	SFUNC = mysfunc_accum,
+	SFUNC = public.mysfunc_accum,
 	STYPE = numeric,
-	PREFUNC = mypre_accum,
+	PREFUNC = public.mypre_accum,
 	INITCOND = 0 );
 `)
 			defer testhelper.AssertQueryRuns(connection, "DROP AGGREGATE testschema.agg_prefunc(numeric, numeric)")
@@ -287,15 +287,15 @@ CREATE AGGREGATE testschema.agg_prefunc(numeric, numeric) (
 			testutils.SkipIfBefore6(connection)
 
 			testhelper.AssertQueryRuns(connection, `
-CREATE AGGREGATE agg_hypo_ord (VARIADIC "any" ORDER BY VARIADIC "any")
+CREATE AGGREGATE public.agg_hypo_ord (VARIADIC "any" ORDER BY VARIADIC "any")
 (
-	SFUNC = ordered_set_transition_multi,
+	SFUNC = pg_catalog.ordered_set_transition_multi,
 	STYPE = internal,
-	FINALFUNC = rank_final,
+	FINALFUNC = pg_catalog.rank_final,
 	FINALFUNC_EXTRA,
 	HYPOTHETICAL
 );`)
-			defer testhelper.AssertQueryRuns(connection, `DROP AGGREGATE agg_hypo_ord(VARIADIC "any" ORDER BY VARIADIC "any")`)
+			defer testhelper.AssertQueryRuns(connection, `DROP AGGREGATE public.agg_hypo_ord(VARIADIC "any" ORDER BY VARIADIC "any")`)
 
 			transitionOid := testutils.OidFromObjectName(connection, "pg_catalog", "ordered_set_transition_multi", backup.TYPE_FUNCTION)
 			finalOid := testutils.OidFromObjectName(connection, "pg_catalog", "rank_final", backup.TYPE_FUNCTION)
@@ -316,10 +316,10 @@ CREATE AGGREGATE agg_hypo_ord (VARIADIC "any" ORDER BY VARIADIC "any")
 		It("returns map containing function information", func() {
 			result := backup.GetFunctionOidToInfoMap(connection)
 			initialLength := len(result)
-			testhelper.AssertQueryRuns(connection, `CREATE FUNCTION add(integer, integer) RETURNS integer
+			testhelper.AssertQueryRuns(connection, `CREATE FUNCTION public.add(integer, integer) RETURNS integer
 AS 'SELECT $1 + $2'
 LANGUAGE SQL`)
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION add(integer, integer)")
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.add(integer, integer)")
 
 			result = backup.GetFunctionOidToInfoMap(connection)
 			oid := testutils.OidFromObjectName(connection, "public", "add", backup.TYPE_FUNCTION)
@@ -339,9 +339,9 @@ LANGUAGE SQL`)
 	Describe("GetCasts", func() {
 		It("returns a slice for a basic cast with a function in 4.3", func() {
 			testutils.SkipIfNot4(connection)
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION casttotext(bool) RETURNS text STRICT IMMUTABLE LANGUAGE PLPGSQL AS $$ BEGIN IF $1 IS TRUE THEN RETURN 'true'; ELSE RETURN 'false'; END IF; END; $$;")
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION casttotext(bool)")
-			testhelper.AssertQueryRuns(connection, "CREATE CAST (bool AS text) WITH FUNCTION casttotext(bool) AS ASSIGNMENT")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.casttotext(bool) RETURNS pg_catalog.text STRICT IMMUTABLE LANGUAGE PLPGSQL AS $$ BEGIN IF $1 IS TRUE THEN RETURN 'true'; ELSE RETURN 'false'; END IF; END; $$;")
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.casttotext(bool)")
+			testhelper.AssertQueryRuns(connection, "CREATE CAST (bool AS text) WITH FUNCTION public.casttotext(bool) AS ASSIGNMENT")
 			defer testhelper.AssertQueryRuns(connection, "DROP CAST (bool AS text)")
 
 			results := backup.GetCasts(connection)
@@ -353,9 +353,9 @@ LANGUAGE SQL`)
 		})
 		It("returns a slice for a basic cast with a function in 5 and 6", func() {
 			testutils.SkipIfBefore5(connection)
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION casttoint(text) RETURNS integer STRICT IMMUTABLE LANGUAGE SQL AS 'SELECT cast($1 as integer);'")
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION casttoint(text)")
-			testhelper.AssertQueryRuns(connection, "CREATE CAST (text AS integer) WITH FUNCTION casttoint(text) AS ASSIGNMENT")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.casttoint(text) RETURNS integer STRICT IMMUTABLE LANGUAGE SQL AS 'SELECT cast($1 as integer);'")
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.casttoint(text)")
+			testhelper.AssertQueryRuns(connection, "CREATE CAST (text AS integer) WITH FUNCTION public.casttoint(text) AS ASSIGNMENT")
 			defer testhelper.AssertQueryRuns(connection, "DROP CAST (text AS int4)")
 
 			results := backup.GetCasts(connection)
@@ -366,10 +366,10 @@ LANGUAGE SQL`)
 			structmatcher.ExpectStructsToMatchExcluding(&castDef, &results[0], "Oid")
 		})
 		It("returns a slice for a basic cast without a function", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION cast_in(cstring) RETURNS casttesttype AS $$textin$$ LANGUAGE internal STRICT NO SQL")
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION cast_out(casttesttype) RETURNS cstring AS $$textout$$ LANGUAGE internal STRICT NO SQL")
-			testhelper.AssertQueryRuns(connection, "CREATE TYPE casttesttype (INTERNALLENGTH = variable, INPUT = cast_in, OUTPUT = cast_out)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TYPE casttesttype CASCADE")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.cast_in(cstring) RETURNS public.casttesttype AS $$textin$$ LANGUAGE internal STRICT NO SQL")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.cast_out(public.casttesttype) RETURNS cstring AS $$textout$$ LANGUAGE internal STRICT NO SQL")
+			testhelper.AssertQueryRuns(connection, "CREATE TYPE public.casttesttype (INTERNALLENGTH = variable, INPUT = public.cast_in, OUTPUT = public.cast_out)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TYPE public.casttesttype CASCADE")
 			testhelper.AssertQueryRuns(connection, "CREATE CAST (text AS public.casttesttype) WITHOUT FUNCTION AS IMPLICIT")
 			defer testhelper.AssertQueryRuns(connection, "DROP CAST (text AS public.casttesttype)")
 
@@ -404,10 +404,10 @@ LANGUAGE SQL`)
 		})
 		It("returns a slice for an inout cast", func() {
 			testutils.SkipIfBefore6(connection)
-			testhelper.AssertQueryRuns(connection, "CREATE TYPE custom_numeric AS (i numeric)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TYPE custom_numeric")
-			testhelper.AssertQueryRuns(connection, "CREATE CAST (varchar AS custom_numeric) WITH INOUT")
-			defer testhelper.AssertQueryRuns(connection, "DROP CAST (varchar AS custom_numeric)")
+			testhelper.AssertQueryRuns(connection, "CREATE TYPE public.custom_numeric AS (i numeric)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TYPE public.custom_numeric")
+			testhelper.AssertQueryRuns(connection, "CREATE CAST (varchar AS public.custom_numeric) WITH INOUT")
+			defer testhelper.AssertQueryRuns(connection, "DROP CAST (varchar AS public.custom_numeric)")
 
 			results := backup.GetCasts(connection)
 
@@ -456,8 +456,8 @@ LANGUAGE SQL`)
 	})
 	Describe("GetConversions", func() {
 		It("returns a slice of conversions", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE CONVERSION testconv FOR 'LATIN1' TO 'MULE_INTERNAL' FROM latin1_to_mic")
-			defer testhelper.AssertQueryRuns(connection, "DROP CONVERSION testconv")
+			testhelper.AssertQueryRuns(connection, "CREATE CONVERSION public.testconv FOR 'LATIN1' TO 'MULE_INTERNAL' FROM latin1_to_mic")
+			defer testhelper.AssertQueryRuns(connection, "DROP CONVERSION public.testconv")
 
 			expectedConversion := backup.Conversion{Oid: 0, Schema: "public", Name: "testconv", ForEncoding: "LATIN1", ToEncoding: "MULE_INTERNAL", ConversionFunction: "pg_catalog.latin1_to_mic", IsDefault: false}
 
@@ -467,8 +467,8 @@ LANGUAGE SQL`)
 			structmatcher.ExpectStructsToMatchExcluding(&expectedConversion, &resultConversions[0], "Oid")
 		})
 		It("returns a slice of conversions in a specific schema", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE CONVERSION testconv FOR 'LATIN1' TO 'MULE_INTERNAL' FROM latin1_to_mic")
-			defer testhelper.AssertQueryRuns(connection, "DROP CONVERSION testconv")
+			testhelper.AssertQueryRuns(connection, "CREATE CONVERSION public.testconv FOR 'LATIN1' TO 'MULE_INTERNAL' FROM latin1_to_mic")
+			defer testhelper.AssertQueryRuns(connection, "DROP CONVERSION public.testconv")
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, "CREATE CONVERSION testschema.testconv FOR 'LATIN1' TO 'MULE_INTERNAL' FROM latin1_to_mic")
@@ -485,14 +485,14 @@ LANGUAGE SQL`)
 	})
 	Describe("ConstructFunctionDependencies", func() {
 		BeforeEach(func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TYPE composite_ints AS (one integer, two integer)")
+			testhelper.AssertQueryRuns(connection, "CREATE TYPE public.composite_ints AS (one integer, two integer)")
 		})
 		AfterEach(func() {
-			testhelper.AssertQueryRuns(connection, "DROP TYPE composite_ints CASCADE")
+			testhelper.AssertQueryRuns(connection, "DROP TYPE public.composite_ints CASCADE")
 		})
 		It("constructs dependencies correctly for a function dependent on a user-defined type in the arguments", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION add(composite_ints) RETURNS integer STRICT IMMUTABLE LANGUAGE SQL AS 'SELECT ($1.one + $1.two);'")
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION add(composite_ints)")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.add(public.composite_ints) RETURNS integer STRICT IMMUTABLE LANGUAGE SQL AS 'SELECT ($1.one + $1.two);'")
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.add(public.composite_ints)")
 
 			allFunctions := backup.GetFunctionsAllVersions(connection)
 			function := backup.Function{}
@@ -511,8 +511,8 @@ LANGUAGE SQL`)
 			Expect(functions[0].DependsUpon[0]).To(Equal("public.composite_ints"))
 		})
 		It("constructs dependencies correctly for a function dependent on a user-defined type in the return type", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION compose(integer, integer) RETURNS composite_ints STRICT IMMUTABLE LANGUAGE PLPGSQL AS 'DECLARE comp composite_ints; BEGIN SELECT $1, $2 INTO comp; RETURN comp; END;';")
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION compose(integer, integer)")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.compose(integer, integer) RETURNS public.composite_ints STRICT IMMUTABLE LANGUAGE PLPGSQL AS 'DECLARE comp public.composite_ints; BEGIN SELECT $1, $2 INTO comp; RETURN comp; END;';")
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.compose(integer, integer)")
 
 			allFunctions := backup.GetFunctionsAllVersions(connection)
 			function := backup.Function{}
@@ -531,13 +531,13 @@ LANGUAGE SQL`)
 			Expect(functions[0].DependsUpon[0]).To(Equal("public.composite_ints"))
 		})
 		It("constructs dependencies correctly for a function dependent on an implicit array type", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TYPE base_type")
-			defer testhelper.AssertQueryRuns(connection, "DROP TYPE base_type CASCADE")
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION base_fn_in(cstring) RETURNS base_type AS 'boolin' LANGUAGE internal")
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION base_fn_out(base_type) RETURNS cstring AS 'boolout' LANGUAGE internal")
-			testhelper.AssertQueryRuns(connection, "CREATE TYPE base_type(INPUT=base_fn_in, OUTPUT=base_fn_out)")
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION compose(base_type[], composite_ints) RETURNS composite_ints STRICT IMMUTABLE LANGUAGE PLPGSQL AS 'DECLARE comp composite_ints; BEGIN SELECT $1[0].one+$2.one, $1[0].two+$2.two INTO comp; RETURN comp; END;';")
-			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION compose(base_type[], composite_ints)")
+			testhelper.AssertQueryRuns(connection, "CREATE TYPE public.base_type")
+			defer testhelper.AssertQueryRuns(connection, "DROP TYPE public.base_type CASCADE")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.base_fn_in(cstring) RETURNS public.base_type AS 'boolin' LANGUAGE internal")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.base_fn_out(public.base_type) RETURNS cstring AS 'boolout' LANGUAGE internal")
+			testhelper.AssertQueryRuns(connection, "CREATE TYPE public.base_type(INPUT=public.base_fn_in, OUTPUT=public.base_fn_out)")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.compose(public.base_type[], public.composite_ints) RETURNS public.composite_ints STRICT IMMUTABLE LANGUAGE PLPGSQL AS 'DECLARE comp public.composite_ints; BEGIN SELECT $1[0].one+$2.one, $1[0].two+$2.two INTO comp; RETURN comp; END;';")
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.compose(public.base_type[], public.composite_ints)")
 
 			allFunctions := backup.GetFunctionsAllVersions(connection)
 			function := backup.Function{}

--- a/integration/predata_operators_queries_test.go
+++ b/integration/predata_operators_queries_test.go
@@ -13,8 +13,8 @@ import (
 var _ = Describe("backup integration tests", func() {
 	Describe("GetOperators", func() {
 		It("returns a slice of operators", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE OPERATOR ## (LEFTARG = bigint, PROCEDURE = numeric_fac)")
-			defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR ## (bigint, NONE)")
+			testhelper.AssertQueryRuns(connection, "CREATE OPERATOR public.## (LEFTARG = bigint, PROCEDURE = numeric_fac)")
+			defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR public.## (bigint, NONE)")
 
 			expectedOperator := backup.Operator{Oid: 0, Schema: "public", Name: "##", Procedure: "numeric_fac", LeftArgType: "bigint", RightArgType: "-", CommutatorOp: "0", NegatorOp: "0", RestrictFunction: "-", JoinFunction: "-", CanHash: false, CanMerge: false}
 
@@ -43,10 +43,10 @@ var _ = Describe("backup integration tests", func() {
 				MERGES
 			)`)
 			defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR testschema.## (path, path)")
-			defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR ### (path, path)")
+			defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR public.### (path, path)")
 
-			version4expectedOperator := backup.Operator{Oid: 0, Schema: "testschema", Name: "##", Procedure: `testschema."testFunc"`, LeftArgType: "path", RightArgType: "path", CommutatorOp: "testschema.##", NegatorOp: "###", RestrictFunction: "eqsel", JoinFunction: "eqjoinsel", CanHash: true, CanMerge: false}
-			expectedOperator := backup.Operator{Oid: 0, Schema: "testschema", Name: "##", Procedure: `testschema."testFunc"`, LeftArgType: "path", RightArgType: "path", CommutatorOp: "testschema.##", NegatorOp: "###", RestrictFunction: "eqsel", JoinFunction: "eqjoinsel", CanHash: true, CanMerge: true}
+			version4expectedOperator := backup.Operator{Oid: 0, Schema: "testschema", Name: "##", Procedure: `testschema."testFunc"`, LeftArgType: "path", RightArgType: "path", CommutatorOp: "testschema.##", NegatorOp: "public.###", RestrictFunction: "eqsel", JoinFunction: "eqjoinsel", CanHash: true, CanMerge: false}
+			expectedOperator := backup.Operator{Oid: 0, Schema: "testschema", Name: "##", Procedure: `testschema."testFunc"`, LeftArgType: "path", RightArgType: "path", CommutatorOp: "testschema.##", NegatorOp: "public.###", RestrictFunction: "eqsel", JoinFunction: "eqjoinsel", CanHash: true, CanMerge: true}
 
 			results := backup.GetOperators(connection)
 
@@ -58,8 +58,8 @@ var _ = Describe("backup integration tests", func() {
 			}
 		})
 		It("returns a slice of operators from a specific schema", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE OPERATOR ## (LEFTARG = bigint, PROCEDURE = numeric_fac)")
-			defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR ## (bigint, NONE)")
+			testhelper.AssertQueryRuns(connection, "CREATE OPERATOR public.## (LEFTARG = bigint, PROCEDURE = numeric_fac)")
+			defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR public.## (bigint, NONE)")
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, "CREATE OPERATOR testschema.## (LEFTARG = bigint, PROCEDURE = numeric_fac)")
@@ -79,8 +79,8 @@ var _ = Describe("backup integration tests", func() {
 			testutils.SkipIfBefore5(connection)
 		})
 		It("returns a slice of operator families", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE OPERATOR FAMILY testfam USING hash;")
-			defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR FAMILY testfam USING hash")
+			testhelper.AssertQueryRuns(connection, "CREATE OPERATOR FAMILY public.testfam USING hash;")
+			defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR FAMILY public.testfam USING hash")
 
 			expectedOperator := backup.OperatorFamily{Oid: 0, Schema: "public", Name: "testfam", IndexMethod: "hash"}
 
@@ -90,8 +90,8 @@ var _ = Describe("backup integration tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&expectedOperator, &results[0], "Oid")
 		})
 		It("returns a slice of operator families in a specific schema", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE OPERATOR FAMILY testfam USING hash;")
-			defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR FAMILY testfam USING hash")
+			testhelper.AssertQueryRuns(connection, "CREATE OPERATOR FAMILY public.testfam USING hash;")
+			defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR FAMILY public.testfam USING hash")
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, "CREATE OPERATOR FAMILY testschema.testfam USING hash;")
@@ -108,11 +108,11 @@ var _ = Describe("backup integration tests", func() {
 	})
 	Describe("GetOperatorClasses", func() {
 		It("returns a slice of operator classes", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE OPERATOR CLASS testclass FOR TYPE int USING hash AS STORAGE int")
+			testhelper.AssertQueryRuns(connection, "CREATE OPERATOR CLASS public.testclass FOR TYPE int USING hash AS STORAGE int")
 			if connection.Version.Before("5") {
-				defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR CLASS testclass USING hash")
+				defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR CLASS public.testclass USING hash")
 			} else {
-				defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR FAMILY testclass USING hash")
+				defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR FAMILY public.testclass USING hash")
 			}
 
 			version4expected := backup.OperatorClass{Oid: 0, Schema: "public", Name: "testclass", FamilySchema: "", FamilyName: "", IndexMethod: "hash", Type: "integer", Default: false, StorageType: "-", Operators: nil, Functions: nil}
@@ -134,7 +134,7 @@ var _ = Describe("backup integration tests", func() {
 
 			testhelper.AssertQueryRuns(connection, "CREATE OPERATOR FAMILY testschema.testfam USING gist;")
 			defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR FAMILY testschema.testfam USING gist CASCADE")
-			testhelper.AssertQueryRuns(connection, "CREATE OPERATOR CLASS testclass FOR TYPE int USING gist FAMILY testschema.testfam AS STORAGE int")
+			testhelper.AssertQueryRuns(connection, "CREATE OPERATOR CLASS public.testclass FOR TYPE int USING gist FAMILY testschema.testfam AS STORAGE int")
 
 			expected := backup.OperatorClass{Oid: 0, Schema: "public", Name: "testclass", FamilySchema: "testschema", FamilyName: "testfam", IndexMethod: "gist", Type: "integer", Default: false, StorageType: "-", Operators: nil, Functions: nil}
 
@@ -144,14 +144,11 @@ var _ = Describe("backup integration tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&expected, &results[0], "Oid")
 		})
 		It("returns a slice of operator classes with different type and storage type", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
-			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema CASCADE")
-
-			testhelper.AssertQueryRuns(connection, "CREATE OPERATOR CLASS testclass DEFAULT FOR TYPE int USING gist AS STORAGE text")
+			testhelper.AssertQueryRuns(connection, "CREATE OPERATOR CLASS public.testclass DEFAULT FOR TYPE int USING gist AS STORAGE text")
 			if connection.Version.Before("5") {
-				defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR CLASS testclass USING gist")
+				defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR CLASS public.testclass USING gist")
 			} else {
-				defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR FAMILY testclass USING gist")
+				defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR FAMILY public.testclass USING gist")
 			}
 
 			version4expected := backup.OperatorClass{Oid: 0, Schema: "public", Name: "testclass", FamilySchema: "", FamilyName: "", IndexMethod: "gist", Type: "integer", Default: true, StorageType: "text", Operators: nil, Functions: nil}
@@ -170,18 +167,18 @@ var _ = Describe("backup integration tests", func() {
 			opClassQuery := ""
 			expectedRecheck := false
 			if connection.Version.Before("6") {
-				opClassQuery = "CREATE OPERATOR CLASS testclass FOR TYPE int USING gist AS OPERATOR 1 = RECHECK, OPERATOR 2 < , FUNCTION 1 abs(integer), FUNCTION 2 int4out(integer)"
+				opClassQuery = "CREATE OPERATOR CLASS public.testclass FOR TYPE int USING gist AS OPERATOR 1 = RECHECK, OPERATOR 2 < , FUNCTION 1 abs(integer), FUNCTION 2 int4out(integer)"
 				expectedRecheck = true
 			} else {
-				opClassQuery = "CREATE OPERATOR CLASS testclass FOR TYPE int USING gist AS OPERATOR 1 =, OPERATOR 2 < , FUNCTION 1 abs(integer), FUNCTION 2 int4out(integer)"
+				opClassQuery = "CREATE OPERATOR CLASS public.testclass FOR TYPE int USING gist AS OPERATOR 1 =, OPERATOR 2 < , FUNCTION 1 abs(integer), FUNCTION 2 int4out(integer)"
 			}
 
 			testhelper.AssertQueryRuns(connection, opClassQuery)
 
 			if connection.Version.Before("5") {
-				defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR CLASS testclass USING gist")
+				defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR CLASS public.testclass USING gist")
 			} else {
-				defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR FAMILY testclass USING gist")
+				defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR FAMILY public.testclass USING gist")
 			}
 
 			expectedOperators := []backup.OperatorClassOperator{{ClassOid: 0, StrategyNumber: 1, Operator: "=(integer,integer)", Recheck: expectedRecheck}, {ClassOid: 0, StrategyNumber: 2, Operator: "<(integer,integer)", Recheck: false}}
@@ -199,11 +196,11 @@ var _ = Describe("backup integration tests", func() {
 			}
 		})
 		It("returns a slice of operator classes for a specific schema", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE OPERATOR CLASS testclass FOR TYPE int USING hash AS STORAGE int")
+			testhelper.AssertQueryRuns(connection, "CREATE OPERATOR CLASS public.testclass FOR TYPE int USING hash AS STORAGE int")
 			if connection.Version.Before("5") {
-				defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR CLASS testclass USING hash")
+				defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR CLASS public.testclass USING hash")
 			} else {
-				defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR FAMILY testclass USING hash")
+				defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR FAMILY public.testclass USING hash")
 			}
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema CASCADE")

--- a/integration/predata_relations_create_test.go
+++ b/integration/predata_relations_create_test.go
@@ -28,36 +28,36 @@ var _ = Describe("backup integration create statement tests", func() {
 			 */
 			partitionDef = `PARTITION BY LIST(gender) ` + `
           (
-          PARTITION girls VALUES('F') WITH (tablename='rank_1_prt_girls', appendonly=false ), ` + `
-          PARTITION boys VALUES('M') WITH (tablename='rank_1_prt_boys', appendonly=false ), ` + `
-          DEFAULT PARTITION other  WITH (tablename='rank_1_prt_other', appendonly=false )
+          PARTITION girls VALUES('F') WITH (tablename='public.rank_1_prt_girls', appendonly=false ), ` + `
+          PARTITION boys VALUES('M') WITH (tablename='public.rank_1_prt_boys', appendonly=false ), ` + `
+          DEFAULT PARTITION other  WITH (tablename='public.rank_1_prt_other', appendonly=false )
           )`
 			subpartitionDef = `PARTITION BY LIST(gender)
           SUBPARTITION BY LIST(region) ` + `
           (
-          PARTITION girls VALUES('F') WITH (tablename='rank_1_prt_girls', appendonly=false ) ` + `
+          PARTITION girls VALUES('F') WITH (tablename='public.rank_1_prt_girls', appendonly=false ) ` + `
                   (
-                  SUBPARTITION usa VALUES('usa') WITH (tablename='rank_1_prt_girls_2_prt_usa', appendonly=false ), ` + `
-                  SUBPARTITION asia VALUES('asia') WITH (tablename='rank_1_prt_girls_2_prt_asia', appendonly=false ), ` + `
-                  SUBPARTITION europe VALUES('europe') WITH (tablename='rank_1_prt_girls_2_prt_europe', appendonly=false ), ` + `
-                  DEFAULT SUBPARTITION other_regions  WITH (tablename='rank_1_prt_girls_2_prt_other_regions', appendonly=false )
+                  SUBPARTITION usa VALUES('usa') WITH (tablename='public.rank_1_prt_girls_2_prt_usa', appendonly=false ), ` + `
+                  SUBPARTITION asia VALUES('asia') WITH (tablename='public.rank_1_prt_girls_2_prt_asia', appendonly=false ), ` + `
+                  SUBPARTITION europe VALUES('europe') WITH (tablename='public.rank_1_prt_girls_2_prt_europe', appendonly=false ), ` + `
+                  DEFAULT SUBPARTITION other_regions  WITH (tablename='public.rank_1_prt_girls_2_prt_other_regions', appendonly=false )
                   ), ` + `
           PARTITION boys VALUES('M') WITH (tablename='rank_1_prt_boys', appendonly=false ) ` + `
                   (
-                  SUBPARTITION usa VALUES('usa') WITH (tablename='rank_1_prt_boys_2_prt_usa', appendonly=false ), ` + `
-                  SUBPARTITION asia VALUES('asia') WITH (tablename='rank_1_prt_boys_2_prt_asia', appendonly=false ), ` + `
-                  SUBPARTITION europe VALUES('europe') WITH (tablename='rank_1_prt_boys_2_prt_europe', appendonly=false ), ` + `
-                  DEFAULT SUBPARTITION other_regions  WITH (tablename='rank_1_prt_boys_2_prt_other_regions', appendonly=false )
+                  SUBPARTITION usa VALUES('usa') WITH (tablename='public.rank_1_prt_boys_2_prt_usa', appendonly=false ), ` + `
+                  SUBPARTITION asia VALUES('asia') WITH (tablename='public.rank_1_prt_boys_2_prt_asia', appendonly=false ), ` + `
+                  SUBPARTITION europe VALUES('europe') WITH (tablename='public.rank_1_prt_boys_2_prt_europe', appendonly=false ), ` + `
+                  DEFAULT SUBPARTITION other_regions  WITH (tablename='public.rank_1_prt_boys_2_prt_other_regions', appendonly=false )
                   ), ` + `
-          DEFAULT PARTITION other  WITH (tablename='rank_1_prt_other', appendonly=false ) ` + `
+          DEFAULT PARTITION other  WITH (tablename='public.rank_1_prt_other', appendonly=false ) ` + `
                   (
-                  SUBPARTITION usa VALUES('usa') WITH (tablename='rank_1_prt_other_2_prt_usa', appendonly=false ), ` + `
-                  SUBPARTITION asia VALUES('asia') WITH (tablename='rank_1_prt_other_2_prt_asia', appendonly=false ), ` + `
-                  SUBPARTITION europe VALUES('europe') WITH (tablename='rank_1_prt_other_2_prt_europe', appendonly=false ), ` + `
-                  DEFAULT SUBPARTITION other_regions  WITH (tablename='rank_1_prt_other_2_prt_other_regions', appendonly=false )
+                  SUBPARTITION usa VALUES('usa') WITH (tablename='public.rank_1_prt_other_2_prt_usa', appendonly=false ), ` + `
+                  SUBPARTITION asia VALUES('asia') WITH (tablename='public.rank_1_prt_other_2_prt_asia', appendonly=false ), ` + `
+                  SUBPARTITION europe VALUES('europe') WITH (tablename='public.rank_1_prt_other_2_prt_europe', appendonly=false ), ` + `
+                  DEFAULT SUBPARTITION other_regions  WITH (tablename='public.rank_1_prt_other_2_prt_other_regions', appendonly=false )
                   )
           )`
-			partTemplateDef = `ALTER TABLE testtable ` + `
+			partTemplateDef = `ALTER TABLE public.testtable ` + `
 SET SUBPARTITION TEMPLATE  ` + `
           (
           SUBPARTITION usa VALUES('usa') WITH (tablename='testtable'), ` + `
@@ -89,14 +89,14 @@ SET SUBPARTITION TEMPLATE  ` + `
 		})
 		It("creates a table of a type", func() {
 			testutils.SkipIfBefore6(connection)
-			testhelper.AssertQueryRuns(connection, `CREATE TYPE some_type AS (i text, j numeric)`)
-			defer testhelper.AssertQueryRuns(connection, `DROP TYPE some_type CASCADE`)
+			testhelper.AssertQueryRuns(connection, `CREATE TYPE public.some_type AS (i text, j numeric)`)
+			defer testhelper.AssertQueryRuns(connection, `DROP TYPE public.some_type CASCADE`)
 
 			rowOne := backup.ColumnDefinition{Oid: 0, Num: 1, Name: "i", NotNull: false, HasDefault: false, Type: "text", Encoding: "", StatTarget: -1, StorageType: "", DefaultVal: "", Comment: "", ACL: emptyACL}
 			rowTwo := backup.ColumnDefinition{Oid: 0, Num: 2, Name: "j", NotNull: false, HasDefault: false, Type: "numeric", Encoding: "", StatTarget: -1, StorageType: "", DefaultVal: "", Comment: "", ACL: emptyACL}
 			tableDef.ColumnDefs = []backup.ColumnDefinition{rowOne, rowTwo}
 
-			tableDef.TableType = "some_type"
+			tableDef.TableType = "public.some_type"
 			backup.PrintRegularTableCreateStatement(backupfile, toc, testTable, tableDef)
 			testhelper.AssertQueryRuns(connection, buffer.String())
 
@@ -185,7 +185,7 @@ SET SUBPARTITION TEMPLATE  ` + `
 			tableDef.TablespaceName = "test_tablespace"
 
 			backup.PrintRegularTableCreateStatement(backupfile, toc, testTable, tableDef)
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE testtable2")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.testtable2")
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
 			testTable.Oid = testutils.OidFromObjectName(connection, "public", "testtable2", backup.TYPE_RELATION)
@@ -264,12 +264,12 @@ SET SUBPARTITION TEMPLATE  ` + `
 			tableDef      backup.TableDefinition
 		)
 		BeforeEach(func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE testtable(i int)")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.testtable(i int)")
 			tableMetadata = backup.ObjectMetadata{Privileges: []backup.ACL{}}
 			tableDef = backup.TableDefinition{DistPolicy: "DISTRIBUTED BY (i)", ColumnDefs: []backup.ColumnDefinition{tableRow}, ExtTableDef: extTableEmpty}
 		})
 		AfterEach(func() {
-			testhelper.AssertQueryRuns(connection, "DROP TABLE testtable")
+			testhelper.AssertQueryRuns(connection, "DROP TABLE public.testtable")
 		})
 		It("prints only owner for a table with no comment or column comments", func() {
 			tableMetadata.Owner = "testrole"
@@ -320,7 +320,7 @@ SET SUBPARTITION TEMPLATE  ` + `
 			backup.PrintCreateViewStatements(backupfile, toc, []backup.View{viewDef}, viewMetadataMap)
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
-			defer testhelper.AssertQueryRuns(connection, "DROP VIEW simpleview")
+			defer testhelper.AssertQueryRuns(connection, "DROP VIEW public.simpleview")
 
 			resultViews := backup.GetViews(connection)
 			resultMetadataMap := backup.GetMetadataForObjectType(connection, backup.TYPE_RELATION)
@@ -355,7 +355,7 @@ SET SUBPARTITION TEMPLATE  ` + `
 			}
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
-			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE my_sequence")
+			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE public.my_sequence")
 
 			resultSequences := backup.GetAllSequences(connection, map[string]string{})
 
@@ -372,7 +372,7 @@ SET SUBPARTITION TEMPLATE  ` + `
 			backup.PrintCreateSequenceStatements(backupfile, toc, []backup.Sequence{sequenceDef}, sequenceMetadataMap)
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
-			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE my_sequence")
+			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE public.my_sequence")
 
 			resultSequences := backup.GetAllSequences(connection, map[string]string{})
 
@@ -394,7 +394,7 @@ SET SUBPARTITION TEMPLATE  ` + `
 			}
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
-			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE my_sequence")
+			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE public.my_sequence")
 
 			resultSequences := backup.GetAllSequences(connection, map[string]string{})
 
@@ -422,11 +422,11 @@ SET SUBPARTITION TEMPLATE  ` + `
 			backup.PrintAlterSequenceStatements(backupfile, toc, []backup.Sequence{sequenceDef}, columnOwnerMap)
 
 			//Create table that sequence can be owned by
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE sequence_table(a int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE sequence_table")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.sequence_table(a int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.sequence_table")
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
-			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE my_sequence")
+			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE public.my_sequence")
 
 			sequenceOwnerTables, sequenceOwnerColumns := backup.GetSequenceColumnOwnerMap(connection)
 			Expect(len(sequenceOwnerTables)).To(Equal(1))

--- a/integration/predata_relations_queries_test.go
+++ b/integration/predata_relations_queries_test.go
@@ -18,8 +18,8 @@ var _ = Describe("backup integration tests", func() {
 			backup.SetLeafPartitionData(false)
 		})
 		It("returns user table information for basic heap tables", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE foo(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE foo")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.foo(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.foo")
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema CASCADE")
 			testhelper.AssertQueryRuns(connection, "CREATE TABLE testschema.testtable(t text)")
@@ -38,18 +38,18 @@ var _ = Describe("backup integration tests", func() {
 				backup.SetLeafPartitionData(true)
 				backup.SetIncludeTables([]string{"public.partition_table_1_prt_boys"})
 				defer backup.SetIncludeTables([]string{})
-				testhelper.AssertQueryRuns(connection, `CREATE TABLE partition_table (id int, gender char(1))
+				testhelper.AssertQueryRuns(connection, `CREATE TABLE public.partition_table (id int, gender char(1))
 DISTRIBUTED BY (id)
 PARTITION BY LIST (gender)
 ( PARTITION girls VALUES ('F'),
   PARTITION boys VALUES ('M'),
   DEFAULT PARTITION other );`)
-				testhelper.AssertQueryRuns(connection, `CREATE EXTERNAL WEB TABLE partition_table_ext_part_ (like partition_table_1_prt_girls)
+				testhelper.AssertQueryRuns(connection, `CREATE EXTERNAL WEB TABLE public.partition_table_ext_part_ (like public.partition_table_1_prt_girls)
 EXECUTE 'echo -e "2\n1"' on host
 FORMAT 'csv';`)
 				testhelper.AssertQueryRuns(connection, `ALTER TABLE public.partition_table EXCHANGE PARTITION girls WITH TABLE public.partition_table_ext_part_ WITHOUT VALIDATION;`)
-				defer testhelper.AssertQueryRuns(connection, "DROP TABLE partition_table")
-				defer testhelper.AssertQueryRuns(connection, "DROP TABLE partition_table_ext_part_")
+				defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.partition_table")
+				defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.partition_table_ext_part_")
 
 				tables := backup.GetAllUserTables(connection)
 
@@ -66,42 +66,42 @@ FORMAT 'csv';`)
 			It("returns external partition tables for an included parent table if the filter includes a parent partition table", func() {
 				backup.SetIncludeTables([]string{"public.partition_table1", "public.partition_table2_1_prt_other"})
 				defer backup.SetIncludeTables([]string{})
-				testhelper.AssertQueryRuns(connection, `CREATE TABLE partition_table1 (id int, gender char(1))
+				testhelper.AssertQueryRuns(connection, `CREATE TABLE public.partition_table1 (id int, gender char(1))
 DISTRIBUTED BY (id)
 PARTITION BY LIST (gender)
 ( PARTITION girls VALUES ('F'),
   PARTITION boys VALUES ('M'),
   DEFAULT PARTITION other );`)
-				testhelper.AssertQueryRuns(connection, `CREATE EXTERNAL WEB TABLE partition_table1_ext_part_ (like partition_table1_1_prt_boys)
+				testhelper.AssertQueryRuns(connection, `CREATE EXTERNAL WEB TABLE public.partition_table1_ext_part_ (like public.partition_table1_1_prt_boys)
 EXECUTE 'echo -e "2\n1"' on host
 FORMAT 'csv';`)
 				testhelper.AssertQueryRuns(connection, `ALTER TABLE public.partition_table1 EXCHANGE PARTITION boys WITH TABLE public.partition_table1_ext_part_ WITHOUT VALIDATION;`)
-				defer testhelper.AssertQueryRuns(connection, "DROP TABLE partition_table1")
-				defer testhelper.AssertQueryRuns(connection, "DROP TABLE partition_table1_ext_part_")
-				testhelper.AssertQueryRuns(connection, `CREATE TABLE partition_table2 (id int, gender char(1))
+				defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.partition_table1")
+				defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.partition_table1_ext_part_")
+				testhelper.AssertQueryRuns(connection, `CREATE TABLE public.partition_table2 (id int, gender char(1))
 DISTRIBUTED BY (id)
 PARTITION BY LIST (gender)
 ( PARTITION girls VALUES ('F'),
   PARTITION boys VALUES ('M'),
   DEFAULT PARTITION other );`)
-				testhelper.AssertQueryRuns(connection, `CREATE EXTERNAL WEB TABLE partition_table2_ext_part_ (like partition_table2_1_prt_girls)
+				testhelper.AssertQueryRuns(connection, `CREATE EXTERNAL WEB TABLE public.partition_table2_ext_part_ (like public.partition_table2_1_prt_girls)
 EXECUTE 'echo -e "2\n1"' on host
 FORMAT 'csv';`)
 				testhelper.AssertQueryRuns(connection, `ALTER TABLE public.partition_table2 EXCHANGE PARTITION girls WITH TABLE public.partition_table2_ext_part_ WITHOUT VALIDATION;`)
-				defer testhelper.AssertQueryRuns(connection, "DROP TABLE partition_table2")
-				defer testhelper.AssertQueryRuns(connection, "DROP TABLE partition_table2_ext_part_")
-				testhelper.AssertQueryRuns(connection, `CREATE TABLE partition_table3 (id int, gender char(1))
+				defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.partition_table2")
+				defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.partition_table2_ext_part_")
+				testhelper.AssertQueryRuns(connection, `CREATE TABLE public.partition_table3 (id int, gender char(1))
 DISTRIBUTED BY (id)
 PARTITION BY LIST (gender)
 ( PARTITION girls VALUES ('F'),
   PARTITION boys VALUES ('M'),
   DEFAULT PARTITION other );`)
-				testhelper.AssertQueryRuns(connection, `CREATE EXTERNAL WEB TABLE partition_table3_ext_part_ (like partition_table3_1_prt_girls)
+				testhelper.AssertQueryRuns(connection, `CREATE EXTERNAL WEB TABLE public.partition_table3_ext_part_ (like public.partition_table3_1_prt_girls)
 EXECUTE 'echo -e "2\n1"' on host
 FORMAT 'csv';`)
 				testhelper.AssertQueryRuns(connection, `ALTER TABLE public.partition_table3 EXCHANGE PARTITION girls WITH TABLE public.partition_table3_ext_part_ WITHOUT VALIDATION;`)
-				defer testhelper.AssertQueryRuns(connection, "DROP TABLE partition_table3")
-				defer testhelper.AssertQueryRuns(connection, "DROP TABLE partition_table3_ext_part_")
+				defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.partition_table3")
+				defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.partition_table3_ext_part_")
 
 				tables := backup.GetAllUserTables(connection)
 
@@ -118,7 +118,7 @@ FORMAT 'csv';`)
 		})
 		Context("leaf-partition-data flag", func() {
 			It("returns only parent partition tables if the leaf-partition-data flag is not set and there are no include tables", func() {
-				createStmt := `CREATE TABLE rank (id int, rank int, year int, gender
+				createStmt := `CREATE TABLE public.rank (id int, rank int, year int, gender
 char(1), count int )
 DISTRIBUTED BY (id)
 PARTITION BY LIST (gender)
@@ -126,7 +126,7 @@ PARTITION BY LIST (gender)
   PARTITION boys VALUES ('M'),
   DEFAULT PARTITION other );`
 				testhelper.AssertQueryRuns(connection, createStmt)
-				defer testhelper.AssertQueryRuns(connection, "DROP TABLE rank")
+				defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.rank")
 
 				tables := backup.GetAllUserTables(connection)
 
@@ -137,7 +137,7 @@ PARTITION BY LIST (gender)
 			})
 			It("returns both parent and leaf partition tables if the leaf-partition-data flag is set and there are no include tables", func() {
 				backup.SetLeafPartitionData(true)
-				createStmt := `CREATE TABLE rank (id int, rank int, year int, gender
+				createStmt := `CREATE TABLE public.rank (id int, rank int, year int, gender
 char(1), count int )
 DISTRIBUTED BY (id)
 PARTITION BY LIST (gender)
@@ -145,7 +145,7 @@ PARTITION BY LIST (gender)
   PARTITION boys VALUES ('M'),
   DEFAULT PARTITION other );`
 				testhelper.AssertQueryRuns(connection, createStmt)
-				defer testhelper.AssertQueryRuns(connection, "DROP TABLE rank")
+				defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.rank")
 
 				tables := backup.GetAllUserTables(connection)
 
@@ -162,7 +162,7 @@ PARTITION BY LIST (gender)
 			It("returns parent and included child partition table if the filter includes a leaf table; with and without leaf-partition-data", func() {
 				backup.SetIncludeTables([]string{"public.rank_1_prt_girls"})
 				defer backup.SetIncludeTables([]string{})
-				createStmt := `CREATE TABLE rank (id int, rank int, year int, gender
+				createStmt := `CREATE TABLE public.rank (id int, rank int, year int, gender
 char(1), count int )
 DISTRIBUTED BY (id)
 PARTITION BY LIST (gender)
@@ -170,7 +170,7 @@ PARTITION BY LIST (gender)
   PARTITION boys VALUES ('M'),
   DEFAULT PARTITION other );`
 				testhelper.AssertQueryRuns(connection, createStmt)
-				defer testhelper.AssertQueryRuns(connection, "DROP TABLE rank")
+				defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.rank")
 
 				expectedTableNames := []string{"public.rank", "public.rank_1_prt_girls"}
 
@@ -199,7 +199,7 @@ PARTITION BY LIST (gender)
 				backup.SetLeafPartitionData(true)
 				backup.SetIncludeTables([]string{"public.rank"})
 				defer backup.SetIncludeTables([]string{})
-				createStmt := `CREATE TABLE rank (id int, rank int, year int, gender
+				createStmt := `CREATE TABLE public.rank (id int, rank int, year int, gender
 char(1), count int )
 DISTRIBUTED BY (id)
 PARTITION BY LIST (gender)
@@ -207,9 +207,9 @@ PARTITION BY LIST (gender)
   PARTITION boys VALUES ('M'),
   DEFAULT PARTITION other );`
 				testhelper.AssertQueryRuns(connection, createStmt)
-				defer testhelper.AssertQueryRuns(connection, "DROP TABLE rank")
-				testhelper.AssertQueryRuns(connection, "CREATE TABLE test_table(i int)")
-				defer testhelper.AssertQueryRuns(connection, "DROP TABLE test_table")
+				defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.rank")
+				testhelper.AssertQueryRuns(connection, "CREATE TABLE public.test_table(i int)")
+				defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.test_table")
 
 				tables := backup.GetAllUserTables(connection)
 
@@ -225,8 +225,8 @@ PARTITION BY LIST (gender)
 			})
 		})
 		It("returns user table information for table in specific schema", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE foo(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE foo")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.foo(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.foo")
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, "CREATE TABLE testschema.foo(i int)")
@@ -241,8 +241,8 @@ PARTITION BY LIST (gender)
 			structmatcher.ExpectStructsToMatchExcluding(&tableFoo, &tables[0], "SchemaOid", "Oid")
 		})
 		It("returns user table information for tables in includeTables", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE foo(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE foo")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.foo(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.foo")
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, "CREATE TABLE testschema.foo(i int)")
@@ -257,8 +257,8 @@ PARTITION BY LIST (gender)
 			structmatcher.ExpectStructsToMatchExcluding(&tableFoo, &tables[0], "SchemaOid", "Oid")
 		})
 		It("returns user table information for tables not in excludeTables", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE foo(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE foo")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.foo(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.foo")
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, "CREATE TABLE testschema.foo(i int)")
@@ -273,8 +273,8 @@ PARTITION BY LIST (gender)
 			structmatcher.ExpectStructsToMatchExcluding(&tableFoo, &tables[0], "SchemaOid", "Oid")
 		})
 		It("returns user table information for tables in includeSchema but not in excludeTables", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE foo(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE foo")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.foo(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.foo")
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, "CREATE TABLE testschema.foo(i int)")
@@ -294,7 +294,7 @@ PARTITION BY LIST (gender)
 	})
 	Describe("GetPartitionTableMap", func() {
 		It("correctly maps oids to parent or leaf table types", func() {
-			createStmt := `CREATE TABLE summer_sales (id int, year int, month int)
+			createStmt := `CREATE TABLE public.summer_sales (id int, year int, month int)
 DISTRIBUTED BY (id)
 PARTITION BY RANGE (year)
     SUBPARTITION BY RANGE (month)
@@ -305,7 +305,7 @@ PARTITION BY RANGE (year)
   DEFAULT PARTITION outlying_years );
 `
 			testhelper.AssertQueryRuns(connection, createStmt)
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE summer_sales")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.summer_sales")
 
 			parent := testutils.OidFromObjectName(connection, "public", "summer_sales", backup.TYPE_RELATION)
 			intermediate1 := testutils.OidFromObjectName(connection, "public", "summer_sales_1_prt_outlying_years", backup.TYPE_RELATION)
@@ -341,11 +341,11 @@ PARTITION BY RANGE (year)
 	Describe("GetColumnDefinitions", func() {
 		emptyColumnACL := []backup.ACL{}
 		It("returns table attribute information for a heap table", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE atttable(a float, b text, c text NOT NULL, d int DEFAULT(5), e text)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE atttable")
-			testhelper.AssertQueryRuns(connection, "COMMENT ON COLUMN atttable.a IS 'att comment'")
-			testhelper.AssertQueryRuns(connection, "ALTER TABLE atttable DROP COLUMN b")
-			testhelper.AssertQueryRuns(connection, "ALTER TABLE atttable ALTER COLUMN e SET STORAGE PLAIN")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.atttable(a float, b text, c text NOT NULL, d int DEFAULT(5), e text)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.atttable")
+			testhelper.AssertQueryRuns(connection, "COMMENT ON COLUMN public.atttable.a IS 'att comment'")
+			testhelper.AssertQueryRuns(connection, "ALTER TABLE public.atttable DROP COLUMN b")
+			testhelper.AssertQueryRuns(connection, "ALTER TABLE public.atttable ALTER COLUMN e SET STORAGE PLAIN")
 			oid := testutils.OidFromObjectName(connection, "public", "atttable", backup.TYPE_RELATION)
 			privileges := backup.GetPrivilegesForColumns(connection)
 			tableAtts := backup.GetColumnDefinitions(connection, privileges)[oid]
@@ -363,8 +363,8 @@ PARTITION BY RANGE (year)
 			structmatcher.ExpectStructsToMatchExcluding(&columnE, &tableAtts[3], "Oid")
 		})
 		It("returns table attributes including encoding for a column oriented table", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE co_atttable(a float, b text ENCODING(blocksize=65536)) WITH (appendonly=true, orientation=column)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE co_atttable")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.co_atttable(a float, b text ENCODING(blocksize=65536)) WITH (appendonly=true, orientation=column)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.co_atttable")
 			oid := testutils.OidFromObjectName(connection, "public", "co_atttable", backup.TYPE_RELATION)
 			privileges := backup.GetPrivilegesForColumns(connection)
 			tableAtts := backup.GetColumnDefinitions(connection, privileges)[oid]
@@ -378,8 +378,8 @@ PARTITION BY RANGE (year)
 			structmatcher.ExpectStructsToMatchExcluding(&columnB, &tableAtts[1], "Oid")
 		})
 		It("returns an empty attribute array for a table with no columns", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE nocol_atttable()")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE nocol_atttable")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.nocol_atttable()")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.nocol_atttable")
 			oid := testutils.OidFromObjectName(connection, "public", "nocol_atttable", backup.TYPE_RELATION)
 
 			privileges := backup.GetPrivilegesForColumns(connection)
@@ -389,8 +389,8 @@ PARTITION BY RANGE (year)
 		})
 		It("returns table attributes with per-attribute options", func() {
 			testutils.SkipIfBefore6(connection)
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE atttable(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE atttable")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.atttable(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.atttable")
 			testhelper.AssertQueryRuns(connection, "ALTER TABLE ONLY public.atttable ALTER COLUMN i SET (n_distinct=1);")
 			oid := testutils.OidFromObjectName(connection, "public", "atttable", backup.TYPE_RELATION)
 			privileges := backup.GetPrivilegesForColumns(connection)
@@ -406,8 +406,8 @@ PARTITION BY RANGE (year)
 	Describe("GetPrivilegesForColumns", func() {
 		It("Default column", func() {
 			testutils.SkipIfBefore6(connection)
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE default_privileges(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE default_privileges")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.default_privileges(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.default_privileges")
 
 			metadataMap := backup.GetPrivilegesForColumns(connection)
 
@@ -419,9 +419,9 @@ PARTITION BY RANGE (year)
 		})
 		It("Column with granted privileges", func() {
 			testutils.SkipIfBefore6(connection)
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE granted_privileges(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE granted_privileges")
-			testhelper.AssertQueryRuns(connection, "GRANT SELECT (i) ON TABLE granted_privileges TO testrole")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.granted_privileges(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.granted_privileges")
+			testhelper.AssertQueryRuns(connection, "GRANT SELECT (i) ON TABLE public.granted_privileges TO testrole")
 
 			metadataMap := backup.GetPrivilegesForColumns(connection)
 
@@ -434,8 +434,8 @@ PARTITION BY RANGE (year)
 	})
 	Describe("GetDistributionPolicies", func() {
 		It("returns distribution policy info for a table DISTRIBUTED RANDOMLY", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE dist_random(a int, b text) DISTRIBUTED RANDOMLY")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE dist_random")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.dist_random(a int, b text) DISTRIBUTED RANDOMLY")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.dist_random")
 			oid := testutils.OidFromObjectName(connection, "public", "dist_random", backup.TYPE_RELATION)
 
 			distPolicies := backup.GetDistributionPolicies(connection)[oid]
@@ -443,8 +443,8 @@ PARTITION BY RANGE (year)
 			Expect(distPolicies).To(Equal("DISTRIBUTED RANDOMLY"))
 		})
 		It("returns distribution policy info for a table DISTRIBUTED BY one column", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE dist_one(a int, b text) DISTRIBUTED BY (a)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE dist_one")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.dist_one(a int, b text) DISTRIBUTED BY (a)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.dist_one")
 			oid := testutils.OidFromObjectName(connection, "public", "dist_one", backup.TYPE_RELATION)
 
 			distPolicies := backup.GetDistributionPolicies(connection)[oid]
@@ -452,8 +452,8 @@ PARTITION BY RANGE (year)
 			Expect(distPolicies).To(Equal("DISTRIBUTED BY (a)"))
 		})
 		It("returns distribution policy info for a table DISTRIBUTED BY two columns", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE dist_two(a int, b text) DISTRIBUTED BY (a, b)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE dist_two")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.dist_two(a int, b text) DISTRIBUTED BY (a, b)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.dist_two")
 			oid := testutils.OidFromObjectName(connection, "public", "dist_two", backup.TYPE_RELATION)
 
 			distPolicies := backup.GetDistributionPolicies(connection)[oid]
@@ -461,8 +461,8 @@ PARTITION BY RANGE (year)
 			Expect(distPolicies).To(Equal("DISTRIBUTED BY (a, b)"))
 		})
 		It("returns distribution policy info for a table DISTRIBUTED BY column name as keyword", func() {
-			testhelper.AssertQueryRuns(connection, `CREATE TABLE dist_one(a int, "group" text) DISTRIBUTED BY ("group")`)
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE dist_one")
+			testhelper.AssertQueryRuns(connection, `CREATE TABLE public.dist_one(a int, "group" text) DISTRIBUTED BY ("group")`)
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.dist_one")
 			oid := testutils.OidFromObjectName(connection, "public", "dist_one", backup.TYPE_RELATION)
 
 			distPolicies := backup.GetDistributionPolicies(connection)[oid]
@@ -471,8 +471,8 @@ PARTITION BY RANGE (year)
 		})
 		It("returns distribution policy info for a table DISTRIBUTED REPLICATED", func() {
 			testutils.SkipIfBefore6(connection)
-			testhelper.AssertQueryRuns(connection, `CREATE TABLE dist_one(a int, "group" text) DISTRIBUTED REPLICATED`)
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE dist_one")
+			testhelper.AssertQueryRuns(connection, `CREATE TABLE public.dist_one(a int, "group" text) DISTRIBUTED REPLICATED`)
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.dist_one")
 			oid := testutils.OidFromObjectName(connection, "public", "dist_one", backup.TYPE_RELATION)
 
 			distPolicies := backup.GetDistributionPolicies(connection)[oid]
@@ -482,8 +482,8 @@ PARTITION BY RANGE (year)
 	})
 	Describe("GetPartitionDefinitions", func() {
 		It("returns empty string when no partition exists", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE simple_table(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE simple_table")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.simple_table(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.simple_table")
 			oid := testutils.OidFromObjectName(connection, "public", "simple_table", backup.TYPE_RELATION)
 
 			result := backup.GetPartitionDefinitions(connection)[oid]
@@ -491,7 +491,7 @@ PARTITION BY RANGE (year)
 			Expect(result).To(Equal(""))
 		})
 		It("returns a value for a partition definition", func() {
-			testhelper.AssertQueryRuns(connection, `CREATE TABLE part_table (id int, rank int, year int, gender 
+			testhelper.AssertQueryRuns(connection, `CREATE TABLE public.part_table (id int, rank int, year int, gender 
 char(1), count int ) 
 DISTRIBUTED BY (id)
 PARTITION BY LIST (gender)
@@ -499,7 +499,7 @@ PARTITION BY LIST (gender)
   PARTITION boys VALUES ('M'), 
   DEFAULT PARTITION other );
 			`)
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE part_table")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.part_table")
 			oid := testutils.OidFromObjectName(connection, "public", "part_table", backup.TYPE_RELATION)
 
 			result := backup.GetPartitionDefinitions(connection)[oid]
@@ -518,20 +518,20 @@ PARTITION BY LIST (gender)
 	Describe("GetTableType", func() {
 		It("Returns a map when a table OF type exists", func() {
 			testutils.SkipIfBefore6(connection)
-			testhelper.AssertQueryRuns(connection, "CREATE TYPE some_type AS (a text, b numeric)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TYPE some_type")
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE some_table OF some_type (PRIMARY KEY (a), b WITH OPTIONS DEFAULT 1000)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE some_table")
+			testhelper.AssertQueryRuns(connection, "CREATE TYPE public.some_type AS (a text, b numeric)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TYPE public.some_type")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.some_table OF public.some_type (PRIMARY KEY (a), b WITH OPTIONS DEFAULT 1000)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.some_table")
 			oid := testutils.OidFromObjectName(connection, "public", "some_table", backup.TYPE_RELATION)
 
 			result := backup.GetTableType(connection)
 			Expect(len(result)).To(Equal(1))
 
-			Expect(result[oid]).To(Equal("some_type"))
+			Expect(result[oid]).To(Equal("public.some_type"))
 		})
 		It("Returns empty map when no tables OF type exist", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE some_table (i int, j int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE some_table")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.some_table (i int, j int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.some_table")
 
 			result := backup.GetTableType(connection)
 			Expect(len(result)).To(Equal(0))
@@ -541,8 +541,8 @@ PARTITION BY LIST (gender)
 	Describe("GetUnloggedTables", func() {
 		It("Returns a map when an UNLOGGED table exists", func() {
 			testutils.SkipIfBefore6(connection)
-			testhelper.AssertQueryRuns(connection, "CREATE UNLOGGED TABLE some_table(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE some_table")
+			testhelper.AssertQueryRuns(connection, "CREATE UNLOGGED TABLE public.some_table(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.some_table")
 			oid := testutils.OidFromObjectName(connection, "public", "some_table", backup.TYPE_RELATION)
 
 			result := backup.GetUnloggedTables(connection)
@@ -551,8 +551,8 @@ PARTITION BY LIST (gender)
 			Expect(result[oid]).To(BeTrue())
 		})
 		It("Returns empty map when no UNLOGGED tables exist", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE some_table (i int, j int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE some_table")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.some_table (i int, j int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.some_table")
 
 			result := backup.GetUnloggedTables(connection)
 			Expect(len(result)).To(Equal(0))
@@ -561,8 +561,8 @@ PARTITION BY LIST (gender)
 
 	Describe("GetPartitionTemplates", func() {
 		It("returns empty string when no partition definition template exists", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE simple_table(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE simple_table")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.simple_table(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.simple_table")
 			oid := testutils.OidFromObjectName(connection, "public", "simple_table", backup.TYPE_RELATION)
 
 			result := backup.GetPartitionTemplates(connection)[oid]
@@ -570,7 +570,7 @@ PARTITION BY LIST (gender)
 			Expect(result).To(Equal(""))
 		})
 		It("returns a value for a subpartition template", func() {
-			testhelper.AssertQueryRuns(connection, `CREATE TABLE part_table (trans_id int, date date, amount decimal(9,2), region text)
+			testhelper.AssertQueryRuns(connection, `CREATE TABLE public.part_table (trans_id int, date date, amount decimal(9,2), region text)
   DISTRIBUTED BY (trans_id)
   PARTITION BY RANGE (date)
   SUBPARTITION BY LIST (region)
@@ -582,13 +582,13 @@ PARTITION BY LIST (gender)
   ( START (date '2014-01-01') INCLUSIVE
     END (date '2014-04-01') EXCLUSIVE
     EVERY (INTERVAL '1 month') ) `)
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE part_table")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.part_table")
 			oid := testutils.OidFromObjectName(connection, "public", "part_table", backup.TYPE_RELATION)
 
 			result := backup.GetPartitionTemplates(connection)[oid]
 
 			// The spacing is very specific here and is output from the postgres function
-			expectedResult := `ALTER TABLE part_table 
+			expectedResult := `ALTER TABLE public.part_table 
 SET SUBPARTITION TEMPLATE  
           (
           SUBPARTITION usa VALUES('usa') WITH (tablename='part_table'), 
@@ -603,8 +603,8 @@ SET SUBPARTITION TEMPLATE
 	})
 	Describe("GetTableStorageOptions", func() {
 		It("returns an empty string when no table storage options exist ", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE simple_table(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE simple_table")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.simple_table(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.simple_table")
 			oid := testutils.OidFromObjectName(connection, "public", "simple_table", backup.TYPE_RELATION)
 
 			result := backup.GetTableStorageOptions(connection)[oid]
@@ -612,8 +612,8 @@ SET SUBPARTITION TEMPLATE
 			Expect(result).To(Equal(""))
 		})
 		It("returns a value for storage options of a table ", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE ao_table(i int) with (appendonly=true)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE ao_table")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.ao_table(i int) with (appendonly=true)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.ao_table")
 			oid := testutils.OidFromObjectName(connection, "public", "ao_table", backup.TYPE_RELATION)
 
 			result := backup.GetTableStorageOptions(connection)[oid]
@@ -623,8 +623,8 @@ SET SUBPARTITION TEMPLATE
 	})
 	Describe("GetAllSequenceRelations", func() {
 		It("returns a slice of all sequences", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE SEQUENCE my_sequence START 10")
-			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE my_sequence")
+			testhelper.AssertQueryRuns(connection, "CREATE SEQUENCE public.my_sequence START 10")
+			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE public.my_sequence")
 			testhelper.AssertQueryRuns(connection, "COMMENT ON SEQUENCE public.my_sequence IS 'this is a sequence comment'")
 
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
@@ -641,8 +641,8 @@ SET SUBPARTITION TEMPLATE
 			structmatcher.ExpectStructsToMatchExcluding(&mySequence2, &sequences[1], "SchemaOid", "Oid")
 		})
 		It("returns a slice of all sequences in a specific schema", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE SEQUENCE my_sequence START 10")
-			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE my_sequence")
+			testhelper.AssertQueryRuns(connection, "CREATE SEQUENCE public.my_sequence START 10")
+			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE public.my_sequence")
 
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema CASCADE")
@@ -656,13 +656,13 @@ SET SUBPARTITION TEMPLATE
 			structmatcher.ExpectStructsToMatchExcluding(&mySequence, &sequences[0], "SchemaOid", "Oid")
 		})
 		It("returns a slice of sequences owned by included tables", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE SEQUENCE my_sequence START 10")
-			testhelper.AssertQueryRuns(connection, "CREATE SEQUENCE no_table_sequence START 5")
-			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE no_table_sequence")
+			testhelper.AssertQueryRuns(connection, "CREATE SEQUENCE public.my_sequence START 10")
+			testhelper.AssertQueryRuns(connection, "CREATE SEQUENCE public.no_table_sequence START 5")
+			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE public.no_table_sequence")
 
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE seq_table(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE seq_table")
-			testhelper.AssertQueryRuns(connection, "ALTER SEQUENCE my_sequence OWNED BY seq_table.i")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.seq_table(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.seq_table")
+			testhelper.AssertQueryRuns(connection, "ALTER SEQUENCE public.my_sequence OWNED BY public.seq_table.i")
 			mySequence := backup.BasicRelation("public", "my_sequence")
 
 			backup.SetIncludeTables([]string{"public.seq_table"})
@@ -672,13 +672,13 @@ SET SUBPARTITION TEMPLATE
 			structmatcher.ExpectStructsToMatchExcluding(&mySequence, &sequences[0], "SchemaOid", "Oid")
 		})
 		It("does not return sequences owned by excluded tables", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE SEQUENCE my_sequence START 10")
-			testhelper.AssertQueryRuns(connection, "CREATE SEQUENCE no_table_sequence START 5")
-			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE no_table_sequence")
+			testhelper.AssertQueryRuns(connection, "CREATE SEQUENCE public.my_sequence START 10")
+			testhelper.AssertQueryRuns(connection, "CREATE SEQUENCE public.no_table_sequence START 5")
+			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE public.no_table_sequence")
 
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE seq_table(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE seq_table")
-			testhelper.AssertQueryRuns(connection, "ALTER SEQUENCE my_sequence OWNED BY seq_table.i")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.seq_table(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.seq_table")
+			testhelper.AssertQueryRuns(connection, "ALTER SEQUENCE public.my_sequence OWNED BY public.seq_table.i")
 			noTableSequence := backup.BasicRelation("public", "no_table_sequence")
 
 			backup.SetExcludeTables([]string{"public.seq_table"})
@@ -690,10 +690,10 @@ SET SUBPARTITION TEMPLATE
 	})
 	Describe("GetSequenceDefinition", func() {
 		It("returns sequence information for sequence with default values", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE SEQUENCE my_sequence")
-			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE my_sequence")
+			testhelper.AssertQueryRuns(connection, "CREATE SEQUENCE public.my_sequence")
+			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE public.my_sequence")
 
-			resultSequenceDef := backup.GetSequenceDefinition(connection, "my_sequence")
+			resultSequenceDef := backup.GetSequenceDefinition(connection, "public.my_sequence")
 
 			expectedSequence := backup.SequenceDefinition{Name: "my_sequence", LastVal: 1, Increment: 1, MaxVal: 9223372036854775807, MinVal: 1, CacheVal: 1}
 			if connection.Version.Before("5") {
@@ -706,15 +706,15 @@ SET SUBPARTITION TEMPLATE
 			structmatcher.ExpectStructsToMatch(&expectedSequence, &resultSequenceDef)
 		})
 		It("returns sequence information for a complex sequence", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE with_sequence(a int, b char(20))")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE with_sequence")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.with_sequence(a int, b char(20))")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.with_sequence")
 			testhelper.AssertQueryRuns(connection,
-				"CREATE SEQUENCE my_sequence INCREMENT BY 5 MINVALUE 20 MAXVALUE 1000 START 100 OWNED BY with_sequence.a")
-			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE my_sequence")
-			testhelper.AssertQueryRuns(connection, "INSERT INTO with_sequence VALUES (nextval('my_sequence'), 'acme')")
-			testhelper.AssertQueryRuns(connection, "INSERT INTO with_sequence VALUES (nextval('my_sequence'), 'beta')")
+				"CREATE SEQUENCE public.my_sequence INCREMENT BY 5 MINVALUE 20 MAXVALUE 1000 START 100 OWNED BY public.with_sequence.a")
+			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE public.my_sequence")
+			testhelper.AssertQueryRuns(connection, "INSERT INTO public.with_sequence VALUES (nextval('public.my_sequence'), 'acme')")
+			testhelper.AssertQueryRuns(connection, "INSERT INTO public.with_sequence VALUES (nextval('public.my_sequence'), 'beta')")
 
-			resultSequenceDef := backup.GetSequenceDefinition(connection, "my_sequence")
+			resultSequenceDef := backup.GetSequenceDefinition(connection, "public.my_sequence")
 
 			expectedSequence := backup.SequenceDefinition{Name: "my_sequence", LastVal: 105, Increment: 5, MaxVal: 1000, MinVal: 20, CacheVal: 1, IsCycled: false, IsCalled: true}
 			if connection.Version.Before("5") {
@@ -731,12 +731,12 @@ SET SUBPARTITION TEMPLATE
 	})
 	Describe("GetSequenceOwnerMap", func() {
 		It("returns sequence information for sequences owned by columns", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE without_sequence(a int, b char(20));")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE without_sequence")
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE with_sequence(a int, b char(20));")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE with_sequence")
-			testhelper.AssertQueryRuns(connection, "CREATE SEQUENCE my_sequence OWNED BY with_sequence.a;")
-			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE my_sequence")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.without_sequence(a int, b char(20));")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.without_sequence")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.with_sequence(a int, b char(20));")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.with_sequence")
+			testhelper.AssertQueryRuns(connection, "CREATE SEQUENCE public.my_sequence OWNED BY public.with_sequence.a;")
+			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE public.my_sequence")
 
 			sequenceOwnerTables, sequenceOwnerColumns := backup.GetSequenceColumnOwnerMap(connection)
 
@@ -748,8 +748,8 @@ SET SUBPARTITION TEMPLATE
 	})
 	Describe("GetAllSequences", func() {
 		It("returns a slice of definitions for all sequences", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE SEQUENCE seq_one START 3")
-			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE seq_one")
+			testhelper.AssertQueryRuns(connection, "CREATE SEQUENCE public.seq_one START 3")
+			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE public.seq_one")
 			testhelper.AssertQueryRuns(connection, "COMMENT ON SEQUENCE public.seq_one IS 'this is a sequence comment'")
 			startValOne := int64(0)
 			startValTwo := int64(0)
@@ -758,8 +758,8 @@ SET SUBPARTITION TEMPLATE
 				startValTwo = 7
 			}
 
-			testhelper.AssertQueryRuns(connection, "CREATE SEQUENCE seq_two START 7")
-			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE seq_two")
+			testhelper.AssertQueryRuns(connection, "CREATE SEQUENCE public.seq_two START 7")
+			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE public.seq_two")
 
 			seqOneRelation := backup.BasicRelation("public", "seq_one")
 			seqOneDef := backup.SequenceDefinition{Name: "seq_one", LastVal: 3, Increment: 1, MaxVal: 9223372036854775807, MinVal: 1, CacheVal: 1, StartVal: startValOne}
@@ -780,8 +780,8 @@ SET SUBPARTITION TEMPLATE
 	})
 	Describe("GetViews", func() {
 		It("returns a slice for a basic view", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE VIEW simpleview AS SELECT rolname FROM pg_roles")
-			defer testhelper.AssertQueryRuns(connection, "DROP VIEW simpleview")
+			testhelper.AssertQueryRuns(connection, "CREATE VIEW public.simpleview AS SELECT rolname FROM pg_roles")
+			defer testhelper.AssertQueryRuns(connection, "DROP VIEW public.simpleview")
 
 			results := backup.GetViews(connection)
 
@@ -791,8 +791,8 @@ SET SUBPARTITION TEMPLATE
 			structmatcher.ExpectStructsToMatchExcluding(&viewDef, &results[0], "Oid")
 		})
 		It("returns a slice for view in a specific schema", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE VIEW simpleview AS SELECT rolname FROM pg_roles")
-			defer testhelper.AssertQueryRuns(connection, "DROP VIEW simpleview")
+			testhelper.AssertQueryRuns(connection, "CREATE VIEW public.simpleview AS SELECT rolname FROM pg_roles")
+			defer testhelper.AssertQueryRuns(connection, "DROP VIEW public.simpleview")
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, "CREATE VIEW testschema.simpleview AS SELECT rolname FROM pg_roles")
@@ -813,10 +813,10 @@ SET SUBPARTITION TEMPLATE
 		childTwo := backup.BasicRelation("public", "child_two")
 		tableDefs := map[uint32]backup.TableDefinition{}
 		It("constructs dependencies correctly if there is one table dependent on one table", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE parent(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE parent")
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE child() INHERITS (parent)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE child")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.parent(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.parent")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.child() INHERITS (public.parent)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.child")
 
 			child.Oid = testutils.OidFromObjectName(connection, "public", "child", backup.TYPE_RELATION)
 			tables := []backup.Relation{child}
@@ -830,12 +830,12 @@ SET SUBPARTITION TEMPLATE
 			Expect(tables[0].Inherits[0]).To(Equal("public.parent"))
 		})
 		It("constructs dependencies correctly if there are two tables dependent on one table", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE parent(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE parent")
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE child_one() INHERITS (parent)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE child_one")
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE child_two() INHERITS (parent)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE child_two")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.parent(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.parent")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.child_one() INHERITS (public.parent)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.child_one")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.child_two() INHERITS (public.parent)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.child_two")
 
 			childOne.Oid = testutils.OidFromObjectName(connection, "public", "child_one", backup.TYPE_RELATION)
 			childTwo.Oid = testutils.OidFromObjectName(connection, "public", "child_two", backup.TYPE_RELATION)
@@ -854,12 +854,12 @@ SET SUBPARTITION TEMPLATE
 			Expect(tables[1].Inherits[0]).To(Equal("public.parent"))
 		})
 		It("constructs dependencies correctly if there is one table dependent on two tables", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE parent_one(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE parent_one")
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE parent_two(j int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE parent_two")
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE child() INHERITS (parent_one, parent_two)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE child")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.parent_one(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.parent_one")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.parent_two(j int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.parent_two")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.child() INHERITS (public.parent_one, public.parent_two)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.child")
 
 			child.Oid = testutils.OidFromObjectName(connection, "public", "child", backup.TYPE_RELATION)
 			tables := []backup.Relation{child}
@@ -882,12 +882,12 @@ SET SUBPARTITION TEMPLATE
 			Expect(len(tables)).To(Equal(0))
 		})
 		It("constructs dependencies correctly if there are two dependent tables but one is not in the backup set", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE parent(i int)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE parent")
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE child_one() INHERITS (parent)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE child_one")
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE child_two() INHERITS (parent)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE child_two")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.parent(i int)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.parent")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.child_one() INHERITS (public.parent)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.child_one")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.child_two() INHERITS (public.parent)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.child_two")
 
 			childOne.Oid = testutils.OidFromObjectName(connection, "public", "child_one", backup.TYPE_RELATION)
 			tables := []backup.Relation{childOne}
@@ -900,17 +900,17 @@ SET SUBPARTITION TEMPLATE
 			Expect(tables[0].Inherits[0]).To(Equal("public.parent"))
 		})
 		It("does not record a dependency of an external leaf partition on a parent table", func() {
-			testhelper.AssertQueryRuns(connection, `CREATE TABLE partition_table (id int, gender char(1))
+			testhelper.AssertQueryRuns(connection, `CREATE TABLE public.partition_table (id int, gender char(1))
 DISTRIBUTED BY (id)
 PARTITION BY LIST (gender)
 ( PARTITION girls VALUES ('F'),
   PARTITION boys VALUES ('M'),
   DEFAULT PARTITION other );`)
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE partition_table")
-			testhelper.AssertQueryRuns(connection, `CREATE EXTERNAL WEB TABLE partition_table_ext_part_ (like partition_table_1_prt_girls)
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.partition_table")
+			testhelper.AssertQueryRuns(connection, `CREATE EXTERNAL WEB TABLE public.partition_table_ext_part_ (like public.partition_table_1_prt_girls)
 EXECUTE 'echo -e "2\n1"' on host
 FORMAT 'csv';`)
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE partition_table_ext_part_")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.partition_table_ext_part_")
 			testhelper.AssertQueryRuns(connection, `ALTER TABLE public.partition_table EXCHANGE PARTITION girls WITH TABLE public.partition_table_ext_part_ WITHOUT VALIDATION;`)
 
 			partition := backup.BasicRelation("public", "partition_table_ext_part_")
@@ -927,12 +927,12 @@ FORMAT 'csv';`)
 	})
 	Describe("ConstructViewDependencies", func() {
 		It("constructs dependencies correctly for a view that depends on two other views", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE VIEW parent1 AS SELECT relname FROM pg_class")
-			defer testhelper.AssertQueryRuns(connection, "DROP VIEW parent1")
-			testhelper.AssertQueryRuns(connection, "CREATE VIEW parent2 AS SELECT relname FROM pg_class")
-			defer testhelper.AssertQueryRuns(connection, "DROP VIEW parent2")
-			testhelper.AssertQueryRuns(connection, "CREATE VIEW child AS (SELECT * FROM parent1 UNION SELECT * FROM parent2)")
-			defer testhelper.AssertQueryRuns(connection, "DROP VIEW child")
+			testhelper.AssertQueryRuns(connection, "CREATE VIEW public.parent1 AS SELECT relname FROM pg_class")
+			defer testhelper.AssertQueryRuns(connection, "DROP VIEW public.parent1")
+			testhelper.AssertQueryRuns(connection, "CREATE VIEW public.parent2 AS SELECT relname FROM pg_class")
+			defer testhelper.AssertQueryRuns(connection, "DROP VIEW public.parent2")
+			testhelper.AssertQueryRuns(connection, "CREATE VIEW public.child AS (SELECT * FROM public.parent1 UNION SELECT * FROM public.parent2)")
+			defer testhelper.AssertQueryRuns(connection, "DROP VIEW public.child")
 
 			childView := backup.View{}
 			childView.Oid = testutils.OidFromObjectName(connection, "public", "child", backup.TYPE_RELATION)

--- a/integration/predata_textsearch_create_test.go
+++ b/integration/predata_textsearch_create_test.go
@@ -21,7 +21,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			backup.PrintCreateTextSearchParserStatements(backupfile, toc, parsers, backup.MetadataMap{})
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
-			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH PARSER testparser")
+			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH PARSER public.testparser")
 
 			resultParsers := backup.GetTextSearchParsers(connection)
 
@@ -36,7 +36,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			backup.PrintCreateTextSearchParserStatements(backupfile, toc, parsers, parserMetadataMap)
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
-			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH PARSER testparser")
+			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH PARSER public.testparser")
 
 			resultParsers := backup.GetTextSearchParsers(connection)
 			resultMetadataMap := backup.GetCommentsForObjectType(connection, backup.TYPE_TSPARSER)
@@ -54,7 +54,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			backup.PrintCreateTextSearchTemplateStatements(backupfile, toc, templates, backup.MetadataMap{})
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
-			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH TEMPLATE testtemplate")
+			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH TEMPLATE public.testtemplate")
 
 			resultTemplates := backup.GetTextSearchTemplates(connection)
 
@@ -69,7 +69,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			backup.PrintCreateTextSearchTemplateStatements(backupfile, toc, templates, templateMetadataMap)
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
-			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH TEMPLATE testtemplate")
+			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH TEMPLATE public.testtemplate")
 
 			resultTemplates := backup.GetTextSearchTemplates(connection)
 			resultMetadataMap := backup.GetCommentsForObjectType(connection, backup.TYPE_TSTEMPLATE)
@@ -88,7 +88,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			backup.PrintCreateTextSearchDictionaryStatements(backupfile, toc, dictionaries, backup.MetadataMap{})
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
-			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH DICTIONARY testdictionary")
+			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH DICTIONARY public.testdictionary")
 
 			resultDictionaries := backup.GetTextSearchDictionaries(connection)
 
@@ -103,7 +103,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			backup.PrintCreateTextSearchDictionaryStatements(backupfile, toc, dictionaries, dictionaryMetadataMap)
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
-			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH DICTIONARY testdictionary")
+			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH DICTIONARY public.testdictionary")
 
 			resultDictionaries := backup.GetTextSearchDictionaries(connection)
 			resultMetadataMap := backup.GetMetadataForObjectType(connection, backup.TYPE_TSDICTIONARY)
@@ -122,7 +122,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			backup.PrintCreateTextSearchConfigurationStatements(backupfile, toc, configurations, backup.MetadataMap{})
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
-			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH CONFIGURATION testconfiguration")
+			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH CONFIGURATION public.testconfiguration")
 
 			resultConfigurations := backup.GetTextSearchConfigurations(connection)
 
@@ -137,7 +137,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			backup.PrintCreateTextSearchConfigurationStatements(backupfile, toc, configurations, configurationMetadataMap)
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
-			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH CONFIGURATION testconfiguration")
+			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH CONFIGURATION public.testconfiguration")
 
 			resultConfigurations := backup.GetTextSearchConfigurations(connection)
 			resultMetadataMap := backup.GetMetadataForObjectType(connection, backup.TYPE_TSCONFIGURATION)

--- a/integration/predata_textsearch_queries_test.go
+++ b/integration/predata_textsearch_queries_test.go
@@ -16,8 +16,8 @@ var _ = Describe("backup integration tests", func() {
 			testutils.SkipIfBefore5(connection)
 		})
 		It("returns a text search parser without a headline", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TEXT SEARCH PARSER testparser(START = prsd_start, GETTOKEN = prsd_nexttoken, END = prsd_end, LEXTYPES = prsd_lextype);")
-			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH PARSER testparser")
+			testhelper.AssertQueryRuns(connection, "CREATE TEXT SEARCH PARSER public.testparser(START = prsd_start, GETTOKEN = prsd_nexttoken, END = prsd_end, LEXTYPES = prsd_lextype);")
+			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH PARSER public.testparser")
 			parsers := backup.GetTextSearchParsers(connection)
 
 			expectedParser := backup.TextSearchParser{Oid: 1, Schema: "public", Name: "testparser", StartFunc: "prsd_start", TokenFunc: "prsd_nexttoken", EndFunc: "prsd_end", LexTypesFunc: "prsd_lextype", HeadlineFunc: ""}
@@ -26,8 +26,8 @@ var _ = Describe("backup integration tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&expectedParser, &parsers[0], "Oid")
 		})
 		It("returns a text search parser with a headline", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TEXT SEARCH PARSER testparser(START = prsd_start, GETTOKEN = prsd_nexttoken, END = prsd_end, LEXTYPES = prsd_lextype, HEADLINE = prsd_headline);")
-			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH PARSER testparser")
+			testhelper.AssertQueryRuns(connection, "CREATE TEXT SEARCH PARSER public.testparser(START = prsd_start, GETTOKEN = prsd_nexttoken, END = prsd_end, LEXTYPES = prsd_lextype, HEADLINE = prsd_headline);")
+			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH PARSER public.testparser")
 			parsers := backup.GetTextSearchParsers(connection)
 
 			expectedParser := backup.TextSearchParser{Oid: 1, Schema: "public", Name: "testparser", StartFunc: "prsd_start", TokenFunc: "prsd_nexttoken", EndFunc: "prsd_end", LexTypesFunc: "prsd_lextype", HeadlineFunc: "prsd_headline"}
@@ -36,8 +36,8 @@ var _ = Describe("backup integration tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&expectedParser, &parsers[0], "Oid")
 		})
 		It("returns a text search parser from a specific schema ", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TEXT SEARCH PARSER testparser(START = prsd_start, GETTOKEN = prsd_nexttoken, END = prsd_end, LEXTYPES = prsd_lextype);")
-			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH PARSER testparser")
+			testhelper.AssertQueryRuns(connection, "CREATE TEXT SEARCH PARSER public.testparser(START = prsd_start, GETTOKEN = prsd_nexttoken, END = prsd_end, LEXTYPES = prsd_lextype);")
+			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH PARSER public.testparser")
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, "CREATE TEXT SEARCH PARSER testschema.testparser(START = prsd_start, GETTOKEN = prsd_nexttoken, END = prsd_end, LEXTYPES = prsd_lextype);")
@@ -57,8 +57,8 @@ var _ = Describe("backup integration tests", func() {
 			testutils.SkipIfBefore5(connection)
 		})
 		It("returns a text search template without an init function", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TEXT SEARCH TEMPLATE testtemplate(LEXIZE = dsimple_lexize);")
-			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH TEMPLATE testtemplate")
+			testhelper.AssertQueryRuns(connection, "CREATE TEXT SEARCH TEMPLATE public.testtemplate(LEXIZE = dsimple_lexize);")
+			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH TEMPLATE public.testtemplate")
 			templates := backup.GetTextSearchTemplates(connection)
 
 			expectedTemplate := backup.TextSearchTemplate{Oid: 1, Schema: "public", Name: "testtemplate", InitFunc: "", LexizeFunc: "dsimple_lexize"}
@@ -67,8 +67,8 @@ var _ = Describe("backup integration tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&expectedTemplate, &templates[0], "Oid")
 		})
 		It("returns a text search template with an init function", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TEXT SEARCH TEMPLATE testtemplate(INIT = dsimple_init, LEXIZE = dsimple_lexize);")
-			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH TEMPLATE testtemplate")
+			testhelper.AssertQueryRuns(connection, "CREATE TEXT SEARCH TEMPLATE public.testtemplate(INIT = dsimple_init, LEXIZE = dsimple_lexize);")
+			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH TEMPLATE public.testtemplate")
 			templates := backup.GetTextSearchTemplates(connection)
 
 			expectedTemplate := backup.TextSearchTemplate{Oid: 1, Schema: "public", Name: "testtemplate", InitFunc: "dsimple_init", LexizeFunc: "dsimple_lexize"}
@@ -77,8 +77,8 @@ var _ = Describe("backup integration tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&expectedTemplate, &templates[0], "Oid")
 		})
 		It("returns a text search template from a specific schema", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TEXT SEARCH TEMPLATE testtemplate(LEXIZE = dsimple_lexize);")
-			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH TEMPLATE testtemplate")
+			testhelper.AssertQueryRuns(connection, "CREATE TEXT SEARCH TEMPLATE public.testtemplate(LEXIZE = dsimple_lexize);")
+			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH TEMPLATE public.testtemplate")
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, "CREATE TEXT SEARCH TEMPLATE testschema.testtemplate(LEXIZE = dsimple_lexize);")
@@ -98,8 +98,8 @@ var _ = Describe("backup integration tests", func() {
 			testutils.SkipIfBefore5(connection)
 		})
 		It("returns a text search dictionary with init options", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TEXT SEARCH DICTIONARY testdictionary(TEMPLATE = snowball, LANGUAGE = 'russian', STOPWORDS = 'russian');")
-			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH DICTIONARY testdictionary")
+			testhelper.AssertQueryRuns(connection, "CREATE TEXT SEARCH DICTIONARY public.testdictionary(TEMPLATE = snowball, LANGUAGE = 'russian', STOPWORDS = 'russian');")
+			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH DICTIONARY public.testdictionary")
 			dictionaries := backup.GetTextSearchDictionaries(connection)
 
 			expectedDictionary := backup.TextSearchDictionary{Oid: 1, Schema: "public", Name: "testdictionary", Template: "pg_catalog.snowball", InitOption: "language = 'russian', stopwords = 'russian'"}
@@ -107,8 +107,8 @@ var _ = Describe("backup integration tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&expectedDictionary, &dictionaries[0], "Oid")
 		})
 		It("returns a text search dictionary without init options", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TEXT SEARCH DICTIONARY testdictionary (TEMPLATE = 'simple');")
-			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH DICTIONARY testdictionary")
+			testhelper.AssertQueryRuns(connection, "CREATE TEXT SEARCH DICTIONARY public.testdictionary (TEMPLATE = 'simple');")
+			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH DICTIONARY public.testdictionary")
 			dictionaries := backup.GetTextSearchDictionaries(connection)
 
 			expectedDictionary := backup.TextSearchDictionary{Oid: 1, Schema: "public", Name: "testdictionary", Template: "pg_catalog.simple", InitOption: ""}
@@ -116,8 +116,8 @@ var _ = Describe("backup integration tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&expectedDictionary, &dictionaries[0], "Oid")
 		})
 		It("returns a text search dictionary from a specific schema", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TEXT SEARCH DICTIONARY testdictionary (TEMPLATE = 'simple');")
-			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH DICTIONARY testdictionary")
+			testhelper.AssertQueryRuns(connection, "CREATE TEXT SEARCH DICTIONARY public.testdictionary (TEMPLATE = 'simple');")
+			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH DICTIONARY public.testdictionary")
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, "CREATE TEXT SEARCH DICTIONARY testschema.testdictionary (TEMPLATE = 'simple');")
@@ -136,8 +136,8 @@ var _ = Describe("backup integration tests", func() {
 			testutils.SkipIfBefore5(connection)
 		})
 		It("returns a text search configuration without an init function", func() {
-			testhelper.AssertQueryRuns(connection, `CREATE TEXT SEARCH CONFIGURATION testconfiguration (PARSER = pg_catalog."default");`)
-			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH CONFIGURATION testconfiguration")
+			testhelper.AssertQueryRuns(connection, `CREATE TEXT SEARCH CONFIGURATION public.testconfiguration (PARSER = pg_catalog."default");`)
+			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH CONFIGURATION public.testconfiguration")
 			configurations := backup.GetTextSearchConfigurations(connection)
 
 			expectedConfiguration := backup.TextSearchConfiguration{Oid: 1, Schema: "public", Name: "testconfiguration", Parser: `pg_catalog."default"`, TokenToDicts: map[string][]string{}}
@@ -146,8 +146,8 @@ var _ = Describe("backup integration tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&expectedConfiguration, &configurations[0], "Oid")
 		})
 		It("returns a text search configuration with an init function", func() {
-			testhelper.AssertQueryRuns(connection, `CREATE TEXT SEARCH CONFIGURATION testconfiguration ( PARSER = pg_catalog."default");`)
-			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH CONFIGURATION testconfiguration")
+			testhelper.AssertQueryRuns(connection, `CREATE TEXT SEARCH CONFIGURATION public.testconfiguration ( PARSER = pg_catalog."default");`)
+			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH CONFIGURATION public.testconfiguration")
 			configurations := backup.GetTextSearchConfigurations(connection)
 
 			expectedConfiguration := backup.TextSearchConfiguration{Oid: 1, Schema: "public", Name: "testconfiguration", Parser: `pg_catalog."default"`, TokenToDicts: map[string][]string{}}
@@ -156,11 +156,11 @@ var _ = Describe("backup integration tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&expectedConfiguration, &configurations[0], "Oid")
 		})
 		It("returns a text search configuration with mappings", func() {
-			testhelper.AssertQueryRuns(connection, `CREATE TEXT SEARCH CONFIGURATION testconfiguration ( PARSER = pg_catalog."default");`)
-			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH CONFIGURATION testconfiguration")
+			testhelper.AssertQueryRuns(connection, `CREATE TEXT SEARCH CONFIGURATION public.testconfiguration ( PARSER = pg_catalog."default");`)
+			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH CONFIGURATION public.testconfiguration")
 
-			testhelper.AssertQueryRuns(connection, "ALTER TEXT SEARCH CONFIGURATION testconfiguration ADD MAPPING FOR uint WITH simple;")
-			testhelper.AssertQueryRuns(connection, "ALTER TEXT SEARCH CONFIGURATION testconfiguration ADD MAPPING FOR asciiword WITH danish_stem;")
+			testhelper.AssertQueryRuns(connection, "ALTER TEXT SEARCH CONFIGURATION public.testconfiguration ADD MAPPING FOR uint WITH simple;")
+			testhelper.AssertQueryRuns(connection, "ALTER TEXT SEARCH CONFIGURATION public.testconfiguration ADD MAPPING FOR asciiword WITH danish_stem;")
 
 			configurations := backup.GetTextSearchConfigurations(connection)
 
@@ -171,8 +171,8 @@ var _ = Describe("backup integration tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&expectedConfiguration, &configurations[0], "Oid")
 		})
 		It("returns a text search configuration from a specific schema", func() {
-			testhelper.AssertQueryRuns(connection, `CREATE TEXT SEARCH CONFIGURATION testconfiguration (PARSER = pg_catalog."default");`)
-			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH CONFIGURATION testconfiguration")
+			testhelper.AssertQueryRuns(connection, `CREATE TEXT SEARCH CONFIGURATION public.testconfiguration (PARSER = pg_catalog."default");`)
+			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH CONFIGURATION public.testconfiguration")
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, `CREATE TEXT SEARCH CONFIGURATION testschema.testconfiguration (PARSER = pg_catalog."default");`)

--- a/integration/predata_types_create_test.go
+++ b/integration/predata_types_create_test.go
@@ -29,7 +29,7 @@ var _ = Describe("backup integration create statement tests", func() {
 		BeforeEach(func() {
 			shellType = backup.Type{Type: "p", Schema: "public", Name: "shell_type"}
 			baseType = backup.Type{
-				Type: "b", Schema: "public", Name: "base_type", Input: "base_fn_in", Output: "base_fn_out", Receive: "",
+				Type: "b", Schema: "public", Name: "base_type", Input: "public.base_fn_in", Output: "public.base_fn_out", Receive: "",
 				Send: "", ModIn: "", ModOut: "", InternalLength: 4, IsPassedByValue: true, Alignment: "i", Storage: "p",
 				DefaultVal: "default", Element: "text", Category: "U", Preferred: false, Delimiter: ";", StorageOptions: "compresstype=zlib, compresslevel=1, blocksize=32768",
 			}
@@ -54,8 +54,8 @@ var _ = Describe("backup integration create statement tests", func() {
 			backup.PrintCreateShellTypeStatements(backupfile, toc, types)
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
-			defer testhelper.AssertQueryRuns(connection, "DROP TYPE shell_type")
-			defer testhelper.AssertQueryRuns(connection, "DROP TYPE base_type")
+			defer testhelper.AssertQueryRuns(connection, "DROP TYPE public.shell_type")
+			defer testhelper.AssertQueryRuns(connection, "DROP TYPE public.base_type")
 
 			shells := backup.GetShellTypes(connection)
 			Expect(len(shells)).To(Equal(2))
@@ -67,7 +67,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			backup.PrintCreateCompositeTypeStatement(backupfile, toc, compositeType, typeMetadata)
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
-			defer testhelper.AssertQueryRuns(connection, "DROP TYPE composite_type")
+			defer testhelper.AssertQueryRuns(connection, "DROP TYPE public.composite_type")
 
 			resultTypes := backup.GetCompositeTypes(connection)
 
@@ -81,7 +81,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			backup.PrintCreateEnumTypeStatements(backupfile, toc, enums, typeMetadataMap)
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
-			defer testhelper.AssertQueryRuns(connection, "DROP TYPE enum_type")
+			defer testhelper.AssertQueryRuns(connection, "DROP TYPE public.enum_type")
 
 			resultTypes := backup.GetEnumTypes(connection)
 
@@ -97,10 +97,10 @@ var _ = Describe("backup integration create statement tests", func() {
 			backup.PrintCreateBaseTypeStatement(backupfile, toc, baseType, typeMetadata)
 
 			//Run queries to set up the database state so we can successfully create base types
-			testhelper.AssertQueryRuns(connection, "CREATE TYPE base_type")
-			defer testhelper.AssertQueryRuns(connection, "DROP TYPE base_type CASCADE")
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION base_fn_in(cstring) RETURNS base_type AS 'boolin' LANGUAGE internal")
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION base_fn_out(base_type) RETURNS cstring AS 'boolout' LANGUAGE internal")
+			testhelper.AssertQueryRuns(connection, "CREATE TYPE public.base_type")
+			defer testhelper.AssertQueryRuns(connection, "DROP TYPE public.base_type CASCADE")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.base_fn_in(cstring) RETURNS public.base_type AS 'boolin' LANGUAGE internal")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.base_fn_out(public.base_type) RETURNS cstring AS 'boolout' LANGUAGE internal")
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
 
@@ -114,7 +114,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			backup.PrintCreateDomainStatement(backupfile, toc, domainType, typeMetadata, constraints)
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
-			defer testhelper.AssertQueryRuns(connection, "DROP TYPE domain_type")
+			defer testhelper.AssertQueryRuns(connection, "DROP TYPE public.domain_type")
 
 			resultTypes := backup.GetDomainTypes(connection)
 
@@ -130,7 +130,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			backup.PrintCreateCollationStatements(backupfile, toc, collations, backup.MetadataMap{})
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
-			defer testhelper.AssertQueryRuns(connection, "DROP COLLATION testcollation")
+			defer testhelper.AssertQueryRuns(connection, "DROP COLLATION public.testcollation")
 
 			resultCollations := backup.GetCollations(connection)
 
@@ -146,7 +146,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			backup.PrintCreateCollationStatements(backupfile, toc, collations, collationMetadataMap)
 
 			testhelper.AssertQueryRuns(connection, buffer.String())
-			defer testhelper.AssertQueryRuns(connection, "DROP COLLATION testcollation")
+			defer testhelper.AssertQueryRuns(connection, "DROP COLLATION public.testcollation")
 
 			resultCollations := backup.GetCollations(connection)
 			resultMetadataMap := backup.GetMetadataForObjectType(connection, backup.TYPE_COLLATION)

--- a/integration/predata_types_queries_test.go
+++ b/integration/predata_types_queries_test.go
@@ -25,12 +25,12 @@ var _ = Describe("backup integration tests", func() {
 		BeforeEach(func() {
 			shellType = backup.Type{Type: "p", Schema: "public", Name: "shell_type"}
 			baseTypeDefault = backup.Type{
-				Oid: 1, Type: "b", Schema: "public", Name: "base_type", Input: "base_fn_in", Output: "base_fn_out", Receive: "",
+				Oid: 1, Type: "b", Schema: "public", Name: "base_type", Input: "public.base_fn_in", Output: "public.base_fn_out", Receive: "",
 				Send: "", ModIn: "", ModOut: "", InternalLength: -1, IsPassedByValue: false, Alignment: "i", Storage: "p",
 				DefaultVal: "", Element: "", Delimiter: ",", Category: "U",
 			}
 			baseTypeCustom = backup.Type{
-				Oid: 1, Type: "b", Schema: "public", Name: "base_type", Input: "base_fn_in", Output: "base_fn_out", Receive: "",
+				Oid: 1, Type: "b", Schema: "public", Name: "base_type", Input: "public.base_fn_in", Output: "public.base_fn_out", Receive: "",
 				Send: "", ModIn: "", ModOut: "", InternalLength: 8, IsPassedByValue: true, Alignment: "d", Storage: "p",
 				DefaultVal: "0", Element: "integer", Delimiter: ";", Category: "U", StorageOptions: "compresstype=zlib, compresslevel=1, blocksize=32768",
 			}
@@ -43,8 +43,8 @@ var _ = Describe("backup integration tests", func() {
 			}
 		})
 		It("returns a slice for a shell type", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TYPE shell_type")
-			defer testhelper.AssertQueryRuns(connection, "DROP TYPE shell_type")
+			testhelper.AssertQueryRuns(connection, "CREATE TYPE public.shell_type")
+			defer testhelper.AssertQueryRuns(connection, "DROP TYPE public.shell_type")
 
 			results := backup.GetShellTypes(connection)
 
@@ -52,8 +52,8 @@ var _ = Describe("backup integration tests", func() {
 			structmatcher.ExpectStructsToMatchIncluding(&shellType, &results[0], "Schema", "Name", "Type")
 		})
 		It("returns a slice of composite types", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TYPE composite_type AS (name int4, name2 int, name1 text);")
-			defer testhelper.AssertQueryRuns(connection, "DROP TYPE composite_type")
+			testhelper.AssertQueryRuns(connection, "CREATE TYPE public.composite_type AS (name int4, name2 int, name1 text);")
+			defer testhelper.AssertQueryRuns(connection, "DROP TYPE public.composite_type")
 
 			results := backup.GetCompositeTypes(connection)
 
@@ -61,11 +61,11 @@ var _ = Describe("backup integration tests", func() {
 			structmatcher.ExpectStructsToMatchIncluding(&compositeType, &results[0], "Type", "Schema", "Name")
 		})
 		It("returns a slice for a base type with default values", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TYPE base_type")
-			defer testhelper.AssertQueryRuns(connection, "DROP TYPE base_type CASCADE")
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION base_fn_in(cstring) RETURNS base_type AS 'boolin' LANGUAGE internal")
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION base_fn_out(base_type) RETURNS cstring AS 'boolout' LANGUAGE internal")
-			testhelper.AssertQueryRuns(connection, "CREATE TYPE base_type(INPUT=base_fn_in, OUTPUT=base_fn_out)")
+			testhelper.AssertQueryRuns(connection, "CREATE TYPE public.base_type")
+			defer testhelper.AssertQueryRuns(connection, "DROP TYPE public.base_type CASCADE")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.base_fn_in(cstring) RETURNS public.base_type AS 'boolin' LANGUAGE internal")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.base_fn_out(public.base_type) RETURNS cstring AS 'boolout' LANGUAGE internal")
+			testhelper.AssertQueryRuns(connection, "CREATE TYPE public.base_type(INPUT=public.base_fn_in, OUTPUT=public.base_fn_out)")
 
 			results := backup.GetBaseTypes(connection)
 
@@ -77,16 +77,16 @@ var _ = Describe("backup integration tests", func() {
 			}
 		})
 		It("returns a slice for a base type with custom configuration", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TYPE base_type")
-			defer testhelper.AssertQueryRuns(connection, "DROP TYPE base_type CASCADE")
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION base_fn_in(cstring) RETURNS base_type AS 'boolin' LANGUAGE internal")
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION base_fn_out(base_type) RETURNS cstring AS 'boolout' LANGUAGE internal")
+			testhelper.AssertQueryRuns(connection, "CREATE TYPE public.base_type")
+			defer testhelper.AssertQueryRuns(connection, "DROP TYPE public.base_type CASCADE")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.base_fn_in(cstring) RETURNS public.base_type AS 'boolin' LANGUAGE internal")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.base_fn_out(public.base_type) RETURNS cstring AS 'boolout' LANGUAGE internal")
 			if connection.Version.Before("6") {
-				testhelper.AssertQueryRuns(connection, "CREATE TYPE base_type(INPUT=base_fn_in, OUTPUT=base_fn_out, INTERNALLENGTH=8, PASSEDBYVALUE, ALIGNMENT=double, STORAGE=plain, DEFAULT=0, ELEMENT=integer, DELIMITER=';')")
+				testhelper.AssertQueryRuns(connection, "CREATE TYPE public.base_type(INPUT=public.base_fn_in, OUTPUT=public.base_fn_out, INTERNALLENGTH=8, PASSEDBYVALUE, ALIGNMENT=double, STORAGE=plain, DEFAULT=0, ELEMENT=integer, DELIMITER=';')")
 			} else {
-				testhelper.AssertQueryRuns(connection, "CREATE TYPE base_type(INPUT=base_fn_in, OUTPUT=base_fn_out, INTERNALLENGTH=8, PASSEDBYVALUE, ALIGNMENT=double, STORAGE=plain, DEFAULT=0, ELEMENT=integer, DELIMITER=';', CATEGORY='N', PREFERRED=true)")
+				testhelper.AssertQueryRuns(connection, "CREATE TYPE public.base_type(INPUT=public.base_fn_in, OUTPUT=public.base_fn_out, INTERNALLENGTH=8, PASSEDBYVALUE, ALIGNMENT=double, STORAGE=plain, DEFAULT=0, ELEMENT=integer, DELIMITER=';', CATEGORY='N', PREFERRED=true)")
 			}
-			testhelper.AssertQueryRuns(connection, "ALTER TYPE base_type SET DEFAULT ENCODING (compresstype=zlib)")
+			testhelper.AssertQueryRuns(connection, "ALTER TYPE public.base_type SET DEFAULT ENCODING (compresstype=zlib)")
 
 			results := backup.GetBaseTypes(connection)
 
@@ -103,8 +103,8 @@ var _ = Describe("backup integration tests", func() {
 		})
 		It("returns a slice for an enum type", func() {
 			testutils.SkipIfBefore5(connection)
-			testhelper.AssertQueryRuns(connection, "CREATE TYPE enum_type AS ENUM ('label1','label2','label3')")
-			defer testhelper.AssertQueryRuns(connection, "DROP TYPE enum_type")
+			testhelper.AssertQueryRuns(connection, "CREATE TYPE public.enum_type AS ENUM ('label1','label2','label3')")
+			defer testhelper.AssertQueryRuns(connection, "DROP TYPE public.enum_type")
 
 			results := backup.GetEnumTypes(connection)
 
@@ -112,19 +112,19 @@ var _ = Describe("backup integration tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&results[0], &enumType, "Oid")
 		})
 		It("does not return types for sequences or views", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE SEQUENCE my_sequence START 10")
-			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE my_sequence")
-			testhelper.AssertQueryRuns(connection, "CREATE VIEW simpleview AS SELECT rolname FROM pg_roles")
-			defer testhelper.AssertQueryRuns(connection, "DROP VIEW simpleview")
+			testhelper.AssertQueryRuns(connection, "CREATE SEQUENCE public.my_sequence START 10")
+			defer testhelper.AssertQueryRuns(connection, "DROP SEQUENCE public.my_sequence")
+			testhelper.AssertQueryRuns(connection, "CREATE VIEW public.simpleview AS SELECT rolname FROM pg_roles")
+			defer testhelper.AssertQueryRuns(connection, "DROP VIEW public.simpleview")
 
 			results := backup.GetCompositeTypes(connection)
 
 			Expect(len(results)).To(Equal(0))
 		})
 		It("does not return implicit base or composite types for tables with length > NAMEDATALEN", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong(i int)")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong(i int)")
 			// The table's name will be truncated to 63 characters upon creation, as will the names of its implicit types
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo;")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo;")
 
 			bases := backup.GetBaseTypes(connection)
 			composites := backup.GetCompositeTypes(connection)
@@ -136,8 +136,8 @@ var _ = Describe("backup integration tests", func() {
 			domainType := backup.Type{
 				Oid: 1, Type: "d", Schema: "public", Name: "domain1", DefaultVal: "4", BaseType: `"numeric"`, NotNull: false,
 			}
-			testhelper.AssertQueryRuns(connection, "CREATE DOMAIN domain1 AS numeric DEFAULT 4")
-			defer testhelper.AssertQueryRuns(connection, "DROP DOMAIN domain1")
+			testhelper.AssertQueryRuns(connection, "CREATE DOMAIN public.domain1 AS numeric DEFAULT 4")
+			defer testhelper.AssertQueryRuns(connection, "DROP DOMAIN public.domain1")
 
 			results := backup.GetDomainTypes(connection)
 
@@ -145,8 +145,8 @@ var _ = Describe("backup integration tests", func() {
 			structmatcher.ExpectStructsToMatchIncluding(&results[0], &domainType, "Schema", "Name", "Type", "DefaultVal", "BaseType", "NotNull")
 		})
 		It("returns a slice for a type in a specific schema", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TYPE shell_type")
-			defer testhelper.AssertQueryRuns(connection, "DROP TYPE shell_type")
+			testhelper.AssertQueryRuns(connection, "CREATE TYPE public.shell_type")
+			defer testhelper.AssertQueryRuns(connection, "DROP TYPE public.shell_type")
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, "CREATE TYPE testschema.shell_type")
@@ -162,20 +162,20 @@ var _ = Describe("backup integration tests", func() {
 	})
 	Describe("ConstructCompositeTypeDependencies", func() {
 		BeforeEach(func() {
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION base_fn_in(cstring) RETURNS base_type AS 'boolin' LANGUAGE internal")
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION base_fn_out(base_type) RETURNS cstring AS 'boolout' LANGUAGE internal")
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION base_fn_in2(cstring) RETURNS base_type2 AS 'boolin' LANGUAGE internal")
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION base_fn_out2(base_type2) RETURNS cstring AS 'boolout' LANGUAGE internal")
-			testhelper.AssertQueryRuns(connection, "CREATE TYPE base_type(INPUT=base_fn_in, OUTPUT=base_fn_out)")
-			testhelper.AssertQueryRuns(connection, "CREATE TYPE base_type2(INPUT=base_fn_in2, OUTPUT=base_fn_out2)")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.base_fn_in(cstring) RETURNS public.base_type AS 'boolin' LANGUAGE internal")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.base_fn_out(public.base_type) RETURNS cstring AS 'boolout' LANGUAGE internal")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.base_fn_in2(cstring) RETURNS public.base_type2 AS 'boolin' LANGUAGE internal")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.base_fn_out2(public.base_type2) RETURNS cstring AS 'boolout' LANGUAGE internal")
+			testhelper.AssertQueryRuns(connection, "CREATE TYPE public.base_type(INPUT=public.base_fn_in, OUTPUT=public.base_fn_out)")
+			testhelper.AssertQueryRuns(connection, "CREATE TYPE public.base_type2(INPUT=public.base_fn_in2, OUTPUT=public.base_fn_out2)")
 		})
 		AfterEach(func() {
-			testhelper.AssertQueryRuns(connection, "DROP TYPE base_type CASCADE")
-			testhelper.AssertQueryRuns(connection, "DROP TYPE base_type2 CASCADE")
+			testhelper.AssertQueryRuns(connection, "DROP TYPE public.base_type CASCADE")
+			testhelper.AssertQueryRuns(connection, "DROP TYPE public.base_type2 CASCADE")
 		})
 		It("constructs dependencies correctly for a composite type dependent on one user-defined type", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TYPE comp_type AS (base base_type, builtin integer)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TYPE comp_type")
+			testhelper.AssertQueryRuns(connection, "CREATE TYPE public.comp_type AS (base public.base_type, builtin integer)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TYPE public.comp_type")
 
 			composites := backup.GetCompositeTypes(connection)
 			compTypes := backup.ConstructCompositeTypeDependencies(connection, composites)
@@ -185,8 +185,8 @@ var _ = Describe("backup integration tests", func() {
 			Expect(compTypes[0].DependsUpon[0]).To(Equal("public.base_type"))
 		})
 		It("constructs dependencies correctly for a composite type dependent on multiple user-defined types", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TYPE comp_type AS (base base_type, base2 base_type2)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TYPE comp_type")
+			testhelper.AssertQueryRuns(connection, "CREATE TYPE public.comp_type AS (base public.base_type, base2 public.base_type2)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TYPE public.comp_type")
 
 			composites := backup.GetCompositeTypes(connection)
 			compTypes := backup.ConstructCompositeTypeDependencies(connection, composites)
@@ -197,8 +197,8 @@ var _ = Describe("backup integration tests", func() {
 			Expect(compTypes[0].DependsUpon).To(Equal([]string{"public.base_type", "public.base_type2"}))
 		})
 		It("constructs dependencies correctly for a composite type dependent on the same user-defined type multiple times", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TYPE comp_type AS (base base_type, base2 base_type)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TYPE comp_type")
+			testhelper.AssertQueryRuns(connection, "CREATE TYPE public.comp_type AS (base public.base_type, base2 public.base_type)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TYPE public.comp_type")
 
 			composites := backup.GetCompositeTypes(connection)
 			compTypes := backup.ConstructCompositeTypeDependencies(connection, composites)
@@ -212,18 +212,18 @@ var _ = Describe("backup integration tests", func() {
 		funcInfoMap := map[uint32]backup.FunctionInfo{}
 		BeforeEach(func() {
 			testutils.SkipIfNot4(connection)
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION base_fn_in(cstring) RETURNS base_type AS 'boolin' LANGUAGE internal")
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION base_fn_out(base_type) RETURNS cstring AS 'boolout' LANGUAGE internal")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.base_fn_in(cstring) RETURNS public.base_type AS 'boolin' LANGUAGE internal")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.base_fn_out(public.base_type) RETURNS cstring AS 'boolout' LANGUAGE internal")
 			inOid := testutils.OidFromObjectName(connection, "public", "base_fn_in", backup.TYPE_FUNCTION)
 			outOid := testutils.OidFromObjectName(connection, "public", "base_fn_out", backup.TYPE_FUNCTION)
 			funcInfoMap[inOid] = backup.FunctionInfo{QualifiedName: "public.base_fn_in", Arguments: "cstring"}
-			funcInfoMap[outOid] = backup.FunctionInfo{QualifiedName: "public.base_fn_out", Arguments: "base_type"}
+			funcInfoMap[outOid] = backup.FunctionInfo{QualifiedName: "public.base_fn_out", Arguments: "public.base_type"}
 		})
 		AfterEach(func() {
-			testhelper.AssertQueryRuns(connection, "DROP TYPE base_type CASCADE")
+			testhelper.AssertQueryRuns(connection, "DROP TYPE public.base_type CASCADE")
 		})
 		It("constructs dependencies on user-defined functions", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TYPE base_type(INPUT=base_fn_in, OUTPUT=base_fn_out)")
+			testhelper.AssertQueryRuns(connection, "CREATE TYPE public.base_type(INPUT=public.base_fn_in, OUTPUT=public.base_fn_out)")
 
 			bases := backup.GetBaseTypes(connection)
 			baseTypes := backup.ConstructBaseTypeDependencies4(connection, bases, funcInfoMap)
@@ -232,10 +232,10 @@ var _ = Describe("backup integration tests", func() {
 			Expect(len(baseTypes[0].DependsUpon)).To(Equal(2))
 			sort.Strings(baseTypes[0].DependsUpon)
 			Expect(baseTypes[0].DependsUpon[0]).To(Equal("public.base_fn_in(cstring)"))
-			Expect(baseTypes[0].DependsUpon[1]).To(Equal("public.base_fn_out(base_type)"))
+			Expect(baseTypes[0].DependsUpon[1]).To(Equal("public.base_fn_out(public.base_type)"))
 		})
 		It("doesn't construct dependencies on built-in functions", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TYPE base_type(INPUT=base_fn_in, OUTPUT=base_fn_out, TYPMOD_IN=numerictypmodin, TYPMOD_OUT=numerictypmodout)")
+			testhelper.AssertQueryRuns(connection, "CREATE TYPE public.base_type(INPUT=public.base_fn_in, OUTPUT=public.base_fn_out, TYPMOD_IN=numerictypmodin, TYPMOD_OUT=numerictypmodout)")
 
 			bases := backup.GetBaseTypes(connection)
 			baseTypes := backup.ConstructBaseTypeDependencies4(connection, bases, funcInfoMap)
@@ -244,20 +244,20 @@ var _ = Describe("backup integration tests", func() {
 			Expect(len(baseTypes[0].DependsUpon)).To(Equal(2))
 			sort.Strings(baseTypes[0].DependsUpon)
 			Expect(baseTypes[0].DependsUpon[0]).To(Equal("public.base_fn_in(cstring)"))
-			Expect(baseTypes[0].DependsUpon[1]).To(Equal("public.base_fn_out(base_type)"))
+			Expect(baseTypes[0].DependsUpon[1]).To(Equal("public.base_fn_out(public.base_type)"))
 		})
 	})
 	Describe("ConstructBaseTypeDependencies5", func() {
 		BeforeEach(func() {
 			testutils.SkipIfBefore5(connection)
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION base_fn_in(cstring) RETURNS base_type AS 'boolin' LANGUAGE internal")
-			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION base_fn_out(base_type) RETURNS cstring AS 'boolout' LANGUAGE internal")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.base_fn_in(cstring) RETURNS public.base_type AS 'boolin' LANGUAGE internal")
+			testhelper.AssertQueryRuns(connection, "CREATE FUNCTION public.base_fn_out(public.base_type) RETURNS cstring AS 'boolout' LANGUAGE internal")
 		})
 		AfterEach(func() {
-			testhelper.AssertQueryRuns(connection, "DROP TYPE base_type CASCADE")
+			testhelper.AssertQueryRuns(connection, "DROP TYPE public.base_type CASCADE")
 		})
 		It("constructs dependencies on user-defined functions", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TYPE base_type(INPUT=base_fn_in, OUTPUT=base_fn_out)")
+			testhelper.AssertQueryRuns(connection, "CREATE TYPE public.base_type(INPUT=public.base_fn_in, OUTPUT=public.base_fn_out)")
 
 			bases := backup.GetBaseTypes(connection)
 			baseTypes := backup.ConstructBaseTypeDependencies5(connection, bases)
@@ -266,10 +266,10 @@ var _ = Describe("backup integration tests", func() {
 			Expect(len(baseTypes[0].DependsUpon)).To(Equal(2))
 			sort.Strings(baseTypes[0].DependsUpon)
 			Expect(baseTypes[0].DependsUpon[0]).To(Equal("public.base_fn_in(cstring)"))
-			Expect(baseTypes[0].DependsUpon[1]).To(Equal("public.base_fn_out(base_type)"))
+			Expect(baseTypes[0].DependsUpon[1]).To(Equal("public.base_fn_out(public.base_type)"))
 		})
 		It("doesn't construct dependencies on built-in functions", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE TYPE base_type(INPUT=base_fn_in, OUTPUT=base_fn_out, TYPMOD_IN=numerictypmodin, TYPMOD_OUT=numerictypmodout)")
+			testhelper.AssertQueryRuns(connection, "CREATE TYPE public.base_type(INPUT=public.base_fn_in, OUTPUT=public.base_fn_out, TYPMOD_IN=numerictypmodin, TYPMOD_OUT=numerictypmodout)")
 
 			bases := backup.GetBaseTypes(connection)
 			baseTypes := backup.ConstructBaseTypeDependencies5(connection, bases)
@@ -278,15 +278,15 @@ var _ = Describe("backup integration tests", func() {
 			Expect(len(baseTypes[0].DependsUpon)).To(Equal(2))
 			sort.Strings(baseTypes[0].DependsUpon)
 			Expect(baseTypes[0].DependsUpon[0]).To(Equal("public.base_fn_in(cstring)"))
-			Expect(baseTypes[0].DependsUpon[1]).To(Equal("public.base_fn_out(base_type)"))
+			Expect(baseTypes[0].DependsUpon[1]).To(Equal("public.base_fn_out(public.base_type)"))
 		})
 	})
 	Describe("ConstructDomainDependencies", func() {
 		It("constructs dependencies on user-defined types", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE DOMAIN parent_domain AS integer")
-			defer testhelper.AssertQueryRuns(connection, "DROP DOMAIN parent_domain")
-			testhelper.AssertQueryRuns(connection, "CREATE DOMAIN domain_type AS parent_domain")
-			defer testhelper.AssertQueryRuns(connection, "DROP DOMAIN domain_type")
+			testhelper.AssertQueryRuns(connection, "CREATE DOMAIN public.parent_domain AS integer")
+			defer testhelper.AssertQueryRuns(connection, "DROP DOMAIN public.parent_domain")
+			testhelper.AssertQueryRuns(connection, "CREATE DOMAIN public.domain_type AS public.parent_domain")
+			defer testhelper.AssertQueryRuns(connection, "DROP DOMAIN public.domain_type")
 
 			domains := backup.GetDomainTypes(connection)
 			domains = backup.ConstructDomainDependencies(connection, domains)
@@ -296,8 +296,8 @@ var _ = Describe("backup integration tests", func() {
 			Expect(domains[0].DependsUpon[0]).To(Equal("public.parent_domain"))
 		})
 		It("doesn't construct dependencies on built-in types", func() {
-			testhelper.AssertQueryRuns(connection, "CREATE DOMAIN parent_domain AS integer")
-			defer testhelper.AssertQueryRuns(connection, "DROP DOMAIN parent_domain")
+			testhelper.AssertQueryRuns(connection, "CREATE DOMAIN public.parent_domain AS integer")
+			defer testhelper.AssertQueryRuns(connection, "DROP DOMAIN public.parent_domain")
 
 			domains := backup.GetDomainTypes(connection)
 			domains = backup.ConstructDomainDependencies(connection, domains)
@@ -309,8 +309,8 @@ var _ = Describe("backup integration tests", func() {
 	Describe("GetCollations", func() {
 		It("returns a slice of collations", func() {
 			testutils.SkipIfBefore6(connection)
-			testhelper.AssertQueryRuns(connection, `CREATE COLLATION some_coll (lc_collate = 'POSIX', lc_ctype = 'POSIX');`)
-			defer testhelper.AssertQueryRuns(connection, "DROP COLLATION some_coll")
+			testhelper.AssertQueryRuns(connection, `CREATE COLLATION public.some_coll (lc_collate = 'POSIX', lc_ctype = 'POSIX');`)
+			defer testhelper.AssertQueryRuns(connection, "DROP COLLATION public.some_coll")
 
 			results := backup.GetCollations(connection)
 
@@ -322,8 +322,8 @@ var _ = Describe("backup integration tests", func() {
 		})
 		It("returns a slice of collations in a specific schema", func() {
 			testutils.SkipIfBefore6(connection)
-			testhelper.AssertQueryRuns(connection, `CREATE COLLATION some_coll (lc_collate = 'POSIX', lc_ctype = 'POSIX');`)
-			defer testhelper.AssertQueryRuns(connection, "DROP COLLATION some_coll")
+			testhelper.AssertQueryRuns(connection, `CREATE COLLATION public.some_coll (lc_collate = 'POSIX', lc_ctype = 'POSIX');`)
+			defer testhelper.AssertQueryRuns(connection, "DROP COLLATION public.some_coll")
 			testhelper.AssertQueryRuns(connection, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, `CREATE COLLATION testschema.some_coll (lc_collate = 'POSIX', lc_ctype = 'POSIX');`)

--- a/integration/statistics_create_test.go
+++ b/integration/statistics_create_test.go
@@ -19,11 +19,11 @@ var _ = Describe("backup integration tests", func() {
 			tables := []backup.Relation{{SchemaOid: 2200, Schema: "public", Name: "foo"}}
 
 			// Create and ANALYZE a table to generate statistics
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE foo(i int, j text, k bool)")
-			defer testhelper.AssertQueryRuns(connection, "DROP TABLE foo")
-			testhelper.AssertQueryRuns(connection, "INSERT INTO foo VALUES (1, 'a', 't')")
-			testhelper.AssertQueryRuns(connection, "INSERT INTO foo VALUES (2, 'b', 'f')")
-			testhelper.AssertQueryRuns(connection, "ANALYZE foo")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.foo(i int, j text, k bool)")
+			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.foo")
+			testhelper.AssertQueryRuns(connection, "INSERT INTO public.foo VALUES (1, 'a', 't')")
+			testhelper.AssertQueryRuns(connection, "INSERT INTO public.foo VALUES (2, 'b', 'f')")
+			testhelper.AssertQueryRuns(connection, "ANALYZE public.foo")
 
 			oldTableOid := testutils.OidFromObjectName(connection, "public", "foo", backup.TYPE_RELATION)
 			tables[0].Oid = oldTableOid
@@ -33,8 +33,8 @@ var _ = Describe("backup integration tests", func() {
 			beforeTupleStat := beforeTupleStats[oldTableOid]
 
 			// Drop and recreate the table to clear the statistics
-			testhelper.AssertQueryRuns(connection, "DROP TABLE foo")
-			testhelper.AssertQueryRuns(connection, "CREATE TABLE foo(i int, j text, k bool)")
+			testhelper.AssertQueryRuns(connection, "DROP TABLE public.foo")
+			testhelper.AssertQueryRuns(connection, "CREATE TABLE public.foo(i int, j text, k bool)")
 
 			// Reload the retrieved statistics into the new table
 			backup.PrintStatisticsStatements(backupfile, toc, tables, beforeAttStats, beforeTupleStats)

--- a/integration/statistics_queries_test.go
+++ b/integration/statistics_queries_test.go
@@ -15,14 +15,14 @@ var _ = Describe("backup integration tests", func() {
 	tables := []backup.Relation{backup.BasicRelation("public", "foo")}
 	var tableOid uint32
 	BeforeEach(func() {
-		testhelper.AssertQueryRuns(connection, "CREATE TABLE foo(i int, j text, k bool)")
+		testhelper.AssertQueryRuns(connection, "CREATE TABLE public.foo(i int, j text, k bool)")
 		tableOid = testutils.OidFromObjectName(connection, "public", "foo", backup.TYPE_RELATION)
-		testhelper.AssertQueryRuns(connection, "INSERT INTO foo VALUES (1, 'a', 't')")
-		testhelper.AssertQueryRuns(connection, "INSERT INTO foo VALUES (2, 'b', 'f')")
-		testhelper.AssertQueryRuns(connection, "ANALYZE foo")
+		testhelper.AssertQueryRuns(connection, "INSERT INTO public.foo VALUES (1, 'a', 't')")
+		testhelper.AssertQueryRuns(connection, "INSERT INTO public.foo VALUES (2, 'b', 'f')")
+		testhelper.AssertQueryRuns(connection, "ANALYZE public.foo")
 	})
 	AfterEach(func() {
-		testhelper.AssertQueryRuns(connection, "DROP TABLE foo")
+		testhelper.AssertQueryRuns(connection, "DROP TABLE public.foo")
 	})
 	Describe("GetAttributeStatistics", func() {
 		It("returns attribute statistics for a table", func() {


### PR DESCRIPTION
Also, fully qualify COMMENT ON and ALTER collation statements and set the search path to pg_catalog during integration tests to prevent these issues in the future.

