### PR TITLE
Properly handle objects created by extensions

### DIFF
--- a/backup/queries_functions.go
+++ b/backup/queries_functions.go
@@ -697,7 +697,8 @@ SELECT
 	) AS options
 FROM pg_user_mapping um
 JOIN pg_foreign_server fs
-ON um.umserver = fs.oid;`)
+ON um.umserver = fs.oid
+WHERE %s;`, ExtensionFilterClause("um"))
 
 	err := connection.Select(&results, query)
 	gplog.FatalOnError(err)

--- a/backup/queries_functions.go
+++ b/backup/queries_functions.go
@@ -449,7 +449,7 @@ JOIN pg_namespace tn ON tt.typnamespace = tn.oid
 LEFT JOIN pg_proc p ON c.castfunc = p.oid
 LEFT JOIN pg_description d ON c.oid = d.objoid
 LEFT JOIN pg_namespace n ON p.pronamespace = n.oid
-WHERE (%s) OR (%s) OR (%s)
+WHERE ((%s) OR (%s) OR (%s))
 AND c.oid NOT IN (select objid from pg_depend where deptype = 'e')
 ORDER BY 1, 2;
 `, argStr, methodStr, SchemaFilterClause("sn"), SchemaFilterClause("tn"), SchemaFilterClause("n"))

--- a/backup/queries_operators.go
+++ b/backup/queries_operators.go
@@ -63,7 +63,7 @@ SELECT
 FROM pg_operator o
 JOIN pg_namespace n on n.oid = o.oprnamespace
 WHERE %s AND oprcode != 0
-AND o.oid NOT IN (select objid from pg_depend where deptype = 'e')`, SchemaFilterClause("n"))
+AND %s`, SchemaFilterClause("n"), ExtensionFilterClause("o"))
 
 	var err error
 	if connection.Version.Before("5") {
@@ -98,7 +98,7 @@ SELECT
 FROM pg_opfamily o
 JOIN pg_namespace n on n.oid = o.opfnamespace
 WHERE %s
-AND o.oid NOT IN (select objid from pg_depend where deptype = 'e')`, SchemaFilterClause("n"))
+AND %s`, SchemaFilterClause("n"), ExtensionFilterClause("o"))
 	err := connection.Select(&results, query)
 	gplog.FatalOnError(err)
 	return results
@@ -157,7 +157,7 @@ LEFT JOIN pg_catalog.pg_opfamily f ON f.oid = opcfamily
 JOIN pg_catalog.pg_namespace cls_ns ON cls_ns.oid = opcnamespace
 JOIN pg_catalog.pg_namespace fam_ns ON fam_ns.oid = opfnamespace
 WHERE %s
-AND c.oid NOT IN (select objid from pg_depend where deptype = 'e')`, SchemaFilterClause("cls_ns"))
+AND %s`, SchemaFilterClause("cls_ns"), ExtensionFilterClause("c"))
 
 	var err error
 	if connection.Version.Before("5") {

--- a/backup/queries_postdata.go
+++ b/backup/queries_postdata.go
@@ -82,7 +82,8 @@ LEFT JOIN pg_tablespace s
 WHERE %s
 AND i.indisprimary = 'f'
 AND n.nspname || '.' || c.relname NOT IN (SELECT partitionschemaname || '.' || partitiontablename FROM pg_partitions)
-ORDER BY name;`, relationAndSchemaFilterClause())
+AND %s
+ORDER BY name;`, relationAndSchemaFilterClause(), ExtensionFilterClause("c"))
 
 		results := make([]IndexDefinition, 0)
 		err := connection.Select(&results, query)
@@ -121,7 +122,8 @@ WHERE %s
 AND i.indisprimary = 'f'
 AND n.nspname || '.' || c.relname NOT IN (SELECT partitionschemaname || '.' || partitiontablename FROM pg_partitions)
 AND con.conindid IS NULL
-ORDER BY name;`, relationAndSchemaFilterClause())
+AND %s
+ORDER BY name;`, relationAndSchemaFilterClause(), ExtensionFilterClause("c")) // The index itself does not have a dependency on the extension, but the index's table does
 		err := connection.Select(&resultIndexes, query)
 		gplog.FatalOnError(err)
 	}
@@ -163,7 +165,8 @@ JOIN pg_namespace n
 WHERE %s
 AND rulename NOT LIKE '%%RETURN'
 AND rulename NOT LIKE 'pg_%%'
-ORDER BY rulename;`, relationAndSchemaFilterClause())
+AND %s
+ORDER BY rulename;`, relationAndSchemaFilterClause(), ExtensionFilterClause("c"))
 
 	results := make([]QuerySimpleDefinition, 0)
 	err := connection.Select(&results, query)
@@ -191,7 +194,8 @@ JOIN pg_namespace n
 WHERE %s
 AND tgname NOT LIKE 'pg_%%'
 AND %s
-ORDER BY tgname;`, relationAndSchemaFilterClause(), constraintClause)
+AND %s
+ORDER BY tgname;`, relationAndSchemaFilterClause(), constraintClause, ExtensionFilterClause("c"))
 
 	results := make([]QuerySimpleDefinition, 0)
 	err := connection.Select(&results, query)

--- a/backup/queries_shared.go
+++ b/backup/queries_shared.go
@@ -267,8 +267,10 @@ SELECT
 	coalesce(description,'') AS comment
 FROM %s o LEFT JOIN %s d ON (d.objoid = o.oid AND d.classoid = '%s'::regclass%s)
 %s
+AND o.oid NOT IN (SELECT objid FROM pg_depend WHERE deptype='e')
 ORDER BY o.oid;
 `, aclStr, kindStr, ownerStr, params.CatalogTable, descFunc, params.CatalogTable, subidStr, schemaStr)
