### PR TITLE
Modify tests for gpdb6 to remove hyperloglog extension

### DIFF
--- a/integration/predata_functions_create_test.go
+++ b/integration/predata_functions_create_test.go
@@ -380,11 +380,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultExtensions := backup.GetExtensions(connection)
 			resultMetadataMap := backup.GetCommentsForObjectType(connection, backup.TYPE_EXTENSION)
 			plperlExtension.Oid = testutils.OidFromObjectName(connection, "", "plperl", backup.TYPE_EXTENSION)
-			if connection.Version.Before("6") {
-				Expect(len(resultExtensions)).To(Equal(1))
-			} else {
-				Expect(len(resultExtensions)).To(Equal(2))
-			}
+			Expect(len(resultExtensions)).To(Equal(1))
 			plperlMetadata := resultMetadataMap[plperlExtension.Oid]
 			structmatcher.ExpectStructsToMatch(&plperlExtension, &resultExtensions[0])
 			structmatcher.ExpectStructsToMatch(&extensionMetadata, &plperlMetadata)

--- a/integration/predata_functions_queries_test.go
+++ b/integration/predata_functions_queries_test.go
@@ -426,19 +426,10 @@ LANGUAGE SQL`)
 
 			results := backup.GetExtensions(connection)
 
-			if connection.Version.Before("6") {
-				Expect(len(results)).To(Equal(1))
+			Expect(len(results)).To(Equal(1))
 
-				plperlDef := backup.Extension{Oid: 0, Name: "plperl", Schema: "pg_catalog"}
-				structmatcher.ExpectStructsToMatchExcluding(&plperlDef, &results[0], "Oid")
-			} else {
-				Expect(len(results)).To(Equal(2))
-
-				plperlDef := backup.Extension{Oid: 0, Name: "plperl", Schema: "pg_catalog"}
-				hyperloglogDef := backup.Extension{Oid: 0, Name: "hyperloglog_counter", Schema: "pg_catalog"}
-				structmatcher.ExpectStructsToMatchExcluding(&plperlDef, &results[0], "Oid")
-				structmatcher.ExpectStructsToMatchExcluding(&hyperloglogDef, &results[1], "Oid")
-			}
+			plperlDef := backup.Extension{Oid: 0, Name: "plperl", Schema: "pg_catalog"}
+			structmatcher.ExpectStructsToMatchExcluding(&plperlDef, &results[0], "Oid")
 		})
 	})
 	Describe("GetProceduralLanguages", func() {

--- a/integration/predata_shared_queries_test.go
+++ b/integration/predata_shared_queries_test.go
@@ -1040,11 +1040,7 @@ LANGUAGE SQL`)
 				oid := testutils.OidFromObjectName(connection, "", "plperl", backup.TYPE_EXTENSION)
 				resultMetadataMap := backup.GetCommentsForObjectType(connection, backup.TYPE_EXTENSION)
 
-				if connection.Version.Before("6") {
-					Expect(len(resultMetadataMap)).To(Equal(1))
-				} else {
-					Expect(len(resultMetadataMap)).To(Equal(2))
-				}
+				Expect(len(resultMetadataMap)).To(Equal(1))
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatch(&extensionMetadata, &resultMetadata)
 			})


### PR DESCRIPTION
This extension was moved to the catalog in GPDB master.

Authored-by: Chris Hajas <chajas@pivotal.io>