### PR TITLE
Manually add protocol dependencies to external tables for GPDB4

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -191,12 +191,12 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Relation, tab
 	BackupCreateSequences(metadataFile, sequences, relationMetadata)
 
 	constraints, conMetadata := RetrieveConstraints()
+	protocols, protoMetadata := RetrieveAndProcessProtocols(funcInfoMap)
 
-	BackupFunctionsAndTypesAndTables(metadataFile, otherFuncs, types, tables, functionMetadata, typeMetadata, relationMetadata, tableDefs, constraints)
+	BackupDependentObjects(metadataFile, otherFuncs, types, tables, protocols, functionMetadata, typeMetadata, relationMetadata, protoMetadata, tableDefs, constraints)
 	PrintAlterSequenceStatements(metadataFile, globalTOC, sequences, sequenceOwnerColumns)
 
 	if len(*includeSchemas) == 0 {
-		BackupProtocols(metadataFile, funcInfoMap)
 		if connectionPool.Version.AtLeast("6") {
 			BackupForeignDataWrappers(metadataFile, funcInfoMap)
 			BackupForeignServers(metadataFile)

--- a/backup/predata_externals_test.go
+++ b/backup/predata_externals_test.go
@@ -369,75 +369,85 @@ ENCODING 'UTF-8'`)
 			})
 		})
 	})
-	Describe("PrintExternalProtocolStatements", func() {
-		protocolUntrustedReadWrite := backup.ExternalProtocol{Oid: 1, Name: "s3", Owner: "testrole", Trusted: false, ReadFunction: 1, WriteFunction: 2, Validator: 0}
-		protocolUntrustedReadValidator := backup.ExternalProtocol{Oid: 1, Name: "s3", Owner: "testrole", Trusted: false, ReadFunction: 1, WriteFunction: 0, Validator: 3}
-		protocolUntrustedWriteOnly := backup.ExternalProtocol{Oid: 1, Name: "s3", Owner: "testrole", Trusted: false, ReadFunction: 0, WriteFunction: 2, Validator: 0}
-		protocolTrustedReadWriteValidator := backup.ExternalProtocol{Oid: 1, Name: "s3", Owner: "testrole", Trusted: true, ReadFunction: 1, WriteFunction: 2, Validator: 3}
+	Describe("ProcessProtocols", func() {
 		protocolUntrustedReadOnly := backup.ExternalProtocol{Oid: 1, Name: "s4", Owner: "testrole", Trusted: false, ReadFunction: 4, WriteFunction: 0, Validator: 0}
 		protocolInternal := backup.ExternalProtocol{Oid: 1, Name: "gphdfs", Owner: "testrole", Trusted: false, ReadFunction: 5, WriteFunction: 6, Validator: 7}
 		protocolInternalReadWrite := backup.ExternalProtocol{Oid: 1, Name: "gphdfs", Owner: "testrole", Trusted: false, ReadFunction: 5, WriteFunction: 6, Validator: 0}
 		funcInfoMap := map[uint32]backup.FunctionInfo{
-			1: {QualifiedName: "public.read_fn_s3", Arguments: ""},
-			2: {QualifiedName: "public.write_fn_s3", Arguments: ""},
-			3: {QualifiedName: "public.validator", Arguments: ""},
-			4: {QualifiedName: "public.read_fn_s4", Arguments: ""},
+			4: {QualifiedName: "public.read_fn_s4", Arguments: "integer, integer"},
 			5: {QualifiedName: "pg_catalog.read_internal_fn", Arguments: "", IsInternal: true},
 			6: {QualifiedName: "pg_catalog.write_internal_fn", Arguments: "", IsInternal: true},
 			7: {QualifiedName: "pg_catalog.validate_internal_fn", Arguments: "", IsInternal: true},
 		}
-		emptyMetadataMap := backup.MetadataMap{}
+		It("adds function name and dependency information to external protocols", func() {
+			protos := []backup.ExternalProtocol{protocolUntrustedReadOnly}
+			expectedFuncMap := map[uint32]string{4: "public.read_fn_s4"}
+			expectedDependencies := []string{"public.read_fn_s4(integer, integer)"}
+			resultProtos := backup.ProcessProtocols(protos, funcInfoMap)
+			Expect(resultProtos[0].FuncMap).To(Equal(expectedFuncMap))
+			Expect(resultProtos[0].DependsUpon).To(Equal(expectedDependencies))
+		})
+		It("does not include an internal protocol", func() {
+			protos := []backup.ExternalProtocol{protocolInternal, protocolUntrustedReadOnly}
+			resultProtos := backup.ProcessProtocols(protos, funcInfoMap)
+			Expect(len(resultProtos)).To(Equal(1))
+			Expect(resultProtos[0].Name).To(Equal("s4"))
+		})
+		It("does not include an internal protocol without a validator", func() {
+			protos := []backup.ExternalProtocol{protocolInternalReadWrite, protocolUntrustedReadOnly}
+			resultProtos := backup.ProcessProtocols(protos, funcInfoMap)
+			Expect(len(resultProtos)).To(Equal(1))
+			Expect(resultProtos[0].Name).To(Equal("s4"))
+		})
+	})
+	Describe("PrintExternalProtocolStatements", func() {
+		protocolUntrustedReadWrite := backup.ExternalProtocol{Oid: 1, Name: "s3", Owner: "testrole", Trusted: false, ReadFunction: 1, WriteFunction: 2, Validator: 0,
+			FuncMap: map[uint32]string{
+				1: "public.read_fn_s3",
+				2: "public.write_fn_s3",
+			},
+		}
+		protocolUntrustedReadValidator := backup.ExternalProtocol{Oid: 1, Name: "s3", Owner: "testrole", Trusted: false, ReadFunction: 1, WriteFunction: 0, Validator: 3,
+			FuncMap: map[uint32]string{
+				1: "public.read_fn_s3",
+				3: "public.validator",
+			},
+		}
+		protocolUntrustedWriteOnly := backup.ExternalProtocol{Oid: 1, Name: "s3", Owner: "testrole", Trusted: false, ReadFunction: 0, WriteFunction: 2, Validator: 0,
+			FuncMap: map[uint32]string{
+				2: "public.write_fn_s3",
+			},
+		}
+		protocolTrustedReadWriteValidator := backup.ExternalProtocol{Oid: 1, Name: "s3", Owner: "testrole", Trusted: true, ReadFunction: 1, WriteFunction: 2, Validator: 3,
+			FuncMap: map[uint32]string{
+				1: "public.read_fn_s3",
+				2: "public.write_fn_s3",
+				3: "public.validator",
+			},
+		}
+		emptyMetadata := backup.ObjectMetadata{}
 
 		It("prints untrusted protocol with read and write function", func() {
-			protos := []backup.ExternalProtocol{protocolUntrustedReadWrite}
-
-			backup.PrintCreateExternalProtocolStatements(backupfile, toc, protos, funcInfoMap, emptyMetadataMap)
+			backup.PrintCreateExternalProtocolStatement(backupfile, toc, protocolUntrustedReadWrite, emptyMetadata)
 			testutils.ExpectEntry(toc.PredataEntries, 0, "", "", "s3", "PROTOCOL")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE PROTOCOL s3 (readfunc = public.read_fn_s3, writefunc = public.write_fn_s3);`)
 		})
 		It("prints untrusted protocol with read and validator", func() {
-			protos := []backup.ExternalProtocol{protocolUntrustedReadValidator}
-
-			backup.PrintCreateExternalProtocolStatements(backupfile, toc, protos, funcInfoMap, emptyMetadataMap)
+			backup.PrintCreateExternalProtocolStatement(backupfile, toc, protocolUntrustedReadValidator, emptyMetadata)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE PROTOCOL s3 (readfunc = public.read_fn_s3, validatorfunc = public.validator);`)
 		})
 		It("prints untrusted protocol with write function only", func() {
-			protos := []backup.ExternalProtocol{protocolUntrustedWriteOnly}
-
-			backup.PrintCreateExternalProtocolStatements(backupfile, toc, protos, funcInfoMap, emptyMetadataMap)
+			backup.PrintCreateExternalProtocolStatement(backupfile, toc, protocolUntrustedWriteOnly, emptyMetadata)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE PROTOCOL s3 (writefunc = public.write_fn_s3);`)
 		})
 		It("prints trusted protocol with read, write, and validator", func() {
-			protos := []backup.ExternalProtocol{protocolTrustedReadWriteValidator}
-
-			backup.PrintCreateExternalProtocolStatements(backupfile, toc, protos, funcInfoMap, emptyMetadataMap)
+			backup.PrintCreateExternalProtocolStatement(backupfile, toc, protocolTrustedReadWriteValidator, emptyMetadata)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TRUSTED PROTOCOL s3 (readfunc = public.read_fn_s3, writefunc = public.write_fn_s3, validatorfunc = public.validator);`)
 		})
-		It("prints multiple protocols", func() {
-			protos := []backup.ExternalProtocol{protocolUntrustedWriteOnly, protocolUntrustedReadOnly}
-
-			backup.PrintCreateExternalProtocolStatements(backupfile, toc, protos, funcInfoMap, emptyMetadataMap)
-			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE PROTOCOL s3 (writefunc = public.write_fn_s3);`, `CREATE PROTOCOL s4 (readfunc = public.read_fn_s4);`)
-		})
-		It("skips printing protocols where all functions are internal", func() {
-			protos := []backup.ExternalProtocol{protocolInternal, protocolUntrustedReadOnly}
-
-			backup.PrintCreateExternalProtocolStatements(backupfile, toc, protos, funcInfoMap, emptyMetadataMap)
-			testhelper.NotExpectRegexp(buffer, `CREATE PROTOCOL gphdfs`)
-			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE PROTOCOL s4 (readfunc = public.read_fn_s4);`)
-		})
-		It("skips printing protocols without validator where all functions are internal", func() {
-			protos := []backup.ExternalProtocol{protocolInternalReadWrite, protocolUntrustedReadOnly}
-
-			backup.PrintCreateExternalProtocolStatements(backupfile, toc, protos, funcInfoMap, emptyMetadataMap)
-			testhelper.NotExpectRegexp(buffer, `CREATE PROTOCOL gphdfs`)
-			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE PROTOCOL s4 (readfunc = public.read_fn_s4);`)
-		})
 		It("prints a protocol with privileges and an owner", func() {
-			protos := []backup.ExternalProtocol{protocolUntrustedReadWrite}
-			protoMetadataMap := testutils.DefaultMetadataMap("PROTOCOL", true, true, false)
+			protoMetadata := backup.ObjectMetadata{Privileges: []backup.ACL{backup.ACL{Grantee: "testrole", Select: true, Insert: true}}, Owner: "testrole"}
 
-			backup.PrintCreateExternalProtocolStatements(backupfile, toc, protos, funcInfoMap, protoMetadataMap)
+			backup.PrintCreateExternalProtocolStatement(backupfile, toc, protocolUntrustedReadWrite, protoMetadata)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE PROTOCOL s3 (readfunc = public.read_fn_s3, writefunc = public.write_fn_s3);
 
 

--- a/backup/predata_shared.go
+++ b/backup/predata_shared.go
@@ -464,7 +464,7 @@ func (obj ObjectMetadata) GetCommentStatement(objectName string, objectType stri
 	return commentStr
 }
 
-func PrintCreateDependentTypeAndFunctionAndTablesStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, objects []Sortable, metadataMap MetadataMap, tableDefsMap map[uint32]TableDefinition, constraints []Constraint) {
+func PrintDependentObjectStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, objects []Sortable, metadataMap MetadataMap, tableDefsMap map[uint32]TableDefinition, constraints []Constraint) {
 	conMap := make(map[string][]Constraint)
 	for _, constraint := range constraints {
 		conMap[constraint.OwningObject] = append(conMap[constraint.OwningObject], constraint)
@@ -485,6 +485,8 @@ func PrintCreateDependentTypeAndFunctionAndTablesStatements(metadataFile *utils.
 			PrintCreateFunctionStatement(metadataFile, toc, obj, metadataMap[obj.Oid])
 		case Relation:
 			PrintCreateTableStatement(metadataFile, toc, obj, tableDefsMap[obj.Oid], metadataMap[obj.Oid])
+		case ExternalProtocol:
+			PrintCreateExternalProtocolStatement(metadataFile, toc, obj, metadataMap[obj.Oid])
 		}
 	}
 }

--- a/backup/predata_shared_test.go
+++ b/backup/predata_shared_test.go
@@ -450,7 +450,7 @@ GRANT ALL ON FOREIGN SERVER foreignserver TO testrole;`)
 			structmatcher.ExpectStructsToMatch(&expected, result)
 		})
 	})
-	Describe("PrintCreateDependentTypeAndFunctionAndTablesStatements", func() {
+	Describe("PrintDependentObjectStatements", func() {
 		var (
 			objects      []backup.Sortable
 			metadataMap  backup.MetadataMap
@@ -464,6 +464,12 @@ GRANT ALL ON FOREIGN SERVER foreignserver TO testrole;`)
 				backup.Type{Oid: 3, Schema: "public", Name: "composite", Type: "c", Attributes: pq.StringArray{"\tfoo integer"}, Category: "U"},
 				backup.Type{Oid: 4, Schema: "public", Name: "domain", Type: "d", BaseType: "numeric", Category: "U"},
 				backup.Relation{Oid: 5, Schema: "public", Name: "relation"},