+	fmt.Println(query)
 
 	results := make([]MetadataQueryStruct, 0)
 	err := connection.Select(&results, query)

--- a/backup/queries_shared_test.go
+++ b/backup/queries_shared_test.go
@@ -29,6 +29,7 @@ var _ = Describe("backup/queries_shared tests", func() {
 	pg_get_userbyid(owner) AS owner,
 	coalesce(description,'') AS comment
 FROM table o LEFT JOIN pg_description d ON (d.objoid = o.oid AND d.classoid = 'table'::regclass AND d.objsubid = 0)
+AND o.oid NOT IN (SELECT objid FROM pg_depend WHERE deptype='e')
 ORDER BY o.oid;`)).WillReturnRows(emptyRows)
 			backup.GetMetadataForObjectType(connectionPool, params)
 		})
@@ -42,6 +43,7 @@ ORDER BY o.oid;`)).WillReturnRows(emptyRows)
 FROM table o LEFT JOIN pg_description d ON (d.objoid = o.oid AND d.classoid = 'table'::regclass AND d.objsubid = 0)
 JOIN pg_namespace n ON o.schema = n.oid
 WHERE n.nspname NOT LIKE 'pg_temp_%' AND n.nspname NOT LIKE 'pg_toast%' AND n.nspname NOT IN ('gp_toolkit', 'information_schema', 'pg_aoseg', 'pg_bitmapindex', 'pg_catalog')
+AND o.oid NOT IN (SELECT objid FROM pg_depend WHERE deptype='e')
 ORDER BY o.oid;`)).WillReturnRows(emptyRows)
 			params.SchemaField = "schema"
 			backup.GetMetadataForObjectType(connectionPool, params)
@@ -60,7 +62,7 @@ ORDER BY o.oid;`)).WillReturnRows(emptyRows)
 	pg_get_userbyid(owner) AS owner,
 	coalesce(description,'') AS comment
 FROM table o LEFT JOIN pg_description d ON (d.objoid = o.oid AND d.classoid = 'table'::regclass AND d.objsubid = 0)
-
+AND o.oid NOT IN (SELECT objid FROM pg_depend WHERE deptype='e')
 ORDER BY o.oid;`)).WillReturnRows(emptyRows)
 			params.ACLField = "acl"
 			backup.GetMetadataForObjectType(connectionPool, params)
@@ -73,7 +75,7 @@ ORDER BY o.oid;`)).WillReturnRows(emptyRows)
 	pg_get_userbyid(owner) AS owner,
 	coalesce(description,'') AS comment
 FROM table o LEFT JOIN pg_shdescription d ON (d.objoid = o.oid AND d.classoid = 'table'::regclass)
