### PR TITLE
Fixes seg prefix resolution when multiple prefixed dirs are present

### DIFF
--- a/restore/restore.go
+++ b/restore/restore.go
@@ -83,7 +83,7 @@ func DoSetup() {
 	InitializeConnection("postgres")
 	segConfig := cluster.MustGetSegmentConfiguration(connectionPool)
 	globalCluster = cluster.NewCluster(segConfig)
-	segPrefix := utils.ParseSegPrefix(MustGetFlagString(utils.BACKUP_DIR))
+	segPrefix := utils.ParseSegPrefix(MustGetFlagString(utils.BACKUP_DIR), MustGetFlagString(utils.TIMESTAMP))
 	globalFPInfo = utils.NewFilePathInfo(globalCluster, MustGetFlagString(utils.BACKUP_DIR), MustGetFlagString(utils.TIMESTAMP), segPrefix)
 
 	// Get restore metadata from plugin

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -159,7 +159,7 @@ func ExecuteRestoreMetadataStatements(statements []utils.StatementWithType, obje
 func GetBackupFPInfoList() []utils.FilePathInfo {
 	fpInfoList := make([]utils.FilePathInfo, 0)
 	for _, entry := range backupConfig.RestorePlan {
-		segPrefix := utils.ParseSegPrefix(MustGetFlagString(utils.BACKUP_DIR))
+		segPrefix := utils.ParseSegPrefix(MustGetFlagString(utils.BACKUP_DIR), entry.Timestamp)
 
 		fpInfo := utils.NewFilePathInfo(globalCluster, MustGetFlagString(utils.BACKUP_DIR), entry.Timestamp, segPrefix)
 		fpInfoList = append(fpInfoList, fpInfo)

--- a/utils/filepath.go
+++ b/utils/filepath.go
@@ -162,14 +162,12 @@ func GetSegPrefix(connection *dbconn.DBConn) string {
 func ParseSegPrefix(backupDir string, timestamp string) string {
 	segPrefix := ""
 	if len(backupDir) > 0 {
-		masterDir, err := operating.System.Glob(fmt.Sprintf("%s/*-1/backups/*/%s", backupDir, timestamp))
-		if err != nil || len(masterDir) == 0 {
+		backupDirForTimestamp, err := operating.System.Glob(fmt.Sprintf("%s/*-1/backups/*/%s", backupDir, timestamp))
+		if err != nil || len(backupDirForTimestamp) == 0 {
 			gplog.Fatal(err, "Master backup directory in %s missing or inaccessible", backupDir)
 		}
-		indexOfBackupsSubstr := strings.LastIndex(masterDir[0], "-1/backups/")
-		segPrefix = masterDir[0][:indexOfBackupsSubstr]
-		_, segPrefix = path.Split(segPrefix)
-		fmt.Println(segPrefix)
+		indexOfBackupsSubstr := strings.LastIndex(backupDirForTimestamp[0], "-1/backups/")
+		_, segPrefix = path.Split(backupDirForTimestamp[0][:indexOfBackupsSubstr])
 	}
 	return segPrefix
 }

--- a/utils/filepath.go
+++ b/utils/filepath.go
@@ -159,15 +159,17 @@ func GetSegPrefix(connection *dbconn.DBConn) string {
 	return segPrefix
 }
 
-func ParseSegPrefix(backupDir string) string {
+func ParseSegPrefix(backupDir string, timestamp string) string {
 	segPrefix := ""
 	if len(backupDir) > 0 {
-		masterDir, err := operating.System.Glob(fmt.Sprintf("%s/*-1", backupDir))
+		masterDir, err := operating.System.Glob(fmt.Sprintf("%s/*-1/backups/*/%s", backupDir, timestamp))
 		if err != nil || len(masterDir) == 0 {
 			gplog.Fatal(err, "Master backup directory in %s missing or inaccessible", backupDir)
 		}
-		_, segPrefix = path.Split(masterDir[0])
-		segPrefix = segPrefix[:len(segPrefix)-2] // Remove "-1" segment ID from string
+		indexOfBackupsSubstr := strings.LastIndex(masterDir[0], "-1/backups/")
+		segPrefix = masterDir[0][:indexOfBackupsSubstr]
+		_, segPrefix = path.Split(segPrefix)
+		fmt.Println(segPrefix)
 	}
 	return segPrefix
 }

--- a/utils/filepath_test.go
+++ b/utils/filepath_test.go
@@ -99,23 +99,26 @@ var _ = Describe("utils/filepath tests", func() {
 			operating.System.Glob = filepath.Glob
 		})
 		It("returns segment prefix from directory path if master backup directory exists", func() {
-			operating.System.Glob = func(pattern string) (matches []string, err error) { return []string{"/tmp/foo/gpseg-1"}, nil }
-			Expect(utils.ParseSegPrefix("/tmp/foo")).To(Equal("gpseg"))
+			operating.System.Glob = func(pattern string) (matches []string, err error) {
+				return []string{"/tmp/foo/gpseg-1/backups/datestamp1/timestamp1"}, nil
+			}
+
+			Expect(utils.ParseSegPrefix("/tmp/foo", "timestamp1")).To(Equal("gpseg"))
 		})
 		It("returns empty string if backup directory is empty", func() {
-			Expect(utils.ParseSegPrefix("")).To(Equal(""))
+			Expect(utils.ParseSegPrefix("", "timestamp1")).To(Equal(""))
 		})
 		It("panics if master backup directory does not exist", func() {
 			operating.System.Glob = func(pattern string) (matches []string, err error) { return []string{}, nil }
 			defer testhelper.ShouldPanicWithMessage("Master backup directory in /tmp/foo missing or inaccessible")
-			Expect(utils.ParseSegPrefix("/tmp/foo")).To(Equal("gpseg"))
+			Expect(utils.ParseSegPrefix("/tmp/foo", "timestamp1")).To(Equal("gpseg"))
 		})
 		It("panics if there is an error accessing master backup directory", func() {
 			operating.System.Glob = func(pattern string) (matches []string, err error) {
 				return []string{""}, os.ErrPermission
 			}
 			defer testhelper.ShouldPanicWithMessage("Master backup directory in /tmp/foo missing or inaccessible")
-			Expect(utils.ParseSegPrefix("/tmp/foo")).To(Equal("gpseg"))
+			Expect(utils.ParseSegPrefix("/tmp/foo", "timestamp1")).To(Equal("gpseg"))
 		})
 	})
 })


### PR DESCRIPTION
Before this fix: GetSegPrefix would incorrectly match on the
directory lexicographically occurring first in order to compute the
prefix. Now, we also incorporate the timestamp into the resolution
process ensuring a correct match.

Authored-by: Soumyadeep Chakraborty <sochakraborty@pivotal.io>