### PR TITLE
Support Resource Group MemoryAuditor and CPUSET

### DIFF
--- a/backup/metadata_globals.go
+++ b/backup/metadata_globals.go
@@ -92,29 +92,27 @@ func PrintCreateResourceQueueStatements(metadataFile *utils.FileWithByteCount, t
 	}
 }
 
-type resGroupPrepareStruct struct {
-	oid     uint32
-	name    string
-	setting string
-}
-
-func PrintPrepareResourceGroupStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, resGroupMetadata MetadataMap) {
+func PrintResetResourceGroupStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, resGroupMetadata MetadataMap) {
 	/*
 	 * total cpu_rate_limit and memory_limit should less than 100, so clean
 	 * them before we seting new memory_limit and cpu_rate_limit.
 	 */
-	defSettings := []resGroupPrepareStruct{
+	defSettings := []struct {
+		oid     uint32
+		name    string
+		setting string
+	}{
 		{6438, "admin_group", "SET CPU_RATE_LIMIT 1"},
 		{6438, "admin_group", "SET MEMORY_LIMIT 1"},
 		{6437, "default_group", "SET CPU_RATE_LIMIT 1"},
 		{6437, "default_group", "SET MEMORY_LIMIT 1"},
 	}
+
 	for _, prepare := range defSettings {
 		start := uint64(0)
 
 		start = metadataFile.ByteCount
 		metadataFile.MustPrintf("\n\nALTER RESOURCE GROUP %s %s;", prepare.name, prepare.setting)
-		PrintObjectMetadata(metadataFile, resGroupMetadata[prepare.oid], prepare.name, "RESOURCE GROUP")
 		toc.AddGlobalEntry("", prepare.name, "RESOURCE GROUP", start, metadataFile)
 	}
 }

--- a/backup/metadata_globals.go
+++ b/backup/metadata_globals.go
@@ -116,17 +116,15 @@ func PrintResetResourceGroupStatements(metadataFile *utils.FileWithByteCount, to
 	}
 }
 
