### PR TITLE
Add concourse job for end_to_end tests using gpbackup 1.0.0 and latest restore

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -187,10 +187,10 @@
   version = "v1.0.22"
 
 [[projects]]
+  branch = "v2"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
-  version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ build :
 		go build -tags '$(BACKUP)' $(GOFLAGS) -o $(BIN_DIR)/$(BACKUP) -ldflags $(BACKUP_VERSION_STR)
 		go build -tags '$(RESTORE)' $(GOFLAGS) -o $(BIN_DIR)/$(RESTORE) -ldflags $(RESTORE_VERSION_STR)
 		go build -tags '$(HELPER)' $(GOFLAGS) -o $(BIN_DIR)/$(HELPER) -ldflags $(HELPER_VERSION_STR)
-		@$(MAKE) install_helper
+		@$(MAKE) install_helper helper_path=$(BIN_DIR)/$(HELPER)
 
 build_linux :
 		env GOOS=linux GOARCH=amd64 go build -tags '$(BACKUP)' $(GOFLAGS) -o $(BACKUP) -ldflags $(BACKUP_VERSION_STR)
@@ -70,7 +70,7 @@ build_mac :
 install_helper :
 		@psql -t -d template1 -c 'select distinct hostname from gp_segment_configuration where content != -1' > /tmp/seg_hosts 2>/dev/null; \
 		if [ $$? -eq 0 ]; then \
-			gpscp -f /tmp/seg_hosts $(BIN_DIR)/$(HELPER) =:$(GPHOME)/bin/$(HELPER); \
+			gpscp -f /tmp/seg_hosts $(helper_path) =:$(GPHOME)/bin/$(HELPER); \
 			if [ $$? -eq 0 ]; then \
 				echo 'Successfully copied gpbackup_helper to $(GPHOME) on all segments'; \
 			else \

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ GOFLAGS :=
 dependencies :
 		go get github.com/alecthomas/gometalinter
 		gometalinter --install
-		go get github.com/golang/dep/cmd/dep
+		curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 		dep ensure
 		@cd vendor/golang.org/x/tools/cmd/goimports; go install .
 		@cd vendor/github.com/onsi/ginkgo/ginkgo; go install .

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -582,6 +582,69 @@ jobs:
   ensure:
     <<: *set_failed
 
+- name: backup-1.0.0-restore-latest
+  plan:
+  - aggregate:
+    - get: gpbackup
+      trigger: true
+    - get: bin_gpdb_5x_stable
+    - get: ccp_src
+    - get: gpdb_src
+  - put: terraform
+    params:
+      <<: *ccp_default_params
+      vars:
+        <<: *ccp_default_vars
+  - task: gen_cluster
+    params:
+      <<: *ccp_gen_cluster_default_params
+    file: ccp_src/ci/tasks/gen_cluster.yml
+    input_mapping:
+      gpdb_binary: bin_gpdb_5x_stable
+      gpdb_src: gpdb_src
+  - task: gpinitsystem
+    file: ccp_src/ci/tasks/gpinitsystem.yml
+  - task: setup-centos-env
+    file: gpbackup/ci/tasks/setup-centos-env.yml
+  - task: integration-tests
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: pivotaldata/centos-gpdb-dev
+          tag: '6-gcc6.2-llvm3.7'
+      inputs:
+      - name: gpbackup
+        path: go/src/github.com/greenplum-db/gpbackup
+      run:
+        path: "sh"
+        args:
+        - -exc
+        - |
+          set -ex
+
+          ccp_src/scripts/setup_ssh_to_cluster.sh
+
+          cat <<SCRIPT > /tmp/run_tests.bash
+          set -ex
+          source env.sh
+
+          cd \$GOPATH/src/github.com/greenplum-db/gpbackup
+          export USE_OLD_BACKUP_VERSION=true
+          make end_to_end
+          SCRIPT
+
+          chmod +x /tmp/run_tests.bash
+          scp /tmp/run_tests.bash mdw:/home/gpadmin/run_tests.bash
+          ssh -t mdw "bash /home/gpadmin/run_tests.bash"
+    on_success:
+      <<: *ccp_destroy
+    on_failure:
+      *slack_alert
+  ensure:
+    <<: *set_failed
+
 - name: scale-master
   plan:
   - aggregate:
@@ -700,6 +763,7 @@ jobs:
        - integrations-GPDB5
        - integrations-GPDB4.3
        - integrations-GPDB5-sles
+       - backup-1.0.0-restore-latest
        - s3_plugin_tests
        - ddboost_plugin_tests
     - get: gpdb_release

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -88,7 +88,7 @@ func buildOldBinaries() (string, string) {
 	os.Chdir("..")
 	err := exec.Command("git", "checkout", "1.0.0").Run()
 	Expect(err).ShouldNot(HaveOccurred())
-	err = exec.Command("make", "depend").Run()
+	err = exec.Command("dep", "ensure").Run()
 	Expect(err).ShouldNot(HaveOccurred())
 	gpbackupOldPath, err := gexec.Build("github.com/greenplum-db/gpbackup", "-tags", "gpbackup", "-ldflags", "-X github.com/greenplum-db/gpbackup/backup.version=1.0.0")
 	Expect(err).ShouldNot(HaveOccurred())
@@ -96,7 +96,7 @@ func buildOldBinaries() (string, string) {
 	Expect(err).ShouldNot(HaveOccurred())
 	err = exec.Command("git", "checkout", "-").Run()
 	Expect(err).ShouldNot(HaveOccurred())
-	err = exec.Command("make", "depend").Run()
+	err = exec.Command("dep", "ensure").Run()
 	Expect(err).ShouldNot(HaveOccurred())
 	os.Chdir("end_to_end")
 	return gpbackupOldPath, gpbackupHelperOldPath


### PR DESCRIPTION
This will help us ensure that the changes we make to gprestore will not break our ability to restore backups taken with an older version of gpbackup.

This uses the USE_OLD_BACKUP_VERSION environment variable to tell the tests to run with the old version. If the variable is false, the tests will run as before. The suite does `git checkout 1.0.0`, builds the binaries, and installs, then checks out back to latest. We need to reinstall the two versions of gpbackup_helper between every backup and restore because the utilities simply use the version located in $GPHOME/bin and it needs to be the same version as backup/restore.

We skip running some tests because features were not supported or changed. The --include/exclude-table{file} tests would fail because we previously didn't support including/excluding sequences and views.