### PR TITLE
Fix backup of external tables with --single-data-file

### DIFF
--- a/restore/restore.go
+++ b/restore/restore.go
@@ -200,7 +200,7 @@ func restoreData(gucStatements []utils.StatementWithType) {
 			filteredOids[i] = fmt.Sprintf("%d", entry.Oid)
 		}
 		utils.WriteOidListToSegments(filteredOids, globalCluster, globalFPInfo)
-		firstOid := filteredMasterDataEntries[0].Oid
+		firstOid := fmt.Sprintf("%d", filteredMasterDataEntries[0].Oid)
 		utils.CreateFirstSegmentPipeOnAllHosts(firstOid, globalCluster, globalFPInfo)
 		utils.StartAgent(globalCluster, globalFPInfo, "--restore-agent", *pluginConfigFile, "")
 	}

--- a/utils/agent_remote.go
+++ b/utils/agent_remote.go
@@ -14,10 +14,10 @@ import (
  * Functions to run commands on entire cluster during both backup and restore
  */
 
-func CreateFirstSegmentPipeOnAllHosts(oid uint32, c *cluster.Cluster, fpInfo FilePathInfo) {
+func CreateFirstSegmentPipeOnAllHosts(oid string, c *cluster.Cluster, fpInfo FilePathInfo) {
 	remoteOutput := c.GenerateAndExecuteCommand("Creating segment data pipes", func(contentID int) string {
 		pipeName := fpInfo.GetSegmentPipeFilePath(contentID)
-		pipeName = fmt.Sprintf("%s_%d", pipeName, oid)
+		pipeName = fmt.Sprintf("%s_%s", pipeName, oid)
 		return fmt.Sprintf("mkfifo %s", pipeName)
 	}, cluster.ON_SEGMENTS)
 	c.CheckClusterError(remoteOutput, "Unable to create segment data pipes", func(contentID int) string {


### PR DESCRIPTION
During the gpbackup --single-data-file refactor to use an agent
approach, the oid list created for the master included external tables,
while the oid list on the segments did not. This caused the backup to
fail as the pipe names did not match (the segment created a pipe with
the name of a regular table, whereas the master executed a COPY TO
command to a pipe with an external table). This only occurred when
--single-data-file was used.

Authored-by: Chris Hajas <chajas@pivotal.io>