+				backup.ExternalProtocol{Oid: 6, Name: "ext_protocol", Trusted: true, ReadFunction: 2, WriteFunction: 1, Validator: 0,
+					FuncMap: map[uint32]string{
+						1: "public.write_to_s3",
+						2: "public.read_from_s3",
+					},
+				},
 			}
 			metadataMap = backup.MetadataMap{
 				1: backup.ObjectMetadata{Comment: "function"},
@@ -471,16 +477,17 @@ GRANT ALL ON FOREIGN SERVER foreignserver TO testrole;`)
 				3: backup.ObjectMetadata{Comment: "composite type"},
 				4: backup.ObjectMetadata{Comment: "domain"},
 				5: backup.ObjectMetadata{Comment: "relation"},
+				6: backup.ObjectMetadata{Comment: "protocol"},
 			}
 			tableDefsMap = map[uint32]backup.TableDefinition{
 				5: {DistPolicy: "DISTRIBUTED RANDOMLY", ColumnDefs: []backup.ColumnDefinition{}},
 			}
 		})
-		It("prints create statements for dependent types, functions, and tables (domain has a constraint)", func() {
+		It("prints create statements for dependent types, functions, protocols, and tables (domain has a constraint)", func() {
 			constraints := []backup.Constraint{
 				{Name: "check_constraint", ConDef: "CHECK (VALUE > 2)", OwningObject: "public.domain"},
 			}
-			backup.PrintCreateDependentTypeAndFunctionAndTablesStatements(backupfile, toc, objects, metadataMap, tableDefsMap, constraints)
+			backup.PrintDependentObjectStatements(backupfile, toc, objects, metadataMap, tableDefsMap, constraints)
 			testhelper.ExpectRegexp(buffer, `
 CREATE FUNCTION public.function(integer, integer) RETURNS integer AS
 $_$SELECT $1 + $2$_$
@@ -517,11 +524,17 @@ CREATE TABLE public.relation (
 
 
 COMMENT ON TABLE public.relation IS 'relation';
+
+
+CREATE TRUSTED PROTOCOL ext_protocol (readfunc = public.read_from_s3, writefunc = public.write_to_s3);
+
+
+COMMENT ON PROTOCOL ext_protocol IS 'protocol';
 `)
 		})
-		It("prints create statements for dependent types, functions, and tables (no domain constraint)", func() {
+		It("prints create statements for dependent types, functions, protocols, and tables (no domain constraint)", func() {
 			constraints := []backup.Constraint{}
-			backup.PrintCreateDependentTypeAndFunctionAndTablesStatements(backupfile, toc, objects, metadataMap, tableDefsMap, constraints)
+			backup.PrintDependentObjectStatements(backupfile, toc, objects, metadataMap, tableDefsMap, constraints)
 			testhelper.ExpectRegexp(buffer, `
 CREATE FUNCTION public.function(integer, integer) RETURNS integer AS
 $_$SELECT $1 + $2$_$
@@ -557,6 +570,12 @@ CREATE TABLE public.relation (
 
 
 COMMENT ON TABLE public.relation IS 'relation';
+
+
+CREATE TRUSTED PROTOCOL ext_protocol (readfunc = public.read_from_s3, writefunc = public.write_to_s3);
+
+
+COMMENT ON PROTOCOL ext_protocol IS 'protocol';
 `)
 		})
 	})

--- a/backup/queries_externals.go
+++ b/backup/queries_externals.go
@@ -107,6 +107,8 @@ type ExternalProtocol struct {
 	ReadFunction  uint32 `db:"ptcreadfn"`
 	WriteFunction uint32 `db:"ptcwritefn"`
 	Validator     uint32 `db:"ptcvalidatorfn"`
+	DependsUpon   []string
+	FuncMap       map[uint32]string
 }
 
 func GetExternalProtocols(connection *dbconn.DBConn) []ExternalProtocol {

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -446,7 +446,7 @@ type Dependency struct {
 	ReferencedObject string
 }
 
-func ConstructTableDependencies(connection *dbconn.DBConn, tables []Relation, tableDefs map[uint32]TableDefinition, isTableFiltered bool) []Relation {
+func ConstructTableDependencies(connection *dbconn.DBConn, tables []Relation, tableDefs map[uint32]TableDefinition, protocols []ExternalProtocol, isTableFiltered bool) []Relation {
 	var tableNameSet *utils.FilterSet
 	var tableOidList []string
 	if isTableFiltered {
@@ -518,6 +518,10 @@ AND %s`, ExtensionFilterClause("p"))
 	for i := 0; i < len(tables); i++ {
 		tables[i].DependsUpon = dependencyMap[tables[i].Oid]
 		tables[i].Inherits = inheritanceMap[tables[i].Oid]
+	}
+
+	if connection.Version.Before("5") {
+		tables = AddProtocolDependenciesForGPDB4(tables, tableDefs, protocols)
 	}
 	return tables
 }

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -457,7 +457,7 @@ func ConstructTableDependencies(connection *dbconn.DBConn, tables []Relation, ta
 			tableOidList[i] = fmt.Sprintf("%d", table.Oid)
 		}
 	}