-
+AND o.oid NOT IN (SELECT objid FROM pg_depend WHERE deptype='e')
 ORDER BY o.oid;`)).WillReturnRows(emptyRows)
 			params.Shared = true
 			backup.GetMetadataForObjectType(connectionPool, params)

--- a/backup/queries_textsearch.go
+++ b/backup/queries_textsearch.go
@@ -40,8 +40,8 @@ SELECT
 FROM pg_ts_parser p
 JOIN pg_namespace n ON n.oid = p.prsnamespace
 WHERE %s
-AND p.oid NOT IN (select objid from pg_depend where deptype = 'e')
-ORDER BY prsname;`, SchemaFilterClause("n"))
+AND %s
+ORDER BY prsname;`, SchemaFilterClause("n"), ExtensionFilterClause("p"))
 
 	results := make([]TextSearchParser, 0)
 	err := connection.Select(&results, query)
@@ -68,8 +68,8 @@ SELECT
 FROM pg_ts_template p
 JOIN pg_namespace n ON n.oid = p.tmplnamespace
 WHERE %s
-AND p.oid NOT IN (select objid from pg_depend where deptype = 'e')
-ORDER BY tmplname;`, SchemaFilterClause("n"))
+AND %s
+ORDER BY tmplname;`, SchemaFilterClause("n"), ExtensionFilterClause("p"))
 
 	results := make([]TextSearchTemplate, 0)
 	err := connection.Select(&results, query)
@@ -98,8 +98,8 @@ JOIN pg_ts_template t ON t.oid = d.dicttemplate
 JOIN pg_namespace tmpl_ns ON tmpl_ns.oid = t.tmplnamespace
 JOIN pg_namespace dict_ns ON dict_ns.oid = d.dictnamespace
 WHERE %s
-AND d.oid NOT IN (select objid from pg_depend where deptype = 'e')
-ORDER BY dictname;`, SchemaFilterClause("dict_ns"))
+AND %s
+ORDER BY dictname;`, SchemaFilterClause("dict_ns"), ExtensionFilterClause("d"))
 
 	results := make([]TextSearchDictionary, 0)
 	err := connection.Select(&results, query)
@@ -128,8 +128,8 @@ JOIN pg_ts_parser p ON p.oid = c.cfgparser
 JOIN pg_namespace cfg_ns ON cfg_ns.oid = c.cfgnamespace
 JOIN pg_namespace prs_ns ON prs_ns.oid = prsnamespace
 WHERE %s
-AND c.oid NOT IN (select objid from pg_depend where deptype = 'e')
-ORDER BY cfgname;`, SchemaFilterClause("cfg_ns"))
+AND %s
+ORDER BY cfgname;`, SchemaFilterClause("cfg_ns"), ExtensionFilterClause("c"))
 
 	results := make([]struct {
 		Schema    string

--- a/backup/queries_types.go
+++ b/backup/queries_types.go
@@ -78,6 +78,7 @@ GROUP BY %s`, selectClause, groupBy, selectClause, groupBy)
 %s
 WHERE %s
 AND t.typtype = '%s'
