### PR TITLE
Ensure all tests run if failure during one suite during unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ lint :
 		gometalinter --config=gometalinter.config -s vendor ./...
 
 unit :
-		ginkgo -r -randomizeSuites -noisySkippings=false -randomizeAllSpecs backup restore utils testutils 2>&1
+		ginkgo -r -keepGoing -randomizeSuites -noisySkippings=false -randomizeAllSpecs backup restore utils testutils 2>&1
 
 integration :
 		ginkgo -r -randomizeSuites -noisySkippings=false -randomizeAllSpecs integration 2>&1


### PR DESCRIPTION
Adds -keepGoing flag to unit tests to ensure we run all suites even if
there is a failure.

Authored-by: Chris Hajas <chajas@pivotal.io>