### PR TITLE
Modify how we print Owner for views and sequences

### DIFF
--- a/backup/predata_shared.go
+++ b/backup/predata_shared.go
@@ -435,11 +435,8 @@ func (obj ObjectMetadata) GetPrivilegesStatements(objectName string, objectType 
 }
 
 func (obj ObjectMetadata) GetOwnerStatement(objectName string, objectType string) string {
-	if objectType == "VIEW" {
-		return ""
-	}
 	typeStr := objectType
-	if objectType == "SEQUENCE" {
+	if connectionPool.Version.Before("6") && (objectType == "SEQUENCE" || objectType == "VIEW") {
 		typeStr = "TABLE"
 	} else if objectType == "FOREIGN SERVER" {
 		typeStr = "SERVER"

--- a/backup/predata_shared_test.go
+++ b/backup/predata_shared_test.go
@@ -346,6 +346,40 @@ REVOKE ALL ON FOREIGN SERVER foreignserver FROM PUBLIC;
 REVOKE ALL ON FOREIGN SERVER foreignserver FROM testrole;
 GRANT ALL ON FOREIGN SERVER foreignserver TO testrole;`)
 		})
+		Context("Views and sequences have owners", func() {
+			objectMetadata := backup.ObjectMetadata{Owner: "testrole"}
+			AfterEach(func() {
+				testutils.SetDBVersion(connectionPool, "5.1.0")
+			})
+			It("prints an ALTER TABLE ... OWNER TO statement to set the owner for a sequence if version < 6", func() {
+				testutils.SetDBVersion(connectionPool, "5.0.0")
+				backup.PrintObjectMetadata(backupfile, objectMetadata, "public.sequencename", "SEQUENCE")
+				testhelper.ExpectRegexp(buffer, `
+
+ALTER TABLE public.sequencename OWNER TO testrole;`)
+			})
+			It("prints an ALTER TABLE ... OWNER TO statement to set the owner for a view if version < 6", func() {
+				testutils.SetDBVersion(connectionPool, "5.0.0")
+				backup.PrintObjectMetadata(backupfile, objectMetadata, "public.viewname", "VIEW")
+				testhelper.ExpectRegexp(buffer, `
+
+ALTER TABLE public.viewname OWNER TO testrole;`)
+			})
+			It("prints an ALTER SEQUENCE ... OWNER TO statement to set the owner for a sequence if version >= 6", func() {
+				testutils.SetDBVersion(connectionPool, "6.0.0")
+				backup.PrintObjectMetadata(backupfile, objectMetadata, "public.sequencename", "SEQUENCE")
+				testhelper.ExpectRegexp(buffer, `
+
+ALTER SEQUENCE public.sequencename OWNER TO testrole;`)
+			})
+			It("prints an ALTER VIEW ... OWNER TO statement to set the owner for a view if version >= 6", func() {
+				testutils.SetDBVersion(connectionPool, "6.0.0")
+				backup.PrintObjectMetadata(backupfile, objectMetadata, "public.viewname", "VIEW")
+				testhelper.ExpectRegexp(buffer, `
+
+ALTER VIEW public.viewname OWNER TO testrole;`)
+			})
+		})
 	})
 	Describe("ConstructMetadataMap", func() {
 		object1A := backup.MetadataQueryStruct{Oid: 1, Privileges: sql.NullString{String: "gpadmin=r/gpadmin", Valid: true}, Kind: "", Owner: "testrole", Comment: ""}


### PR DESCRIPTION
* Print owner for views in all versions (we weren't doing this before)
* Print ALTER SEQUENCE/VIEW for sequences and views in 6+ but ALTER TABLE
before that

Authored-by: Karen Huddleston <khuddleston@pivotal.io>