### PR TITLE
Add content id argument to setup/cleanup commands

### DIFF
--- a/helper/helper.go
+++ b/helper/helper.go
@@ -390,6 +390,6 @@ func DoCleanup() {
 }
 
 func log(s string, v ...interface{}) {
-	s = fmt.Sprintf("SEGMENT %d: %s", *content, s)
+	s = fmt.Sprintf("Segment %d: %s", *content, s)
 	gplog.Verbose(s, v...)
 }

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -390,6 +390,6 @@ func DoCleanup() {
 }
 
 func log(s string, v ...interface{}) {
-	s = fmt.Sprintf("Segment %d: %s", *content, s)
+	s = fmt.Sprintf("SEGMENT %d: %s", *content, s)
 	gplog.Verbose(s, v...)
 }

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -81,6 +81,7 @@ of each method with the parameter "master", offering a chance to perform some se
 
 Note: "segment_host" and "segment" are both provided as a single physical segment host may house multiple segment processes in Greenplum. There maybe some setup or cleanup required at the segment host level as compared to each segment process.
 
+[contentID](#contentID): The contentID corresponding to the scope. This is passed in only for the "master" and "segment" scopes.
 
 [filepath](#filepath): The local path to a file written by gpbackup and/or read by gprestore.
 
@@ -104,13 +105,16 @@ Called at the start of the backup process on the master and each segment host.
 
 [scope](#scope)
 
+[contentID](#contentID)
+
 **Return Value:** None
 
 **Example:**
 ```
-test_plugin setup_plugin_for_backup /home/test_plugin_config.yaml /data_dir/backups/20180101/20180101010101 master
-test_plugin setup_plugin_for_backup /home/test_plugin_config.yaml /data_dir/backups/20180101/20180101010101 segment_host
-test_plugin setup_plugin_for_backup /home/test_plugin_config.yaml /data_dir/backups/20180101/20180101010101 segment
+test_plugin setup_plugin_for_backup /home/test_plugin_config.yaml /data_dir-1/backups/20180101/20180101010101 master -1
+test_plugin setup_plugin_for_backup /home/test_plugin_config.yaml /data_dir0/backups/20180101/20180101010101 segment_host
+test_plugin setup_plugin_for_backup /home/test_plugin_config.yaml /data_dir0/backups/20180101/20180101010101 segment 0
+test_plugin setup_plugin_for_backup /home/test_plugin_config.yaml /data_dir1/backups/20180101/20180101010101 segment 1
 ```
 
 ### [setup_plugin_for_restore](#setup_plugin_for_restore)
@@ -129,13 +133,16 @@ Called at the start of the restore process on the master and each segment host.
 
 [scope](#scope)
 
+[contentID](#contentID)
+
 **Return Value:** None
 
 **Example:**
 ```
-test_plugin setup_plugin_for_restore /home/test_plugin_config.yaml /data_dir/backups/20180101/20180101010101 master
-test_plugin setup_plugin_for_restore /home/test_plugin_config.yaml /data_dir/backups/20180101/20180101010101 segment_host
-test_plugin setup_plugin_for_restore /home/test_plugin_config.yaml /data_dir/backups/20180101/20180101010101 segment
+test_plugin setup_plugin_for_restore /home/test_plugin_config.yaml /data_dir-1/backups/20180101/20180101010101 master -1
+test_plugin setup_plugin_for_restore /home/test_plugin_config.yaml /data_dir0/backups/20180101/20180101010101 segment_host
+test_plugin setup_plugin_for_restore /home/test_plugin_config.yaml /data_dir0/backups/20180101/20180101010101 segment 0
+test_plugin setup_plugin_for_restore /home/test_plugin_config.yaml /data_dir1/backups/20180101/20180101010101 segment 1
 ```
 
 ### [cleanup_plugin_for_backup](#cleanup_plugin_for_backup)
@@ -154,13 +161,16 @@ Called during the backup teardown phase on the master and each segment host. Thi
 
 [scope](#scope)
 
+[contentID](#contentID)
+
 **Return Value:** None
 
 **Example:**
 ```
-test_plugin cleanup_plugin_for_backup /home/test_plugin_config.yaml /data_dir/backups/20180101/20180101010101 master
-test_plugin cleanup_plugin_for_backup /home/test_plugin_config.yaml /data_dir/backups/20180101/20180101010101 segment_host
-test_plugin cleanup_plugin_for_backup /home/test_plugin_config.yaml /data_dir/backups/20180101/20180101010101 segment
+test_plugin cleanup_plugin_for_backup /home/test_plugin_config.yaml /data_dir-1/backups/20180101/20180101010101 master -1
+test_plugin cleanup_plugin_for_backup /home/test_plugin_config.yaml /data_dir0/backups/20180101/20180101010101 segment_host
+test_plugin cleanup_plugin_for_backup /home/test_plugin_config.yaml /data_dir0/backups/20180101/20180101010101 segment 0
+test_plugin cleanup_plugin_for_backup /home/test_plugin_config.yaml /data_dir1/backups/20180101/20180101010101 segment 1
 ```
 
 ### [cleanup_plugin_for_restore](#cleanup_plugin_for_restore)
@@ -179,13 +189,16 @@ Called during the restore teardown phase on the master and each segment host. Th
 
 [scope](#scope)
 
+[contentID](#contentID)
+
 **Return Value:** None
 
 **Example:**
 ```
-test_plugin cleanup_plugin_for_restore /home/test_plugin_config.yaml /data_dir/backups/20180101/20180101010101 master
-test_plugin cleanup_plugin_for_restore /home/test_plugin_config.yaml /data_dir/backups/20180101/20180101010101 segment_host
-test_plugin cleanup_plugin_for_restore /home/test_plugin_config.yaml /data_dir/backups/20180101/20180101010101 segment
+test_plugin cleanup_plugin_for_restore /home/test_plugin_config.yaml /data_dir-1/backups/20180101/20180101010101 master -1
+test_plugin cleanup_plugin_for_restore /home/test_plugin_config.yaml /data_dir0/backups/20180101/20180101010101 segment_host
+test_plugin cleanup_plugin_for_restore /home/test_plugin_config.yaml /data_dir0/backups/20180101/20180101010101 segment 0
+test_plugin cleanup_plugin_for_restore /home/test_plugin_config.yaml /data_dir1/backups/20180101/20180101010101 segment 1
 ```
 
 ### [backup_file](#backup_file)

--- a/plugins/example_plugin.sh
+++ b/plugins/example_plugin.sh
@@ -2,7 +2,7 @@
 set -e
 
 setup_plugin_for_backup(){
-  echo "setup_plugin_for_backup $1 $2 $3" >> /tmp/plugin_out.txt
+  echo "setup_plugin_for_backup $1 $2 $3 $4" >> /tmp/plugin_out.txt
   if [ "$3" = "master" ]
     then echo "setup_plugin_for_backup was called for scope = master" >> /tmp/plugin_out.txt
   elif [ "$3" = "segment_host" ]
@@ -14,7 +14,7 @@ setup_plugin_for_backup(){
 }
 
 setup_plugin_for_restore(){
-  echo "setup_plugin_for_restore $1 $2 $3" >> /tmp/plugin_out.txt
+  echo "setup_plugin_for_restore $1 $2 $3 $4" >> /tmp/plugin_out.txt
   if [ "$3" = "master" ]
     then echo "setup_plugin_for_restore was called for scope = master" >> /tmp/plugin_out.txt
   elif [ "$3" = "segment_host" ]
@@ -25,7 +25,7 @@ setup_plugin_for_restore(){
 }
 
 cleanup_plugin_for_backup(){
-  echo "cleanup_plugin_for_backup $1 $2 $3" >> /tmp/plugin_out.txt
+  echo "cleanup_plugin_for_backup $1 $2 $3 $4" >> /tmp/plugin_out.txt
   if [ "$3" = "master" ]
     then echo "cleanup_plugin_for_backup was called for scope = master" >> /tmp/plugin_out.txt
   elif [ "$3" = "segment_host" ]
@@ -36,7 +36,7 @@ cleanup_plugin_for_backup(){
 }
 
 cleanup_plugin_for_restore(){
-  echo "cleanup_plugin_for_restore $1 $2 $3" >> /tmp/plugin_out.txt
+  echo "cleanup_plugin_for_restore $1 $2 $3 $4" >> /tmp/plugin_out.txt
   if [ "$3" = "master" ]
     then echo "cleanup_plugin_for_restore was called for scope = master" >> /tmp/plugin_out.txt
   elif [ "$3" = "segment_host" ]
@@ -71,8 +71,8 @@ restore_data() {
 }
 
 plugin_api_version(){
-  echo "0.2.0"
-  echo "0.2.0" >> /tmp/plugin_out.txt
+  echo "0.3.0"
+  echo "0.3.0" >> /tmp/plugin_out.txt
 }
 
 "$@"

--- a/plugins/plugin_test_bench.sh
+++ b/plugins/plugin_test_bench.sh
@@ -3,7 +3,7 @@
 plugin=$1
 plugin_config=$2
 secondary_plugin_config=$3
-SUPPORTED_API_VERSION="0.2.0"
+SUPPORTED_API_VERSION="0.3.0"
 
 # ----------------------------------------------
 # Test suite setup
@@ -46,11 +46,11 @@ echo "[PASSED] plugin_api_version"
 # ----------------------------------------------
 
 echo "[RUNNING] setup_plugin_for_backup on master"
-$plugin setup_plugin_for_backup $plugin_config $testdir master
+$plugin setup_plugin_for_backup $plugin_config $testdir master -1
 echo "[RUNNING] setup_plugin_for_backup on segment_host"
 $plugin setup_plugin_for_backup $plugin_config $testdir segment_host
-echo "[RUNNING] setup_plugin_for_backup on segment"
-$plugin setup_plugin_for_backup $plugin_config $testdir segment
+echo "[RUNNING] setup_plugin_for_backup on segment 0"
+$plugin setup_plugin_for_backup $plugin_config $testdir segment 0
 
 echo "[RUNNING] backup_file"
 $plugin backup_file $plugin_config $testfile
@@ -58,11 +58,11 @@ $plugin backup_file $plugin_config $testfile
 test -f $testfile
 
 echo "[RUNNING] setup_plugin_for_restore on master"
-$plugin setup_plugin_for_restore $plugin_config $testdir master
+$plugin setup_plugin_for_restore $plugin_config $testdir master -1
 echo "[RUNNING] setup_plugin_for_restore on segment_host"
 $plugin setup_plugin_for_restore $plugin_config $testdir segment_host
-echo "[RUNNING] setup_plugin_for_restore on segment"
-$plugin setup_plugin_for_restore $plugin_config $testdir segment
+echo "[RUNNING] setup_plugin_for_restore on segment 0"
+$plugin setup_plugin_for_restore $plugin_config $testdir segment 0
 
 echo "[RUNNING] restore_file"
 rm $testfile
@@ -118,19 +118,19 @@ echo "[PASSED] restore_data"
 # ----------------------------------------------
 
 echo "[RUNNING] cleanup_plugin_for_backup on master"
-$plugin cleanup_plugin_for_backup $plugin_config $testdir master
+$plugin cleanup_plugin_for_backup $plugin_config $testdir master -1
 echo "[RUNNING] cleanup_plugin_for_backup on segment_host"
 $plugin cleanup_plugin_for_backup $plugin_config $testdir segment_host
-echo "[RUNNING] cleanup_plugin_for_backup on segment"
-$plugin cleanup_plugin_for_backup $plugin_config $testdir segment
+echo "[RUNNING] cleanup_plugin_for_backup on segment 0"
+$plugin cleanup_plugin_for_backup $plugin_config $testdir segment 0
 echo "[PASSED] cleanup_plugin_for_backup"
 
 echo "[RUNNING] cleanup_plugin_for_restore on master"
-$plugin cleanup_plugin_for_restore $plugin_config $testdir master
+$plugin cleanup_plugin_for_restore $plugin_config $testdir master -1
 echo "[RUNNING] cleanup_plugin_for_restore on segment_host"
 $plugin cleanup_plugin_for_restore $plugin_config $testdir segment_host
-echo "[RUNNING] cleanup_plugin_for_restore on segment"
-$plugin cleanup_plugin_for_restore $plugin_config $testdir segment
+echo "[RUNNING] cleanup_plugin_for_restore on segment 0"
+$plugin cleanup_plugin_for_restore $plugin_config $testdir segment 0
 echo "[PASSED] cleanup_plugin_for_restore"
 
 


### PR DESCRIPTION
Now passing in the content id for scope=master, segment to setup/cleanup methods. For scope=segment_host, content id is not passed in.

Co-authored-by: Soumyadeep Chakraborty <sochakraborty@pivotal.io>
Co-authored-by: Chris Hajas <chajas@pivotal.io>