### PR TITLE
Ensure COPY FROM SEGMENT restores data to correct segment

### DIFF
--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -38,7 +38,6 @@ func InitializeConnection(dbname string) {
 	setupQuery := `
 SET application_name TO 'gprestore';
 SET search_path TO pg_catalog;
-SET gp_enable_segment_copy_checking TO false;
 SET gp_default_storage_options='';
 SET statement_timeout = 0;
 SET check_function_bodies = false;


### PR DESCRIPTION
Previously, the gp_enable_segment_copy_checking GUC was set to false,
which didn't check that data was restored to the correct segment.
Although we backup/restore to the same segment, we now set this GUC to
its default, true, to ensure the data is restored to the correct
segment in all cases.

Authored-by: Chris Hajas <chajas@pivotal.io>