### PR TITLE
Use goimports instead of gofmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,10 +29,9 @@ dependencies :
 
 format :
 		goimports -w .
-		gofmt -w -s .
 
 lint :
-		! gofmt -l backup/ restore/ utils/ helper/ testutils/ integration/ end_to_end/ | read
+		! goimports -l backup/ restore/ utils/ helper/ testutils/ integration/ end_to_end/ | read
 		gometalinter --config=gometalinter.config -s vendor ./...
 
 unit :


### PR DESCRIPTION
goimports is a superset of gofmt and will organize imports in addition to formatting code.

Authored-by: Chris Hajas <chajas@pivotal.io>