### PR TITLE
Restore from restore plans for both backup types

### DIFF
--- a/backup/dependencies.go
+++ b/backup/dependencies.go
@@ -102,7 +102,7 @@ func TopologicalSort(slice []Sortable) []Sortable {
 	isDependentOn := make(map[string][]string, 0)
 	queue := make([]Sortable, 0)
 	sorted := make([]Sortable, 0)
-	notVisited := utils.NewEmptyIncludeSet()
+	notVisited := utils.NewIncludeSet([]string{})
 	for i, item := range slice {
 		name := item.FQN()
 		deps := item.Dependencies()

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -444,7 +444,7 @@ func ConstructTableDependencies(connection *dbconn.DBConn, tables []Relation, ta
 	var tableNameSet *utils.FilterSet
 	var tableOidList []string
 	if isTableFiltered {
-		tableNameSet = utils.NewEmptyIncludeSet()
+		tableNameSet = utils.NewIncludeSet([]string{})
 		tableOidList = make([]string, len(tables))
 		for i, table := range tables {
 			tableNameSet.Add(table.ToString())

--- a/end_to_end.sh
+++ b/end_to_end.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+ginkgo -r -randomizeSuites -slowSpecThreshold=10 -noisySkippings=false -randomizeAllSpecs end_to_end 2>&1

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -145,12 +145,24 @@ var _ = Describe("backup end to end integration tests", func() {
 	})
 
 	Describe("end to end gpbackup and gprestore tests", func() {
-		publicSchemaTupleCounts := map[string]int{"public.foo": 40000, "public.holds": 50000, "public.sales": 13}
-		schema2TupleCounts := map[string]int{"schema2.returns": 6, "schema2.foo2": 0, "schema2.foo3": 100}
+		var publicSchemaTupleCounts, schema2TupleCounts map[string]int
+
 		BeforeEach(func() {
 			testhelper.AssertQueryRuns(restoreConn, "DROP SCHEMA IF EXISTS schema2 CASCADE; DROP SCHEMA public CASCADE; CREATE SCHEMA public;")
+			publicSchemaTupleCounts = map[string]int{
+				"public.foo":   40000,
+				"public.holds": 50000,
+				"public.sales": 13,
+			}
+			schema2TupleCounts = map[string]int{
+				"schema2.returns": 6,
+				"schema2.foo2":    0,
+				"schema2.foo3":    100,
+				"schema2.ao1":     1000,
+				"schema2.ao2":     1000,
+			}
 		})
-		Context("Backup include filtering", func() {
+		Describe("Backup include filtering", func() {
 			It("runs gpbackup and gprestore with include-schema backup flag and compression level", func() {
 				timestamp := gpbackup(gpbackupPath, "--include-schema", "public", "--compression-level", "2")
 				gprestore(gprestorePath, timestamp, "--redirect-db", "restoredb")
@@ -180,13 +192,13 @@ var _ = Describe("backup end to end integration tests", func() {
 			})
 
 		})
-		Context("Restore include filtering", func() {
+		Describe("Restore include filtering", func() {
 			It("runs gpbackup and gprestore with include-schema restore flag", func() {
 				backupdir := "/tmp/include_schema"
 				timestamp := gpbackup(gpbackupPath, "--backup-dir", backupdir)
 				gprestore(gprestorePath, timestamp, "--redirect-db", "restoredb", "--backup-dir", backupdir, "--include-schema", "schema2")
 
-				assertRelationsCreated(restoreConn, 15)
+				assertRelationsCreated(restoreConn, 17)
 				assertDataRestored(restoreConn, schema2TupleCounts)
 
 				os.RemoveAll(backupdir)
@@ -214,19 +226,19 @@ var _ = Describe("backup end to end integration tests", func() {
 				os.Remove("/tmp/include-tables.txt")
 			})
 		})
-		Context("Backup exclude filtering", func() {
+		Describe("Backup exclude filtering", func() {
 			It("runs gpbackup and gprestore with exclude-schema backup flag", func() {
 				timestamp := gpbackup(gpbackupPath, "--exclude-schema", "public")
 				gprestore(gprestorePath, timestamp, "--redirect-db", "restoredb")
 
-				assertRelationsCreated(restoreConn, 15)
+				assertRelationsCreated(restoreConn, 17)
 				assertDataRestored(restoreConn, schema2TupleCounts)
 			})
 			It("runs gpbackup and gprestore with exclude-table backup flag", func() {
 				timestamp := gpbackup(gpbackupPath, "--exclude-table", "schema2.foo2", "--exclude-table", "schema2.returns", "--exclude-table", "public.myseq1", "--exclude-table", "public.myview1")
 				gprestore(gprestorePath, timestamp, "--redirect-db", "restoredb")
 
-				assertRelationsCreated(restoreConn, 18)
+				assertRelationsCreated(restoreConn, 20)
 				assertDataRestored(restoreConn, map[string]int{"schema2.foo3": 100, "public.foo": 40000, "public.holds": 50000, "public.sales": 13})
 
 				os.Remove("/tmp/exclude-tables.txt")
@@ -237,25 +249,25 @@ var _ = Describe("backup end to end integration tests", func() {
 				timestamp := gpbackup(gpbackupPath, "--exclude-table-file", "/tmp/exclude-tables.txt")
 				gprestore(gprestorePath, timestamp, "--redirect-db", "restoredb")
 
-				assertRelationsCreated(restoreConn, 5)
+				assertRelationsCreated(restoreConn, 7)
 				assertDataRestored(restoreConn, map[string]int{"schema2.foo3": 100, "public.foo": 40000, "public.holds": 50000})
 
 				os.Remove("/tmp/exclude-tables.txt")
 			})
 		})
-		Context("Restore exclude filtering", func() {
+		Describe("Restore exclude filtering", func() {
 			It("runs gpbackup and gprestore with exclude-schema restore flag", func() {
 				timestamp := gpbackup(gpbackupPath)
 				gprestore(gprestorePath, timestamp, "--redirect-db", "restoredb", "--exclude-schema", "public")
 
-				assertRelationsCreated(restoreConn, 15)
+				assertRelationsCreated(restoreConn, 17)
 				assertDataRestored(restoreConn, schema2TupleCounts)
 			})
 			It("runs gpbackup and gprestore with exclude-table restore flag", func() {
 				timestamp := gpbackup(gpbackupPath)
 				gprestore(gprestorePath, timestamp, "--redirect-db", "restoredb", "--exclude-table", "schema2.foo2", "--exclude-table", "schema2.returns", "--exclude-table", "public.myseq1", "--exclude-table", "public.myview1")
 
-				assertRelationsCreated(restoreConn, 18)
+				assertRelationsCreated(restoreConn, 20)
 				assertDataRestored(restoreConn, map[string]int{"schema2.foo3": 100, "public.foo": 40000, "public.holds": 50000, "public.sales": 13})
 
 				os.Remove("/tmp/exclude-tables.txt")
@@ -267,20 +279,20 @@ var _ = Describe("backup end to end integration tests", func() {
 				timestamp := gpbackup(gpbackupPath, "--backup-dir", backupdir)
 				gprestore(gprestorePath, timestamp, "--redirect-db", "restoredb", "--backup-dir", backupdir, "--exclude-table-file", "/tmp/exclude-tables.txt")
 
-				assertRelationsCreated(restoreConn, 18)
+				assertRelationsCreated(restoreConn, 20)
 				assertDataRestored(restoreConn, map[string]int{"public.sales": 13, "public.foo": 40000})
 
 				os.RemoveAll(backupdir)
 				os.Remove("/tmp/exclude-tables.txt")
 			})
 		})
-		Context("Single data file", func() {
+		Describe("Single data file", func() {
 			It("runs gpbackup and gprestore with single-data-file flag", func() {
 				backupdir := "/tmp/single_data_file"
 				timestamp := gpbackup(gpbackupPath, "--single-data-file", "--backup-dir", backupdir)
 				gprestore(gprestorePath, timestamp, "--redirect-db", "restoredb", "--backup-dir", backupdir)
 
-				assertRelationsCreated(restoreConn, 34)
+				assertRelationsCreated(restoreConn, 36)
 				assertDataRestored(restoreConn, publicSchemaTupleCounts)
 				assertDataRestored(restoreConn, schema2TupleCounts)
 
@@ -292,7 +304,7 @@ var _ = Describe("backup end to end integration tests", func() {
 				timestamp := gpbackup(gpbackupPath, "--single-data-file", "--backup-dir", backupdir, "--no-compression")
 				gprestore(gprestorePath, timestamp, "--redirect-db", "restoredb", "--backup-dir", backupdir)
 
-				assertRelationsCreated(restoreConn, 34)
+				assertRelationsCreated(restoreConn, 36)
 				assertDataRestored(restoreConn, publicSchemaTupleCounts)
 				assertDataRestored(restoreConn, schema2TupleCounts)
 
@@ -308,7 +320,7 @@ var _ = Describe("backup end to end integration tests", func() {
 				timestamp := gpbackup(gpbackupPath, "--single-data-file", "--no-compression", "--plugin-config", pluginConfigPath)
 				gprestore(gprestorePath, timestamp, "--redirect-db", "restoredb", "--plugin-config", pluginConfigPath)
 
-				assertRelationsCreated(restoreConn, 34)
+				assertRelationsCreated(restoreConn, 36)
 				assertDataRestored(restoreConn, publicSchemaTupleCounts)
 				assertDataRestored(restoreConn, schema2TupleCounts)
 
@@ -323,7 +335,7 @@ var _ = Describe("backup end to end integration tests", func() {
 				timestamp := gpbackup(gpbackupPath, "--single-data-file", "--plugin-config", pluginConfigPath)
 				gprestore(gprestorePath, timestamp, "--redirect-db", "restoredb", "--plugin-config", pluginConfigPath)
 
-				assertRelationsCreated(restoreConn, 34)
+				assertRelationsCreated(restoreConn, 36)
 				assertDataRestored(restoreConn, publicSchemaTupleCounts)
 				assertDataRestored(restoreConn, schema2TupleCounts)
 
@@ -346,7 +358,7 @@ var _ = Describe("backup end to end integration tests", func() {
 				timestamp := gpbackup(gpbackupPath, "--backup-dir", backupdir, "--single-data-file")
 				gprestore(gprestorePath, timestamp, "--redirect-db", "restoredb", "--backup-dir", backupdir, "--include-schema", "schema2")
 
-				assertRelationsCreated(restoreConn, 15)
+				assertRelationsCreated(restoreConn, 17)
 				assertDataRestored(restoreConn, schema2TupleCounts)
 
 				os.RemoveAll(backupdir)
@@ -368,6 +380,26 @@ var _ = Describe("backup end to end integration tests", func() {
 
 			})
 		})
+		Describe("Incremental", func() {
+			It("restores from an incremental backup", func() {
+				fullBackupTimestamp := gpbackup(gpbackupPath)
+
+				testhelper.AssertQueryRuns(backupConn, "INSERT into schema2.ao1 values(1001)")
+				defer testhelper.AssertQueryRuns(backupConn, "DELETE from schema2.ao1 where i=1001")
+				incremental1Timestamp := gpbackup(gpbackupPath, "--incremental", fullBackupTimestamp)
+
+				testhelper.AssertQueryRuns(backupConn, "INSERT into schema2.ao1 values(1002)")
+				defer testhelper.AssertQueryRuns(backupConn, "DELETE from schema2.ao1 where i=1002")
+				incremental2Timestamp := gpbackup(gpbackupPath, "--incremental", incremental1Timestamp)
+
+				gprestore(gprestorePath, incremental2Timestamp, "--redirect-db", "restoredb")
+
+				assertRelationsCreated(restoreConn, 36)
+				assertDataRestored(restoreConn, publicSchemaTupleCounts)
+				schema2TupleCounts["schema2.ao1"] = 1002
+				assertDataRestored(restoreConn, schema2TupleCounts)
+			})
+		})
 		It("runs gpbackup and gprestore without redirecting restore to another db", func() {
 			timestamp := gpbackup(gpbackupPath)
 			backupConn.Close()
@@ -384,7 +416,7 @@ var _ = Describe("backup end to end integration tests", func() {
 			timestamp2 := gpbackup(gpbackupPath, "--data-only")
 			gprestore(gprestorePath, timestamp, "--redirect-db", "restoredb")
 			assertDataRestored(restoreConn, map[string]int{"public.foo": 0, "schema2.foo3": 0})
-			assertRelationsCreated(restoreConn, 34)
+			assertRelationsCreated(restoreConn, 36)
 			gprestore(gprestorePath, timestamp2, "--redirect-db", "restoredb")
 
 			assertDataRestored(restoreConn, publicSchemaTupleCounts)
@@ -395,7 +427,7 @@ var _ = Describe("backup end to end integration tests", func() {
 			gprestore(gprestorePath, timestamp, "--redirect-db", "restoredb")
 
 			assertDataRestored(restoreConn, map[string]int{"public.foo": 0, "schema2.foo3": 0})
-			assertRelationsCreated(restoreConn, 34)
+			assertRelationsCreated(restoreConn, 36)
 		})
 		It("runs gpbackup and gprestore with data-only backup flag", func() {
 			testutils.ExecuteSQLFile(restoreConn, "test_tables_ddl.sql")
@@ -420,13 +452,13 @@ var _ = Describe("backup end to end integration tests", func() {
 			gprestore(gprestorePath, timestamp, "--redirect-db", "restoredb", "--metadata-only")
 
 			assertDataRestored(restoreConn, map[string]int{"public.foo": 0, "schema2.foo3": 0})
-			assertRelationsCreated(restoreConn, 34)
+			assertRelationsCreated(restoreConn, 36)
 		})
 		It("runs gpbackup and gprestore with leaf-partition-data and backupdir flags", func() {
 			backupdir := "/tmp/leaf_partition_data"
 			timestamp := gpbackup(gpbackupPath, "--leaf-partition-data", "--backup-dir", backupdir)
 			output := gprestore(gprestorePath, timestamp, "--redirect-db", "restoredb", "--backup-dir", backupdir)
-			Expect(strings.Contains(string(output), "Tables restored:  28 / 28")).To(BeTrue())
+			Expect(strings.Contains(string(output), "Tables restored:  30 / 30")).To(BeTrue())
 
 			assertDataRestored(restoreConn, publicSchemaTupleCounts)
 			assertDataRestored(restoreConn, schema2TupleCounts)
@@ -441,7 +473,7 @@ var _ = Describe("backup end to end integration tests", func() {
 			contents, _ := ioutil.ReadFile(configFile[0])
 
 			Expect(strings.Contains(string(contents), "compressed: false")).To(BeTrue())
-			assertRelationsCreated(restoreConn, 34)
+			assertRelationsCreated(restoreConn, 36)
 			assertDataRestored(restoreConn, publicSchemaTupleCounts)
 			assertDataRestored(restoreConn, schema2TupleCounts)
 
@@ -466,7 +498,7 @@ var _ = Describe("backup end to end integration tests", func() {
 			timestamp := gpbackup(gpbackupPath, "--backup-dir", backupdir, "--jobs", "4")
 			gprestore(gprestorePath, timestamp, "--redirect-db", "restoredb", "--backup-dir", backupdir, "--jobs", "4")
 
-			assertRelationsCreated(restoreConn, 34)
+			assertRelationsCreated(restoreConn, 36)
 			assertDataRestored(restoreConn, schema2TupleCounts)
 			assertDataRestored(restoreConn, publicSchemaTupleCounts)
 

--- a/end_to_end/test_tables_data.sql
+++ b/end_to_end/test_tables_data.sql
@@ -50,6 +50,10 @@ SET search_path = schema2, pg_catalog;
 
 INSERT INTO foo3 SELECT generate_series(201,300);
 
+INSERT INTO ao1 SELECT generate_series(1,1000);
+
+INSERT INTO ao2 SELECT generate_series(1,1000);
+
 --
 --
 

--- a/end_to_end/test_tables_ddl.sql
+++ b/end_to_end/test_tables_ddl.sql
@@ -54,19 +54,19 @@ CREATE TABLE sales (
     id integer,
     date date,
     amt numeric(10,2)
-) DISTRIBUTED BY (id) PARTITION BY RANGE(date) 
+) DISTRIBUTED BY (id) PARTITION BY RANGE(date)
           (
-          PARTITION jan17 START ('2017-01-01'::date) END ('2017-02-01'::date) WITH (tablename='sales_1_prt_jan17', appendonly=false ), 
-          PARTITION feb17 START ('2017-02-01'::date) END ('2017-03-01'::date) WITH (tablename='sales_1_prt_feb17', appendonly=false ), 
-          PARTITION mar17 START ('2017-03-01'::date) END ('2017-04-01'::date) WITH (tablename='sales_1_prt_mar17', appendonly=false ), 
-          PARTITION apr17 START ('2017-04-01'::date) END ('2017-05-01'::date) WITH (tablename='sales_1_prt_apr17', appendonly=false ), 
-          PARTITION may17 START ('2017-05-01'::date) END ('2017-06-01'::date) WITH (tablename='sales_1_prt_may17', appendonly=false ), 
-          PARTITION jun17 START ('2017-06-01'::date) END ('2017-07-01'::date) WITH (tablename='sales_1_prt_jun17', appendonly=false ), 
-          PARTITION jul17 START ('2017-07-01'::date) END ('2017-08-01'::date) WITH (tablename='sales_1_prt_jul17', appendonly=false ), 
-          PARTITION aug17 START ('2017-08-01'::date) END ('2017-09-01'::date) WITH (tablename='sales_1_prt_aug17', appendonly=false ), 
-          PARTITION sep17 START ('2017-09-01'::date) END ('2017-10-01'::date) WITH (tablename='sales_1_prt_sep17', appendonly=false ), 
-          PARTITION oct17 START ('2017-10-01'::date) END ('2017-11-01'::date) WITH (tablename='sales_1_prt_oct17', appendonly=false ), 
-          PARTITION nov17 START ('2017-11-01'::date) END ('2017-12-01'::date) WITH (tablename='sales_1_prt_nov17', appendonly=false ), 
+          PARTITION jan17 START ('2017-01-01'::date) END ('2017-02-01'::date) WITH (tablename='sales_1_prt_jan17', appendonly=false ),
+          PARTITION feb17 START ('2017-02-01'::date) END ('2017-03-01'::date) WITH (tablename='sales_1_prt_feb17', appendonly=false ),
+          PARTITION mar17 START ('2017-03-01'::date) END ('2017-04-01'::date) WITH (tablename='sales_1_prt_mar17', appendonly=false ),
+          PARTITION apr17 START ('2017-04-01'::date) END ('2017-05-01'::date) WITH (tablename='sales_1_prt_apr17', appendonly=false ),
+          PARTITION may17 START ('2017-05-01'::date) END ('2017-06-01'::date) WITH (tablename='sales_1_prt_may17', appendonly=false ),
+          PARTITION jun17 START ('2017-06-01'::date) END ('2017-07-01'::date) WITH (tablename='sales_1_prt_jun17', appendonly=false ),
+          PARTITION jul17 START ('2017-07-01'::date) END ('2017-08-01'::date) WITH (tablename='sales_1_prt_jul17', appendonly=false ),
+          PARTITION aug17 START ('2017-08-01'::date) END ('2017-09-01'::date) WITH (tablename='sales_1_prt_aug17', appendonly=false ),
+          PARTITION sep17 START ('2017-09-01'::date) END ('2017-10-01'::date) WITH (tablename='sales_1_prt_sep17', appendonly=false ),
+          PARTITION oct17 START ('2017-10-01'::date) END ('2017-11-01'::date) WITH (tablename='sales_1_prt_oct17', appendonly=false ),
+          PARTITION nov17 START ('2017-11-01'::date) END ('2017-12-01'::date) WITH (tablename='sales_1_prt_nov17', appendonly=false ),
           PARTITION dec17 START ('2017-12-01'::date) END ('2018-01-01'::date) WITH (tablename='sales_1_prt_dec17', appendonly=false )
           );
 
@@ -98,21 +98,29 @@ CREATE TABLE returns (
     id integer,
     date date,
     amt numeric(10,2)
-) DISTRIBUTED BY (id) PARTITION BY RANGE(date) 
+) DISTRIBUTED BY (id) PARTITION BY RANGE(date)
           (
-          PARTITION jan17 START ('2017-01-01'::date) END ('2017-02-01'::date) WITH (tablename='returns_1_prt_jan17', appendonly=false ), 
-          PARTITION feb17 START ('2017-02-01'::date) END ('2017-03-01'::date) WITH (tablename='returns_1_prt_feb17', appendonly=false ), 
-          PARTITION mar17 START ('2017-03-01'::date) END ('2017-04-01'::date) WITH (tablename='returns_1_prt_mar17', appendonly=false ), 
-          PARTITION apr17 START ('2017-04-01'::date) END ('2017-05-01'::date) WITH (tablename='returns_1_prt_apr17', appendonly=false ), 
-          PARTITION may17 START ('2017-05-01'::date) END ('2017-06-01'::date) WITH (tablename='returns_1_prt_may17', appendonly=false ), 
-          PARTITION jun17 START ('2017-06-01'::date) END ('2017-07-01'::date) WITH (tablename='returns_1_prt_jun17', appendonly=false ), 
-          PARTITION jul17 START ('2017-07-01'::date) END ('2017-08-01'::date) WITH (tablename='returns_1_prt_jul17', appendonly=false ), 
-          PARTITION aug17 START ('2017-08-01'::date) END ('2017-09-01'::date) WITH (tablename='returns_1_prt_aug17', appendonly=false ), 
-          PARTITION sep17 START ('2017-09-01'::date) END ('2017-10-01'::date) WITH (tablename='returns_1_prt_sep17', appendonly=false ), 
-          PARTITION oct17 START ('2017-10-01'::date) END ('2017-11-01'::date) WITH (tablename='returns_1_prt_oct17', appendonly=false ), 
-          PARTITION nov17 START ('2017-11-01'::date) END ('2017-12-01'::date) WITH (tablename='returns_1_prt_nov17', appendonly=false ), 
+          PARTITION jan17 START ('2017-01-01'::date) END ('2017-02-01'::date) WITH (tablename='returns_1_prt_jan17', appendonly=false ),
+          PARTITION feb17 START ('2017-02-01'::date) END ('2017-03-01'::date) WITH (tablename='returns_1_prt_feb17', appendonly=false ),
+          PARTITION mar17 START ('2017-03-01'::date) END ('2017-04-01'::date) WITH (tablename='returns_1_prt_mar17', appendonly=false ),
+          PARTITION apr17 START ('2017-04-01'::date) END ('2017-05-01'::date) WITH (tablename='returns_1_prt_apr17', appendonly=false ),
+          PARTITION may17 START ('2017-05-01'::date) END ('2017-06-01'::date) WITH (tablename='returns_1_prt_may17', appendonly=false ),
+          PARTITION jun17 START ('2017-06-01'::date) END ('2017-07-01'::date) WITH (tablename='returns_1_prt_jun17', appendonly=false ),
+          PARTITION jul17 START ('2017-07-01'::date) END ('2017-08-01'::date) WITH (tablename='returns_1_prt_jul17', appendonly=false ),
+          PARTITION aug17 START ('2017-08-01'::date) END ('2017-09-01'::date) WITH (tablename='returns_1_prt_aug17', appendonly=false ),
+          PARTITION sep17 START ('2017-09-01'::date) END ('2017-10-01'::date) WITH (tablename='returns_1_prt_sep17', appendonly=false ),
+          PARTITION oct17 START ('2017-10-01'::date) END ('2017-11-01'::date) WITH (tablename='returns_1_prt_oct17', appendonly=false ),
+          PARTITION nov17 START ('2017-11-01'::date) END ('2017-12-01'::date) WITH (tablename='returns_1_prt_nov17', appendonly=false ),
           PARTITION dec17 START ('2017-12-01'::date) END ('2018-01-01'::date) WITH (tablename='returns_1_prt_dec17', appendonly=false )
           );
+
+CREATE TABLE ao1 (
+    i integer
+) WITH (appendonly=true);
+
+CREATE TABLE ao2 (
+    i integer
+) WITH (appendonly=true, orientation=column);
 
 --
 --

--- a/restore/data.go
+++ b/restore/data.go
@@ -38,7 +38,7 @@ func CopyTableIn(connection *dbconn.DBConn, tableName string, tableAttributes st
 	return numRows
 }
 
-func restoreSingleTableData(entry utils.MasterDataEntry, tableNum uint32, totalTables int, whichConn int) {
+func restoreSingleTableData(fpInfo *utils.FilePathInfo, entry utils.MasterDataEntry, tableNum uint32, totalTables int, whichConn int) {
 	name := utils.MakeFQN(entry.Schema, entry.Name)
 	if gplog.GetVerbosity() > gplog.LOGINFO {
 		// No progress bar at this log level, so we note table count here
@@ -48,9 +48,9 @@ func restoreSingleTableData(entry utils.MasterDataEntry, tableNum uint32, totalT
 	}
 	backupFile := ""
 	if backupConfig.SingleDataFile {
-		backupFile = fmt.Sprintf("%s_%d", globalFPInfo.GetSegmentPipePathForCopyCommand(), entry.Oid)
+		backupFile = fmt.Sprintf("%s_%d", fpInfo.GetSegmentPipePathForCopyCommand(), entry.Oid)
 	} else {
-		backupFile = globalFPInfo.GetTableBackupFilePathForCopyCommand(entry.Oid, backupConfig.SingleDataFile)
+		backupFile = fpInfo.GetTableBackupFilePathForCopyCommand(entry.Oid, backupConfig.SingleDataFile)
 	}
 	numRowsRestored := CopyTableIn(connectionPool, name, entry.AttributeString, backupFile, backupConfig.SingleDataFile, whichConn)
 	numRowsBackedUp := entry.RowsCopied

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -62,6 +62,11 @@ func InitializeBackupConfig() {
 	utils.InitializeCompressionParameters(backupConfig.Compressed, 0)
 	utils.EnsureBackupVersionCompatibility(backupConfig.BackupVersion, version)
 	utils.EnsureDatabaseVersionCompatibility(backupConfig.DatabaseVersion, connectionPool.Version)
+
+	// Legacy backups prior to the incremental feature would have no restoreplan yaml element
+	if isLegacyBackup := backupConfig.RestorePlan == nil; isLegacyBackup {
+		utils.SetRestorePlanForLegacyBackup(globalTOC, globalFPInfo.Timestamp, backupConfig)
+	}
 }
 
 func InitializeFilterLists() {

--- a/utils/report.go
+++ b/utils/report.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/blang/semver"
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
@@ -40,6 +40,18 @@ type BackupConfig struct {
 type RestorePlanEntry struct {
 	Timestamp string
 	TableFQNs []string
+}
+
+func SetRestorePlanForLegacyBackup(toc *TOC, backupTimestamp string, backupConfig *BackupConfig) {
+	tableFQNs := make([]string, 0, len(toc.DataEntries))
+	for _, entry := range toc.DataEntries {
+		entryFQN := MakeFQN(entry.Schema, entry.Name)
+		tableFQNs = append(tableFQNs, entryFQN)
+	}
+	backupConfig.RestorePlan = []RestorePlanEntry{
+		{Timestamp: backupTimestamp, TableFQNs: tableFQNs},
+	}
+
 }
 
 /*

--- a/utils/report_test.go
+++ b/utils/report_test.go
@@ -25,6 +25,33 @@ import (
 )
 
 var _ = Describe("utils/report tests", func() {
+	Describe("SetRestorePlanForLegacyBackup", func() {
+		legacyBackupConfig := utils.BackupConfig{}
+		legacyBackupConfig.RestorePlan = nil
+		legacyBackupTOC := utils.TOC{
+			DataEntries: []utils.MasterDataEntry{
+				{Schema: "schema1", Name: "table1"},
+				{Schema: "schema2", Name: "table2"},
+			},
+		}
+		legacyBackupTimestamp := "ts0"
+
+		utils.SetRestorePlanForLegacyBackup(&legacyBackupTOC, legacyBackupTimestamp, &legacyBackupConfig)
+
+		Specify("That there should be only one resultant restore plan entry", func() {
+			Expect(len(legacyBackupConfig.RestorePlan)).To(Equal(1))
+		})
+
+		Specify("That the restore plan entry should have the legacy backup's timestamp", func() {
+			Expect(legacyBackupConfig.RestorePlan[0].Timestamp).To(Equal(legacyBackupTimestamp))
+		})
+
+		Specify("That the restore plan entry should have all table FQNs as in the TOC's DataEntries", func() {
+			Expect(legacyBackupConfig.RestorePlan[0].TableFQNs).
+				To(Equal([]string{"schema1.table1", "schema2.table2"}))
+		})
+
+	})
 	Describe("ParseErrorMessage", func() {
 		It("Parses a CRITICAL error message and returns error code 1", func() {
 			errStr := "testProgram:testUser:testHost:000000-[CRITICAL]:-Error Message"

--- a/utils/set.go
+++ b/utils/set.go
@@ -34,18 +34,10 @@ func NewIncludeSet(list []string) *FilterSet {
 	return &newSet
 }
 
-func NewEmptyIncludeSet() *FilterSet {
-	return NewIncludeSet([]string{})
-}
-
 func NewExcludeSet(list []string) *FilterSet {
 	newSet := NewIncludeSet(list)
 	(*newSet).IsExclude = true
 	return newSet
-}
-
-func NewEmptyExcludeSet() *FilterSet {
-	return NewExcludeSet([]string{})
 }
 
 func (s *FilterSet) MatchesFilter(item string) bool {

--- a/utils/toc.go
+++ b/utils/toc.go
@@ -176,6 +176,7 @@ func (toc *TOC) GetDataEntriesMatching(includeSchemas []string, excludeSchemas [
 	}
 
 	restorePlanTableSet := NewIncludeSet(restorePlanTableFQNs)
+	restorePlanTableSet.AlwaysMatchesFilter = false
 
 	matchingEntries := make([]MasterDataEntry, 0)
 	for _, entry := range toc.DataEntries {

--- a/utils/toc.go
+++ b/utils/toc.go
@@ -158,30 +158,31 @@ func (toc *TOC) GetAllSQLStatements(section string, metadataFile io.ReaderAt) []
 	return statements
 }
 
-func (toc *TOC) GetDataEntriesMatching(includeSchemas []string, excludeSchemas []string, includeTables []string, excludeTables []string) []MasterDataEntry {
-	restoreAllSchemas := len(includeSchemas) == 0 && len(excludeSchemas) == 0
-	var schemaSet *FilterSet
-	if !restoreAllSchemas {
-		if len(includeSchemas) > 0 {
-			schemaSet = NewIncludeSet(includeSchemas)
-		} else {
-			schemaSet = NewExcludeSet(excludeSchemas)
-		}
+func (toc *TOC) GetDataEntriesMatching(includeSchemas []string, excludeSchemas []string,
+	includeTableFQNs []string, excludeTableFQNs []string, restorePlanTableFQNs []string) []MasterDataEntry {
+
+	schemaSet := NewIncludeSet([]string{})
+	if len(includeSchemas) > 0 {
+		schemaSet = NewIncludeSet(includeSchemas)
+	} else if len(excludeSchemas) > 0 {
+		schemaSet = NewExcludeSet(excludeSchemas)
 	}
-	restoreAllTables := len(includeTables) == 0 && len(excludeTables) == 0
-	var tableSet *FilterSet
-	if !restoreAllTables {
-		if len(includeTables) > 0 {
-			tableSet = NewIncludeSet(includeTables)
-		} else {
-			tableSet = NewExcludeSet(excludeTables)
-		}
+
+	tableSet := NewIncludeSet([]string{})
+	if len(includeTableFQNs) > 0 {
+		tableSet = NewIncludeSet(includeTableFQNs)
+	} else if len(excludeTableFQNs) > 0 {
+		tableSet = NewExcludeSet(excludeTableFQNs)
 	}
+
+	restorePlanTableSet := NewIncludeSet(restorePlanTableFQNs)
+
 	matchingEntries := make([]MasterDataEntry, 0)
 	for _, entry := range toc.DataEntries {
-		validSchema := restoreAllSchemas || schemaSet.MatchesFilter(entry.Schema)
 		tableFQN := MakeFQN(entry.Schema, entry.Name)
-		validTable := restoreAllTables || tableSet.MatchesFilter(tableFQN)
+
+		validSchema := schemaSet.MatchesFilter(entry.Schema)
+		validTable := restorePlanTableSet.MatchesFilter(tableFQN) && tableSet.MatchesFilter(tableFQN)
 		if validSchema && validTable {
 			matchingEntries = append(matchingEntries, entry)
 		}

--- a/utils/toc_test.go
+++ b/utils/toc_test.go
@@ -219,57 +219,75 @@ var _ = Describe("utils/toc tests", func() {
 		})
 	})
 	Describe("GetDataEntriesMatching", func() {
-		var restorePlanTableFQNs []string
 		BeforeEach(func() {
 			toc.AddMasterDataEntry("schema1", "table1", 1, "(i)", 0)
 			toc.AddMasterDataEntry("schema2", "table2", 1, "(i)", 0)
 			toc.AddMasterDataEntry("schema3", "table3", 1, "(i)", 0)
-			restorePlanTableFQNs = []string{"schema1.table1", "schema2.table2"}
 		})
 
-		It("returns matching entry on include schema", func() {
-			includeSchemas := []string{"schema1"}
+		Context("Non-empty restore plan", func() {
+			restorePlanTableFQNs := []string{"schema1.table1", "schema2.table2"}
 
-			matchingEntries := toc.GetDataEntriesMatching(includeSchemas, []string{},
-				[]string{}, []string{}, restorePlanTableFQNs)
+			It("returns matching entry on include schema", func() {
+				includeSchemas := []string{"schema1"}
 
-			Expect(matchingEntries).
-				To(Equal([]utils.MasterDataEntry{{Schema: "schema1", Name: "table1", Oid: 1, AttributeString: "(i)"}}))
+				matchingEntries := toc.GetDataEntriesMatching(includeSchemas, []string{},
+					[]string{}, []string{}, restorePlanTableFQNs)
+
+				Expect(matchingEntries).
+					To(Equal([]utils.MasterDataEntry{{Schema: "schema1", Name: "table1",
+						Oid: 1, AttributeString: "(i)"}}))
+			})
+			It("returns matching entry on exclude schema", func() {
+				excludeSchemas := []string{"schema2"}
+
+				matchingEntries := toc.GetDataEntriesMatching([]string{}, excludeSchemas,
+					[]string{}, []string{}, restorePlanTableFQNs)
+
+				Expect(matchingEntries).
+					To(Equal([]utils.MasterDataEntry{{Schema: "schema1", Name: "table1",
+						Oid: 1, AttributeString: "(i)"}}))
+			})
+			It("returns matching entry on include table", func() {
+				includeTables := []string{"schema1.table1"}
+
+				matchingEntries := toc.GetDataEntriesMatching([]string{}, []string{},
+					includeTables, []string{}, restorePlanTableFQNs)
+
+				Expect(matchingEntries).
+					To(Equal([]utils.MasterDataEntry{{Schema: "schema1", Name: "table1",
+						Oid: 1, AttributeString: "(i)"}}))
+			})
+			It("returns matching entry on exclude table", func() {
+				excludeTables := []string{"schema2.table2"}
+
+				matchingEntries := toc.GetDataEntriesMatching([]string{}, []string{},
+					[]string{}, excludeTables, restorePlanTableFQNs)
+
+				Expect(matchingEntries).
+					To(Equal([]utils.MasterDataEntry{{Schema: "schema1", Name: "table1",
+						Oid: 1, AttributeString: "(i)"}}))
+			})
+			It("returns all entries when not schema-filtered or table-filtered", func() {
+				matchingEntries := toc.GetDataEntriesMatching([]string{}, []string{},
+					[]string{}, []string{}, restorePlanTableFQNs)
+
+				Expect(matchingEntries).
+					To(Equal([]utils.MasterDataEntry{{Schema: "schema1", Name: "table1",
+						Oid: 1, AttributeString: "(i)"},
+						{Schema: "schema2", Name: "table2", Oid: 1, AttributeString: "(i)"}}))
+			})
 		})
-		It("returns matching entry on exclude schema", func() {
-			excludeSchemas := []string{"schema2"}
 
-			matchingEntries := toc.GetDataEntriesMatching([]string{}, excludeSchemas,
-				[]string{}, []string{}, restorePlanTableFQNs)
+		Context("Empty restore plan", func() {
+			restorePlanTableFQNs := make([]string, 0)
 
-			Expect(matchingEntries).
-				To(Equal([]utils.MasterDataEntry{{Schema: "schema1", Name: "table1", Oid: 1, AttributeString: "(i)"}}))
-		})
-		It("returns matching entry on include table", func() {
-			includeTables := []string{"schema1.table1"}
+			Specify("That there are no matching entries", func() {
+				matchingEntries := toc.GetDataEntriesMatching([]string{}, []string{},
+					[]string{}, []string{}, restorePlanTableFQNs)
 
-			matchingEntries := toc.GetDataEntriesMatching([]string{}, []string{},
-				includeTables, []string{}, restorePlanTableFQNs)
-
-			Expect(matchingEntries).
-				To(Equal([]utils.MasterDataEntry{{Schema: "schema1", Name: "table1", Oid: 1, AttributeString: "(i)"}}))
-		})
-		It("returns matching entry on exclude table", func() {
-			excludeTables := []string{"schema2.table2"}
-
-			matchingEntries := toc.GetDataEntriesMatching([]string{}, []string{},
-				[]string{}, excludeTables, restorePlanTableFQNs)
-
-			Expect(matchingEntries).
-				To(Equal([]utils.MasterDataEntry{{Schema: "schema1", Name: "table1", Oid: 1, AttributeString: "(i)"}}))
-		})
-		It("returns all entries when not schema-filtered or table-filtered", func() {
-			matchingEntries := toc.GetDataEntriesMatching([]string{}, []string{},
-				[]string{}, []string{}, restorePlanTableFQNs)
-
-			Expect(matchingEntries).
-				To(Equal([]utils.MasterDataEntry{{Schema: "schema1", Name: "table1", Oid: 1, AttributeString: "(i)"},
-					{Schema: "schema2", Name: "table2", Oid: 1, AttributeString: "(i)"}}))
+				Expect(matchingEntries).To(BeEmpty())
+			})
 		})
 	})
 

--- a/utils/toc_test.go
+++ b/utils/toc_test.go
@@ -34,7 +34,7 @@ var _ = Describe("utils/toc tests", func() {
 	BeforeEach(func() {
 		toc, backupfile = testutils.InitializeTestTOC(buffer, "global")
 	})
-	Context("GetSqlStatementForObjectTypes", func() {
+	Describe("GetSqlStatementForObjectTypes", func() {
 		// Dummy variables to help clarify which arguments are non-empty in a given test
 		var noInObj, noExObj, noInSchema, noExSchema, noInRelation, noExRelation []string
 		It("returns statement for a single object type", func() {
@@ -218,44 +218,62 @@ var _ = Describe("utils/toc tests", func() {
 			Expect(statements).To(Equal([]utils.StatementWithType{}))
 		})
 	})
-	Context("GetDataEntriesMatching", func() {
-		It("returns matching entry on include schema", func() {
-			includeSchemas := []string{"schema1"}
+	Describe("GetDataEntriesMatching", func() {
+		var restorePlanTableFQNs []string
+		BeforeEach(func() {
 			toc.AddMasterDataEntry("schema1", "table1", 1, "(i)", 0)
 			toc.AddMasterDataEntry("schema2", "table2", 1, "(i)", 0)
-			matchingEntries := toc.GetDataEntriesMatching(includeSchemas, []string{}, []string{}, []string{})
-			Expect(matchingEntries).To(Equal([]utils.MasterDataEntry{{Schema: "schema1", Name: "table1", Oid: 1, AttributeString: "(i)"}}))
+			toc.AddMasterDataEntry("schema3", "table3", 1, "(i)", 0)
+			restorePlanTableFQNs = []string{"schema1.table1", "schema2.table2"}
+		})
+
+		It("returns matching entry on include schema", func() {
+			includeSchemas := []string{"schema1"}
+
+			matchingEntries := toc.GetDataEntriesMatching(includeSchemas, []string{},
+				[]string{}, []string{}, restorePlanTableFQNs)
+
+			Expect(matchingEntries).
+				To(Equal([]utils.MasterDataEntry{{Schema: "schema1", Name: "table1", Oid: 1, AttributeString: "(i)"}}))
 		})
 		It("returns matching entry on exclude schema", func() {
 			excludeSchemas := []string{"schema2"}
-			toc.AddMasterDataEntry("schema1", "table1", 1, "(i)", 0)
-			toc.AddMasterDataEntry("schema2", "table2", 1, "(i)", 0)
-			matchingEntries := toc.GetDataEntriesMatching([]string{}, excludeSchemas, []string{}, []string{})
-			Expect(matchingEntries).To(Equal([]utils.MasterDataEntry{{Schema: "schema1", Name: "table1", Oid: 1, AttributeString: "(i)"}}))
+
+			matchingEntries := toc.GetDataEntriesMatching([]string{}, excludeSchemas,
+				[]string{}, []string{}, restorePlanTableFQNs)
+
+			Expect(matchingEntries).
+				To(Equal([]utils.MasterDataEntry{{Schema: "schema1", Name: "table1", Oid: 1, AttributeString: "(i)"}}))
 		})
 		It("returns matching entry on include table", func() {
 			includeTables := []string{"schema1.table1"}
-			toc.AddMasterDataEntry("schema1", "table1", 1, "(i)", 0)
-			toc.AddMasterDataEntry("schema2", "table2", 1, "(i)", 0)
-			matchingEntries := toc.GetDataEntriesMatching([]string{}, []string{}, includeTables, []string{})
-			Expect(matchingEntries).To(Equal([]utils.MasterDataEntry{{Schema: "schema1", Name: "table1", Oid: 1, AttributeString: "(i)"}}))
+
+			matchingEntries := toc.GetDataEntriesMatching([]string{}, []string{},
+				includeTables, []string{}, restorePlanTableFQNs)
+
+			Expect(matchingEntries).
+				To(Equal([]utils.MasterDataEntry{{Schema: "schema1", Name: "table1", Oid: 1, AttributeString: "(i)"}}))
 		})
 		It("returns matching entry on exclude table", func() {
 			excludeTables := []string{"schema2.table2"}
-			toc.AddMasterDataEntry("schema1", "table1", 1, "(i)", 0)
-			toc.AddMasterDataEntry("schema2", "table2", 1, "(i)", 0)
-			matchingEntries := toc.GetDataEntriesMatching([]string{}, []string{}, []string{}, excludeTables)
-			Expect(matchingEntries).To(Equal([]utils.MasterDataEntry{{Schema: "schema1", Name: "table1", Oid: 1, AttributeString: "(i)"}}))
+
+			matchingEntries := toc.GetDataEntriesMatching([]string{}, []string{},
+				[]string{}, excludeTables, restorePlanTableFQNs)
+
+			Expect(matchingEntries).
+				To(Equal([]utils.MasterDataEntry{{Schema: "schema1", Name: "table1", Oid: 1, AttributeString: "(i)"}}))
 		})
 		It("returns all entries when not schema-filtered or table-filtered", func() {
-			toc.AddMasterDataEntry("schema1", "table1", 1, "(i)", 0)
-			toc.AddMasterDataEntry("schema2", "table2", 1, "(i)", 0)
-			matchingEntries := toc.GetDataEntriesMatching([]string{}, []string{}, []string{}, []string{})
-			Expect(matchingEntries).To(Equal([]utils.MasterDataEntry{{Schema: "schema1", Name: "table1", Oid: 1, AttributeString: "(i)"}, {Schema: "schema2", Name: "table2", Oid: 1, AttributeString: "(i)"}}))
+			matchingEntries := toc.GetDataEntriesMatching([]string{}, []string{},
+				[]string{}, []string{}, restorePlanTableFQNs)
+
+			Expect(matchingEntries).
+				To(Equal([]utils.MasterDataEntry{{Schema: "schema1", Name: "table1", Oid: 1, AttributeString: "(i)"},
+					{Schema: "schema2", Name: "table2", Oid: 1, AttributeString: "(i)"}}))
 		})
 	})
 
-	Context("GetAllSqlStatements", func() {
+	Describe("GetAllSqlStatements", func() {
 		It("returns statement for a single object type", func() {
 			backupfile.ByteCount = createLen
 			toc.AddMetadataEntry("", "somedatabase", "DATABASE", "", 0, backupfile, "global")
@@ -285,7 +303,7 @@ var _ = Describe("utils/toc tests", func() {
 			Expect(statements).To(Equal([]utils.StatementWithType{}))
 		})
 	})
-	Context("SubstituteRedirectDatabaseInStatements", func() {
+	Describe("SubstituteRedirectDatabaseInStatements", func() {
 		wrongCreate := utils.StatementWithType{ObjectType: "TABLE", Statement: "CREATE DATABASE somedatabase;\n"}
 		encoding := utils.StatementWithType{ObjectType: "DATABASE", Statement: "CREATE DATABASE somedatabase TEMPLATE template0 ENCODING 'UTF8';\n"}
 		gucs := utils.StatementWithType{ObjectType: "DATABASE GUC", Statement: "ALTER DATABASE somedatabase SET fsync TO off;\n"}


### PR DESCRIPTION
Iterate through timestamps found in restore plan of specified backup
and restore table data corresponding to each timestamp.
Also, ensure that if a restore is done on a legacy backup (having a
missing restore plan), a default restore plan is supplied. Here we
have assumed that such a legacy backup can only be a full backup.
Thus, the default restore plan would always be a single entry with
a list of all tables backed up in the full backup.

Co-authored-by: Chris Hajas <chajas@pivotal.io>
Co-authored-by: Soumyadeep Chakraborty <sochakraborty@pivotal.io>
Co-authored-by: Karen Huddleston <khuddleston@pivotal.io>