### PR TITLE
Plugin revamp

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -82,7 +82,7 @@ func DoSetup() {
 		pluginConfig = utils.ReadPluginConfig(*pluginConfigFile)
 		pluginConfig.CheckPluginExistsOnAllHosts(globalCluster)
 		pluginConfig.CopyPluginConfigToAllHosts(globalCluster, *pluginConfigFile)
-		pluginConfig.SetupPluginForBackupOnAllHosts(globalCluster, pluginConfig.ConfigPath, globalFPInfo.GetDirForContent(-1))
+		pluginConfig.SetupPluginForBackup(globalCluster, pluginConfig.ConfigPath, globalFPInfo.GetDirForContent(-1))
 		backupReport.Plugin = pluginConfig.ExecutablePath
 	}
 }
@@ -360,7 +360,7 @@ func DoTeardown() {
 		if pluginConfig != nil {
 			pluginConfig.BackupFile(configFilename, true)
 			pluginConfig.BackupFile(reportFilename, true)
-			pluginConfig.CleanupPluginForBackupOnAllHosts(globalCluster, pluginConfig.ConfigPath, globalFPInfo.GetDirForContent(-1))
+			pluginConfig.CleanupPluginForBackup(globalCluster, pluginConfig.ConfigPath, globalFPInfo.GetDirForContent(-1))
 		}
 	}
 

--- a/plugins/example_plugin.sh
+++ b/plugins/example_plugin.sh
@@ -1,44 +1,50 @@
-#!/bin/bash
+  #!/bin/bash
 set -e
 
 setup_plugin_for_backup(){
+  echo "setup_plugin_for_backup $1 $2 $3" >> /tmp/plugin_out.txt
   mkdir -p /tmp/plugin_dest
 }
 
 setup_plugin_for_restore(){
-  :
+  echo "setup_plugin_for_restore $1 $2 $3" >> /tmp/plugin_out.txt
 }
 
 cleanup_plugin_for_backup(){
-  :
+  echo "cleanup_plugin_for_backup $1 $2 $3" >> /tmp/plugin_out.txt
 }
 
 cleanup_plugin_for_restore(){
-  :
+  echo "cleanup_plugin_for_restore $1 $2 $3" >> /tmp/plugin_out.txt
 }
 
 restore_file() {
+  echo "restore_file $1 $2" >> /tmp/plugin_out.txt
   filename=`basename "$2"`
 	cat /tmp/plugin_dest/$filename > $2
 }
 
 backup_file() {
+  echo "backup_file $1 $2" >> /tmp/plugin_out.txt
   filename=`basename "$2"`
 	cat $2 > /tmp/plugin_dest/$filename
 }
 
 backup_data() {
+  echo "backup_data $1 $2" >> /tmp/plugin_out.txt
   filename=`basename "$2"`
 	cat - > /tmp/plugin_dest/$filename
 }
 
 restore_data() {
+  echo "restore_data $1 $2" >> /tmp/plugin_out.txt
   filename=`basename "$2"`
 	cat /tmp/plugin_dest/$filename
 }
 
 plugin_api_version(){
   echo "0.2.0"
+  echo "0.2.0" >> /tmp/plugin_out.txt
 }
 
 "$@"

