### PR TITLE
Add support for tablespace modifications introduced in master

### DIFF
--- a/backup/metadata_globals.go
+++ b/backup/metadata_globals.go
@@ -288,17 +288,9 @@ func PrintRoleMembershipStatements(metadataFile *utils.FileWithByteCount, toc *u
 func PrintCreateTablespaceStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, tablespaces []Tablespace, tablespaceMetadata MetadataMap) {
 	for _, tablespace := range tablespaces {
 		start := metadataFile.ByteCount
-		if tablespace.SegmentLocation != nil {
-			metadataFile.MustPrintf("\n\nCREATE TABLESPACE %s LOCATION %s\n\tOPTIONS (", tablespace.Tablespace, tablespace.FileLocation)
-			for i, seg := range tablespace.SegmentLocation {
-				if i != len(tablespace.SegmentLocation)-1 {
-					metadataFile.MustPrintf("%s %s, ", seg.Tablespace, seg.FileLocation)
-				} else {
-					metadataFile.MustPrintf("%s %s", seg.Tablespace, seg.FileLocation)
-				}
-
-			}
-			metadataFile.MustPrintf(");")
+		if tablespace.SegmentLocations != nil {
+			metadataFile.MustPrintf("\n\nCREATE TABLESPACE %s LOCATION %s\n\tOPTIONS (%s);",
+				tablespace.Tablespace, tablespace.FileLocation, strings.Join(tablespace.SegmentLocations, ", "))
 		} else {
 			metadataFile.MustPrintf("\n\nCREATE TABLESPACE %s FILESPACE %s;", tablespace.Tablespace, tablespace.FileLocation)
 		}

--- a/backup/metadata_globals_test.go
+++ b/backup/metadata_globals_test.go
@@ -345,7 +345,10 @@ REVOKE ALL ON TABLESPACE test_tablespace FROM testrole;
 GRANT ALL ON TABLESPACE test_tablespace TO testrole;`)
 		})
 		It("prints a tablespace with per-segment tablespaces", func() {
-			expectedTablespace := backup.Tablespace{Oid: 1, Tablespace: "test_tablespace", FileLocation: "'/data/dir'", SegmentLocation: []backup.SegmentTablespace{{Tablespace: "content1", FileLocation: "'/data/dir1'"}, {Tablespace: "content2", FileLocation: "'/data/dir2'"}, {Tablespace: "content3", FileLocation: "'/data/dir3'"}}}
+			expectedTablespace := backup.Tablespace{
+				Oid: 1, Tablespace: "test_tablespace", FileLocation: "'/data/dir'",
+				SegmentLocations: []string{"content1 '/data/dir1'", "content2 '/data/dir2'", "content3 '/data/dir3'"},
+			}
 			emptyMetadataMap := backup.MetadataMap{}
 			backup.PrintCreateTablespaceStatements(backupfile, toc, []backup.Tablespace{expectedTablespace}, emptyMetadataMap)
 			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "", "test_tablespace", "TABLESPACE")

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -66,11 +66,11 @@ var _ = BeforeSuite(func() {
 	if connection.Version.Before("6") {
 		setupTestFilespace(testCluster)
 	} else {
-		remoteOutput := testCluster.GenerateAndExecuteCommand("Creating /tmp/test_dir directory on all hosts", func(contentID int) string {
-			return fmt.Sprintf("mkdir -p /tmp/test_dir")
+		remoteOutput := testCluster.GenerateAndExecuteCommand("Creating filespace test directories on all hosts", func(contentID int) string {
+			return fmt.Sprintf("mkdir -p /tmp/test_dir && mkdir -p /tmp/test_dir1 && mkdir -p /tmp/test_dir2")
 		}, cluster.ON_HOSTS_AND_MASTER)
 		if remoteOutput.NumErrors != 0 {
-			Fail("Could not create /tmp/test_dir directory on 1 or more hosts")
+			Fail("Could not create filespace test directory on 1 or more hosts")
 		}
 	}
 
@@ -98,11 +98,11 @@ var _ = AfterSuite(func() {
 	if connection.Version.Before("6") {
 		destroyTestFilespace()
 	} else {
-		remoteOutput := testCluster.GenerateAndExecuteCommand("Removing /tmp/test_dir directory on all hosts", func(contentID int) string {
-			return fmt.Sprintf("rm -rf /tmp/test_dir")
+		remoteOutput := testCluster.GenerateAndExecuteCommand("Removing /tmp/test_dir* directories on all hosts", func(contentID int) string {
+			return fmt.Sprintf("rm -rf /tmp/test_dir*")
 		}, cluster.ON_HOSTS_AND_MASTER)
 		if remoteOutput.NumErrors != 0 {
-			Fail("Could not remove /tmp/test_dir directory on 1 or more hosts")
+			Fail("Could not remove /tmp/testdir* directories on 1 or more hosts")
 		}
 	}
 	if connection != nil {

--- a/integration/metadata_globals_create_test.go
+++ b/integration/metadata_globals_create_test.go
@@ -303,7 +303,7 @@ var _ = Describe("backup integration create statement tests", func() {
 		var expectedTablespace backup.Tablespace
 		BeforeEach(func() {
 			if connection.Version.AtLeast("6") {
-				expectedTablespace = backup.Tablespace{Oid: 1, Tablespace: "test_tablespace", FileLocation: "'/tmp/test_dir'", SegmentLocation: []backup.SegmentTablespace{}}
+				expectedTablespace = backup.Tablespace{Oid: 1, Tablespace: "test_tablespace", FileLocation: "'/tmp/test_dir'", SegmentLocations: []string{}}
 			} else {
 				expectedTablespace = backup.Tablespace{Oid: 1, Tablespace: "test_tablespace", FileLocation: "test_dir"}
 			}
@@ -329,7 +329,10 @@ var _ = Describe("backup integration create statement tests", func() {
 		It("creates a basic tablespace with different filespace locations", func() {
 			testutils.SkipIfBefore6(connection)
 
-			expectedTablespace = backup.Tablespace{Oid: 1, Tablespace: "test_tablespace", FileLocation: "'/tmp/test_dir'", SegmentLocation: []backup.SegmentTablespace{{Tablespace: "content0", FileLocation: "'/tmp/test_dir1'"}, {Tablespace: "content1", FileLocation: "'/tmp/test_dir2'"}}}
+			expectedTablespace = backup.Tablespace{
+				Oid: 1, Tablespace: "test_tablespace", FileLocation: "'/tmp/test_dir'",
+				SegmentLocations: []string{"content0 '/tmp/test_dir1'", "content1 '/tmp/test_dir2'"},
+			}
 			numTablespaces := len(backup.GetTablespaces(connection))
 			emptyMetadataMap := backup.MetadataMap{}
 			backup.PrintCreateTablespaceStatements(backupfile, toc, []backup.Tablespace{expectedTablespace}, emptyMetadataMap)

--- a/integration/metadata_globals_queries_test.go
+++ b/integration/metadata_globals_queries_test.go
@@ -331,7 +331,7 @@ CREATEEXTTABLE (protocol='gphdfs', type='writable')`)
 				expectedTablespace = backup.Tablespace{Oid: 0, Tablespace: "test_tablespace", FileLocation: "test_dir"}
 			} else {
 				testhelper.AssertQueryRuns(connection, "CREATE TABLESPACE test_tablespace LOCATION '/tmp/test_dir'")
-				expectedTablespace = backup.Tablespace{Oid: 0, Tablespace: "test_tablespace", FileLocation: "'/tmp/test_dir'", SegmentLocation: []backup.SegmentTablespace{}}
+				expectedTablespace = backup.Tablespace{Oid: 0, Tablespace: "test_tablespace", FileLocation: "'/tmp/test_dir'", SegmentLocations: []string{}}
 			}
 			defer testhelper.AssertQueryRuns(connection, "DROP TABLESPACE test_tablespace")
 
@@ -349,7 +349,10 @@ CREATEEXTTABLE (protocol='gphdfs', type='writable')`)
 			testutils.SkipIfBefore6(connection)
 
 			testhelper.AssertQueryRuns(connection, "CREATE TABLESPACE test_tablespace LOCATION '/tmp/test_dir' OPTIONS (content0 '/tmp/test_dir1')")
-			expectedTablespace := backup.Tablespace{Oid: 0, Tablespace: "test_tablespace", FileLocation: "'/tmp/test_dir'", SegmentLocation: []backup.SegmentTablespace{{Tablespace: "content0", FileLocation: "'/tmp/test_dir1'"}}}
+			expectedTablespace := backup.Tablespace{
+				Oid: 0, Tablespace: "test_tablespace", FileLocation: "'/tmp/test_dir'",
+				SegmentLocations: []string{"content0 '/tmp/test_dir1'"},
+			}
 
 			defer testhelper.AssertQueryRuns(connection, "DROP TABLESPACE test_tablespace")
 


### PR DESCRIPTION
The FILESPACE keyword no longer exists in the GPDB master branch and has
been replaced with new syntax that specifies the directory for each
segment. This commit adds support for this new syntax.

Co-authored-by: Chris Hajas <chajas@pivotal.io>
Co-authored-by: Karen Huddleston <khuddleston@pivotal.io>