-	nonTableQuery := fmt.Sprintf(`
+	typeQuery := fmt.Sprintf(`
 SELECT
 	objid AS oid,
 	quote_ident(n.nspname) || '.' || quote_ident(p.typname) AS referencedobject,
@@ -468,6 +468,14 @@ JOIN pg_namespace n ON p.typnamespace = n.oid
 JOIN pg_class c ON d.objid = c.oid AND c.relkind = 'r'
 WHERE %s
 AND %s`, SchemaFilterClause("n"), ExtensionFilterClause("p"))
+	protocolQuery := fmt.Sprintf(`
+SELECT
+	objid AS oid,
+	quote_ident(ptc.ptcname) AS referencedobject,
+	'f' AS istable
+FROM pg_depend d
+JOIN pg_extprotocol ptc ON d.refobjid = ptc.oid
+AND %s`, ExtensionFilterClause("ptc"))
 	tableQuery := fmt.Sprintf(`
 SELECT
 	objid AS oid,
@@ -484,7 +492,7 @@ AND %s`, ExtensionFilterClause("p"))
 	if isTableFiltered && len(tableOidList) > 0 {
 		query = fmt.Sprintf("%s\nWHERE objid IN (%s);", tableQuery, strings.Join(tableOidList, ","))
 	} else {
-		query = fmt.Sprintf("%s\nUNION\n%s;", nonTableQuery, tableQuery)
+		query = fmt.Sprintf("%s\nUNION\n%s\nUNION\n%s;", typeQuery, protocolQuery, tableQuery)
 	}
 	results := make([]struct {
 		Oid              uint32

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -323,7 +323,7 @@ func BackupDependentObjects(metadataFile *utils.FileWithByteCount, otherFuncs []
 	gplog.Verbose("Writing CREATE TYPE statements for base, composite, and domain types to metadata file")
 	gplog.Verbose("Writing CREATE TABLE statements to metadata file")
 	gplog.Verbose("Writing CREATE PROTOCOL statements to metadata file")
-	tables = ConstructTableDependencies(connectionPool, tables, tableDefs, false)
+	tables = ConstructTableDependencies(connectionPool, tables, tableDefs, protocols, false)
 	sortedSlice := SortObjectsInDependencyOrder(otherFuncs, types, tables, protocols)
 	filteredMetadata := ConstructDependentObjectMetadataMap(functionMetadata, typeMetadata, relationMetadata, protoMetadata)
 	PrintDependentObjectStatements(metadataFile, globalTOC, sortedSlice, filteredMetadata, tableDefs, constraints)
@@ -337,7 +337,7 @@ func BackupDependentObjects(metadataFile *utils.FileWithByteCount, otherFuncs []
 // This function should be used only with a table-only backup.  For an unfiltered backup, the above function is used.
 func BackupTables(metadataFile *utils.FileWithByteCount, tables []Relation, relationMetadata MetadataMap, tableDefs map[uint32]TableDefinition, constraints []Constraint) {
 	gplog.Verbose("Writing CREATE TABLE statements to metadata file")
-	tables = ConstructTableDependencies(connectionPool, tables, tableDefs, true)
+	tables = ConstructTableDependencies(connectionPool, tables, tableDefs, []ExternalProtocol{}, true)
 	sortable := make([]Sortable, 0)
 	for _, table := range tables {
 		sortable = append(sortable, table)

--- a/integration/predata_externals_create_test.go
+++ b/integration/predata_externals_create_test.go
@@ -97,21 +97,31 @@ var _ = Describe("backup integration create statement tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&extTable, &resultTableDef, "Oid")
 		})
 	})
-	Describe("PrintCreateExternalProtocolStatements", func() {
-		funcInfoMap := map[uint32]backup.FunctionInfo{
-			1: {QualifiedName: "public.write_to_s3", Arguments: "", IsInternal: false},
-			2: {QualifiedName: "public.read_from_s3", Arguments: "", IsInternal: false},
+	Describe("PrintCreateExternalProtocolStatement", func() {
+		protocolReadOnly := backup.ExternalProtocol{Oid: 1, Name: "s3_read", Owner: "testrole", Trusted: true, ReadFunction: 2, WriteFunction: 0, Validator: 0,
+			FuncMap: map[uint32]string{
+				1: "public.write_to_s3",
+				2: "public.read_from_s3",
+			},
 		}
-		protocolReadOnly := backup.ExternalProtocol{Oid: 1, Name: "s3_read", Owner: "testrole", Trusted: true, ReadFunction: 2, WriteFunction: 0, Validator: 0}
-		protocolWriteOnly := backup.ExternalProtocol{Oid: 1, Name: "s3_write", Owner: "testrole", Trusted: false, ReadFunction: 0, WriteFunction: 1, Validator: 0}
-		protocolReadWrite := backup.ExternalProtocol{Oid: 1, Name: "s3_read_write", Owner: "testrole", Trusted: false, ReadFunction: 2, WriteFunction: 1, Validator: 0}
-		emptyMetadataMap := backup.MetadataMap{}
+		protocolWriteOnly := backup.ExternalProtocol{Oid: 1, Name: "s3_write", Owner: "testrole", Trusted: false, ReadFunction: 0, WriteFunction: 1, Validator: 0,
+			FuncMap: map[uint32]string{
+				1: "public.write_to_s3",
+				2: "public.read_from_s3",
+			},
+		}
+		protocolReadWrite := backup.ExternalProtocol{Oid: 1, Name: "s3_read_write", Owner: "testrole", Trusted: false, ReadFunction: 2, WriteFunction: 1, Validator: 0,
+			FuncMap: map[uint32]string{
+				1: "public.write_to_s3",
+				2: "public.read_from_s3",
+			},
+		}
+		emptyMetadata := backup.ObjectMetadata{}
 
 		It("creates a trusted protocol with a read function, privileges, and an owner", func() {
-			externalProtocols := []backup.ExternalProtocol{protocolReadOnly}
-			protoMetadataMap := testutils.DefaultMetadataMap("PROTOCOL", true, true, false)
+			protoMetadata := backup.ObjectMetadata{Privileges: []backup.ACL{backup.ACL{Grantee: "testrole", Select: true, Insert: true}}, Owner: "testrole"}
 
-			backup.PrintCreateExternalProtocolStatements(backupfile, toc, externalProtocols, funcInfoMap, protoMetadataMap)
+			backup.PrintCreateExternalProtocolStatement(backupfile, toc, protocolReadOnly, protoMetadata)
 
 			testhelper.AssertQueryRuns(connection, "CREATE OR REPLACE FUNCTION public.read_from_s3() RETURNS integer AS '$libdir/gps3ext.so', 's3_import' LANGUAGE C STABLE;")
 			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.read_from_s3()")
@@ -122,12 +132,10 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultExternalProtocols := backup.GetExternalProtocols(connection)
 
 			Expect(len(resultExternalProtocols)).To(Equal(1))
-			structmatcher.ExpectStructsToMatchExcluding(&protocolReadOnly, &resultExternalProtocols[0], "Oid", "ReadFunction")
+			structmatcher.ExpectStructsToMatchExcluding(&protocolReadOnly, &resultExternalProtocols[0], "Oid", "ReadFunction", "FuncMap")
 		})
 		It("creates a protocol with a write function", func() {
-			externalProtocols := []backup.ExternalProtocol{protocolWriteOnly}
-
-			backup.PrintCreateExternalProtocolStatements(backupfile, toc, externalProtocols, funcInfoMap, emptyMetadataMap)
+			backup.PrintCreateExternalProtocolStatement(backupfile, toc, protocolWriteOnly, emptyMetadata)
 
 			testhelper.AssertQueryRuns(connection, "CREATE OR REPLACE FUNCTION public.write_to_s3() RETURNS integer AS '$libdir/gps3ext.so', 's3_export' LANGUAGE C STABLE;")
 			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.write_to_s3()")
@@ -138,12 +146,10 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultExternalProtocols := backup.GetExternalProtocols(connection)
 
 			Expect(len(resultExternalProtocols)).To(Equal(1))
-			structmatcher.ExpectStructsToMatchExcluding(&protocolWriteOnly, &resultExternalProtocols[0], "Oid", "WriteFunction")
+			structmatcher.ExpectStructsToMatchExcluding(&protocolWriteOnly, &resultExternalProtocols[0], "Oid", "WriteFunction", "FuncMap")
 		})
 		It("creates a protocol with a read and write function", func() {
-			externalProtocols := []backup.ExternalProtocol{protocolReadWrite}
-
-			backup.PrintCreateExternalProtocolStatements(backupfile, toc, externalProtocols, funcInfoMap, emptyMetadataMap)
+			backup.PrintCreateExternalProtocolStatement(backupfile, toc, protocolReadWrite, emptyMetadata)
 
 			testhelper.AssertQueryRuns(connection, "CREATE OR REPLACE FUNCTION public.read_from_s3() RETURNS integer AS '$libdir/gps3ext.so', 's3_import' LANGUAGE C STABLE;")
 			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION public.read_from_s3()")
@@ -157,7 +163,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultExternalProtocols := backup.GetExternalProtocols(connection)
 
 			Expect(len(resultExternalProtocols)).To(Equal(1))
-			structmatcher.ExpectStructsToMatchExcluding(&protocolReadWrite, &resultExternalProtocols[0], "Oid", "ReadFunction", "WriteFunction")
+			structmatcher.ExpectStructsToMatchExcluding(&protocolReadWrite, &resultExternalProtocols[0], "Oid", "ReadFunction", "WriteFunction", "FuncMap")
 		})
 	})
 	Describe("PrintExchangeExternalPartitionStatements", func() {

--- a/integration/predata_relations_create_test.go
+++ b/integration/predata_relations_create_test.go
@@ -207,7 +207,7 @@ SET SUBPARTITION TEMPLATE  ` + `
 			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.testtable")
 			testTable.Oid = testutils.OidFromObjectName(connection, "public", "testtable", backup.TYPE_RELATION)
 			tables := []backup.Relation{testTable}
-			tables = backup.ConstructTableDependencies(connection, tables, tableDefs, false)
+			tables = backup.ConstructTableDependencies(connection, tables, tableDefs, []backup.ExternalProtocol{}, false)
 
 			Expect(len(tables)).To(Equal(1))
 			Expect(len(tables[0].DependsUpon)).To(Equal(1))
@@ -230,7 +230,7 @@ SET SUBPARTITION TEMPLATE  ` + `
 			defer testhelper.AssertQueryRuns(connection, "DROP TABLE public.testtable")
 			testTable.Oid = testutils.OidFromObjectName(connection, "public", "testtable", backup.TYPE_RELATION)
 			tables := []backup.Relation{testTable}
-			tables = backup.ConstructTableDependencies(connection, tables, tableDefs, false)
+			tables = backup.ConstructTableDependencies(connection, tables, tableDefs, []backup.ExternalProtocol{}, false)
 
 			sort.Strings(tables[0].DependsUpon)
 			sort.Strings(tables[0].Inherits)

--- a/integration/predata_relations_queries_test.go
+++ b/integration/predata_relations_queries_test.go
@@ -1152,6 +1152,32 @@ FORMAT 'csv';`)
 			Expect(len(tables[0].DependsUpon)).To(Equal(0))
 			Expect(len(tables[0].Inherits)).To(Equal(0))
 		})
