### PR TITLE
Fix dependency ordering of protocols, tables, and functions.

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -191,7 +191,7 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Relation, tab
 	BackupCreateSequences(metadataFile, sequences, relationMetadata)
 
 	constraints, conMetadata := RetrieveConstraints()
-	protocols, protoMetadata := RetrieveProtocols(funcInfoMap)
+	protocols, protoMetadata := RetrieveAndProcessProtocols(funcInfoMap)
 
 	BackupFunctionsAndTypesAndTablesAndProtocols(metadataFile, otherFuncs, types, tables, protocols, functionMetadata, typeMetadata, relationMetadata, protoMetadata, tableDefs, constraints)
 	PrintAlterSequenceStatements(metadataFile, globalTOC, sequences, sequenceOwnerColumns)

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -193,7 +193,7 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Relation, tab
 	constraints, conMetadata := RetrieveConstraints()
 	protocols, protoMetadata := RetrieveAndProcessProtocols(funcInfoMap)
 
-	BackupFunctionsAndTypesAndTablesAndProtocols(metadataFile, otherFuncs, types, tables, protocols, functionMetadata, typeMetadata, relationMetadata, protoMetadata, tableDefs, constraints)
+	BackupDependentObjects(metadataFile, otherFuncs, types, tables, protocols, functionMetadata, typeMetadata, relationMetadata, protoMetadata, tableDefs, constraints)
 	PrintAlterSequenceStatements(metadataFile, globalTOC, sequences, sequenceOwnerColumns)
 
 	if len(*includeSchemas) == 0 {

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -191,12 +191,12 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Relation, tab
 	BackupCreateSequences(metadataFile, sequences, relationMetadata)
 
 	constraints, conMetadata := RetrieveConstraints()
+	protocols, protoMetadata := RetrieveProtocols(funcInfoMap)
 
-	BackupFunctionsAndTypesAndTables(metadataFile, otherFuncs, types, tables, functionMetadata, typeMetadata, relationMetadata, tableDefs, constraints)
+	BackupFunctionsAndTypesAndTablesAndProtocols(metadataFile, otherFuncs, types, tables, protocols, functionMetadata, typeMetadata, relationMetadata, protoMetadata, tableDefs, constraints)
 	PrintAlterSequenceStatements(metadataFile, globalTOC, sequences, sequenceOwnerColumns)
 
 	if len(*includeSchemas) == 0 {
-		BackupProtocols(metadataFile, funcInfoMap)
 		if connectionPool.Version.AtLeast("6") {
 			BackupForeignDataWrappers(metadataFile, funcInfoMap)
 			BackupForeignServers(metadataFile)

--- a/backup/dependencies.go
+++ b/backup/dependencies.go
@@ -8,7 +8,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-func SortFunctionsAndTypesAndTablesInDependencyOrder(functions []Function, types []Type, tables []Relation) []Sortable {
+func SortFunctionsAndTypesAndTablesAndProtocolsInDependencyOrder(functions []Function, types []Type, tables []Relation, protocols []ExternalProtocol) []Sortable {
 	objects := make([]Sortable, 0)
 	for _, function := range functions {
 		objects = append(objects, function)
@@ -21,11 +21,14 @@ func SortFunctionsAndTypesAndTablesInDependencyOrder(functions []Function, types
 	for _, table := range tables {
 		objects = append(objects, table)
 	}
+	for _, protocol := range protocols {
+		objects = append(objects, protocol)
+	}
 	sorted := TopologicalSort(objects)
 	return sorted
 }
 
-func ConstructFunctionAndTypeAndTableMetadataMap(functions MetadataMap, types MetadataMap, tables MetadataMap) MetadataMap {
+func ConstructFunctionAndTypeAndTableMetadataMap(functions MetadataMap, types MetadataMap, tables MetadataMap, protocols MetadataMap) MetadataMap {
 	metadataMap := make(MetadataMap, 0)
 	for k, v := range functions {
 		metadataMap[k] = v
@@ -34,6 +37,9 @@ func ConstructFunctionAndTypeAndTableMetadataMap(functions MetadataMap, types Me
 		metadataMap[k] = v
 	}
 	for k, v := range tables {
+		metadataMap[k] = v
+	}
+	for k, v := range protocols {
 		metadataMap[k] = v
 	}
 	return metadataMap
@@ -68,6 +74,10 @@ func (t Type) FQN() string {
 	return utils.MakeFQN(t.Schema, t.Name)
 }
 
+func (p ExternalProtocol) FQN() string {
+	return p.Name
+}
+
 func (r Relation) Dependencies() []string {
 	return r.DependsUpon
 }
@@ -82,6 +92,10 @@ func (f Function) Dependencies() []string {
 
 func (t Type) Dependencies() []string {
 	return t.DependsUpon
+}
+
+func (p ExternalProtocol) Dependencies() []string {
+	return p.DependsUpon
 }
 
 func SortViews(views []View) []View {

--- a/backup/dependencies.go
+++ b/backup/dependencies.go
@@ -8,7 +8,21 @@ import (
 	"github.com/pkg/errors"
 )
 
-func SortFunctionsAndTypesAndTablesAndProtocolsInDependencyOrder(functions []Function, types []Type, tables []Relation, protocols []ExternalProtocol) []Sortable {
+/* This file contains functions to sort objects that have dependencies among themselves.
+ *  For example, functions and types can be dependent on one another, we cannot simply
+ *  dump all functions and then all types.
+ *  The following objects are included the dependency sorting logic:
+ *   - Functions
+ *   - Types
+ *   - Tables
+ *   - Protocols
+ */
+
+/*
+ * We need to include arguments to differentiate functions with the same name;
+ * we don't use IdentArgs because we already have Arguments in the funcInfoMap.
+ */
+func SortObjectsInDependencyOrder(functions []Function, types []Type, tables []Relation, protocols []ExternalProtocol) []Sortable {
 	objects := make([]Sortable, 0)
 	for _, function := range functions {
 		objects = append(objects, function)
@@ -28,7 +42,7 @@ func SortFunctionsAndTypesAndTablesAndProtocolsInDependencyOrder(functions []Fun
 	return sorted
 }
 
-func ConstructFunctionAndTypeAndTableMetadataMap(functions MetadataMap, types MetadataMap, tables MetadataMap, protocols MetadataMap) MetadataMap {
+func ConstructDependentObjectMetadataMap(functions MetadataMap, types MetadataMap, tables MetadataMap, protocols MetadataMap) MetadataMap {
 	metadataMap := make(MetadataMap, 0)
 	for k, v := range functions {
 		metadataMap[k] = v

--- a/backup/dependencies_test.go
+++ b/backup/dependencies_test.go
@@ -89,7 +89,7 @@ var _ = Describe("backup/dependencies tests", func() {
 			Expect(types[1].FQN()).To(Equal("public.type3"))
 			Expect(types[2].FQN()).To(Equal("public.type2"))
 		})
-		It("sorts the slice correctly if there are complex dependencies", func() {
+		It("sorts the slice correctly if there are explicit dependencies", func() {
 			type2.DependsUpon = []string{"public.type1", "public.function3(integer, integer)"}
 			function3.DependsUpon = []string{"public.type1"}
 			sortable := []backup.Sortable{type1, type2, function3}

--- a/backup/dependencies_test.go
+++ b/backup/dependencies_test.go
@@ -117,13 +117,13 @@ var _ = Describe("backup/dependencies tests", func() {
 			sortable = backup.TopologicalSort(sortable)
 		})
 	})
-	Describe("SortFunctionsAndTypesAndTablesAndProtocolsInDependencyOrder", func() {
+	Describe("SortObjectsInDependencyOrder", func() {
 		It("returns a slice of unsorted functions followed by types followed by tables followed by protocols if there are no dependencies among objects", func() {
 			functions := []backup.Function{function1, function2, function3}
 			types := []backup.Type{type1, type2, type3}
 			relations := []backup.Relation{relation1, relation2, relation3}
 			protocols := []backup.ExternalProtocol{protocol1, protocol2, protocol3}
-			results := backup.SortFunctionsAndTypesAndTablesAndProtocolsInDependencyOrder(functions, types, relations, protocols)
+			results := backup.SortObjectsInDependencyOrder(functions, types, relations, protocols)
 			expected := []backup.Sortable{function1, function2, function3, type1, type2, type3, relation1, relation2, relation3, protocol1, protocol2, protocol3}
 			Expect(results).To(Equal(expected))
 		})
@@ -136,7 +136,7 @@ var _ = Describe("backup/dependencies tests", func() {
 			types := []backup.Type{type1, type2, type3}
 			relations := []backup.Relation{relation1, relation2, relation3}
 			protocols := []backup.ExternalProtocol{protocol1, protocol2, protocol3}
-			results := backup.SortFunctionsAndTypesAndTablesAndProtocolsInDependencyOrder(functions, types, relations, protocols)
+			results := backup.SortObjectsInDependencyOrder(functions, types, relations, protocols)
 			expected := []backup.Sortable{function1, function3, type1, type3, relation1, relation3, protocol1, protocol3, function2, type2, relation2, protocol2}
 			Expect(results).To(Equal(expected))
 		})
@@ -149,7 +149,7 @@ var _ = Describe("backup/dependencies tests", func() {
 			types := []backup.Type{type1, type2, type3}
 			relations := []backup.Relation{relation1, relation2, relation3}
 			protocols := []backup.ExternalProtocol{protocol1, protocol2, protocol3}
-			results := backup.SortFunctionsAndTypesAndTablesAndProtocolsInDependencyOrder(functions, types, relations, protocols)
+			results := backup.SortObjectsInDependencyOrder(functions, types, relations, protocols)
 			expected := []backup.Sortable{function1, function3, type1, type3, relation1, relation3, protocol1, protocol3, relation2, function2, type2, protocol2}
 			Expect(results).To(Equal(expected))
 		})
@@ -277,13 +277,13 @@ var _ = Describe("backup/dependencies tests", func() {
 			Expect(types[0].DependsUpon).To(Equal([]string{"public.builtin"}))
 		})
 	})
-	Describe("ConstructFunctionAndTypeAndTableMetadataMap", func() {
+	Describe("ConstructDependentObjectMetadataMap", func() {
 		It("composes metadata maps for functions, types, and tables into one map", func() {
 			funcMap := backup.MetadataMap{1: backup.ObjectMetadata{Comment: "function"}}
 			typeMap := backup.MetadataMap{2: backup.ObjectMetadata{Comment: "type"}}
 			tableMap := backup.MetadataMap{3: backup.ObjectMetadata{Comment: "relation"}}
 			protoMap := backup.MetadataMap{4: backup.ObjectMetadata{Comment: "protocol"}}
-			result := backup.ConstructFunctionAndTypeAndTableMetadataMap(funcMap, typeMap, tableMap, protoMap)
+			result := backup.ConstructDependentObjectMetadataMap(funcMap, typeMap, tableMap, protoMap)
 			expected := backup.MetadataMap{
 				1: backup.ObjectMetadata{Comment: "function"},
 				2: backup.ObjectMetadata{Comment: "type"},

--- a/backup/dependencies_test.go
+++ b/backup/dependencies_test.go
@@ -26,12 +26,15 @@ var _ = Describe("backup/dependencies tests", func() {
 		view1     backup.View
 		view2     backup.View
 		view3     backup.View
+		protocol1 backup.ExternalProtocol
+		protocol2 backup.ExternalProtocol
+		protocol3 backup.ExternalProtocol
 	)
 
 	BeforeEach(func() {
 		function1 = backup.Function{Schema: "public", Name: "function1", Arguments: "integer, integer", DependsUpon: []string{}}
-		function2 = backup.Function{Schema: "public", Name: "function1", Arguments: "numeric, text", DependsUpon: []string{}}
-		function3 = backup.Function{Schema: "public", Name: "function2", Arguments: "integer, integer", DependsUpon: []string{}}
+		function2 = backup.Function{Schema: "public", Name: "function2", Arguments: "numeric, text", DependsUpon: []string{}}
+		function3 = backup.Function{Schema: "public", Name: "function3", Arguments: "integer, integer", DependsUpon: []string{}}
 		relation1 = backup.Relation{Schema: "public", Name: "relation1", DependsUpon: []string{}}
 		relation2 = backup.Relation{Schema: "public", Name: "relation2", DependsUpon: []string{}}
 		relation3 = backup.Relation{Schema: "public", Name: "relation3", DependsUpon: []string{}}
@@ -41,6 +44,9 @@ var _ = Describe("backup/dependencies tests", func() {
 		view1 = backup.View{Schema: "public", Name: "view1", DependsUpon: []string{}}
 		view2 = backup.View{Schema: "public", Name: "view2", DependsUpon: []string{}}
 		view3 = backup.View{Schema: "public", Name: "view3", DependsUpon: []string{}}
+		protocol1 = backup.ExternalProtocol{Name: "protocol1", DependsUpon: []string{}}
+		protocol2 = backup.ExternalProtocol{Name: "protocol2", DependsUpon: []string{}}
+		protocol3 = backup.ExternalProtocol{Name: "protocol3", DependsUpon: []string{}}
 	})
 	Describe("TopologicalSort", func() {
 		It("returns the original slice if there are no dependencies among objects", func() {
@@ -84,14 +90,14 @@ var _ = Describe("backup/dependencies tests", func() {
 			Expect(types[2].FQN()).To(Equal("public.type2"))
 		})
 		It("sorts the slice correctly if there are complex dependencies", func() {
-			type2.DependsUpon = []string{"public.type1", "public.function2(integer, integer)"}
+			type2.DependsUpon = []string{"public.type1", "public.function3(integer, integer)"}
 			function3.DependsUpon = []string{"public.type1"}
 			sortable := []backup.Sortable{type1, type2, function3}
 
 			sortable = backup.TopologicalSort(sortable)
 
 			Expect(sortable[0].FQN()).To(Equal("public.type1"))
-			Expect(sortable[1].FQN()).To(Equal("public.function2(integer, integer)"))
+			Expect(sortable[1].FQN()).To(Equal("public.function3(integer, integer)"))
 			Expect(sortable[2].FQN()).To(Equal("public.type2"))
 		})
 		It("aborts if dependency loop (this shouldn't be possible)", func() {
@@ -111,35 +117,40 @@ var _ = Describe("backup/dependencies tests", func() {
 			sortable = backup.TopologicalSort(sortable)
 		})
 	})
-	Describe("SortFunctionsAndTypesAndTablesInDependencyOrder", func() {
-		It("returns a slice of unsorted functions followed by unsorted types followed by unsorted tables if there are no dependencies among objects", func() {
+	Describe("SortFunctionsAndTypesAndTablesAndProtocolsInDependencyOrder", func() {
+		It("returns a slice of unsorted functions followed by types followed by tables followed by protocols if there are no dependencies among objects", func() {
 			functions := []backup.Function{function1, function2, function3}
 			types := []backup.Type{type1, type2, type3}
 			relations := []backup.Relation{relation1, relation2, relation3}
-			results := backup.SortFunctionsAndTypesAndTablesInDependencyOrder(functions, types, relations)
-			expected := []backup.Sortable{function1, function2, function3, type1, type2, type3, relation1, relation2, relation3}
+			protocols := []backup.ExternalProtocol{protocol1, protocol2, protocol3}
+			results := backup.SortFunctionsAndTypesAndTablesAndProtocolsInDependencyOrder(functions, types, relations, protocols)
+			expected := []backup.Sortable{function1, function2, function3, type1, type2, type3, relation1, relation2, relation3, protocol1, protocol2, protocol3}
 			Expect(results).To(Equal(expected))
 		})
 		It("returns a slice of sorted functions, types, and relations if there are dependencies among objects of the same type", func() {
-			function2.DependsUpon = []string{"public.function2(integer, integer)"}
+			function2.DependsUpon = []string{"public.function3(integer, integer)"}
 			type2.DependsUpon = []string{"public.type3"}
 			relation2.DependsUpon = []string{"public.relation3"}
+			protocol2.DependsUpon = []string{"protocol3"}
 			functions := []backup.Function{function1, function2, function3}
 			types := []backup.Type{type1, type2, type3}
 			relations := []backup.Relation{relation1, relation2, relation3}
-			results := backup.SortFunctionsAndTypesAndTablesInDependencyOrder(functions, types, relations)
-			expected := []backup.Sortable{function1, function3, type1, type3, relation1, relation3, function2, type2, relation2}
+			protocols := []backup.ExternalProtocol{protocol1, protocol2, protocol3}
+			results := backup.SortFunctionsAndTypesAndTablesAndProtocolsInDependencyOrder(functions, types, relations, protocols)
+			expected := []backup.Sortable{function1, function3, type1, type3, relation1, relation3, protocol1, protocol3, function2, type2, relation2, protocol2}
 			Expect(results).To(Equal(expected))
 		})
 		It("returns a slice of sorted functions, types, and relations if there are dependencies among objects of different types", func() {
 			function2.DependsUpon = []string{"public.type3"}
 			type2.DependsUpon = []string{"public.relation3"}
 			relation2.DependsUpon = []string{"public.type1"}
+			protocol2.DependsUpon = []string{"public.function1(integer, integer)", "public.relation2"}
 			functions := []backup.Function{function1, function2, function3}
 			types := []backup.Type{type1, type2, type3}
 			relations := []backup.Relation{relation1, relation2, relation3}
-			results := backup.SortFunctionsAndTypesAndTablesInDependencyOrder(functions, types, relations)
-			expected := []backup.Sortable{function1, function3, type1, type3, relation1, relation3, relation2, function2, type2}
+			protocols := []backup.ExternalProtocol{protocol1, protocol2, protocol3}
+			results := backup.SortFunctionsAndTypesAndTablesAndProtocolsInDependencyOrder(functions, types, relations, protocols)
+			expected := []backup.Sortable{function1, function3, type1, type3, relation1, relation3, protocol1, protocol3, relation2, function2, type2, protocol2}
 			Expect(results).To(Equal(expected))
 		})
 	})
@@ -271,11 +282,13 @@ var _ = Describe("backup/dependencies tests", func() {
 			funcMap := backup.MetadataMap{1: backup.ObjectMetadata{Comment: "function"}}
 			typeMap := backup.MetadataMap{2: backup.ObjectMetadata{Comment: "type"}}
 			tableMap := backup.MetadataMap{3: backup.ObjectMetadata{Comment: "relation"}}
-			result := backup.ConstructFunctionAndTypeAndTableMetadataMap(funcMap, typeMap, tableMap)
+			protoMap := backup.MetadataMap{4: backup.ObjectMetadata{Comment: "protocol"}}
+			result := backup.ConstructFunctionAndTypeAndTableMetadataMap(funcMap, typeMap, tableMap, protoMap)
 			expected := backup.MetadataMap{
 				1: backup.ObjectMetadata{Comment: "function"},
 				2: backup.ObjectMetadata{Comment: "type"},
 				3: backup.ObjectMetadata{Comment: "relation"},
+				4: backup.ObjectMetadata{Comment: "protocol"},
 			}
 			Expect(result).To(Equal(expected))
 		})

--- a/backup/predata_externals.go
+++ b/backup/predata_externals.go
@@ -210,43 +210,26 @@ func PrintExternalTableStatements(metadataFile *utils.FileWithByteCount, table R
 	}
 }
 
-func PrintCreateExternalProtocolStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, protocols []ExternalProtocol, funcInfoMap map[uint32]FunctionInfo, protoMetadata MetadataMap) {
-	for _, protocol := range protocols {
-		start := metadataFile.ByteCount
-		hasUserDefinedFunc := false
-		if function, ok := funcInfoMap[protocol.WriteFunction]; ok && !function.IsInternal {
-			hasUserDefinedFunc = true
-		}
-		if function, ok := funcInfoMap[protocol.ReadFunction]; ok && !function.IsInternal {
-			hasUserDefinedFunc = true
-		}
-		if function, ok := funcInfoMap[protocol.Validator]; ok && !function.IsInternal {
-			hasUserDefinedFunc = true
-		}
-
-		if !hasUserDefinedFunc {
-			continue
-		}
-
-		protocolFunctions := []string{}
-		if protocol.ReadFunction != 0 {
-			protocolFunctions = append(protocolFunctions, fmt.Sprintf("readfunc = %s", funcInfoMap[protocol.ReadFunction].QualifiedName))
-		}
-		if protocol.WriteFunction != 0 {
-			protocolFunctions = append(protocolFunctions, fmt.Sprintf("writefunc = %s", funcInfoMap[protocol.WriteFunction].QualifiedName))
-		}
-		if protocol.Validator != 0 {
-			protocolFunctions = append(protocolFunctions, fmt.Sprintf("validatorfunc = %s", funcInfoMap[protocol.Validator].QualifiedName))
-		}
-
-		metadataFile.MustPrintf("\n\nCREATE ")
-		if protocol.Trusted {
-			metadataFile.MustPrintf("TRUSTED ")
-		}
-		metadataFile.MustPrintf("PROTOCOL %s (%s);\n", protocol.Name, strings.Join(protocolFunctions, ", "))
-		PrintObjectMetadata(metadataFile, protoMetadata[protocol.Oid], protocol.Name, "PROTOCOL")
-		toc.AddPredataEntry("", protocol.Name, "PROTOCOL", "", start, metadataFile)
+func PrintCreateExternalProtocolStatement(metadataFile *utils.FileWithByteCount, toc *utils.TOC, protocol ExternalProtocol, protoMetadata ObjectMetadata) {
+	start := metadataFile.ByteCount
+	protocolFunctions := []string{}
+	if protocol.ReadFunction != 0 {
+		protocolFunctions = append(protocolFunctions, fmt.Sprintf("readfunc = %s", protocol.FuncMap[protocol.ReadFunction]))
 	}
+	if protocol.WriteFunction != 0 {
+		protocolFunctions = append(protocolFunctions, fmt.Sprintf("writefunc = %s", protocol.FuncMap[protocol.WriteFunction]))
+	}
+	if protocol.Validator != 0 {
+		protocolFunctions = append(protocolFunctions, fmt.Sprintf("validatorfunc = %s", protocol.FuncMap[protocol.Validator]))
+	}
+
+	metadataFile.MustPrintf("\n\nCREATE ")
+	if protocol.Trusted {
+		metadataFile.MustPrintf("TRUSTED ")
+	}
+	metadataFile.MustPrintf("PROTOCOL %s (%s);\n", protocol.Name, strings.Join(protocolFunctions, ", "))
+	PrintObjectMetadata(metadataFile, protoMetadata, protocol.Name, "PROTOCOL")
+	toc.AddPredataEntry("", protocol.Name, "PROTOCOL", "", start, metadataFile)
 }
 
 func PrintExchangeExternalPartitionStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, extPartitions []PartitionInfo, partInfoMap map[uint32]PartitionInfo, tables []Relation) {

--- a/backup/predata_externals.go
+++ b/backup/predata_externals.go
@@ -211,7 +211,7 @@ func PrintExternalTableStatements(metadataFile *utils.FileWithByteCount, table R
 }
 
 func ProcessProtocols(protocols []ExternalProtocol, funcInfoMap map[uint32]FunctionInfo) []ExternalProtocol {
-	protocolsTobackup := make([]ExternalProtocol, 0, len(protocols))
+	protocolsToBackup := make([]ExternalProtocol, 0, len(protocols))
 	for _, p := range protocols {
 		p.FuncMap = make(map[uint32]string)
 		funcOidList := []uint32{p.ReadFunction, p.WriteFunction, p.Validator}
@@ -227,10 +227,10 @@ func ProcessProtocols(protocols []ExternalProtocol, funcInfoMap map[uint32]Funct
 			}
 		}
 		if hasUserDefinedFunc {
-			protocolsTobackup = append(protocolsTobackup, p)
+			protocolsToBackup = append(protocolsToBackup, p)
 		}
 	}
-	return protocolsTobackup
+	return protocolsToBackup
 }
 
 func PrintCreateExternalProtocolStatement(metadataFile *utils.FileWithByteCount, toc *utils.TOC, protocol ExternalProtocol, protoMetadata ObjectMetadata) {

--- a/backup/predata_externals.go
+++ b/backup/predata_externals.go
@@ -211,7 +211,7 @@ func PrintExternalTableStatements(metadataFile *utils.FileWithByteCount, table R
 }
 
 func ProcessProtocols(protocols []ExternalProtocol, funcInfoMap map[uint32]FunctionInfo) []ExternalProtocol {
-	protocolsToBackUp := make([]ExternalProtocol, 0, len(protocols))
+	protocolsTobackup := make([]ExternalProtocol, 0, len(protocols))
 	for _, p := range protocols {
 		p.FuncMap = make(map[uint32]string)
 		funcOidList := []uint32{p.ReadFunction, p.WriteFunction, p.Validator}
@@ -227,10 +227,10 @@ func ProcessProtocols(protocols []ExternalProtocol, funcInfoMap map[uint32]Funct
 			}
 		}
 		if hasUserDefinedFunc {
-			protocolsToBackUp = append(protocolsToBackUp, p)
+			protocolsTobackup = append(protocolsTobackup, p)
 		}
 	}
-	return protocolsToBackUp
+	return protocolsTobackup
 }
 
 func PrintCreateExternalProtocolStatement(metadataFile *utils.FileWithByteCount, toc *utils.TOC, protocol ExternalProtocol, protoMetadata ObjectMetadata) {

--- a/backup/predata_externals_test.go
+++ b/backup/predata_externals_test.go
@@ -369,75 +369,85 @@ ENCODING 'UTF-8'`)
 			})
 		})
 	})
-	Describe("PrintExternalProtocolStatements", func() {
-		protocolUntrustedReadWrite := backup.ExternalProtocol{Oid: 1, Name: "s3", Owner: "testrole", Trusted: false, ReadFunction: 1, WriteFunction: 2, Validator: 0}
-		protocolUntrustedReadValidator := backup.ExternalProtocol{Oid: 1, Name: "s3", Owner: "testrole", Trusted: false, ReadFunction: 1, WriteFunction: 0, Validator: 3}
-		protocolUntrustedWriteOnly := backup.ExternalProtocol{Oid: 1, Name: "s3", Owner: "testrole", Trusted: false, ReadFunction: 0, WriteFunction: 2, Validator: 0}
-		protocolTrustedReadWriteValidator := backup.ExternalProtocol{Oid: 1, Name: "s3", Owner: "testrole", Trusted: true, ReadFunction: 1, WriteFunction: 2, Validator: 3}
+	Describe("ProcessProtocols", func() {
 		protocolUntrustedReadOnly := backup.ExternalProtocol{Oid: 1, Name: "s4", Owner: "testrole", Trusted: false, ReadFunction: 4, WriteFunction: 0, Validator: 0}
 		protocolInternal := backup.ExternalProtocol{Oid: 1, Name: "gphdfs", Owner: "testrole", Trusted: false, ReadFunction: 5, WriteFunction: 6, Validator: 7}
 		protocolInternalReadWrite := backup.ExternalProtocol{Oid: 1, Name: "gphdfs", Owner: "testrole", Trusted: false, ReadFunction: 5, WriteFunction: 6, Validator: 0}
 		funcInfoMap := map[uint32]backup.FunctionInfo{
-			1: {QualifiedName: "public.read_fn_s3", Arguments: ""},
-			2: {QualifiedName: "public.write_fn_s3", Arguments: ""},
-			3: {QualifiedName: "public.validator", Arguments: ""},
-			4: {QualifiedName: "public.read_fn_s4", Arguments: ""},
+			4: {QualifiedName: "public.read_fn_s4", Arguments: "integer, integer"},
 			5: {QualifiedName: "pg_catalog.read_internal_fn", Arguments: "", IsInternal: true},
 			6: {QualifiedName: "pg_catalog.write_internal_fn", Arguments: "", IsInternal: true},
 			7: {QualifiedName: "pg_catalog.validate_internal_fn", Arguments: "", IsInternal: true},
 		}
-		emptyMetadataMap := backup.MetadataMap{}
+		It("adds function name and dependency information to external protocols", func() {
+			protos := []backup.ExternalProtocol{protocolUntrustedReadOnly}
+			expectedFuncMap := map[uint32]string{4: "public.read_fn_s4"}
+			expectedDependencies := []string{"public.read_fn_s4(integer, integer)"}
+			resultProtos := backup.ProcessProtocols(protos, funcInfoMap)
+			Expect(resultProtos[0].FuncMap).To(Equal(expectedFuncMap))
+			Expect(resultProtos[0].DependsUpon).To(Equal(expectedDependencies))
+		})
+		It("does not include an internal protocol", func() {
+			protos := []backup.ExternalProtocol{protocolInternal, protocolUntrustedReadOnly}
+			resultProtos := backup.ProcessProtocols(protos, funcInfoMap)
+			Expect(len(resultProtos)).To(Equal(1))
+			Expect(resultProtos[0].Name).To(Equal("s4"))
+		})
+		It("does not include an internal protocol without a validator", func() {
+			protos := []backup.ExternalProtocol{protocolInternalReadWrite, protocolUntrustedReadOnly}
+			resultProtos := backup.ProcessProtocols(protos, funcInfoMap)
+			Expect(len(resultProtos)).To(Equal(1))
+			Expect(resultProtos[0].Name).To(Equal("s4"))
+		})
+	})
+	Describe("PrintExternalProtocolStatements", func() {
+		protocolUntrustedReadWrite := backup.ExternalProtocol{Oid: 1, Name: "s3", Owner: "testrole", Trusted: false, ReadFunction: 1, WriteFunction: 2, Validator: 0,
+			FuncMap: map[uint32]string{
+				1: "public.read_fn_s3",
+				2: "public.write_fn_s3",
+			},
+		}
+		protocolUntrustedReadValidator := backup.ExternalProtocol{Oid: 1, Name: "s3", Owner: "testrole", Trusted: false, ReadFunction: 1, WriteFunction: 0, Validator: 3,
+			FuncMap: map[uint32]string{
+				1: "public.read_fn_s3",
+				3: "public.validator",
+			},
+		}
+		protocolUntrustedWriteOnly := backup.ExternalProtocol{Oid: 1, Name: "s3", Owner: "testrole", Trusted: false, ReadFunction: 0, WriteFunction: 2, Validator: 0,
+			FuncMap: map[uint32]string{
+				2: "public.write_fn_s3",
+			},
+		}
+		protocolTrustedReadWriteValidator := backup.ExternalProtocol{Oid: 1, Name: "s3", Owner: "testrole", Trusted: true, ReadFunction: 1, WriteFunction: 2, Validator: 3,
+			FuncMap: map[uint32]string{
+				1: "public.read_fn_s3",
+				2: "public.write_fn_s3",
+				3: "public.validator",
+			},
+		}
+		emptyMetadata := backup.ObjectMetadata{}
 
 		It("prints untrusted protocol with read and write function", func() {
-			protos := []backup.ExternalProtocol{protocolUntrustedReadWrite}
-
-			backup.PrintCreateExternalProtocolStatements(backupfile, toc, protos, funcInfoMap, emptyMetadataMap)
+			backup.PrintCreateExternalProtocolStatement(backupfile, toc, protocolUntrustedReadWrite, emptyMetadata)
 			testutils.ExpectEntry(toc.PredataEntries, 0, "", "", "s3", "PROTOCOL")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE PROTOCOL s3 (readfunc = public.read_fn_s3, writefunc = public.write_fn_s3);`)
 		})
 		It("prints untrusted protocol with read and validator", func() {
-			protos := []backup.ExternalProtocol{protocolUntrustedReadValidator}
-
-			backup.PrintCreateExternalProtocolStatements(backupfile, toc, protos, funcInfoMap, emptyMetadataMap)
+			backup.PrintCreateExternalProtocolStatement(backupfile, toc, protocolUntrustedReadValidator, emptyMetadata)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE PROTOCOL s3 (readfunc = public.read_fn_s3, validatorfunc = public.validator);`)
 		})
 		It("prints untrusted protocol with write function only", func() {
-			protos := []backup.ExternalProtocol{protocolUntrustedWriteOnly}
-
-			backup.PrintCreateExternalProtocolStatements(backupfile, toc, protos, funcInfoMap, emptyMetadataMap)
+			backup.PrintCreateExternalProtocolStatement(backupfile, toc, protocolUntrustedWriteOnly, emptyMetadata)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE PROTOCOL s3 (writefunc = public.write_fn_s3);`)
 		})
 		It("prints trusted protocol with read, write, and validator", func() {
-			protos := []backup.ExternalProtocol{protocolTrustedReadWriteValidator}
-
-			backup.PrintCreateExternalProtocolStatements(backupfile, toc, protos, funcInfoMap, emptyMetadataMap)
+			backup.PrintCreateExternalProtocolStatement(backupfile, toc, protocolTrustedReadWriteValidator, emptyMetadata)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TRUSTED PROTOCOL s3 (readfunc = public.read_fn_s3, writefunc = public.write_fn_s3, validatorfunc = public.validator);`)
 		})
-		It("prints multiple protocols", func() {
-			protos := []backup.ExternalProtocol{protocolUntrustedWriteOnly, protocolUntrustedReadOnly}
-
-			backup.PrintCreateExternalProtocolStatements(backupfile, toc, protos, funcInfoMap, emptyMetadataMap)
-			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE PROTOCOL s3 (writefunc = public.write_fn_s3);`, `CREATE PROTOCOL s4 (readfunc = public.read_fn_s4);`)
-		})
-		It("skips printing protocols where all functions are internal", func() {
-			protos := []backup.ExternalProtocol{protocolInternal, protocolUntrustedReadOnly}
-
-			backup.PrintCreateExternalProtocolStatements(backupfile, toc, protos, funcInfoMap, emptyMetadataMap)
-			testhelper.NotExpectRegexp(buffer, `CREATE PROTOCOL gphdfs`)
-			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE PROTOCOL s4 (readfunc = public.read_fn_s4);`)
-		})
-		It("skips printing protocols without validator where all functions are internal", func() {
-			protos := []backup.ExternalProtocol{protocolInternalReadWrite, protocolUntrustedReadOnly}
-
-			backup.PrintCreateExternalProtocolStatements(backupfile, toc, protos, funcInfoMap, emptyMetadataMap)
-			testhelper.NotExpectRegexp(buffer, `CREATE PROTOCOL gphdfs`)
-			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE PROTOCOL s4 (readfunc = public.read_fn_s4);`)
-		})
 		It("prints a protocol with privileges and an owner", func() {
-			protos := []backup.ExternalProtocol{protocolUntrustedReadWrite}
-			protoMetadataMap := testutils.DefaultMetadataMap("PROTOCOL", true, true, false)
+			protoMetadata := backup.ObjectMetadata{Privileges: []backup.ACL{backup.ACL{Grantee: "testrole", Select: true, Insert: true}}, Owner: "testrole"}
 
-			backup.PrintCreateExternalProtocolStatements(backupfile, toc, protos, funcInfoMap, protoMetadataMap)
+			backup.PrintCreateExternalProtocolStatement(backupfile, toc, protocolUntrustedReadWrite, protoMetadata)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE PROTOCOL s3 (readfunc = public.read_fn_s3, writefunc = public.write_fn_s3);
 
 

--- a/backup/predata_shared.go
+++ b/backup/predata_shared.go
@@ -464,7 +464,7 @@ func (obj ObjectMetadata) GetCommentStatement(objectName string, objectType stri
 	return commentStr
 }
 
-func PrintCreateDependentTypeAndFunctionAndTablesStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, objects []Sortable, metadataMap MetadataMap, tableDefsMap map[uint32]TableDefinition, constraints []Constraint) {
+func PrintCreateDependentTypeAndFunctionAndTablesAndProtocolsStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, objects []Sortable, metadataMap MetadataMap, tableDefsMap map[uint32]TableDefinition, constraints []Constraint) {
 	conMap := make(map[string][]Constraint)
 	for _, constraint := range constraints {
 		conMap[constraint.OwningObject] = append(conMap[constraint.OwningObject], constraint)

--- a/backup/predata_shared.go
+++ b/backup/predata_shared.go
@@ -464,7 +464,7 @@ func (obj ObjectMetadata) GetCommentStatement(objectName string, objectType stri
 	return commentStr
 }
 
-func PrintCreateDependentTypeAndFunctionAndTablesAndProtocolsStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, objects []Sortable, metadataMap MetadataMap, tableDefsMap map[uint32]TableDefinition, constraints []Constraint) {
+func PrintDependentObjectStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, objects []Sortable, metadataMap MetadataMap, tableDefsMap map[uint32]TableDefinition, constraints []Constraint) {
 	conMap := make(map[string][]Constraint)
 	for _, constraint := range constraints {
 		conMap[constraint.OwningObject] = append(conMap[constraint.OwningObject], constraint)

--- a/backup/predata_shared.go
+++ b/backup/predata_shared.go
@@ -485,6 +485,8 @@ func PrintCreateDependentTypeAndFunctionAndTablesStatements(metadataFile *utils.
 			PrintCreateFunctionStatement(metadataFile, toc, obj, metadataMap[obj.Oid])
 		case Relation:
 			PrintCreateTableStatement(metadataFile, toc, obj, tableDefsMap[obj.Oid], metadataMap[obj.Oid])
+		case ExternalProtocol:
+			PrintCreateExternalProtocolStatement(metadataFile, toc, obj, metadataMap[obj.Oid])
 		}
 	}
 }

--- a/backup/predata_shared_test.go
+++ b/backup/predata_shared_test.go
@@ -450,7 +450,7 @@ GRANT ALL ON FOREIGN SERVER foreignserver TO testrole;`)
 			structmatcher.ExpectStructsToMatch(&expected, result)
 		})
 	})
-	Describe("PrintCreateDependentTypeAndFunctionAndTablesStatements", func() {
+	Describe("PrintDependentObjectStatements", func() {
 		var (
 			objects      []backup.Sortable
 			metadataMap  backup.MetadataMap
@@ -487,7 +487,7 @@ GRANT ALL ON FOREIGN SERVER foreignserver TO testrole;`)
 			constraints := []backup.Constraint{
 				{Name: "check_constraint", ConDef: "CHECK (VALUE > 2)", OwningObject: "public.domain"},
 			}
-			backup.PrintCreateDependentTypeAndFunctionAndTablesAndProtocolsStatements(backupfile, toc, objects, metadataMap, tableDefsMap, constraints)
+			backup.PrintDependentObjectStatements(backupfile, toc, objects, metadataMap, tableDefsMap, constraints)
 			testhelper.ExpectRegexp(buffer, `
 CREATE FUNCTION public.function(integer, integer) RETURNS integer AS
 $_$SELECT $1 + $2$_$
@@ -534,7 +534,7 @@ COMMENT ON PROTOCOL ext_protocol IS 'protocol';
 		})
 		It("prints create statements for dependent types, functions, protocols, and tables (no domain constraint)", func() {
 			constraints := []backup.Constraint{}
-			backup.PrintCreateDependentTypeAndFunctionAndTablesAndProtocolsStatements(backupfile, toc, objects, metadataMap, tableDefsMap, constraints)
+			backup.PrintDependentObjectStatements(backupfile, toc, objects, metadataMap, tableDefsMap, constraints)
 			testhelper.ExpectRegexp(buffer, `
 CREATE FUNCTION public.function(integer, integer) RETURNS integer AS
 $_$SELECT $1 + $2$_$

--- a/backup/predata_shared_test.go
+++ b/backup/predata_shared_test.go
@@ -464,6 +464,12 @@ GRANT ALL ON FOREIGN SERVER foreignserver TO testrole;`)
 				backup.Type{Oid: 3, Schema: "public", Name: "composite", Type: "c", Attributes: pq.StringArray{"\tfoo integer"}, Category: "U"},
 				backup.Type{Oid: 4, Schema: "public", Name: "domain", Type: "d", BaseType: "numeric", Category: "U"},
 				backup.Relation{Oid: 5, Schema: "public", Name: "relation"},
+				backup.ExternalProtocol{Oid: 6, Name: "ext_protocol", Trusted: true, ReadFunction: 2, WriteFunction: 1, Validator: 0,
+					FuncMap: map[uint32]string{
+						1: "public.write_to_s3",
+						2: "public.read_from_s3",
+					},
+				},
 			}
 			metadataMap = backup.MetadataMap{
 				1: backup.ObjectMetadata{Comment: "function"},
@@ -471,16 +477,17 @@ GRANT ALL ON FOREIGN SERVER foreignserver TO testrole;`)
 				3: backup.ObjectMetadata{Comment: "composite type"},
 				4: backup.ObjectMetadata{Comment: "domain"},
 				5: backup.ObjectMetadata{Comment: "relation"},
+				6: backup.ObjectMetadata{Comment: "protocol"},
 			}
 			tableDefsMap = map[uint32]backup.TableDefinition{
 				5: {DistPolicy: "DISTRIBUTED RANDOMLY", ColumnDefs: []backup.ColumnDefinition{}},
 			}
 		})
-		It("prints create statements for dependent types, functions, and tables (domain has a constraint)", func() {
+		It("prints create statements for dependent types, functions, protocols, and tables (domain has a constraint)", func() {
 			constraints := []backup.Constraint{
 				{Name: "check_constraint", ConDef: "CHECK (VALUE > 2)", OwningObject: "public.domain"},
 			}
-			backup.PrintCreateDependentTypeAndFunctionAndTablesStatements(backupfile, toc, objects, metadataMap, tableDefsMap, constraints)
+			backup.PrintCreateDependentTypeAndFunctionAndTablesAndProtocolsStatements(backupfile, toc, objects, metadataMap, tableDefsMap, constraints)
 			testhelper.ExpectRegexp(buffer, `
 CREATE FUNCTION public.function(integer, integer) RETURNS integer AS
 $_$SELECT $1 + $2$_$
@@ -517,11 +524,17 @@ CREATE TABLE public.relation (
 
 
 COMMENT ON TABLE public.relation IS 'relation';
+
+
+CREATE TRUSTED PROTOCOL ext_protocol (readfunc = public.read_from_s3, writefunc = public.write_to_s3);
+
+
+COMMENT ON PROTOCOL ext_protocol IS 'protocol';
 `)
 		})
-		It("prints create statements for dependent types, functions, and tables (no domain constraint)", func() {
+		It("prints create statements for dependent types, functions, protocols, and tables (no domain constraint)", func() {
 			constraints := []backup.Constraint{}
-			backup.PrintCreateDependentTypeAndFunctionAndTablesStatements(backupfile, toc, objects, metadataMap, tableDefsMap, constraints)
+			backup.PrintCreateDependentTypeAndFunctionAndTablesAndProtocolsStatements(backupfile, toc, objects, metadataMap, tableDefsMap, constraints)
 			testhelper.ExpectRegexp(buffer, `
 CREATE FUNCTION public.function(integer, integer) RETURNS integer AS
 $_$SELECT $1 + $2$_$
@@ -557,6 +570,12 @@ CREATE TABLE public.relation (
 
 
 COMMENT ON TABLE public.relation IS 'relation';
+
+
+CREATE TRUSTED PROTOCOL ext_protocol (readfunc = public.read_from_s3, writefunc = public.write_to_s3);
+
+
+COMMENT ON PROTOCOL ext_protocol IS 'protocol';
 `)
 		})
 	})

--- a/backup/queries_externals.go
+++ b/backup/queries_externals.go
@@ -107,6 +107,8 @@ type ExternalProtocol struct {
 	ReadFunction  uint32 `db:"ptcreadfn"`
 	WriteFunction uint32 `db:"ptcwritefn"`
 	Validator     uint32 `db:"ptcvalidatorfn"`
+	DependsUpon   []string
+	FuncMap       map[uint32]string
 }
 
 func GetExternalProtocols(connection *dbconn.DBConn) []ExternalProtocol {

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -457,7 +457,7 @@ func ConstructTableDependencies(connection *dbconn.DBConn, tables []Relation, ta
 			tableOidList[i] = fmt.Sprintf("%d", table.Oid)
 		}
 	}
-	nonTableQuery := fmt.Sprintf(`
+	typeQuery := fmt.Sprintf(`
 SELECT
 	objid AS oid,
 	quote_ident(n.nspname) || '.' || quote_ident(p.typname) AS referencedobject,
@@ -468,6 +468,14 @@ JOIN pg_namespace n ON p.typnamespace = n.oid
 JOIN pg_class c ON d.objid = c.oid AND c.relkind = 'r'
 WHERE %s
 AND %s`, SchemaFilterClause("n"), ExtensionFilterClause("p"))
+	protocolQuery := fmt.Sprintf(`
+SELECT
+	objid AS oid,
+	quote_ident(ptc.ptcname) AS referencedobject,
+	'f' AS istable
+FROM pg_depend d
+JOIN pg_extprotocol ptc ON d.refobjid = ptc.oid
+AND %s`, ExtensionFilterClause("ptc"))
 	tableQuery := fmt.Sprintf(`
 SELECT
 	objid AS oid,
@@ -484,7 +492,7 @@ AND %s`, ExtensionFilterClause("p"))
 	if isTableFiltered && len(tableOidList) > 0 {
 		query = fmt.Sprintf("%s\nWHERE objid IN (%s);", tableQuery, strings.Join(tableOidList, ","))
 	} else {
-		query = fmt.Sprintf("%s\nUNION\n%s;", nonTableQuery, tableQuery)
+		query = fmt.Sprintf("%s\nUNION\n%s\nUNION\n%s;", typeQuery, protocolQuery, tableQuery)
 	}
 	results := make([]struct {
 		Oid              uint32

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -326,7 +326,7 @@ func BackupFunctionsAndTypesAndTablesAndProtocols(metadataFile *utils.FileWithBy
 	tables = ConstructTableDependencies(connectionPool, tables, tableDefs, false)
 	sortedSlice := SortFunctionsAndTypesAndTablesAndProtocolsInDependencyOrder(otherFuncs, types, tables, protocols)
 	filteredMetadata := ConstructFunctionAndTypeAndTableMetadataMap(functionMetadata, typeMetadata, relationMetadata, protoMetadata)
-	PrintCreateDependentTypeAndFunctionAndTablesStatements(metadataFile, globalTOC, sortedSlice, filteredMetadata, tableDefs, constraints)
+	PrintCreateDependentTypeAndFunctionAndTablesAndProtocolsStatements(metadataFile, globalTOC, sortedSlice, filteredMetadata, tableDefs, constraints)
 	extPartInfo, partInfoMap := GetExternalPartitionInfo(connectionPool)
 	if len(extPartInfo) > 0 {
 		gplog.Verbose("Writing EXCHANGE PARTITION statements to metadata file")
@@ -343,7 +343,7 @@ func BackupTables(metadataFile *utils.FileWithByteCount, tables []Relation, rela
 		sortable = append(sortable, table)
 	}
 	sortedSlice := TopologicalSort(sortable)
-	PrintCreateDependentTypeAndFunctionAndTablesStatements(metadataFile, globalTOC, sortedSlice, relationMetadata, tableDefs, constraints)
+	PrintCreateDependentTypeAndFunctionAndTablesAndProtocolsStatements(metadataFile, globalTOC, sortedSlice, relationMetadata, tableDefs, constraints)
 	extPartInfo, partInfoMap := GetExternalPartitionInfo(connectionPool)
 	if len(extPartInfo) > 0 {
 		gplog.Verbose("Writing EXCHANGE PARTITION statements to metadata file")

--- a/integration/predata_externals_create_test.go
+++ b/integration/predata_externals_create_test.go
@@ -97,21 +97,31 @@ var _ = Describe("backup integration create statement tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&extTable, &resultTableDef, "Oid")
 		})
 	})
-	Describe("PrintCreateExternalProtocolStatements", func() {
-		funcInfoMap := map[uint32]backup.FunctionInfo{
-			1: {QualifiedName: "public.write_to_s3", Arguments: "", IsInternal: false},
-			2: {QualifiedName: "public.read_from_s3", Arguments: "", IsInternal: false},
+	Describe("PrintCreateExternalProtocolStatement", func() {
+		protocolReadOnly := backup.ExternalProtocol{Oid: 1, Name: "s3_read", Owner: "testrole", Trusted: true, ReadFunction: 2, WriteFunction: 0, Validator: 0,
+			FuncMap: map[uint32]string{
+				1: "public.write_to_s3",
+				2: "public.read_from_s3",
+			},
 		}
-		protocolReadOnly := backup.ExternalProtocol{Oid: 1, Name: "s3_read", Owner: "testrole", Trusted: true, ReadFunction: 2, WriteFunction: 0, Validator: 0}
-		protocolWriteOnly := backup.ExternalProtocol{Oid: 1, Name: "s3_write", Owner: "testrole", Trusted: false, ReadFunction: 0, WriteFunction: 1, Validator: 0}
-		protocolReadWrite := backup.ExternalProtocol{Oid: 1, Name: "s3_read_write", Owner: "testrole", Trusted: false, ReadFunction: 2, WriteFunction: 1, Validator: 0}
-		emptyMetadataMap := backup.MetadataMap{}
+		protocolWriteOnly := backup.ExternalProtocol{Oid: 1, Name: "s3_write", Owner: "testrole", Trusted: false, ReadFunction: 0, WriteFunction: 1, Validator: 0,
+			FuncMap: map[uint32]string{
+				1: "public.write_to_s3",
+				2: "public.read_from_s3",
+			},
+		}
+		protocolReadWrite := backup.ExternalProtocol{Oid: 1, Name: "s3_read_write", Owner: "testrole", Trusted: false, ReadFunction: 2, WriteFunction: 1, Validator: 0,
+			FuncMap: map[uint32]string{
+				1: "public.write_to_s3",
+				2: "public.read_from_s3",
+			},
+		}
+		emptyMetadata := backup.ObjectMetadata{}
 
 		It("creates a trusted protocol with a read function, privileges, and an owner", func() {
-			externalProtocols := []backup.ExternalProtocol{protocolReadOnly}
-			protoMetadataMap := testutils.DefaultMetadataMap("PROTOCOL", true, true, false)
+			protoMetadata := backup.ObjectMetadata{Privileges: []backup.ACL{backup.ACL{Grantee: "testrole", Select: true, Insert: true}}, Owner: "testrole"}
 
-			backup.PrintCreateExternalProtocolStatements(backupfile, toc, externalProtocols, funcInfoMap, protoMetadataMap)
+			backup.PrintCreateExternalProtocolStatement(backupfile, toc, protocolReadOnly, protoMetadata)
 
 			testhelper.AssertQueryRuns(connection, "CREATE OR REPLACE FUNCTION public.read_from_s3() RETURNS integer AS '$libdir/gps3ext.so', 's3_import' LANGUAGE C STABLE;")
 			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.read_from_s3()")
@@ -122,12 +132,10 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultExternalProtocols := backup.GetExternalProtocols(connection)
 
 			Expect(len(resultExternalProtocols)).To(Equal(1))
-			structmatcher.ExpectStructsToMatchExcluding(&protocolReadOnly, &resultExternalProtocols[0], "Oid", "ReadFunction")
+			structmatcher.ExpectStructsToMatchExcluding(&protocolReadOnly, &resultExternalProtocols[0], "Oid", "ReadFunction", "FuncMap")
 		})
 		It("creates a protocol with a write function", func() {
-			externalProtocols := []backup.ExternalProtocol{protocolWriteOnly}
-
-			backup.PrintCreateExternalProtocolStatements(backupfile, toc, externalProtocols, funcInfoMap, emptyMetadataMap)
+			backup.PrintCreateExternalProtocolStatement(backupfile, toc, protocolWriteOnly, emptyMetadata)
 
 			testhelper.AssertQueryRuns(connection, "CREATE OR REPLACE FUNCTION public.write_to_s3() RETURNS integer AS '$libdir/gps3ext.so', 's3_export' LANGUAGE C STABLE;")
 			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.write_to_s3()")
@@ -138,12 +146,10 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultExternalProtocols := backup.GetExternalProtocols(connection)
 
 			Expect(len(resultExternalProtocols)).To(Equal(1))
-			structmatcher.ExpectStructsToMatchExcluding(&protocolWriteOnly, &resultExternalProtocols[0], "Oid", "WriteFunction")
+			structmatcher.ExpectStructsToMatchExcluding(&protocolWriteOnly, &resultExternalProtocols[0], "Oid", "WriteFunction", "FuncMap")
 		})
 		It("creates a protocol with a read and write function", func() {
-			externalProtocols := []backup.ExternalProtocol{protocolReadWrite}
-
-			backup.PrintCreateExternalProtocolStatements(backupfile, toc, externalProtocols, funcInfoMap, emptyMetadataMap)
+			backup.PrintCreateExternalProtocolStatement(backupfile, toc, protocolReadWrite, emptyMetadata)
 
 			testhelper.AssertQueryRuns(connection, "CREATE OR REPLACE FUNCTION public.read_from_s3() RETURNS integer AS '$libdir/gps3ext.so', 's3_import' LANGUAGE C STABLE;")
 			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.read_from_s3()")
@@ -157,7 +163,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultExternalProtocols := backup.GetExternalProtocols(connection)
 
 			Expect(len(resultExternalProtocols)).To(Equal(1))
-			structmatcher.ExpectStructsToMatchExcluding(&protocolReadWrite, &resultExternalProtocols[0], "Oid", "ReadFunction", "WriteFunction")
+			structmatcher.ExpectStructsToMatchExcluding(&protocolReadWrite, &resultExternalProtocols[0], "Oid", "ReadFunction", "WriteFunction", "FuncMap")
 		})
 	})
 	Describe("PrintExchangeExternalPartitionStatements", func() {

--- a/integration/predata_relations_queries_test.go
+++ b/integration/predata_relations_queries_test.go
@@ -1152,6 +1152,33 @@ FORMAT 'csv';`)
 			Expect(len(tables[0].DependsUpon)).To(Equal(0))
 			Expect(len(tables[0].Inherits)).To(Equal(0))
 		})
+		It("constructs dependencies correctly if there is one table dependent on one protocol", func() {
+			testhelper.AssertQueryRuns(connection, `CREATE FUNCTION read_from_s3() RETURNS integer
+    AS '$libdir/gps3ext.so', 's3_import'
+    LANGUAGE c STABLE NO SQL;`)
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION read_from_s3()")
+			testhelper.AssertQueryRuns(connection, `CREATE PROTOCOL s3 (readfunc = 'read_from_s3'); `)
+			defer testhelper.AssertQueryRuns(connection, "DROP PROTOCOL s3")
+			testhelper.AssertQueryRuns(connection, `CREATE EXTERNAL TABLE public.ext_tbl (
+	 i int
+ ) LOCATION (
+	 's3://192.168.0.1'
+ ) ON ALL
+ FORMAT 'csv' (delimiter E',' null E'' escape E'"' quote E'"')
+ OPTIONS ()
+ ENCODING 'UTF8';`)
+
+			defer testhelper.AssertQueryRuns(connection, "DROP EXTERNAL TABLE public.ext_tbl")
+			child.Oid = testutils.OidFromObjectName(connection, "public", "ext_tbl", backup.TYPE_RELATION)
+			tables := []backup.Relation{child}
+
+			tables = backup.ConstructTableDependencies(connection, tables, tableDefs, false)
+
+			Expect(len(tables)).To(Equal(1))
+			Expect(len(tables[0].DependsUpon)).To(Equal(1))
+			Expect(tables[0].DependsUpon[0]).To(Equal("s3"))
+			Expect(len(tables[0].Inherits)).To(Equal(0))
+		})
 	})
 	Describe("ConstructViewDependencies", func() {
 		It("constructs dependencies correctly for a view that depends on two other views", func() {


### PR DESCRIPTION
Previously, protocols were dumped after tables and functions. However,
protocols can be used in tables (and protocols are dependent on
functions). Therefore, we need to add them to the dependency logic.

Co-authored-by: Karen Huddleston <khuddleston@pivotal.io>
Co-authored-by: Chris Hajas <chajas@pivotal.io>