+AND t.oid NOT IN (SELECT objid FROM pg_depend WHERE deptype='e')
 GROUP BY %s
 EXCEPT (
 %s

--- a/backup/queries_types.go
+++ b/backup/queries_types.go
@@ -66,26 +66,26 @@ GROUP BY %s`, selectClause, groupBy)
 	 */
 	tableTypesClause := fmt.Sprintf(`
 %s
-AND t.oid NOT IN (select objid from pg_depend where deptype = 'e')
+AND %s
 JOIN pg_class c ON t.typrelid = c.oid AND c.relkind IN ('r', 'S', 'v')
 GROUP BY %s
 UNION ALL
 %s
 JOIN pg_type it ON t.typelem = it.oid
 JOIN pg_class c ON it.typrelid = c.oid AND c.relkind IN ('r', 'S', 'v')
-GROUP BY %s`, selectClause, groupBy, selectClause, groupBy)
+GROUP BY %s`, selectClause, ExtensionFilterClause("t"), groupBy, selectClause, groupBy)
 	return fmt.Sprintf(`
 %s
 WHERE %s
 AND t.typtype = '%s'
-AND t.oid NOT IN (SELECT objid FROM pg_depend WHERE deptype='e')
+AND %s
 GROUP BY %s
 EXCEPT (
 %s
 UNION ALL
 %s
 )
-ORDER BY schema, name;`, selectClause, SchemaFilterClause("n"), typeType, groupBy, arrayTypesClause, tableTypesClause)
+ORDER BY schema, name;`, selectClause, SchemaFilterClause("n"), typeType, ExtensionFilterClause("t"), groupBy, arrayTypesClause, tableTypesClause)
 }
 
 type Type struct {
@@ -252,8 +252,8 @@ JOIN pg_namespace n ON t.typnamespace = n.oid
 JOIN pg_type b ON t.typbasetype = b.oid
 WHERE %s
 AND t.typtype = 'd'
-AND t.oid NOT IN (select objid from pg_depend where deptype = 'e')
-ORDER BY n.nspname, t.typname;`, SchemaFilterClause("n"))
+AND %s
+ORDER BY n.nspname, t.typname;`, SchemaFilterClause("n"), ExtensionFilterClause("t"))
 
 	results := make([]Type, 0)
 	err := connection.Select(&results, query)
@@ -276,8 +276,8 @@ LEFT JOIN (
 	) e ON t.oid = e.enumtypid
 WHERE %s
 AND t.typtype = 'e'
-AND t.oid NOT IN (select objid from pg_depend where deptype = 'e')
-ORDER BY n.nspname, t.typname;`, SchemaFilterClause("n"))
+AND %s
+ORDER BY n.nspname, t.typname;`, SchemaFilterClause("n"), ExtensionFilterClause("t"))
 
 	results := make([]Type, 0)
 	err := connection.Select(&results, query)
@@ -296,8 +296,8 @@ FROM pg_type t
 JOIN pg_namespace n ON t.typnamespace = n.oid
 WHERE %s
 AND t.typtype = 'p'
-AND t.oid NOT IN (select objid from pg_depend where deptype = 'e')
-ORDER BY n.nspname, t.typname;`, SchemaFilterClause("n"))
+AND %s
+ORDER BY n.nspname, t.typname;`, SchemaFilterClause("n"), ExtensionFilterClause("t"))
 
 	results := make([]Type, 0)
 	err := connection.Select(&results, query)

--- a/integration/predata_functions_create_test.go
+++ b/integration/predata_functions_create_test.go
@@ -370,24 +370,24 @@ var _ = Describe("backup integration create statement tests", func() {
 	Describe("PrintCreateExtensions", func() {
 		It("creates extensions", func() {
 			testutils.SkipIfBefore5(connection)
-			extension := backup.Extension{Oid: 1, Name: "plperl", Schema: "pg_catalog"}
-			extensions := []backup.Extension{extension}
+			plperlExtension := backup.Extension{Oid: 1, Name: "plperl", Schema: "pg_catalog"}
+			extensions := []backup.Extension{plperlExtension}
 			extensionMetadataMap := testutils.DefaultMetadataMap("EXTENSION", false, false, true)
 			extensionMetadata := extensionMetadataMap[1]
-
 			backup.PrintCreateExtensionStatements(backupfile, toc, extensions, extensionMetadataMap)
-
 			testhelper.AssertQueryRuns(connection, buffer.String())
 			defer testhelper.AssertQueryRuns(connection, "DROP EXTENSION plperl; SET search_path=pg_catalog")
-
 			resultExtensions := backup.GetExtensions(connection)
 			resultMetadataMap := backup.GetCommentsForObjectType(connection, backup.TYPE_EXTENSION)
-
-			extension.Oid = testutils.OidFromObjectName(connection, "", "plperl", backup.TYPE_EXTENSION)
-			Expect(len(resultExtensions)).To(Equal(1))
-			resultMetadata := resultMetadataMap[extension.Oid]
-			structmatcher.ExpectStructsToMatch(&extension, &resultExtensions[0])
-			structmatcher.ExpectStructsToMatch(&extensionMetadata, &resultMetadata)
+			plperlExtension.Oid = testutils.OidFromObjectName(connection, "", "plperl", backup.TYPE_EXTENSION)
+			if connection.Version.Before("6") {
+				Expect(len(resultExtensions)).To(Equal(1))
+			} else {
+				Expect(len(resultExtensions)).To(Equal(2))
+			}
+			plperlMetadata := resultMetadataMap[plperlExtension.Oid]
+			structmatcher.ExpectStructsToMatch(&plperlExtension, &resultExtensions[0])
+			structmatcher.ExpectStructsToMatch(&extensionMetadata, &plperlMetadata)
 		})
 	})
 	Describe("PrintCreateConversionStatements", func() {

--- a/integration/predata_functions_create_test.go
+++ b/integration/predata_functions_create_test.go
@@ -388,7 +388,6 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultMetadata := resultMetadataMap[extension.Oid]
 			structmatcher.ExpectStructsToMatch(&extension, &resultExtensions[0])
 			structmatcher.ExpectStructsToMatch(&extensionMetadata, &resultMetadata)
-
 		})
 	})
 	Describe("PrintCreateConversionStatements", func() {

--- a/integration/predata_functions_queries_test.go
+++ b/integration/predata_functions_queries_test.go
@@ -425,10 +425,19 @@ LANGUAGE SQL`)
 
 			results := backup.GetExtensions(connection)
 