+		It("constructs dependencies correctly if there is one table dependent on one protocol", func() {
+			testhelper.AssertQueryRuns(connection, `CREATE FUNCTION read_from_s3() RETURNS integer
+    AS '$libdir/gps3ext.so', 's3_import'
+    LANGUAGE c STABLE NO SQL;`)
+			defer testhelper.AssertQueryRuns(connection, "DROP FUNCTION read_from_s3()")
+			testhelper.AssertQueryRuns(connection, `CREATE PROTOCOL s3 (readfunc = 'read_from_s3'); `)
+			defer testhelper.AssertQueryRuns(connection, "DROP PROTOCOL s3")
+			testhelper.AssertQueryRuns(connection, `CREATE EXTERNAL TABLE public.ext_tbl (
+	 i int
+ ) LOCATION (
+	 's3://192.168.0.1'
+ )
+ FORMAT 'csv' (delimiter E',' null E'' escape E'"' quote E'"')
+ ENCODING 'UTF8';`)
+
+			defer testhelper.AssertQueryRuns(connection, "DROP EXTERNAL TABLE public.ext_tbl")
+			child.Oid = testutils.OidFromObjectName(connection, "public", "ext_tbl", backup.TYPE_RELATION)
+			tables := []backup.Relation{child}
+
+			tables = backup.ConstructTableDependencies(connection, tables, tableDefs, false)
+
+			Expect(len(tables)).To(Equal(1))
+			Expect(len(tables[0].DependsUpon)).To(Equal(1))
+			Expect(tables[0].DependsUpon[0]).To(Equal("s3"))
+			Expect(len(tables[0].Inherits)).To(Equal(0))
+		})
 	})
 	Describe("ConstructViewDependencies", func() {
 		It("constructs dependencies correctly for a view that depends on two other views", func() {

--- a/integration/predata_relations_queries_test.go
+++ b/integration/predata_relations_queries_test.go
@@ -1043,7 +1043,7 @@ SET SUBPARTITION TEMPLATE
 			child.Oid = testutils.OidFromObjectName(connection, "public", "child", backup.TYPE_RELATION)
 			tables := []backup.Relation{child}
 
-			tables = backup.ConstructTableDependencies(connection, tables, tableDefs, false)
+			tables = backup.ConstructTableDependencies(connection, tables, tableDefs, []backup.ExternalProtocol{}, false)
 
 			Expect(len(tables)).To(Equal(1))
 			Expect(len(tables[0].DependsUpon)).To(Equal(1))
@@ -1063,7 +1063,7 @@ SET SUBPARTITION TEMPLATE
 			childTwo.Oid = testutils.OidFromObjectName(connection, "public", "child_two", backup.TYPE_RELATION)
 			tables := []backup.Relation{childOne, childTwo}
 
-			tables = backup.ConstructTableDependencies(connection, tables, tableDefs, false)
+			tables = backup.ConstructTableDependencies(connection, tables, tableDefs, []backup.ExternalProtocol{}, false)
 
 			Expect(len(tables)).To(Equal(2))
 			Expect(len(tables[0].DependsUpon)).To(Equal(1))
@@ -1086,7 +1086,7 @@ SET SUBPARTITION TEMPLATE
 			child.Oid = testutils.OidFromObjectName(connection, "public", "child", backup.TYPE_RELATION)
 			tables := []backup.Relation{child}
 
-			tables = backup.ConstructTableDependencies(connection, tables, tableDefs, false)
+			tables = backup.ConstructTableDependencies(connection, tables, tableDefs, []backup.ExternalProtocol{}, false)
 
 			sort.Strings(tables[0].DependsUpon)
 			sort.Strings(tables[0].Inherits)
@@ -1100,12 +1100,12 @@ SET SUBPARTITION TEMPLATE
 		})
 		It("constructs dependencies correctly if there are no table dependencies", func() {
 			tables := []backup.Relation{}
-			tables = backup.ConstructTableDependencies(connection, tables, tableDefs, false)
+			tables = backup.ConstructTableDependencies(connection, tables, tableDefs, []backup.ExternalProtocol{}, false)
 			Expect(len(tables)).To(Equal(0))
 		})
 		It("constructs dependencies correctly if there are no table dependencies while filtering", func() {
 			tables := []backup.Relation{}
-			tables = backup.ConstructTableDependencies(connection, tables, tableDefs, true)
+			tables = backup.ConstructTableDependencies(connection, tables, tableDefs, []backup.ExternalProtocol{}, true)
 			Expect(len(tables)).To(Equal(0))
 		})
 		It("constructs dependencies correctly if there are two dependent tables but one is not in the backup set", func() {
@@ -1119,7 +1119,7 @@ SET SUBPARTITION TEMPLATE
 			childOne.Oid = testutils.OidFromObjectName(connection, "public", "child_one", backup.TYPE_RELATION)
 			tables := []backup.Relation{childOne}
 
-			tables = backup.ConstructTableDependencies(connection, tables, tableDefs, true)
+			tables = backup.ConstructTableDependencies(connection, tables, tableDefs, []backup.ExternalProtocol{}, true)
 
 			Expect(len(tables)).To(Equal(1))
 			Expect(len(tables[0].DependsUpon)).To(Equal(0))
@@ -1146,7 +1146,7 @@ FORMAT 'csv';`)
 			tables := []backup.Relation{partition}
 			partTableDefs := map[uint32]backup.TableDefinition{partition.Oid: {IsExternal: true, PartitionType: "l"}}
 
-			tables = backup.ConstructTableDependencies(connection, tables, partTableDefs, false)
+			tables = backup.ConstructTableDependencies(connection, tables, partTableDefs, []backup.ExternalProtocol{}, false)
 
 			Expect(len(tables)).To(Equal(1))
 			Expect(len(tables[0].DependsUpon)).To(Equal(0))
@@ -1171,7 +1171,9 @@ FORMAT 'csv';`)
 			child.Oid = testutils.OidFromObjectName(connection, "public", "ext_tbl", backup.TYPE_RELATION)
 			tables := []backup.Relation{child}
 
-			tables = backup.ConstructTableDependencies(connection, tables, tableDefs, false)
+			tableOid := testutils.OidFromObjectName(connection, "public", "ext_tbl", backup.TYPE_RELATION)
+			tableDef := backup.TableDefinition{ExtTableDef: backup.ExternalTableDefinition{Location: "s3://192.168.0.1"}}
+			tables = backup.ConstructTableDependencies(connection, tables, map[uint32]backup.TableDefinition{tableOid: tableDef}, []backup.ExternalProtocol{{Name: "s3"}}, false)
 
 			Expect(len(tables)).To(Equal(1))
 			Expect(len(tables[0].DependsUpon)).To(Equal(1))


### PR DESCRIPTION
This builds upon the protocol dependencies that had been reverted.

In GPDB4, there is no entry in pg_depend that maps an external table to
its corresponding protocol. While this was fixed in GPDB5, we need to
work around this limitation in GPDB4 by manually adding the dependency.