### PR TITLE
Add option to disable slack alerts to slack resource

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -152,6 +152,7 @@ resources:
   type: slack-notification
   source:
     url: {{dpm_webhook_url}}
+    disable: {{dpm_disable_slack_alert}}
 
 - name: component_gpbackup
   type: s3


### PR DESCRIPTION
This recently introduced feature makes it easier to disable slack alerts
for dev testing.

Authored-by: Chris Hajas <chajas@pivotal.io>