### PR TITLE
Refactor global flag variables to single cmdFlags var in gpbackup and gprestore

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -17,30 +17,32 @@ import (
  * The flag variables, and setter functions for them, are in global_variables.go.
  */
 func initializeFlags(cmd *cobra.Command) {
-	backupDir = cmd.Flags().String("backup-dir", "", "The absolute path of the directory to which all backup files will be written")
-	compressionLevel = cmd.Flags().Int("compression-level", 0, "Level of compression to use during data backup. Valid values are between 1 and 9.")
-	dataOnly = cmd.Flags().Bool("data-only", false, "Only back up data, do not back up metadata")
-	dbname = cmd.Flags().String("dbname", "", "The database to be backed up")
-	debug = cmd.Flags().Bool("debug", false, "Print verbose and debug log messages")
-	excludeSchemas = cmd.Flags().StringSlice("exclude-schema", []string{}, "Back up all metadata except objects in the specified schema(s). --exclude-schema can be specified multiple times.")
-	excludeRelations = cmd.Flags().StringSlice("exclude-table", []string{}, "Back up all metadata except the specified table(s). --exclude-table can be specified multiple times.")
-	excludeRelationFile = cmd.Flags().String("exclude-table-file", "", "A file containing a list of fully-qualified tables to be excluded from the backup")
+	cmd.Flags().String(BACKUP_DIR, "", "The absolute path of the directory to which all backup files will be written")
+	cmd.Flags().Int(COMPRESSION_LEVEL, 0, "Level of compression to use during data backup. Valid values are between 1 and 9.")
+	cmd.Flags().Bool(DATA_ONLY, false, "Only back up data, do not back up metadata")
+	cmd.Flags().String(DBNAME, "", "The database to be backed up")
+	cmd.Flags().Bool(DEBUG, false, "Print verbose and debug log messages")
+	cmd.Flags().StringSlice(EXCLUDE_SCHEMA, []string{}, "Back up all metadata except objects in the specified schema(s). --exclude-schema can be specified multiple times.")
+	cmd.Flags().StringSlice(EXCLUDE_RELATION, []string{}, "Back up all metadata except the specified table(s). --exclude-table can be specified multiple times.")
+	cmd.Flags().String(EXCLUDE_RELATION_FILE, "", "A file containing a list of fully-qualified tables to be excluded from the backup")
 	cmd.Flags().Bool("help", false, "Help for gpbackup")
-	includeSchemas = cmd.Flags().StringSlice("include-schema", []string{}, "Back up only the specified schema(s). --include-schema can be specified multiple times.")
-	includeRelations = cmd.Flags().StringSlice("include-table", []string{}, "Back up only the specified table(s). --include-table can be specified multiple times.")
-	includeRelationFile = cmd.Flags().String("include-table-file", "", "A file containing a list of fully-qualified tables to be included in the backup")
-	numJobs = cmd.Flags().Int("jobs", 1, "The number of parallel connections to use when backing up data")
-	leafPartitionData = cmd.Flags().Bool("leaf-partition-data", false, "For partition tables, create one data file per leaf partition instead of one data file for the whole table")
-	metadataOnly = cmd.Flags().Bool("metadata-only", false, "Only back up metadata, do not back up data")
-	noCompression = cmd.Flags().Bool("no-compression", false, "Disable compression of data files")
-	pluginConfigFile = cmd.Flags().String("plugin-config", "", "The configuration file to use for a plugin")
+	cmd.Flags().StringSlice(INCLUDE_SCHEMA, []string{}, "Back up only the specified schema(s). --include-schema can be specified multiple times.")
+	cmd.Flags().StringSlice(INCLUDE_RELATION, []string{}, "Back up only the specified table(s). --include-table can be specified multiple times.")
+	cmd.Flags().String(INCLUDE_RELATION_FILE, "", "A file containing a list of fully-qualified tables to be included in the backup")
+	cmd.Flags().Int(JOBS, 1, "The number of parallel connections to use when backing up data")
+	cmd.Flags().Bool(LEAF_PARTITION_DATA, false, "For partition tables, create one data file per leaf partition instead of one data file for the whole table")
+	cmd.Flags().Bool(METADATA_ONLY, false, "Only back up metadata, do not back up data")
+	cmd.Flags().Bool(NO_COMPRESSION, false, "Disable compression of data files")
+	cmd.Flags().String(PLUGIN_CONFIG, "", "The configuration file to use for a plugin")
 	cmd.Flags().Bool("version", false, "Print version number and exit")
-	quiet = cmd.Flags().Bool("quiet", false, "Suppress non-warning, non-error log messages")
-	singleDataFile = cmd.Flags().Bool("single-data-file", false, "Back up all data to a single file instead of one per table")
-	verbose = cmd.Flags().Bool("verbose", false, "Print verbose log messages")
-	withStats = cmd.Flags().Bool("with-stats", false, "Back up query plan statistics")
+	cmd.Flags().Bool(QUIET, false, "Suppress non-warning, non-error log messages")
+	cmd.Flags().Bool(SINGLE_DATA_FILE, false, "Back up all data to a single file instead of one per table")
+	cmd.Flags().Bool(VERBOSE, false, "Print verbose log messages")
+	cmd.Flags().Bool(WITH_STATS, false, "Back up query plan statistics")
 
-	_ = cmd.MarkFlagRequired("dbname")
+	_ = cmd.MarkFlagRequired(DBNAME)
+
+	cmdFlags = cmd.Flags()
 }
 
 // This function handles setup that can be done before parsing flags.
@@ -63,7 +65,7 @@ func DoSetup() {
 	timestamp := utils.CurrentTimestamp()
 	utils.CreateBackupLockFile(timestamp)
 
-	gplog.Info("Starting backup of database %s", *dbname)
+	gplog.Info("Starting backup of database %s", MustGetFlagString(DBNAME))
 	InitializeConnectionPool()
 
 	InitializeFilterLists()
@@ -73,15 +75,16 @@ func DoSetup() {
 	segConfig := cluster.MustGetSegmentConfiguration(connectionPool)
 	globalCluster = cluster.NewCluster(segConfig)
 	segPrefix := utils.GetSegPrefix(connectionPool)
-	globalFPInfo = utils.NewFilePathInfo(globalCluster, *backupDir, timestamp, segPrefix)
+	globalFPInfo = utils.NewFilePathInfo(globalCluster, MustGetFlagString(BACKUP_DIR), timestamp, segPrefix)
 	CreateBackupDirectoriesOnAllHosts()
 	globalTOC = &utils.TOC{}
 	globalTOC.InitializeMetadataEntryMap()
-
-	if *pluginConfigFile != "" {
-		pluginConfig = utils.ReadPluginConfig(*pluginConfigFile)
+	pluginConfigFlag := MustGetFlagString(PLUGIN_CONFIG)
+	if pluginConfigFlag != "" {
+		pluginConfig = utils.ReadPluginConfig(pluginConfigFlag)
 		pluginConfig.CheckPluginExistsOnAllHosts(globalCluster)
-		pluginConfig.CopyPluginConfigToAllHosts(globalCluster, *pluginConfigFile)
+
+		pluginConfig.CopyPluginConfigToAllHosts(globalCluster, pluginConfigFlag)
 		pluginConfig.SetupPluginForBackup(globalCluster, globalFPInfo)
 		backupReport.Plugin = pluginConfig.ExecutablePath
 	}
@@ -99,8 +102,8 @@ func DoBackup() {
 	metadataFile := utils.NewFileWithByteCountFromFile(metadataFilename)
 
 	BackupSessionGUCs(metadataFile)
-	if !*dataOnly {
-		if len(*includeRelations) > 0 {
+	if !MustGetFlagBool(DATA_ONLY) {
+		if len(MustGetFlagStringSlice(INCLUDE_RELATION)) > 0 {
 			backupRelationPredata(metadataFile, metadataTables, tableDefs)
 		} else {
 			backupGlobal(metadataFile)
@@ -119,7 +122,7 @@ func DoBackup() {
 		backupData(dataTables, tableDefs)
 	}
 
-	if *withStats {
+	if MustGetFlagBool(WITH_STATS) {
 		backupStatistics(metadataTables)
 	}
 
@@ -128,10 +131,10 @@ func DoBackup() {
 		connectionPool.MustCommit(connNum)
 	}
 	metadataFile.Close()
-	if *pluginConfigFile != "" {
+	if MustGetFlagString(PLUGIN_CONFIG) != "" {
 		pluginConfig.BackupFile(metadataFilename)
 		pluginConfig.BackupFile(globalFPInfo.GetTOCFilePath())
-		if *withStats {
+		if MustGetFlagBool(WITH_STATS) {
 			pluginConfig.BackupFile(globalFPInfo.GetStatisticsFilePath())
 		}
 	}
@@ -144,7 +147,7 @@ func backupGlobal(metadataFile *utils.FileWithByteCount) {
 	BackupCreateDatabase(metadataFile)
 	BackupDatabaseGUCs(metadataFile)
 
-	if len(*includeSchemas) == 0 {
+	if len(MustGetFlagStringSlice(INCLUDE_SCHEMA)) == 0 {
 		BackupResourceQueues(metadataFile)
 		if connectionPool.Version.AtLeast("5") {
 			BackupResourceGroups(metadataFile)
@@ -166,7 +169,7 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Relation, tab
 	gplog.Info("Writing pre-data metadata")
 
 	BackupSchemas(metadataFile)
-	if len(*includeSchemas) == 0 && connectionPool.Version.AtLeast("5") {
+	if len(MustGetFlagStringSlice(INCLUDE_SCHEMA)) == 0 && connectionPool.Version.AtLeast("5") {
 		BackupExtensions(metadataFile)
 	}
 
@@ -177,7 +180,7 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Relation, tab
 	langFuncs, otherFuncs, functionMetadata := RetrieveFunctions(procLangs)
 	types, typeMetadata, funcInfoMap := RetrieveTypes()
 
-	if len(*includeSchemas) == 0 {
+	if len(MustGetFlagStringSlice(INCLUDE_SCHEMA)) == 0 {
 		BackupProceduralLanguages(metadataFile, procLangs, langFuncs, functionMetadata, funcInfoMap)
 	}
 
@@ -196,7 +199,7 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Relation, tab
 	BackupDependentObjects(metadataFile, otherFuncs, types, tables, protocols, functionMetadata, typeMetadata, relationMetadata, protoMetadata, tableDefs, constraints)
 	PrintAlterSequenceStatements(metadataFile, globalTOC, sequences, sequenceOwnerColumns)
 
-	if len(*includeSchemas) == 0 {
+	if len(MustGetFlagStringSlice(INCLUDE_SCHEMA)) == 0 {
 		if connectionPool.Version.AtLeast("6") {
 			BackupForeignDataWrappers(metadataFile, funcInfoMap)
 			BackupForeignServers(metadataFile)
@@ -252,7 +255,7 @@ func backupRelationPredata(metadataFile *utils.FileWithByteCount, tables []Relat
 }
 
 func backupData(tables []Relation, tableDefs map[uint32]TableDefinition) {
-	if *singleDataFile {
+	if MustGetFlagBool(SINGLE_DATA_FILE) {
 		gplog.Verbose("Initializing pipes and gpbackup_helper on segments for single data file backup")
 		utils.VerifyHelperVersionOnSegments(version, globalCluster)
 		oidList := make([]string, 0, len(tables))
@@ -263,16 +266,17 @@ func backupData(tables []Relation, tableDefs map[uint32]TableDefinition) {
 		}
 		utils.WriteOidListToSegments(oidList, globalCluster, globalFPInfo)
 		utils.CreateFirstSegmentPipeOnAllHosts(oidList[0], globalCluster, globalFPInfo)
-		compressStr := fmt.Sprintf(" --compression-level %d", *compressionLevel)
-		if !*noCompression && *compressionLevel == 0 {
+		compressStr := fmt.Sprintf(" --compression-level %d", MustGetFlagInt(COMPRESSION_LEVEL))
+		if !MustGetFlagBool(NO_COMPRESSION) && MustGetFlagInt(COMPRESSION_LEVEL) == 0 {
 			compressStr = " --compression-level 1"
 		}
-		utils.StartAgent(globalCluster, globalFPInfo, "--backup-agent", *pluginConfigFile, compressStr)
+		utils.StartAgent(globalCluster, globalFPInfo, "--backup-agent",
+			MustGetFlagString(PLUGIN_CONFIG), compressStr)
 	}
 	gplog.Info("Writing data to file")
 	rowsCopiedMaps := BackupDataForAllTables(tables, tableDefs)
 	AddTableDataEntriesToTOC(tables, tableDefs, rowsCopiedMaps)
-	if *singleDataFile && *pluginConfigFile != "" {
+	if MustGetFlagBool(SINGLE_DATA_FILE) && MustGetFlagString(PLUGIN_CONFIG) != "" {
 		pluginConfig.BackupSegmentTOCs(globalCluster, globalFPInfo)
 	}
 	if wasTerminated {
@@ -383,7 +387,7 @@ func DoCleanup() {
 	}()
 	gplog.Verbose("Beginning cleanup")
 	if globalFPInfo.Timestamp != "" {
-		if *singleDataFile {
+		if MustGetFlagBool(SINGLE_DATA_FILE) {
 			utils.CleanUpHelperFilesOnAllHosts(globalCluster, globalFPInfo)
 			if wasTerminated {
 				utils.CleanUpSegmentHelperProcesses(globalCluster, globalFPInfo, "backup")

--- a/backup/backup_suite_test.go
+++ b/backup/backup_suite_test.go
@@ -17,6 +17,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
+	"github.com/spf13/pflag"
 )
 
 var (
@@ -36,15 +37,23 @@ func TestBackup(t *testing.T) {
 	RunSpecs(t, "backup tests")
 }
 
+var cmdFlags *pflag.FlagSet
+
 var _ = BeforeSuite(func() {
 	connectionPool, mock, stdout, stderr, logfile = testutils.SetupTestEnvironment()
-	backup.SetIncludeSchemas([]string{})
-	backup.SetExcludeSchemas([]string{})
-	backup.SetIncludeRelations([]string{})
-	backup.SetExcludeRelations([]string{})
 })
 
 var _ = BeforeEach(func() {
+	cmdFlags = pflag.NewFlagSet("gpbackup", pflag.ExitOnError)
+
+	cmdFlags.Bool(backup.SINGLE_DATA_FILE, false, "")
+	cmdFlags.Bool(backup.LEAF_PARTITION_DATA, false, "")
+	cmdFlags.StringSlice(backup.INCLUDE_SCHEMA, []string{}, "")
+	cmdFlags.StringSlice(backup.EXCLUDE_SCHEMA, []string{}, "")
+	cmdFlags.StringSlice(backup.INCLUDE_RELATION, []string{}, "")
+	cmdFlags.StringSlice(backup.EXCLUDE_RELATION, []string{}, "")
+	backup.SetCmdFlags(cmdFlags)
+
 	buffer = gbytes.NewBuffer()
 	connectionPool, mock = testutils.CreateAndConnectMockDB(1)
 })

--- a/backup/data.go
+++ b/backup/data.go
@@ -57,7 +57,7 @@ type BackupProgressCounters struct {
 func CopyTableOut(connectionPool *dbconn.DBConn, table Relation, backupFile string, connNum int) int64 {
 	usingCompression, compressionProgram := utils.GetCompressionParameters()
 	copyCommand := ""
-	if *singleDataFile {
+	if MustGetFlagBool(SINGLE_DATA_FILE) {
 		/*
 		 * The segment TOC files are always written to the segment data directory for
 		 * performance reasons, in case the user-specified directory is on a mounted
@@ -75,7 +75,7 @@ func CopyTableOut(connectionPool *dbconn.DBConn, table Relation, backupFile stri
 	result, err := connectionPool.Exec(query, connNum)
 	if err != nil {
 		errStr := ""
-		if *singleDataFile {
+		if MustGetFlagBool(SINGLE_DATA_FILE) {
 			helperLogName := globalFPInfo.GetHelperLogPath()
 			errStr = fmt.Sprintf("Check %s on the affected segment host for more info.", helperLogName)
 		}
@@ -99,7 +99,7 @@ func BackupSingleTableData(tableDef TableDefinition, table Relation, rowsCopiedM
 		}
 
 		backupFile := ""
-		if *singleDataFile {
+		if MustGetFlagBool(SINGLE_DATA_FILE) {
 			backupFile = fmt.Sprintf("%s_%d", globalFPInfo.GetSegmentPipePathForCopyCommand(), table.Oid)
 		} else {
 			backupFile = globalFPInfo.GetTableBackupFilePathForCopyCommand(table.Oid, false)

--- a/backup/data_test.go
+++ b/backup/data_test.go
@@ -58,7 +58,7 @@ var _ bool = Describe("backup/data tests", func() {
 	})
 	Describe("CopyTableOut", func() {
 		It("will back up a table to its own file with compression", func() {
-			backup.SetSingleDataFile(false)
+			cmdFlags.Set(backup.SINGLE_DATA_FILE, "false")
 			utils.SetCompressionParameters(true, utils.Compression{Name: "gzip", CompressCommand: "gzip -c -8", DecompressCommand: "gzip -d -c", Extension: ".gz"})
 			testTable := backup.Relation{SchemaOid: 2345, Oid: 3456, Schema: "public", Name: "foo", DependsUpon: nil, Inherits: nil}
 			execStr := regexp.QuoteMeta("COPY public.foo TO PROGRAM 'gzip -c -8 > <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.gz' WITH CSV DELIMITER ',' ON SEGMENT IGNORE EXTERNAL PARTITIONS;")
@@ -68,7 +68,7 @@ var _ bool = Describe("backup/data tests", func() {
 			backup.CopyTableOut(connectionPool, testTable, filename, defaultConnNum)
 		})
 		It("will back up a table to its own file without compression", func() {
-			backup.SetSingleDataFile(false)
+			cmdFlags.Set(backup.SINGLE_DATA_FILE, "false")
 			utils.SetCompressionParameters(false, utils.Compression{})
 			testTable := backup.Relation{SchemaOid: 2345, Oid: 3456, Schema: "public", Name: "foo", DependsUpon: nil, Inherits: nil}
 			execStr := regexp.QuoteMeta("COPY public.foo TO '<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456' WITH CSV DELIMITER ',' ON SEGMENT IGNORE EXTERNAL PARTITIONS;")
@@ -78,7 +78,7 @@ var _ bool = Describe("backup/data tests", func() {
 			backup.CopyTableOut(connectionPool, testTable, filename, defaultConnNum)
 		})
 		It("will back up a table to a single file", func() {
-			backup.SetSingleDataFile(true)
+			cmdFlags.Set(backup.SINGLE_DATA_FILE, "true")
 			utils.SetCompressionParameters(false, utils.Compression{})
 			testTable := backup.Relation{SchemaOid: 2345, Oid: 3456, Schema: "public", Name: "foo", DependsUpon: nil, Inherits: nil}
 			execStr := regexp.QuoteMeta(`COPY public.foo TO PROGRAM '(test -p "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456" || (echo "Pipe not found">&2; exit 1)) && cat - > <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456' WITH CSV DELIMITER ',' ON SEGMENT IGNORE EXTERNAL PARTITIONS;`)
@@ -99,7 +99,7 @@ var _ bool = Describe("backup/data tests", func() {
 		BeforeEach(func() {
 			tableDef = backup.TableDefinition{IsExternal: false}
 			testTable = backup.Relation{Oid: 0, Schema: "public", Name: "testtable"}
-			backup.SetSingleDataFile(false)
+			cmdFlags.Set(backup.SINGLE_DATA_FILE, "false")
 			rowsCopiedMap = make(map[uint32]int64, 0)
 			counters = backup.BackupProgressCounters{NumRegTables: 0, TotalRegTables: 1}
 			counters.ProgressBar = utils.NewProgressBar(int(counters.TotalRegTables), "Tables backed up: ", utils.PB_INFO)
@@ -107,7 +107,7 @@ var _ bool = Describe("backup/data tests", func() {
 			counters.ProgressBar.Start()
 		})
 		It("backs up a single regular table with single data file", func() {
-			backup.SetSingleDataFile(true)
+			cmdFlags.Set(backup.SINGLE_DATA_FILE, "true")
 
 			backupFile := fmt.Sprintf("<SEG_DATA_DIR>/gpbackup_<SEGID>_20170101010101_pipe_(.*)_%d", testTable.Oid)
 			copyCmd := fmt.Sprintf(copyFmtStr, backupFile)
@@ -118,7 +118,7 @@ var _ bool = Describe("backup/data tests", func() {
 			Expect(counters.NumRegTables).To(Equal(int64(1)))
 		})
 		It("backs up a single regular table without a single data file", func() {
-			backup.SetSingleDataFile(false)
+			cmdFlags.Set(backup.SINGLE_DATA_FILE, "false")
 
 			backupFile := fmt.Sprintf("<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_%d", testTable.Oid)
 			copyCmd := fmt.Sprintf(copyFmtStr, backupFile)
@@ -129,7 +129,7 @@ var _ bool = Describe("backup/data tests", func() {
 			Expect(counters.NumRegTables).To(Equal(int64(1)))
 		})
 		It("backs up a single external table", func() {
-			backup.SetLeafPartitionData(false)
+			cmdFlags.Set(backup.LEAF_PARTITION_DATA, "false")
 			tableDef.IsExternal = true
 			backup.BackupSingleTableData(tableDef, testTable, rowsCopiedMap, &counters, 0)
 

--- a/backup/global_variables.go
+++ b/backup/global_variables.go
@@ -7,7 +7,6 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gpbackup/utils"
 
-	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/spf13/pflag"
 )
 
@@ -102,26 +101,20 @@ func SetVersion(v string) {
 	version = v
 }
 
+// Util functions to enable ease of access to global flag values
+
 func MustGetFlagString(flagName string) string {
-	value, err := cmdFlags.GetString(flagName)
-	gplog.FatalOnError(err)
-	return value
+	return utils.MustGetFlagString(cmdFlags, flagName)
 }
 
 func MustGetFlagInt(flagName string) int {
-	value, err := cmdFlags.GetInt(flagName)
-	gplog.FatalOnError(err)
-	return value
+	return utils.MustGetFlagInt(cmdFlags, flagName)
 }
 
 func MustGetFlagBool(flagName string) bool {
-	value, err := cmdFlags.GetBool(flagName)
-	gplog.FatalOnError(err)
-	return value
+	return utils.MustGetFlagBool(cmdFlags, flagName)
 }
 
 func MustGetFlagStringSlice(flagName string) []string {
-	value, err := cmdFlags.GetStringSlice(flagName)
-	gplog.FatalOnError(err)
-	return value
+	return utils.MustGetFlagStringSlice(cmdFlags, flagName)
 }

--- a/backup/global_variables.go
+++ b/backup/global_variables.go
@@ -6,6 +6,9 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gpbackup/utils"
+
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/spf13/pflag"
 )
 
 /*
@@ -38,32 +41,38 @@ var (
 /*
  * Command-line flags
  */
-var (
-	backupDir           *string
-	compressionLevel    *int
-	dataOnly            *bool
-	dbname              *string
-	debug               *bool
-	excludeSchemas      *[]string
-	excludeRelationFile *string
-	excludeRelations    *[]string
-	includeSchemas      *[]string
-	includeRelationFile *string
-	includeRelations    *[]string
-	numJobs             *int
-	leafPartitionData   *bool
-	metadataOnly        *bool
-	noCompression       *bool
-	pluginConfigFile    *string
-	quiet               *bool
-	singleDataFile      *bool
-	verbose             *bool
-	withStats           *bool
+var cmdFlags *pflag.FlagSet
+
+const (
+	BACKUP_DIR            = "backup-dir"
+	COMPRESSION_LEVEL     = "compression-level"
+	DATA_ONLY             = "data-only"
+	DBNAME                = "dbname"
+	DEBUG                 = "debug"
+	EXCLUDE_RELATION      = "exclude-table"
+	EXCLUDE_RELATION_FILE = "exclude-table-file"
+	EXCLUDE_SCHEMA        = "exclude-schema"
+	INCLUDE_RELATION      = "include-table-file"
+	INCLUDE_RELATION_FILE = "include-table-file"
+	INCLUDE_SCHEMA        = "include-schema"
+	JOBS                  = "jobs"
+	LEAF_PARTITION_DATA   = "leaf-partition-data"
+	METADATA_ONLY         = "metadata-only"
+	NO_COMPRESSION        = "no-compression"
+	PLUGIN_CONFIG         = "plugin-config"
+	QUIET                 = "quiet"
+	SINGLE_DATA_FILE      = "single-data-file"
+	VERBOSE               = "verbose"
+	WITH_STATS            = "with-stats"
 )
 
 /*
  * Setter functions
  */
+
+func SetCmdFlags(flagSet *pflag.FlagSet) {
+	cmdFlags = flagSet
+}
 
 func SetConnection(conn *dbconn.DBConn) {
 	connectionPool = conn
@@ -73,28 +82,8 @@ func SetCluster(cluster *cluster.Cluster) {
 	globalCluster = cluster
 }
 
-func SetExcludeSchemas(schemas []string) {
-	excludeSchemas = &schemas
-}
-
-func SetExcludeRelations(relations []string) {
-	excludeRelations = &relations
-}
-
 func SetFPInfo(fpInfo utils.FilePathInfo) {
 	globalFPInfo = fpInfo
-}
-
-func SetIncludeSchemas(schemas []string) {
-	includeSchemas = &schemas
-}
-
-func SetIncludeRelations(relations []string) {
-	includeRelations = &relations
-}
-
-func SetLeafPartitionData(which bool) {
-	leafPartitionData = &which
 }
 
 func SetReport(report *utils.Report) {
@@ -105,14 +94,34 @@ func GetReport() *utils.Report {
 	return backupReport
 }
 
-func SetSingleDataFile(which bool) {
-	singleDataFile = &which
-}
-
 func SetTOC(toc *utils.TOC) {
 	globalTOC = toc
 }
 
 func SetVersion(v string) {
 	version = v
+}
+
+func MustGetFlagString(flagName string) string {
+	value, err := cmdFlags.GetString(flagName)
+	gplog.FatalOnError(err)
+	return value
+}
+
+func MustGetFlagInt(flagName string) int {
+	value, err := cmdFlags.GetInt(flagName)
+	gplog.FatalOnError(err)
+	return value
+}
+
+func MustGetFlagBool(flagName string) bool {
+	value, err := cmdFlags.GetBool(flagName)
+	gplog.FatalOnError(err)
+	return value
+}
+
+func MustGetFlagStringSlice(flagName string) []string {
+	value, err := cmdFlags.GetStringSlice(flagName)
+	gplog.FatalOnError(err)
+	return value
 }

--- a/backup/global_variables.go
+++ b/backup/global_variables.go
@@ -52,7 +52,7 @@ const (
 	EXCLUDE_RELATION      = "exclude-table"
 	EXCLUDE_RELATION_FILE = "exclude-table-file"
 	EXCLUDE_SCHEMA        = "exclude-schema"
-	INCLUDE_RELATION      = "include-table-file"
+	INCLUDE_RELATION      = "include-table"
 	INCLUDE_RELATION_FILE = "include-table-file"
 	INCLUDE_SCHEMA        = "include-schema"
 	JOBS                  = "jobs"

--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -66,7 +66,7 @@ func GetUniqueSchemas(schemas []Schema, tables []Relation) []Schema {
 func SplitTablesByPartitionType(tables []Relation, tableDefs map[uint32]TableDefinition, includeList []string) ([]Relation, []Relation) {
 	metadataTables := make([]Relation, 0)
 	dataTables := make([]Relation, 0)
-	if *leafPartitionData || len(includeList) > 0 {
+	if MustGetFlagBool(LEAF_PARTITION_DATA) || len(includeList) > 0 {
 		includeSet := utils.NewIncludeSet(includeList)
 		for _, table := range tables {
 			if tableDefs[table.Oid].IsExternal && tableDefs[table.Oid].PartitionType == "l" {
@@ -77,7 +77,7 @@ func SplitTablesByPartitionType(tables []Relation, tableDefs map[uint32]TableDef
 			if partType != "l" && partType != "i" {
 				metadataTables = append(metadataTables, table)
 			}
-			if *leafPartitionData {
+			if MustGetFlagBool(LEAF_PARTITION_DATA) {
 				if partType != "p" && partType != "i" {
 					dataTables = append(dataTables, table)
 				}
@@ -116,23 +116,24 @@ func AppendExtPartSuffix(name string) string {
 	return name + SUFFIX
 }
 
-func ExpandIncludeRelations(tables []Relation) []string {
-	if len(*includeRelations) == 0 {
-		return *includeRelations
+func ExpandIncludeRelations(tables []Relation) {
+	includeRelations := MustGetFlagStringSlice(INCLUDE_RELATION)
+
+	if len(includeRelations) == 0 {
+		return
 	}
 
 	includeMap := make(map[string]bool, 0)
-	for _, relation := range *includeRelations {
+	for _, relation := range includeRelations {
 		includeMap[relation] = true
 	}
 
-	expandedIncludeRelations := *includeRelations
 	for _, table := range tables {
 		if _, ok := includeMap[table.FQN()]; !ok {
-			expandedIncludeRelations = append(expandedIncludeRelations, table.FQN())
+			err := cmdFlags.Set(INCLUDE_RELATION, table.FQN()) //This appends to the slice underlying the flag.
+			gplog.FatalOnError(err)
 		}
 	}
-	return expandedIncludeRelations
 }
 
 type TableDefinition struct {

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -17,12 +17,12 @@ import (
 
 func relationAndSchemaFilterClause() string {
 	filterClause := SchemaFilterClause("n")
-	if len(*excludeRelations) > 0 {
-		excludeOids := GetOidsFromRelationList(connectionPool, *excludeRelations)
+	if len(MustGetFlagStringSlice(EXCLUDE_RELATION)) > 0 {
+		excludeOids := GetOidsFromRelationList(connectionPool, MustGetFlagStringSlice(EXCLUDE_RELATION))
 		filterClause += fmt.Sprintf("\nAND c.oid NOT IN (%s)", strings.Join(excludeOids, ", "))
 	}
-	if len(*includeRelations) > 0 {
-		includeOids := GetOidsFromRelationList(connectionPool, *includeRelations)
+	if len(MustGetFlagStringSlice(INCLUDE_RELATION)) > 0 {
+		includeOids := GetOidsFromRelationList(connectionPool, MustGetFlagStringSlice(INCLUDE_RELATION))
 		filterClause += fmt.Sprintf("\nAND c.oid IN (%s)", strings.Join(includeOids, ", "))
 	}
 	return filterClause
@@ -40,7 +40,7 @@ WHERE quote_ident(n.nspname) || '.' || quote_ident(c.relname) IN (%s)`, relList)
 }
 
 func GetAllUserTables(connection *dbconn.DBConn) []Relation {
-	if len(*includeRelations) > 0 {
+	if len(MustGetFlagStringSlice(INCLUDE_RELATION)) > 0 {
 		return GetUserTablesWithIncludeFiltering(connection)
 	}
 	return GetUserTables(connection)
@@ -52,7 +52,7 @@ func GetAllUserTables(connection *dbconn.DBConn) []Relation {
  */
 func GetUserTables(connection *dbconn.DBConn) []Relation {
 	childPartitionFilter := ""
-	if !*leafPartitionData {
+	if !MustGetFlagBool(LEAF_PARTITION_DATA) {
 		//Filter out non-external child partitions
 		childPartitionFilter = `
 	AND c.oid NOT IN (
@@ -86,10 +86,10 @@ ORDER BY c.oid;`, relationAndSchemaFilterClause(), childPartitionFilter, Extensi
 }
 
 func GetUserTablesWithIncludeFiltering(connection *dbconn.DBConn) []Relation {
-	includeOids := GetOidsFromRelationList(connection, *includeRelations)
+	includeOids := GetOidsFromRelationList(connection, MustGetFlagStringSlice(INCLUDE_RELATION))
 	oidStr := strings.Join(includeOids, ", ")
 	childPartitionFilter := ""
-	if *leafPartitionData {
+	if MustGetFlagBool(LEAF_PARTITION_DATA) {
 		//Get all leaf partition tables whose parents are in the include list
 		childPartitionFilter = fmt.Sprintf(`
 	OR c.oid IN (

--- a/backup/queries_shared.go
+++ b/backup/queries_shared.go
@@ -214,11 +214,11 @@ func InitializeMetadataParams(connection *dbconn.DBConn) {
 // A list of schemas we don't want to back up, formatted for use in a WHERE clause
 func SchemaFilterClause(namespace string) string {
 	schemaFilterClauseStr := ""
-	if len(*includeSchemas) > 0 {
-		schemaFilterClauseStr = fmt.Sprintf("\nAND %s.nspname IN (%s)", namespace, utils.SliceToQuotedString(*includeSchemas))
+	if len(MustGetFlagStringSlice(INCLUDE_SCHEMA)) > 0 {
+		schemaFilterClauseStr = fmt.Sprintf("\nAND %s.nspname IN (%s)", namespace, utils.SliceToQuotedString(MustGetFlagStringSlice(INCLUDE_SCHEMA)))
 	}
-	if len(*excludeSchemas) > 0 {
-		schemaFilterClauseStr = fmt.Sprintf("\nAND %s.nspname NOT IN (%s)", namespace, utils.SliceToQuotedString(*excludeSchemas))
+	if len(MustGetFlagStringSlice(EXCLUDE_SCHEMA)) > 0 {
+		schemaFilterClauseStr = fmt.Sprintf("\nAND %s.nspname NOT IN (%s)", namespace, utils.SliceToQuotedString(MustGetFlagStringSlice(EXCLUDE_SCHEMA)))
 	}
 	return fmt.Sprintf(`%s.nspname NOT LIKE 'pg_temp_%%' AND %s.nspname NOT LIKE 'pg_toast%%' AND %s.nspname NOT IN ('gp_toolkit', 'information_schema', 'pg_aoseg', 'pg_bitmapindex', 'pg_catalog') %s`, namespace, namespace, namespace, schemaFilterClauseStr)
 }

--- a/backup/validate.go
+++ b/backup/validate.go
@@ -15,10 +15,10 @@ import (
  */
 
 func validateFilterLists() {
-	ValidateFilterSchemas(connectionPool, *excludeSchemas)
-	ValidateFilterSchemas(connectionPool, *includeSchemas)
-	ValidateFilterTables(connectionPool, *excludeRelations)
-	ValidateFilterTables(connectionPool, *includeRelations)
+	ValidateFilterSchemas(connectionPool, MustGetFlagStringSlice(EXCLUDE_SCHEMA))
+	ValidateFilterSchemas(connectionPool, MustGetFlagStringSlice(INCLUDE_SCHEMA))
+	ValidateFilterTables(connectionPool, MustGetFlagStringSlice(EXCLUDE_RELATION))
+	ValidateFilterTables(connectionPool, MustGetFlagStringSlice(INCLUDE_RELATION))
 }
 
 func ValidateFilterSchemas(connection *dbconn.DBConn, schemaList []string) {
@@ -73,16 +73,16 @@ WHERE quote_ident(n.nspname) || '.' || quote_ident(c.relname) IN (%s)`, quotedTa
 }
 
 func ValidateFlagCombinations(flags *pflag.FlagSet) {
-	utils.CheckExclusiveFlags(flags, "debug", "quiet", "verbose")
-	utils.CheckExclusiveFlags(flags, "data-only", "metadata-only")
-	utils.CheckExclusiveFlags(flags, "include-schema", "include-table", "include-table-file")
-	utils.CheckExclusiveFlags(flags, "exclude-schema", "include-schema")
-	utils.CheckExclusiveFlags(flags, "exclude-schema", "exclude-table", "include-table", "exclude-table-file", "include-table-file")
-	utils.CheckExclusiveFlags(flags, "exclude-table", "exclude-table-file", "leaf-partition-data")
-	utils.CheckExclusiveFlags(flags, "jobs", "metadata-only", "single-data-file")
-	utils.CheckExclusiveFlags(flags, "metadata-only", "leaf-partition-data")
-	utils.CheckExclusiveFlags(flags, "no-compression", "compression-level")
-	if *pluginConfigFile != "" && !(*singleDataFile || *metadataOnly) {
+	utils.CheckExclusiveFlags(flags, DEBUG, QUIET, VERBOSE)
+	utils.CheckExclusiveFlags(flags, DATA_ONLY, METADATA_ONLY)
+	utils.CheckExclusiveFlags(flags, INCLUDE_SCHEMA, INCLUDE_RELATION, INCLUDE_RELATION_FILE)
+	utils.CheckExclusiveFlags(flags, EXCLUDE_SCHEMA, INCLUDE_SCHEMA)
+	utils.CheckExclusiveFlags(flags, EXCLUDE_SCHEMA, EXCLUDE_RELATION, INCLUDE_RELATION, EXCLUDE_RELATION_FILE, INCLUDE_RELATION_FILE)
+	utils.CheckExclusiveFlags(flags, EXCLUDE_RELATION, EXCLUDE_RELATION_FILE, LEAF_PARTITION_DATA)
+	utils.CheckExclusiveFlags(flags, JOBS, METADATA_ONLY, SINGLE_DATA_FILE)
+	utils.CheckExclusiveFlags(flags, METADATA_ONLY, LEAF_PARTITION_DATA)
+	utils.CheckExclusiveFlags(flags, NO_COMPRESSION, COMPRESSION_LEVEL)
+	if MustGetFlagString(PLUGIN_CONFIG) != "" && !(MustGetFlagBool(SINGLE_DATA_FILE) || MustGetFlagBool(METADATA_ONLY)) {
 		gplog.Fatal(errors.Errorf("--plugin-config must be specified with either --single-data-file or --metadata-only"), "")
 	}
 }
@@ -95,7 +95,7 @@ func ValidateCompressionLevel(compressionLevel int) {
 }
 
 func ValidateFlagValues() {
-	utils.ValidateFullPath(*backupDir)
-	utils.ValidateFullPath(*pluginConfigFile)
-	ValidateCompressionLevel(*compressionLevel)
+	utils.ValidateFullPath(MustGetFlagString(BACKUP_DIR))
+	utils.ValidateFullPath(MustGetFlagString(PLUGIN_CONFIG))
+	ValidateCompressionLevel(MustGetFlagInt(COMPRESSION_LEVEL))
 }

--- a/backup/validate_test.go
+++ b/backup/validate_test.go
@@ -47,9 +47,6 @@ var _ = Describe("backup/validate tests", func() {
 			partitionTables = sqlmock.NewRows([]string{"oid", "value"})
 		})
 		Context("Non-partition tables", func() {
-			BeforeEach(func() {
-				backup.SetLeafPartitionData(false)
-			})
 			It("passes if there are no filter tables", func() {
 				backup.ValidateFilterTables(connectionPool, filterList)
 			})
@@ -77,9 +74,6 @@ var _ = Describe("backup/validate tests", func() {
 			})
 		})
 		Context("Partition tables", func() {
-			BeforeEach(func() {
-				backup.SetLeafPartitionData(false)
-			})
 			It("passes if given a parent partition table", func() {
 				tableRows.AddRow("1", "public.table1")
 				mock.ExpectQuery("SELECT (.*)").WillReturnRows(tableRows)
@@ -97,8 +91,7 @@ var _ = Describe("backup/validate tests", func() {
 				backup.ValidateFilterTables(connectionPool, filterList)
 			})
 			It("panics if given an intermediate partition table and --leaf-partition-data is set", func() {
-				backup.SetLeafPartitionData(true)
-				defer backup.SetLeafPartitionData(false)
+				cmdFlags.Set(backup.LEAF_PARTITION_DATA, "true")
 				tableRows.AddRow("1", "public.table1")
 				mock.ExpectQuery("SELECT (.*)").WillReturnRows(tableRows)
 				partitionTables.AddRow("1", "i")

--- a/integration/incremental_queries_test.go
+++ b/integration/incremental_queries_test.go
@@ -241,7 +241,7 @@ var _ = Describe("backup integration tests", func() {
 			var aoIncrementalMetadata map[string]utils.AOEntry
 			Context("During a table-filtered backup", func() {
 				It("only retrieves ao metadata for specific tables", func() {
-					backup.SetIncludeRelations([]string{aoTableFQN})
+					cmdFlags.Set(backup.INCLUDE_RELATION, aoTableFQN)
 
 					aoIncrementalMetadata = backup.GetAOIncrementalMetadata(connection)
 					Expect(len(aoIncrementalMetadata)).To(Equal(1))
@@ -253,7 +253,7 @@ var _ = Describe("backup integration tests", func() {
 					defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema CASCADE")
 					testhelper.AssertQueryRuns(connection, "CREATE TABLE testschema.ao_foo (i int) WITH (appendonly=true)")
 
-					backup.SetIncludeSchemas([]string{"testschema"})
+					cmdFlags.Set(backup.INCLUDE_SCHEMA, "testschema")
 
 					aoIncrementalMetadata = backup.GetAOIncrementalMetadata(connection)
 					Expect(len(aoIncrementalMetadata)).To(Equal(1))

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -17,6 +17,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
+	"github.com/spf13/pflag"
 )
 
 var (
@@ -76,12 +77,20 @@ var _ = BeforeSuite(func() {
 	gpbackupHelperPath = buildAndInstallBinaries()
 })
 
+var cmdFlags *pflag.FlagSet
+
 var _ = BeforeEach(func() {
 	buffer = bytes.NewBuffer([]byte(""))
-	backup.SetExcludeSchemas([]string{})
-	backup.SetIncludeSchemas([]string{})
-	backup.SetExcludeRelations([]string{})
-	backup.SetIncludeRelations([]string{})
+
+	cmdFlags = pflag.NewFlagSet("gpbackup", pflag.ExitOnError)
+
+	cmdFlags.Bool(backup.LEAF_PARTITION_DATA, false, "")
+	cmdFlags.StringSlice(backup.INCLUDE_SCHEMA, []string{}, "")
+	cmdFlags.StringSlice(backup.EXCLUDE_SCHEMA, []string{}, "")
+	cmdFlags.StringSlice(backup.INCLUDE_RELATION, []string{}, "")
+	cmdFlags.StringSlice(backup.EXCLUDE_RELATION, []string{}, "")
+
+	backup.SetCmdFlags(cmdFlags)
 })
 
 var _ = AfterSuite(func() {

--- a/integration/parallel_queries_test.go
+++ b/integration/parallel_queries_test.go
@@ -66,7 +66,6 @@ var _ = Describe("backup, utils, and restore integration tests related to parall
 		createQuery := "CREATE TABLE public.timestamps(exec_index int, exec_time timestamp);"
 		orderQuery := "SELECT exec_index AS string FROM public.timestamps ORDER BY exec_time;"
 		BeforeEach(func() {
-			restore.SetOnErrorContinue(false)
 			tempConn = dbconn.NewDBConnFromEnvironment("testdb")
 			restore.SetConnection(tempConn)
 		})

--- a/integration/postdata_queries_test.go
+++ b/integration/postdata_queries_test.go
@@ -126,7 +126,7 @@ PARTITION BY RANGE (date)
 			defer testhelper.AssertQueryRuns(connection, "DROP TABLE testschema.simple_table")
 			testhelper.AssertQueryRuns(connection, "CREATE INDEX simple_table_idx1 ON testschema.simple_table(i)")
 			defer testhelper.AssertQueryRuns(connection, "DROP INDEX testschema.simple_table_idx1")
-			backup.SetIncludeSchemas([]string{"testschema"})
+			cmdFlags.Set(backup.INCLUDE_SCHEMA, "testschema")
 
 			index1 := backup.IndexDefinition{Oid: 0, Name: "simple_table_idx1", OwningSchema: "testschema", OwningTable: "simple_table", Def: "CREATE INDEX simple_table_idx1 ON testschema.simple_table USING btree (i)"}
 
@@ -148,7 +148,7 @@ PARTITION BY RANGE (date)
 			defer testhelper.AssertQueryRuns(connection, "DROP TABLE testschema.simple_table")
 			testhelper.AssertQueryRuns(connection, "CREATE INDEX simple_table_idx1 ON testschema.simple_table(i)")
 			defer testhelper.AssertQueryRuns(connection, "DROP INDEX testschema.simple_table_idx1")
-			backup.SetIncludeRelations([]string{"testschema.simple_table"})
+			cmdFlags.Set(backup.INCLUDE_RELATION, "testschema.simple_table")
 
 			index1 := backup.IndexDefinition{Oid: 0, Name: "simple_table_idx1", OwningSchema: "testschema", OwningTable: "simple_table", Def: "CREATE INDEX simple_table_idx1 ON testschema.simple_table USING btree (i)"}
 
@@ -213,7 +213,7 @@ PARTITION BY RANGE (date)
 			defer testhelper.AssertQueryRuns(connection, "DROP TABLE testschema.rule_table1")
 			testhelper.AssertQueryRuns(connection, "CREATE RULE double_insert AS ON INSERT TO testschema.rule_table1 DO INSERT INTO testschema.rule_table1 (i) VALUES (1)")
 			defer testhelper.AssertQueryRuns(connection, "DROP RULE double_insert ON testschema.rule_table1")
-			backup.SetIncludeSchemas([]string{"testschema"})
+			cmdFlags.Set(backup.INCLUDE_SCHEMA, "testschema")
 
 			rule1 := backup.QuerySimpleDefinition{Oid: 0, Name: "double_insert", OwningSchema: "testschema", OwningTable: "rule_table1", Def: "CREATE RULE double_insert AS ON INSERT TO testschema.rule_table1 DO INSERT INTO testschema.rule_table1 (i) VALUES (1);"}
 
@@ -233,7 +233,7 @@ PARTITION BY RANGE (date)
 			defer testhelper.AssertQueryRuns(connection, "DROP TABLE testschema.rule_table1")
 			testhelper.AssertQueryRuns(connection, "CREATE RULE double_insert AS ON INSERT TO testschema.rule_table1 DO INSERT INTO testschema.rule_table1 (i) VALUES (1)")
 			defer testhelper.AssertQueryRuns(connection, "DROP RULE double_insert ON testschema.rule_table1")
-			backup.SetIncludeRelations([]string{"testschema.rule_table1"})
+			cmdFlags.Set(backup.INCLUDE_RELATION, "testschema.rule_table1")
 
 			rule1 := backup.QuerySimpleDefinition{Oid: 0, Name: "double_insert", OwningSchema: "testschema", OwningTable: "rule_table1", Def: "CREATE RULE double_insert AS ON INSERT TO testschema.rule_table1 DO INSERT INTO testschema.rule_table1 (i) VALUES (1);"}
 
@@ -291,7 +291,7 @@ PARTITION BY RANGE (date)
 			defer testhelper.AssertQueryRuns(connection, "DROP TABLE testschema.trigger_table1")
 			testhelper.AssertQueryRuns(connection, `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON testschema.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`)
 			defer testhelper.AssertQueryRuns(connection, "DROP TRIGGER sync_trigger_table1 ON testschema.trigger_table1")
-			backup.SetIncludeSchemas([]string{"testschema"})
+			cmdFlags.Set(backup.INCLUDE_SCHEMA, "testschema")
 
 			trigger1 := backup.QuerySimpleDefinition{Oid: 0, Name: "sync_trigger_table1", OwningSchema: "testschema", OwningTable: "trigger_table1", Def: `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON testschema.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}
 
@@ -311,7 +311,7 @@ PARTITION BY RANGE (date)
 			defer testhelper.AssertQueryRuns(connection, "DROP TABLE testschema.trigger_table1")
 			testhelper.AssertQueryRuns(connection, `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON testschema.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`)
 			defer testhelper.AssertQueryRuns(connection, "DROP TRIGGER sync_trigger_table1 ON testschema.trigger_table1")
-			backup.SetIncludeRelations([]string{"testschema.trigger_table1"})
+			cmdFlags.Set(backup.INCLUDE_RELATION, "testschema.trigger_table1")
 
 			trigger1 := backup.QuerySimpleDefinition{Oid: 0, Name: "sync_trigger_table1", OwningSchema: "testschema", OwningTable: "trigger_table1", Def: `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON testschema.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}
 

--- a/integration/predata_functions_queries_test.go
+++ b/integration/predata_functions_queries_test.go
@@ -68,7 +68,7 @@ LANGUAGE SQL`)
 				BinaryPath: "", Arguments: "integer, integer", IdentArgs: "integer, integer", ResultType: "integer",
 				Volatility: "v", IsStrict: false, IsSecurityDefiner: false, Config: "", Cost: 100, NumRows: 0, DataAccess: "c",
 				Language: "sql", ExecLocation: "a"}
-			backup.SetIncludeSchemas([]string{"testschema"})
+			cmdFlags.Set(backup.INCLUDE_SCHEMA, "testschema")
 			results := backup.GetFunctionsMaster(connection)
 
 			Expect(len(results)).To(Equal(1))
@@ -181,7 +181,7 @@ LANGUAGE SQL`)
 				Schema: "testschema", Name: "add", ReturnsSet: false, FunctionBody: "SELECT $1 + $2",
 				BinaryPath: "", Arguments: "", IdentArgs: "", ResultType: "",
 				Volatility: "v", IsStrict: false, IsSecurityDefiner: false, Language: "sql", ExecLocation: "a"}
-			backup.SetIncludeSchemas([]string{"testschema"})
+			cmdFlags.Set(backup.INCLUDE_SCHEMA, "testschema")
 			results := backup.GetFunctions4(connection)
 
 			Expect(len(results)).To(Equal(1))
@@ -276,7 +276,7 @@ CREATE AGGREGATE testschema.agg_prefunc(numeric, numeric) (
 				IdentArgs: "numeric, numeric", TransitionFunction: transitionOid, PreliminaryFunction: prelimOid,
 				FinalFunction: 0, SortOperator: 0, TransitionDataType: "numeric", InitialValue: "0", IsOrdered: false,
 			}
-			backup.SetIncludeSchemas([]string{"testschema"})
+			cmdFlags.Set(backup.INCLUDE_SCHEMA, "testschema")
 
 			result := backup.GetAggregates(connection)
 
@@ -484,7 +484,7 @@ LANGUAGE SQL`)
 
 			expectedConversion := backup.Conversion{Oid: 0, Schema: "testschema", Name: "testconv", ForEncoding: "LATIN1", ToEncoding: "MULE_INTERNAL", ConversionFunction: "pg_catalog.latin1_to_mic", IsDefault: false}
 
-			backup.SetIncludeSchemas([]string{"testschema"})
+			cmdFlags.Set(backup.INCLUDE_SCHEMA, "testschema")
 			resultConversions := backup.GetConversions(connection)
 
 			Expect(len(resultConversions)).To(Equal(1))

--- a/integration/predata_operators_queries_test.go
+++ b/integration/predata_operators_queries_test.go
@@ -64,7 +64,7 @@ var _ = Describe("backup integration tests", func() {
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, "CREATE OPERATOR testschema.## (LEFTARG = bigint, PROCEDURE = numeric_fac)")
 			defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR testschema.## (bigint, NONE)")
-			backup.SetIncludeSchemas([]string{"testschema"})
+			cmdFlags.Set(backup.INCLUDE_SCHEMA, "testschema")
 
 			expectedOperator := backup.Operator{Oid: 0, Schema: "testschema", Name: "##", Procedure: "numeric_fac", LeftArgType: "bigint", RightArgType: "-", CommutatorOp: "0", NegatorOp: "0", RestrictFunction: "-", JoinFunction: "-", CanHash: false, CanMerge: false}
 
@@ -96,7 +96,7 @@ var _ = Describe("backup integration tests", func() {
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, "CREATE OPERATOR FAMILY testschema.testfam USING hash;")
 			defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR FAMILY testschema.testfam USING hash")
-			backup.SetIncludeSchemas([]string{"testschema"})
+			cmdFlags.Set(backup.INCLUDE_SCHEMA, "testschema")
 
 			expectedOperator := backup.OperatorFamily{Oid: 0, Schema: "testschema", Name: "testfam", IndexMethod: "hash"}
 
@@ -210,7 +210,7 @@ var _ = Describe("backup integration tests", func() {
 			} else {
 				defer testhelper.AssertQueryRuns(connection, "DROP OPERATOR FAMILY testschema.testclass USING hash")
 			}
-			backup.SetIncludeSchemas([]string{"testschema"})
+			cmdFlags.Set(backup.INCLUDE_SCHEMA, "testschema")
 
 			version4expected := backup.OperatorClass{Oid: 0, Schema: "testschema", Name: "testclass", FamilySchema: "", FamilyName: "", IndexMethod: "hash", Type: "integer", Default: false, StorageType: "-", Operators: nil, Functions: nil}
 			expected := backup.OperatorClass{Oid: 0, Schema: "testschema", Name: "testclass", FamilySchema: "testschema", FamilyName: "testclass", IndexMethod: "hash", Type: "integer", Default: false, StorageType: "-", Operators: nil, Functions: nil}

--- a/integration/predata_textsearch_queries_test.go
+++ b/integration/predata_textsearch_queries_test.go
@@ -42,7 +42,7 @@ var _ = Describe("backup integration tests", func() {
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, "CREATE TEXT SEARCH PARSER testschema.testparser(START = prsd_start, GETTOKEN = prsd_nexttoken, END = prsd_end, LEXTYPES = prsd_lextype);")
 			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH PARSER testschema.testparser")
-			backup.SetIncludeSchemas([]string{"testschema"})
+			cmdFlags.Set(backup.INCLUDE_SCHEMA, "testschema")
 
 			parsers := backup.GetTextSearchParsers(connection)
 
@@ -84,7 +84,7 @@ var _ = Describe("backup integration tests", func() {
 			testhelper.AssertQueryRuns(connection, "CREATE TEXT SEARCH TEMPLATE testschema.testtemplate(LEXIZE = dsimple_lexize);")
 			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH TEMPLATE testschema.testtemplate")
 
-			backup.SetIncludeSchemas([]string{"testschema"})
+			cmdFlags.Set(backup.INCLUDE_SCHEMA, "testschema")
 			templates := backup.GetTextSearchTemplates(connection)
 
 			expectedTemplate := backup.TextSearchTemplate{Oid: 1, Schema: "testschema", Name: "testtemplate", InitFunc: "", LexizeFunc: "dsimple_lexize"}
@@ -123,7 +123,7 @@ var _ = Describe("backup integration tests", func() {
 			testhelper.AssertQueryRuns(connection, "CREATE TEXT SEARCH DICTIONARY testschema.testdictionary (TEMPLATE = 'simple');")
 			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH DICTIONARY testschema.testdictionary")
 
-			backup.SetIncludeSchemas([]string{"testschema"})
+			cmdFlags.Set(backup.INCLUDE_SCHEMA, "testschema")
 			dictionaries := backup.GetTextSearchDictionaries(connection)
 
 			expectedDictionary := backup.TextSearchDictionary{Oid: 1, Schema: "testschema", Name: "testdictionary", Template: "pg_catalog.simple", InitOption: ""}
@@ -178,7 +178,7 @@ var _ = Describe("backup integration tests", func() {
 			testhelper.AssertQueryRuns(connection, `CREATE TEXT SEARCH CONFIGURATION testschema.testconfiguration (PARSER = pg_catalog."default");`)
 			defer testhelper.AssertQueryRuns(connection, "DROP TEXT SEARCH CONFIGURATION testschema.testconfiguration")
 
-			backup.SetIncludeSchemas([]string{"testschema"})
+			cmdFlags.Set(backup.INCLUDE_SCHEMA, "testschema")
 			configurations := backup.GetTextSearchConfigurations(connection)
 
 			expectedConfiguration := backup.TextSearchConfiguration{Oid: 1, Schema: "testschema", Name: "testconfiguration", Parser: `pg_catalog."default"`, TokenToDicts: map[string][]string{}}

--- a/integration/predata_types_queries_test.go
+++ b/integration/predata_types_queries_test.go
@@ -151,7 +151,7 @@ var _ = Describe("backup integration tests", func() {
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, "CREATE TYPE testschema.shell_type")
 			defer testhelper.AssertQueryRuns(connection, "DROP TYPE testschema.shell_type")
-			backup.SetIncludeSchemas([]string{"testschema"})
+			cmdFlags.Set(backup.INCLUDE_SCHEMA, "testschema")
 
 			results := backup.GetShellTypes(connection)
 			shellTypeOtherSchema := backup.Type{Type: "p", Schema: "testschema", Name: "shell_type"}
@@ -328,7 +328,7 @@ var _ = Describe("backup integration tests", func() {
 			defer testhelper.AssertQueryRuns(connection, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connection, `CREATE COLLATION testschema.some_coll (lc_collate = 'POSIX', lc_ctype = 'POSIX');`)
 			defer testhelper.AssertQueryRuns(connection, "DROP COLLATION testschema.some_coll")
-			backup.SetIncludeSchemas([]string{"testschema"})
+			cmdFlags.Set(backup.INCLUDE_SCHEMA, "testschema")
 
 			results := backup.GetCollations(connection)
 

--- a/restore/data.go
+++ b/restore/data.go
@@ -60,7 +60,7 @@ func restoreSingleTableData(entry utils.MasterDataEntry, tableNum uint32, totalT
 func CheckRowsRestored(rowsRestored int64, rowsBackedUp int64, tableName string) {
 	if rowsRestored != rowsBackedUp {
 		rowsErrMsg := fmt.Sprintf("Expected to restore %d rows to table %s, but restored %d instead", rowsBackedUp, tableName, rowsRestored)
-		if *onErrorContinue {
+		if MustGetFlagBool(ON_ERROR_CONTINUE) {
 			gplog.Error(rowsErrMsg)
 		} else {
 			agentErr := CheckAgentErrorsOnSegments()

--- a/restore/data_test.go
+++ b/restore/data_test.go
@@ -69,14 +69,11 @@ var _ = Describe("restore/data tests", func() {
 			testFPInfo = utils.NewFilePathInfo(testCluster, "", "20170101010101", "gpseg")
 			backup.SetFPInfo(testFPInfo)
 		})
-		AfterEach(func() {
-			restore.SetOnErrorContinue(false)
-		})
 		It("does nothing if the number of rows match ", func() {
 			restore.CheckRowsRestored(10, expectedRows, name)
 		})
 		It("panics if the numbers of rows do not match and there is an error with a segment agent", func() {
-			restore.SetOnErrorContinue(false)
+			cmdFlags.Set(restore.ON_ERROR_CONTINUE, "false")
 			testExecutor.ClusterOutput = &cluster.RemoteOutput{
 				Stdouts: map[int]string{
 					1: "error",
@@ -91,7 +88,7 @@ var _ = Describe("restore/data tests", func() {
 			restore.CheckRowsRestored(5, expectedRows, name)
 		})
 		It("panics if the numbers of rows do not match and there is no error with a segment agent", func() {
-			restore.SetOnErrorContinue(false)
+			cmdFlags.Set(restore.ON_ERROR_CONTINUE, "false")
 			testExecutor.ClusterOutput = &cluster.RemoteOutput{
 				Stdouts: map[int]string{
 					1: "",
@@ -103,7 +100,7 @@ var _ = Describe("restore/data tests", func() {
 			restore.CheckRowsRestored(5, expectedRows, name)
 		})
 		It("prints an error if the numbers of rows do not match and onErrorContinue is set", func() {
-			restore.SetOnErrorContinue(true)
+			cmdFlags.Set(restore.ON_ERROR_CONTINUE, "true")
 			testExecutor.ClusterOutput = &cluster.RemoteOutput{
 				Stdouts: map[int]string{
 					1: "",

--- a/restore/global_variables.go
+++ b/restore/global_variables.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gpbackup/utils"
+	"github.com/spf13/pflag"
 )
 
 /*
@@ -39,33 +41,39 @@ var (
 /*
  * Command-line flags
  */
+var cmdFlags *pflag.FlagSet
 
-var (
-	backupDir           *string
-	createDB            *bool
-	dataOnly            *bool
-	debug               *bool
-	excludeSchemas      *[]string
-	excludeRelationFile *string
-	excludeRelations    *[]string
-	includeSchemas      *[]string
-	includeRelationFile *string
-	includeRelations    *[]string
-	metadataOnly        *bool
-	numJobs             *int
-	onErrorContinue     *bool
-	pluginConfigFile    *string
-	quiet               *bool
-	redirect            *string
-	restoreGlobals      *bool
-	timestamp           *string
-	verbose             *bool
-	withStats           *bool
+const (
+	BACKUP_DIR            = "backup-dir"
+	CREATE_DB             = "create-db"
+	DATA_ONLY             = "data-only"
+	DEBUG                 = "debug"
+	EXCLUDE_RELATION      = "exclude-table"
+	EXCLUDE_RELATION_FILE = "exclude-table-file"
+	EXCLUDE_SCHEMA        = "exclude-schema"
+	INCLUDE_RELATION      = "include-table"
+	INCLUDE_RELATION_FILE = "include-table-file"
+	INCLUDE_SCHEMA        = "include-schema"
+	JOBS                  = "jobs"
+	LEAF_PARTITION_DATA   = "leaf-partition-data"
+	METADATA_ONLY         = "metadata-only"
+	ON_ERROR_CONTINUE     = "on-error-continue"
+	PLUGIN_CONFIG         = "plugin-config"
+	QUIET                 = "quiet"
+	REDIRECT_DB           = "redirect-db"
+	TIMESTAMP             = "timestamp"
+	VERBOSE               = "verbose"
+	WITH_GLOBALS          = "with-globals"
+	WITH_STATS            = "with-stats"
 )
 
 /*
  * Setter functions
  */
+
+func SetCmdFlags(flagSet *pflag.FlagSet) {
+	cmdFlags = flagSet
+}
 
 func SetBackupConfig(config *utils.BackupConfig) {
 	backupConfig = config
@@ -83,14 +91,30 @@ func SetFPInfo(fpInfo utils.FilePathInfo) {
 	globalFPInfo = fpInfo
 }
 
-func SetOnErrorContinue(errContinue bool) {
-	onErrorContinue = &errContinue
-}
-
-func SetNumJobs(jobs int) {
-	numJobs = &jobs
-}
-
 func SetTOC(toc *utils.TOC) {
 	globalTOC = toc
+}
+
+func MustGetFlagString(flagName string) string {
+	value, err := cmdFlags.GetString(flagName)
+	gplog.FatalOnError(err)
+	return value
+}
+
+func MustGetFlagInt(flagName string) int {
+	value, err := cmdFlags.GetInt(flagName)
+	gplog.FatalOnError(err)
+	return value
+}
+
+func MustGetFlagBool(flagName string) bool {
+	value, err := cmdFlags.GetBool(flagName)
+	gplog.FatalOnError(err)
+	return value
+}
+
+func MustGetFlagStringSlice(flagName string) []string {
+	value, err := cmdFlags.GetStringSlice(flagName)
+	gplog.FatalOnError(err)
+	return value
 }

--- a/restore/global_variables.go
+++ b/restore/global_variables.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
-	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/spf13/pflag"
 )
@@ -95,26 +94,20 @@ func SetTOC(toc *utils.TOC) {
 	globalTOC = toc
 }
 
+// Util functions to enable ease of access to global flag values
+
 func MustGetFlagString(flagName string) string {
-	value, err := cmdFlags.GetString(flagName)
-	gplog.FatalOnError(err)
-	return value
+	return utils.MustGetFlagString(cmdFlags, flagName)
 }
 
 func MustGetFlagInt(flagName string) int {
-	value, err := cmdFlags.GetInt(flagName)
-	gplog.FatalOnError(err)
-	return value
+	return utils.MustGetFlagInt(cmdFlags, flagName)
 }
 
 func MustGetFlagBool(flagName string) bool {
-	value, err := cmdFlags.GetBool(flagName)
-	gplog.FatalOnError(err)
-	return value
+	return utils.MustGetFlagBool(cmdFlags, flagName)
 }
 
 func MustGetFlagStringSlice(flagName string) []string {
-	value, err := cmdFlags.GetStringSlice(flagName)
-	gplog.FatalOnError(err)
-	return value
+	return utils.MustGetFlagStringSlice(cmdFlags, flagName)
 }

--- a/restore/parallel.go
+++ b/restore/parallel.go
@@ -24,7 +24,7 @@ func executeStatement(statement utils.StatementWithType, showProgressBar int, wh
 	_, err := connectionPool.Exec(statement.Statement, whichConn)
 	if err != nil {
 		gplog.Verbose("Error encountered when executing statement: %s Error was: %s", strings.TrimSpace(statement.Statement), err.Error())
-		if *onErrorContinue {
+		if MustGetFlagBool(ON_ERROR_CONTINUE) {
 			return 1
 		}
 		if showProgressBar >= utils.PB_INFO && gplog.GetVerbosity() == gplog.LOGINFO {

--- a/restore/restore_suite_test.go
+++ b/restore/restore_suite_test.go
@@ -9,14 +9,16 @@ import (
 	"os/exec"
 	"testing"
 
-	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
+	"github.com/greenplum-db/gpbackup/restore"
 	"github.com/greenplum-db/gpbackup/testutils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
+	"github.com/spf13/pflag"
 )
 
 var (
@@ -45,6 +47,8 @@ func TestRestore(t *testing.T) {
 	RunSpecs(t, "restore tests")
 }
 
+var cmdFlags *pflag.FlagSet
+
 var _ = BeforeSuite(func() {
 	connection, mock, stdout, stderr, logfile = testutils.SetupTestEnvironment()
 	buffer = gbytes.NewBuffer()
@@ -52,4 +56,9 @@ var _ = BeforeSuite(func() {
 
 var _ = BeforeEach(func() {
 	connection, mock = testutils.CreateAndConnectMockDB(1)
+
+	cmdFlags = pflag.NewFlagSet("gprestore", pflag.ExitOnError)
+	restore.SetCmdFlags(cmdFlags)
+
+	cmdFlags.Bool(restore.ON_ERROR_CONTINUE, false, "")
 })

--- a/restore/validate.go
+++ b/restore/validate.go
@@ -17,8 +17,8 @@ import (
  */
 
 func validateFilterListsInBackupSet() {
-	ValidateFilterSchemasInBackupSet(*includeSchemas)
-	ValidateFilterRelationsInBackupSet(*includeRelations)
+	ValidateFilterSchemasInBackupSet(MustGetFlagStringSlice(INCLUDE_SCHEMA))
+	ValidateFilterRelationsInBackupSet(MustGetFlagStringSlice(INCLUDE_RELATION))
 }
 
 func ValidateFilterSchemasInBackupSet(schemaList []string) {
@@ -138,36 +138,36 @@ END AS string;`, dbname)))
 }
 
 func ValidateBackupFlagCombinations() {
-	if backupConfig.SingleDataFile && *numJobs != 1 {
+	if backupConfig.SingleDataFile && MustGetFlagInt(JOBS) != 1 {
 		gplog.Fatal(errors.Errorf("Cannot use jobs flag when restoring backups with a single data file per segment."), "")
 	}
-	if (backupConfig.IncludeTableFiltered || backupConfig.DataOnly) && *restoreGlobals {
+	if (backupConfig.IncludeTableFiltered || backupConfig.DataOnly) && MustGetFlagBool(WITH_GLOBALS) {
 		gplog.Fatal(errors.Errorf("Global metadata is not backed up in table-filtered or data-only backups."), "")
 	}
-	if backupConfig.MetadataOnly && *dataOnly {
+	if backupConfig.MetadataOnly && MustGetFlagBool(DATA_ONLY) {
 		gplog.Fatal(errors.Errorf("Cannot use data-only flag when restoring metadata-only backup"), "")
 	}
-	if backupConfig.DataOnly && *metadataOnly {
+	if backupConfig.DataOnly && MustGetFlagBool(METADATA_ONLY) {
 		gplog.Fatal(errors.Errorf("Cannot use metadata-only flag when restoring data-only backup"), "")
 	}
 	validateBackupFlagPluginCombinations()
 }
 
 func validateBackupFlagPluginCombinations() {
-	if backupConfig.Plugin != "" && *pluginConfigFile == "" {
+	if backupConfig.Plugin != "" && MustGetFlagString(PLUGIN_CONFIG) == "" {
 		gplog.Fatal(errors.Errorf("Backup was taken with plugin %s. The --plugin-config flag must be used to restore.", backupConfig.Plugin), "")
-	} else if backupConfig.Plugin == "" && *pluginConfigFile != "" {
+	} else if backupConfig.Plugin == "" && MustGetFlagString(PLUGIN_CONFIG) != "" {
 		gplog.Fatal(errors.Errorf("The --plugin-config flag cannot be used to restore a backup taken without a plugin."), "")
 	}
 }
 
 func ValidateFlagCombinations(flags *pflag.FlagSet) {
-	utils.CheckExclusiveFlags(flags, "data-only", "with-globals")
-	utils.CheckExclusiveFlags(flags, "data-only", "create-db")
-	utils.CheckExclusiveFlags(flags, "debug", "quiet", "verbose")
-	utils.CheckExclusiveFlags(flags, "include-schema", "include-table", "include-table-file")
-	utils.CheckExclusiveFlags(flags, "exclude-schema", "include-schema")
-	utils.CheckExclusiveFlags(flags, "exclude-schema", "exclude-table", "include-table", "exclude-table-file", "include-table-file")
-	utils.CheckExclusiveFlags(flags, "exclude-table", "exclude-table-file", "leaf-partition-data")
-	utils.CheckExclusiveFlags(flags, "metadata-only", "data-only")
+	utils.CheckExclusiveFlags(flags, DATA_ONLY, WITH_GLOBALS)
+	utils.CheckExclusiveFlags(flags, DATA_ONLY, CREATE_DB)
+	utils.CheckExclusiveFlags(flags, DEBUG, QUIET, VERBOSE)
+	utils.CheckExclusiveFlags(flags, INCLUDE_SCHEMA, INCLUDE_RELATION, INCLUDE_RELATION_FILE)
+	utils.CheckExclusiveFlags(flags, EXCLUDE_SCHEMA, INCLUDE_SCHEMA)
+	utils.CheckExclusiveFlags(flags, EXCLUDE_SCHEMA, EXCLUDE_RELATION, INCLUDE_RELATION, EXCLUDE_RELATION_FILE, INCLUDE_RELATION_FILE)
+	utils.CheckExclusiveFlags(flags, EXCLUDE_RELATION, EXCLUDE_RELATION_FILE, LEAF_PARTITION_DATA)
+	utils.CheckExclusiveFlags(flags, METADATA_ONLY, DATA_ONLY)
 }

--- a/utils/flag.go
+++ b/utils/flag.go
@@ -57,3 +57,27 @@ func HandleSingleDashes(args []string) []string {
 	}
 	return newArgs
 }
+
+func MustGetFlagString(cmdFlags *pflag.FlagSet, flagName string) string {
+	value, err := cmdFlags.GetString(flagName)
+	gplog.FatalOnError(err)
+	return value
+}
+
+func MustGetFlagInt(cmdFlags *pflag.FlagSet, flagName string) int {
+	value, err := cmdFlags.GetInt(flagName)
+	gplog.FatalOnError(err)
+	return value
+}
+
+func MustGetFlagBool(cmdFlags *pflag.FlagSet, flagName string) bool {
+	value, err := cmdFlags.GetBool(flagName)
+	gplog.FatalOnError(err)
+	return value
+}
+
+func MustGetFlagStringSlice(cmdFlags *pflag.FlagSet, flagName string) []string {
+	value, err := cmdFlags.GetStringSlice(flagName)
+	gplog.FatalOnError(err)
+	return value
+}


### PR DESCRIPTION
This will enable easier storage and controlled access to user-supplied
command line flags.

Co-authored-by: Soumyadeep Chakraborty <sochakraborty@pivotal.io>
Co-authored-by: Chris Hajas <chajas@pivotal.io>