--- a/plugins/example_plugin.sh
+++ b/plugins/example_plugin.sh
@@ -3,19 +3,47 @@ set -e
 
 setup_plugin_for_backup(){
   echo "setup_plugin_for_backup $1 $2 $3" >> /tmp/plugin_out.txt
+  if [ "$3" = "master" ]
+    then echo "setup_plugin_for_backup was called for scope = master" >> /tmp/plugin_out.txt
+  elif [ "$3" = "segment_host" ]
+    then echo "setup_plugin_for_backup was called for scope = segment_host" >> /tmp/plugin_out.txt
+  elif [ "$3" = "segment" ]
+    then echo "setup_plugin_for_backup was called for scope = segment" >> /tmp/plugin_out.txt
+  fi
   mkdir -p /tmp/plugin_dest
 }
 
 setup_plugin_for_restore(){
   echo "setup_plugin_for_restore $1 $2 $3" >> /tmp/plugin_out.txt
+  if [ "$3" = "master" ]
+    then echo "setup_plugin_for_restore was called for scope = master" >> /tmp/plugin_out.txt
+  elif [ "$3" = "segment_host" ]
+    then echo "setup_plugin_for_restore was called for scope = segment_host" >> /tmp/plugin_out.txt
+  elif [ "$3" = "segment" ]
+    then echo "setup_plugin_for_restore was called for scope = segment" >> /tmp/plugin_out.txt
+  fi
 }
 
 cleanup_plugin_for_backup(){
   echo "cleanup_plugin_for_backup $1 $2 $3" >> /tmp/plugin_out.txt
+  if [ "$3" = "master" ]
+    then echo "cleanup_plugin_for_backup was called for scope = master" >> /tmp/plugin_out.txt
+  elif [ "$3" = "segment_host" ]
+    then echo "cleanup_plugin_for_backup was called for scope = segment_host" >> /tmp/plugin_out.txt
+  elif [ "$3" = "segment" ]
+    then echo "cleanup_plugin_for_backup was called for scope = segment" >> /tmp/plugin_out.txt
+  fi
 }
 
 cleanup_plugin_for_restore(){
   echo "cleanup_plugin_for_restore $1 $2 $3" >> /tmp/plugin_out.txt
+  if [ "$3" = "master" ]
+    then echo "cleanup_plugin_for_restore was called for scope = master" >> /tmp/plugin_out.txt
+  elif [ "$3" = "segment_host" ]
+    then echo "cleanup_plugin_for_restore was called for scope = segment_host" >> /tmp/plugin_out.txt
+  elif [ "$3" = "segment" ]
+    then echo "cleanup_plugin_for_restore was called for scope = segment" >> /tmp/plugin_out.txt
+  fi
 }
 
 restore_file() {

--- a/plugins/example_plugin.sh
+++ b/plugins/example_plugin.sh
@@ -38,7 +38,7 @@ restore_data() {
 }
 
 plugin_api_version(){
-  echo "0.1.0"
+  echo "0.2.0"
 }
 
 "$@"

--- a/plugins/plugin_test_bench.sh
+++ b/plugins/plugin_test_bench.sh
@@ -3,7 +3,7 @@
 plugin=$1
 plugin_config=$2
 secondary_plugin_config=$3
-SUPPORTED_API_VERSION="0.1.0"
+SUPPORTED_API_VERSION="0.2.0"
 
 # ----------------------------------------------
 # Test suite setup

--- a/plugins/plugin_test_bench.sh
+++ b/plugins/plugin_test_bench.sh
@@ -45,14 +45,25 @@ echo "[PASSED] plugin_api_version"
 # Setup and Backup/Restore file functions
 # ----------------------------------------------
 
-echo "[RUNNING] setup_plugin_for_backup"
-$plugin setup_plugin_for_backup $plugin_config $testdir
+echo "[RUNNING] setup_plugin_for_backup on master"
+$plugin setup_plugin_for_backup $plugin_config $testdir master
+echo "[RUNNING] setup_plugin_for_backup on segment_host"
+$plugin setup_plugin_for_backup $plugin_config $testdir segment_host
+echo "[RUNNING] setup_plugin_for_backup on segment"
+$plugin setup_plugin_for_backup $plugin_config $testdir segment
+
 echo "[RUNNING] backup_file"
 $plugin backup_file $plugin_config $testfile
 # plugins should leave copies of the files locally when they run backup_file
 test -f $testfile
-echo "[RUNNING] setup_plugin_for_restore"
-$plugin setup_plugin_for_restore $plugin_config $testdir
+
+echo "[RUNNING] setup_plugin_for_restore on master"
+$plugin setup_plugin_for_restore $plugin_config $testdir master
+echo "[RUNNING] setup_plugin_for_restore on segment_host"
+$plugin setup_plugin_for_restore $plugin_config $testdir segment_host
+echo "[RUNNING] setup_plugin_for_restore on segment"
+$plugin setup_plugin_for_restore $plugin_config $testdir segment
+
 echo "[RUNNING] restore_file"
 rm $testfile
 $plugin restore_file $plugin_config $testfile
@@ -106,11 +117,20 @@ echo "[PASSED] restore_data"
 # Cleanup functions
 # ----------------------------------------------
 
-echo "[RUNNING] cleanup_plugin_for_backup"
-$plugin cleanup_plugin_for_backup $plugin_config $testdir
+echo "[RUNNING] cleanup_plugin_for_backup on master"
+$plugin cleanup_plugin_for_backup $plugin_config $testdir master
+echo "[RUNNING] cleanup_plugin_for_backup on segment_host"
+$plugin cleanup_plugin_for_backup $plugin_config $testdir segment_host
+echo "[RUNNING] cleanup_plugin_for_backup on segment"
+$plugin cleanup_plugin_for_backup $plugin_config $testdir segment
 echo "[PASSED] cleanup_plugin_for_backup"
-echo "[RUNNING] cleanup_plugin_for_restore"
-$plugin cleanup_plugin_for_restore $plugin_config $testdir
+
+echo "[RUNNING] cleanup_plugin_for_restore on master"
+$plugin cleanup_plugin_for_restore $plugin_config $testdir master
+echo "[RUNNING] cleanup_plugin_for_restore on segment_host"
+$plugin cleanup_plugin_for_restore $plugin_config $testdir segment_host
+echo "[RUNNING] cleanup_plugin_for_restore on segment"
+$plugin cleanup_plugin_for_restore $plugin_config $testdir segment
 echo "[PASSED] cleanup_plugin_for_restore"
 
 

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -304,7 +304,7 @@ func DoTeardown() {
 		utils.WriteRestoreReportFile(reportFilename, globalFPInfo.Timestamp, restoreStartTime, connectionPool, version, errMsg)
 		utils.EmailReport(globalCluster, globalFPInfo.Timestamp, reportFilename, "gprestore")
 		if pluginConfig != nil {
-			pluginConfig.CleanupPluginForRestoreOnAllHosts(globalCluster, pluginConfig.ConfigPath, globalFPInfo.GetDirForContent(-1))
+			pluginConfig.CleanupPluginForRestore(globalCluster, pluginConfig.ConfigPath, globalFPInfo.GetDirForContent(-1))
 		}
 	}
 

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -93,7 +93,7 @@ func RecoverMetadataFilesUsingPlugin() {
 	pluginConfig := utils.ReadPluginConfig(*pluginConfigFile)
 	pluginConfig.CheckPluginExistsOnAllHosts(globalCluster)
 	pluginConfig.CopyPluginConfigToAllHosts(globalCluster, *pluginConfigFile)
-	pluginConfig.SetupPluginForRestoreOnAllHosts(globalCluster, pluginConfig.ConfigPath, globalFPInfo.GetDirForContent(-1))
+	pluginConfig.SetupPluginForRestore(globalCluster, pluginConfig.ConfigPath, globalFPInfo.GetDirForContent(-1))
 	pluginConfig.RestoreFile(globalFPInfo.GetConfigFilePath())
 
 	InitializeBackupConfig()

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -90,7 +90,7 @@ func BackupConfigurationValidation() {
 }
 
 func RecoverMetadataFilesUsingPlugin() {
-	pluginConfig := utils.ReadPluginConfig(*pluginConfigFile)
+	pluginConfig = utils.ReadPluginConfig(*pluginConfigFile)
 	pluginConfig.CheckPluginExistsOnAllHosts(globalCluster)
 	pluginConfig.CopyPluginConfigToAllHosts(globalCluster, *pluginConfigFile)
 	pluginConfig.SetupPluginForRestore(globalCluster, pluginConfig.ConfigPath, globalFPInfo.GetDirForContent(-1))

--- a/utils/plugin.go
+++ b/utils/plugin.go
@@ -11,7 +11,7 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gp-common-go-libs/operating"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 type PluginConfig struct {
@@ -19,6 +19,14 @@ type PluginConfig struct {
 	ConfigPath     string
 	Options        map[string]string
 }
+
+type PluginScope string
+
+const (
+	Master      PluginScope = "master"
+	SegmentHost PluginScope = "segment_host"
+	Segment     PluginScope = "segment"
+)
 
 func ReadPluginConfig(configFile string) *PluginConfig {
 	config := &PluginConfig{}
@@ -66,7 +74,7 @@ func (plugin *PluginConfig) CheckPluginExistsOnAllHosts(c *cluster.Cluster) {
 
 	numIncorrect := 0
 	for contentID := range remoteOutput.Stdouts {
-		supportedVersion, _ := semver.Make("0.1.0")
+		supportedVersion, _ := semver.Make("0.2.0")
 		version, err := semver.Make(strings.TrimSpace(remoteOutput.Stdouts[contentID]))
 		if err != nil {
 			gplog.Fatal(fmt.Errorf("Unable to parse plugin API version: %s", err.Error()), "")
@@ -81,41 +89,82 @@ func (plugin *PluginConfig) CheckPluginExistsOnAllHosts(c *cluster.Cluster) {
 	}
 }
 
-func (plugin *PluginConfig) SetupPluginForBackupOnAllHosts(c *cluster.Cluster, configPath string, backupDir string) {
-	remoteOutput := c.GenerateAndExecuteCommand("Running plugin setup for backup on all hosts", func(contentID int) string {
-		return fmt.Sprintf("source %s/greenplum_path.sh && %s setup_plugin_for_backup %s %s", operating.System.Getenv("GPHOME"), plugin.ExecutablePath, configPath, backupDir)
-	}, cluster.ON_HOSTS_AND_MASTER)
-	c.CheckClusterError(remoteOutput, fmt.Sprintf("Unable to setup plugin %s", plugin.ExecutablePath), func(contentID int) string {
-		return fmt.Sprintf("Unable to setup plugin %s", plugin.ExecutablePath)
-	})
+/*-----------------------------Hooks------------------------------------------*/
+
+func (plugin *PluginConfig) SetupPluginForBackup(c *cluster.Cluster, configPath string, backupDir string) {
+	const command = "setup_plugin_for_backup"
+	const verboseCommandMsg = "Running plugin setup for backup on %s"
+	plugin.executeHook(c, verboseCommandMsg, command, configPath, backupDir, false)
 }
 
-func (plugin *PluginConfig) SetupPluginForRestoreOnAllHosts(c *cluster.Cluster, configPath string, backupDir string) {
-	remoteOutput := c.GenerateAndExecuteCommand("Running plugin setup for restore on all hosts", func(contentID int) string {
-		return fmt.Sprintf("source %s/greenplum_path.sh && %s setup_plugin_for_restore %s %s", operating.System.Getenv("GPHOME"), plugin.ExecutablePath, configPath, backupDir)
-	}, cluster.ON_HOSTS_AND_MASTER)
-	c.CheckClusterError(remoteOutput, fmt.Sprintf("Unable to setup plugin %s", plugin.ExecutablePath), func(contentID int) string {
-		return fmt.Sprintf("Unable to setup plugin %s", plugin.ExecutablePath)
-	})
+func (plugin *PluginConfig) SetupPluginForRestore(c *cluster.Cluster, configPath string, backupDir string) {
+	const command = "setup_plugin_for_restore"
+	const verboseCommandMsg = "Running plugin setup for restore on %s"
+	plugin.executeHook(c, verboseCommandMsg, command, configPath, backupDir, false)
 }
 
-func (plugin *PluginConfig) CleanupPluginForBackupOnAllHosts(c *cluster.Cluster, configPath string, backupDir string) {
-	remoteOutput := c.GenerateAndExecuteCommand("Running plugin cleanup for backup on all hosts", func(contentID int) string {
-		return fmt.Sprintf("source %s/greenplum_path.sh && %s cleanup_plugin_for_backup %s %s", operating.System.Getenv("GPHOME"), plugin.ExecutablePath, configPath, backupDir)
-	}, cluster.ON_HOSTS_AND_MASTER)
-	c.CheckClusterError(remoteOutput, fmt.Sprintf("Unable to cleanup plugin %s", plugin.ExecutablePath), func(contentID int) string {
-		return fmt.Sprintf("Unable to cleanup plugin %s", plugin.ExecutablePath)
-	}, true)
+func (plugin *PluginConfig) CleanupPluginForBackup(c *cluster.Cluster, configPath string, backupDir string) {
+	const command = "cleanup_plugin_for_backup"
+	const verboseCommandMsg = "Running plugin cleanup for backup on %s"
+	plugin.executeHook(c, verboseCommandMsg, command, configPath, backupDir, true)
 }
 
-func (plugin *PluginConfig) CleanupPluginForRestoreOnAllHosts(c *cluster.Cluster, configPath string, backupDir string) {
-	remoteOutput := c.GenerateAndExecuteCommand("Running plugin cleanup for restore on all hosts", func(contentID int) string {
-		return fmt.Sprintf("source %s/greenplum_path.sh && %s cleanup_plugin_for_restore %s %s", operating.System.Getenv("GPHOME"), plugin.ExecutablePath, configPath, backupDir)
-	}, cluster.ON_HOSTS_AND_MASTER)
-	c.CheckClusterError(remoteOutput, fmt.Sprintf("Unable to cleanup plugin %s", plugin.ExecutablePath), func(contentID int) string {
-		return fmt.Sprintf("Unable to cleanup plugin %s", plugin.ExecutablePath)
-	}, true)
+func (plugin *PluginConfig) CleanupPluginForRestore(c *cluster.Cluster, configPath string, backupDir string) {
+	const command = "cleanup_plugin_for_restore"
+	const verboseCommandMsg = "Running plugin cleanup for restore on %s"
+	plugin.executeHook(c, verboseCommandMsg, command, configPath, backupDir, true)
 }
+
+func (plugin *PluginConfig) executeHook(c *cluster.Cluster, verboseCommandMsg,
+	command, configPath, backupDir string, noFatal bool) {
+	// Execute command once on master
+	scope := Master
+	hookFunc := plugin.buildHookFunc(command, configPath, backupDir, scope)
+	verboseErrorMsg, errorMsgFunc := plugin.buildHookErrorMsgAndFunc(command, scope)
+	masterOutput, masterErr := c.ExecuteLocalCommand(plugin.buildHookString(command,
+		configPath, backupDir, scope))
+	gplog.FatalOnError(masterErr, masterOutput)
+
+	// Execute command once on each segment host
+	scope = SegmentHost
+	hookFunc = plugin.buildHookFunc(command, configPath, backupDir, scope)
+	verboseErrorMsg, errorMsgFunc = plugin.buildHookErrorMsgAndFunc(command, scope)
+	verboseCommandHostMasterMsg := fmt.Sprintf(verboseCommandMsg, "segment hosts")
+	remoteOutput := c.GenerateAndExecuteCommand(verboseCommandHostMasterMsg, hookFunc, cluster.ON_HOSTS)
+	c.CheckClusterError(remoteOutput, verboseErrorMsg, errorMsgFunc, noFatal)
+
+	// Execute command once for each segment
+	scope = Segment
+	hookFunc = plugin.buildHookFunc(command, configPath, backupDir, scope)
+	verboseErrorMsg, errorMsgFunc = plugin.buildHookErrorMsgAndFunc(command, scope)
+	verboseCommandSegMsg := fmt.Sprintf(verboseCommandMsg, "segments")
+	remoteOutput = c.GenerateAndExecuteCommand(verboseCommandSegMsg, hookFunc, cluster.ON_SEGMENTS)
+	c.CheckClusterError(remoteOutput, verboseErrorMsg, errorMsgFunc, noFatal)
+}
+
+func (plugin *PluginConfig) buildHookFunc(command, configPath, backupDir string,
+	scope PluginScope) func(int) string {
+	return func(contentID int) string {
+		return plugin.buildHookString(command, configPath, backupDir, scope)
+	}
+}
+
+func (plugin *PluginConfig) buildHookString(command, configPath,
+	backupDir string, scope PluginScope) string {
+	return fmt.Sprintf("source %s/greenplum_path.sh && %s %s %s %s %s",
+		operating.System.Getenv("GPHOME"), plugin.ExecutablePath, command, configPath, backupDir, scope)
+}
+
+func (plugin *PluginConfig) buildHookErrorMsgAndFunc(command string,
+	scope PluginScope) (string, func(int) string) {
+	errorMsg := fmt.Sprintf("Unable to execute command: %s at: %s, on: %s",
+		command, plugin.ExecutablePath, scope)
+	return errorMsg, func(contentID int) string {
+		return errorMsg
+	}
+}
+
+/*---------------------------------------------------------------------------------------------------*/
 
 func (plugin *PluginConfig) CopyPluginConfigToAllHosts(c *cluster.Cluster, configPath string) {
 	remoteOutput := c.GenerateAndExecuteCommand("Copying plugin config to all hosts", func(contentID int) string {


### PR DESCRIPTION
1) Additional hooks for plugin lifecycle methods:
Now plugin lifecycle methods (setup and cleanup) are invoked once each
in the following scopes:
- Master
- Segment Host
- Segment
Also, refactored lifecycle methods : plugin.go

2) Fix: Cleanup plugin now executes for restore
cleanup_plugin_for_restore function was not executing as the
pluginConfig global was nil. It was not getting set as it was being
shadowed inside RecoverMetadataFilesUsingPlugin.

3) Logging plugin method invocations in example_plugin.sh for ease of verification.