-			Expect(len(results)).To(Equal(1))
+			if connection.Version.Before("6") {
+				Expect(len(results)).To(Equal(1))
 
-			plperlDef := backup.Extension{Oid: 0, Name: "plperl", Schema: "pg_catalog"}
-			structmatcher.ExpectStructsToMatchExcluding(&plperlDef, &results[0], "Oid")
+				plperlDef := backup.Extension{Oid: 0, Name: "plperl", Schema: "pg_catalog"}
+				structmatcher.ExpectStructsToMatchExcluding(&plperlDef, &results[0], "Oid")
+			} else {
+				Expect(len(results)).To(Equal(2))
+
+				plperlDef := backup.Extension{Oid: 0, Name: "plperl", Schema: "pg_catalog"}
+				hyperloglogDef := backup.Extension{Oid: 0, Name: "hyperloglog_counter", Schema: "pg_catalog"}
+				structmatcher.ExpectStructsToMatchExcluding(&plperlDef, &results[0], "Oid")
+				structmatcher.ExpectStructsToMatchExcluding(&hyperloglogDef, &results[1], "Oid")
+			}
 		})
 	})
 	Describe("GetProceduralLanguages", func() {

--- a/integration/predata_functions_queries_test.go
+++ b/integration/predata_functions_queries_test.go
@@ -427,9 +427,8 @@ LANGUAGE SQL`)
 
 			Expect(len(results)).To(Equal(1))
 
-			extensionDef := backup.Extension{Oid: 0, Name: "plperl", Schema: "pg_catalog"}
-			structmatcher.ExpectStructsToMatchExcluding(&extensionDef, &results[0], "Oid")
-
+			plperlDef := backup.Extension{Oid: 0, Name: "plperl", Schema: "pg_catalog"}
+			structmatcher.ExpectStructsToMatchExcluding(&plperlDef, &results[0], "Oid")
 		})
 	})
 	Describe("GetProceduralLanguages", func() {

--- a/integration/predata_shared_queries_test.go
+++ b/integration/predata_shared_queries_test.go
@@ -1042,7 +1042,11 @@ LANGUAGE SQL`)
 				oid := testutils.OidFromObjectName(connection, "", "plperl", backup.TYPE_EXTENSION)
 				resultMetadataMap := backup.GetCommentsForObjectType(connection, backup.TYPE_EXTENSION)
 
-				Expect(len(resultMetadataMap)).To(Equal(1))
+				if connection.Version.Before("6") {
+					Expect(len(resultMetadataMap)).To(Equal(1))
+				} else {
+					Expect(len(resultMetadataMap)).To(Equal(2))
+				}
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatch(&extensionMetadata, &resultMetadata)
 			})


### PR DESCRIPTION
Objects that are created by extensions should not be dumped explicitly since they are created by a script when CREATE EXTENSION is invoked (this statement is dumped). While we had most objects covered, there were a few objects that we missed (functions, types, constraints, postdata).

Additionally, we drop the hyperloglog extension so it does not pollute our tests.