-type resGroupStruct struct {
-	setting string
-	value   int
-}
-
 func PrintCreateResourceGroupStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, resGroups []ResourceGroup, resGroupMetadata MetadataMap) {
 	for _, resGroup := range resGroups {
 		start := uint64(0)
 
 		if resGroup.Name == "default_group" || resGroup.Name == "admin_group" {
-			resGroupList := []resGroupStruct{
+			resGroupList := []struct {
+				setting string
+				value   int
+			}{
 				{"MEMORY_LIMIT", resGroup.MemoryLimit},
 				{"MEMORY_SHARED_QUOTA", resGroup.MemorySharedQuota},
 				{"MEMORY_SPILL_RATIO", resGroup.MemorySpillRatio},

--- a/backup/metadata_globals.go
+++ b/backup/metadata_globals.go
@@ -98,14 +98,13 @@ func PrintResetResourceGroupStatements(metadataFile *utils.FileWithByteCount, to
 	 * them before we seting new memory_limit and cpu_rate_limit.
 	 */
 	defSettings := []struct {
-		oid     uint32
 		name    string
 		setting string
 	}{
-		{6438, "admin_group", "SET CPU_RATE_LIMIT 1"},
-		{6438, "admin_group", "SET MEMORY_LIMIT 1"},
-		{6437, "default_group", "SET CPU_RATE_LIMIT 1"},
-		{6437, "default_group", "SET MEMORY_LIMIT 1"},
+		{"admin_group", "SET CPU_RATE_LIMIT 1"},
+		{"admin_group", "SET MEMORY_LIMIT 1"},
+		{"default_group", "SET CPU_RATE_LIMIT 1"},
+		{"default_group", "SET MEMORY_LIMIT 1"},
 	}
 
 	for _, prepare := range defSettings {

--- a/backup/metadata_globals_test.go
+++ b/backup/metadata_globals_test.go
@@ -181,10 +181,10 @@ COMMENT ON RESOURCE QUEUE "commentQueue" IS 'This is a resource queue comment.';
 				`CREATE RESOURCE GROUP some_group2 WITH (CPUSET='0-3', MEMORY_AUDITOR=vmtracker, MEMORY_LIMIT=30, MEMORY_SHARED_QUOTA=35, MEMORY_SPILL_RATIO=10, CONCURRENCY=25);`)
 		})
 	})
-	Describe("PrintPrepareResourceGroupStatements", func() {
+	Describe("PrintResetResourceGroupStatements", func() {
 		var emptyResGroupMetadata = map[uint32]backup.ObjectMetadata{}
 		It("prints prepare resource groups", func() {
-			backup.PrintPrepareResourceGroupStatements(backupfile, toc, emptyResGroupMetadata)
+			backup.PrintResetResourceGroupStatements(backupfile, toc, emptyResGroupMetadata)
 			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "", "admin_group", "RESOURCE GROUP")
 			testutils.AssertBufferContents(toc.GlobalEntries, buffer,
 				`ALTER RESOURCE GROUP admin_group SET CPU_RATE_LIMIT 1;`,

--- a/backup/metadata_globals_test.go
+++ b/backup/metadata_globals_test.go
@@ -140,8 +140,8 @@ COMMENT ON RESOURCE QUEUE "commentQueue" IS 'This is a resource queue comment.';
 			backup.PrintCreateResourceGroupStatements(backupfile, toc, resGroups, emptyResGroupMetadata)
 			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "", "some_group", "RESOURCE GROUP")
 			testutils.AssertBufferContents(toc.GlobalEntries, buffer,
-				`CREATE RESOURCE GROUP some_group WITH (CPU_RATE_LIMIT=10, MEMORY_LIMIT=20, MEMORY_SHARED_QUOTA=25, MEMORY_SPILL_RATIO=30, CONCURRENCY=15);`,
-				`CREATE RESOURCE GROUP some_group2 WITH (CPU_RATE_LIMIT=20, MEMORY_LIMIT=30, MEMORY_SHARED_QUOTA=35, MEMORY_SPILL_RATIO=10, CONCURRENCY=25);`)
+				`CREATE RESOURCE GROUP some_group WITH (CPU_RATE_LIMIT=10, MEMORY_AUDITOR=vmtracker, MEMORY_LIMIT=20, MEMORY_SHARED_QUOTA=25, MEMORY_SPILL_RATIO=30, CONCURRENCY=15);`,
+				`CREATE RESOURCE GROUP some_group2 WITH (CPU_RATE_LIMIT=20, MEMORY_AUDITOR=vmtracker, MEMORY_LIMIT=30, MEMORY_SHARED_QUOTA=35, MEMORY_SPILL_RATIO=10, CONCURRENCY=25);`)
 		})
 		It("prints ALTER statement for default_group resource group", func() {
 			default_group := backup.ResourceGroup{Oid: 1, Name: "default_group", CPURateLimit: 10, MemoryLimit: 20, Concurrency: 15, MemorySharedQuota: 25, MemorySpillRatio: 30}
@@ -149,11 +149,48 @@ COMMENT ON RESOURCE QUEUE "commentQueue" IS 'This is a resource queue comment.';
 
 			backup.PrintCreateResourceGroupStatements(backupfile, toc, resGroups, emptyResGroupMetadata)
 			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "", "default_group", "RESOURCE GROUP")
-			testutils.AssertBufferContents(toc.GlobalEntries, buffer, `ALTER RESOURCE GROUP default_group SET CPU_RATE_LIMIT 10;`,
+			testutils.AssertBufferContents(toc.GlobalEntries, buffer,
 				`ALTER RESOURCE GROUP default_group SET MEMORY_LIMIT 20;`,
 				`ALTER RESOURCE GROUP default_group SET MEMORY_SHARED_QUOTA 25;`,
 				`ALTER RESOURCE GROUP default_group SET MEMORY_SPILL_RATIO 30;`,
-				`ALTER RESOURCE GROUP default_group SET CONCURRENCY 15;`)
+				`ALTER RESOURCE GROUP default_group SET CONCURRENCY 15;`,
+				`ALTER RESOURCE GROUP default_group SET CPU_RATE_LIMIT 10;`)
+		})
+		It("prints memory_auditor resource groups", func() {
+			someGroup := backup.ResourceGroup{Oid: 1, Name: "some_group", CPURateLimit: 10, MemoryLimit: 20, Concurrency: 15, MemorySharedQuota: 25, MemorySpillRatio: 30}
+			someGroup2 := backup.ResourceGroup{Oid: 2, Name: "some_group2", CPURateLimit: 10, MemoryLimit: 30, Concurrency: 0, MemorySharedQuota: 35, MemorySpillRatio: 10, MemoryAuditor: 1}
+			someGroup3 := backup.ResourceGroup{Oid: 3, Name: "some_group3", CPURateLimit: 10, MemoryLimit: 30, Concurrency: 25, MemorySharedQuota: 35, MemorySpillRatio: 10, MemoryAuditor: 0}
+			resGroups := []backup.ResourceGroup{someGroup, someGroup2, someGroup3}
+
+			backup.PrintCreateResourceGroupStatements(backupfile, toc, resGroups, emptyResGroupMetadata)
+			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "", "some_group", "RESOURCE GROUP")
+			testutils.AssertBufferContents(toc.GlobalEntries, buffer,
+				`CREATE RESOURCE GROUP some_group WITH (CPU_RATE_LIMIT=10, MEMORY_AUDITOR=vmtracker, MEMORY_LIMIT=20, MEMORY_SHARED_QUOTA=25, MEMORY_SPILL_RATIO=30, CONCURRENCY=15);`,
+				`CREATE RESOURCE GROUP some_group2 WITH (CPU_RATE_LIMIT=10, MEMORY_AUDITOR=cgroup, MEMORY_LIMIT=30, MEMORY_SHARED_QUOTA=35, MEMORY_SPILL_RATIO=10, CONCURRENCY=0);`,
+				`CREATE RESOURCE GROUP some_group3 WITH (CPU_RATE_LIMIT=10, MEMORY_AUDITOR=vmtracker, MEMORY_LIMIT=30, MEMORY_SHARED_QUOTA=35, MEMORY_SPILL_RATIO=10, CONCURRENCY=25);`)
+		})
+		It("prints cpuset resource groups", func() {
+			someGroup := backup.ResourceGroup{Oid: 1, Name: "some_group", CPURateLimit: 10, MemoryLimit: 20, Concurrency: 15, MemorySharedQuota: 25, MemorySpillRatio: 30}
+			someGroup2 := backup.ResourceGroup{Oid: 2, Name: "some_group2", CPURateLimit: -1, Cpuset: "0-3", MemoryLimit: 30, Concurrency: 25, MemorySharedQuota: 35, MemorySpillRatio: 10}
+			resGroups := []backup.ResourceGroup{someGroup, someGroup2}
+
+			backup.PrintCreateResourceGroupStatements(backupfile, toc, resGroups, emptyResGroupMetadata)
+			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "", "some_group", "RESOURCE GROUP")
+			testutils.AssertBufferContents(toc.GlobalEntries, buffer,
+				`CREATE RESOURCE GROUP some_group WITH (CPU_RATE_LIMIT=10, MEMORY_AUDITOR=vmtracker, MEMORY_LIMIT=20, MEMORY_SHARED_QUOTA=25, MEMORY_SPILL_RATIO=30, CONCURRENCY=15);`,
+				`CREATE RESOURCE GROUP some_group2 WITH (CPUSET='0-3', MEMORY_AUDITOR=vmtracker, MEMORY_LIMIT=30, MEMORY_SHARED_QUOTA=35, MEMORY_SPILL_RATIO=10, CONCURRENCY=25);`)
+		})
+	})
+	Describe("PrintPrepareResourceGroupStatements", func() {
+		var emptyResGroupMetadata = map[uint32]backup.ObjectMetadata{}
+		It("prints prepare resource groups", func() {
+			backup.PrintPrepareResourceGroupStatements(backupfile, toc, emptyResGroupMetadata)
+			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "", "admin_group", "RESOURCE GROUP")
+			testutils.AssertBufferContents(toc.GlobalEntries, buffer,
+				`ALTER RESOURCE GROUP admin_group SET CPU_RATE_LIMIT 1;`,
+				`ALTER RESOURCE GROUP admin_group SET MEMORY_LIMIT 1;`,
+				`ALTER RESOURCE GROUP default_group SET CPU_RATE_LIMIT 1;`,
+				`ALTER RESOURCE GROUP default_group SET MEMORY_LIMIT 1;`)
 		})
 	})
 	Describe("PrintCreateRoleStatements", func() {

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -230,7 +230,7 @@ func BackupResourceGroups(metadataFile *utils.FileWithByteCount) {
 	resGroups := GetResourceGroups(connectionPool)
 	objectCounts["Resource Groups"] = len(resGroups)
 	resGroupMetadata := GetCommentsForObjectType(connectionPool, TYPE_RESOURCEGROUP)
-	PrintPrepareResourceGroupStatements(metadataFile, globalTOC, resGroupMetadata)
+	PrintResetResourceGroupStatements(metadataFile, globalTOC, resGroupMetadata)
 	PrintCreateResourceGroupStatements(metadataFile, globalTOC, resGroups, resGroupMetadata)
 }
 

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -230,6 +230,7 @@ func BackupResourceGroups(metadataFile *utils.FileWithByteCount) {
 	resGroups := GetResourceGroups(connectionPool)
 	objectCounts["Resource Groups"] = len(resGroups)
 	resGroupMetadata := GetCommentsForObjectType(connectionPool, TYPE_RESOURCEGROUP)
+	PrintPrepareResourceGroupStatements(metadataFile, globalTOC, resGroupMetadata)
 	PrintCreateResourceGroupStatements(metadataFile, globalTOC, resGroups, resGroupMetadata)
 }
 

--- a/integration/metadata_globals_create_test.go
+++ b/integration/metadata_globals_create_test.go
@@ -87,7 +87,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			testutils.SkipIfBefore5(connection)
 		})
 		It("creates a basic resource group", func() {
-			someGroup := backup.ResourceGroup{Oid: 1, Name: "some_group", CPURateLimit: 10, MemoryLimit: 20, Concurrency: 15, MemorySharedQuota: 25, MemorySpillRatio: 30}
+			someGroup := backup.ResourceGroup{Oid: 1, Name: "some_group", CPURateLimit: 10, MemoryLimit: 20, Concurrency: 15, MemorySharedQuota: 25, MemorySpillRatio: 30, MemoryAuditor: 0, Cpuset: "-1"}
 			emptyMetadataMap := map[uint32]backup.ObjectMetadata{}
 
 			backup.PrintCreateResourceGroupStatements(backupfile, toc, []backup.ResourceGroup{someGroup}, emptyMetadataMap)
@@ -106,7 +106,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			Fail("Could not find some_group")
 		})
 		It("alters a default resource group", func() {
-			defaultGroup := backup.ResourceGroup{Oid: 1, Name: "default_group", CPURateLimit: 10, MemoryLimit: 20, Concurrency: 15, MemorySharedQuota: 25, MemorySpillRatio: 30}
+			defaultGroup := backup.ResourceGroup{Oid: 1, Name: "default_group", CPURateLimit: 10, MemoryLimit: 20, Concurrency: 15, MemorySharedQuota: 25, MemorySpillRatio: 30, MemoryAuditor: 0, Cpuset: "-1"}
 			emptyMetadataMap := map[uint32]backup.ObjectMetadata{}
 
 			backup.PrintCreateResourceGroupStatements(backupfile, toc, []backup.ResourceGroup{defaultGroup}, emptyMetadataMap)


### PR DESCRIPTION
- gpbackup can backup resgroup with memoryauditor and cpuset
  property
- Be sure it can restore correctly on default resource groups, adjust some
  parameters to 1 first, which the total sum can't exceed 100.