### PR TITLE
Modify table validation in restore database

### DIFF
--- a/restore/restore.go
+++ b/restore/restore.go
@@ -117,7 +117,7 @@ func DoSetup() {
 	 * should not error out for validation reasons once the restore database exists.
 	 */
 	if !MustGetFlagBool(utils.CREATE_DB) {
-		ValidateFilterRelationsInRestoreDatabase(connectionPool, MustGetFlagStringSlice(utils.INCLUDE_RELATION))
+		ValidateRelationsInRestoreDatabase(connectionPool, MustGetFlagStringSlice(utils.INCLUDE_RELATION))
 	}
 }
 

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -115,8 +115,10 @@ func DoSetup() {
 	/*
 	 * We don't need to validate anything if we're creating the database; we
 	 * should not error out for validation reasons once the restore database exists.
+	 * For on-error-continue, we will see the same errors later when we try to run SQL,
+	 * but since they will not stop the restore, it is not necessary to log them twice.
 	 */
-	if !MustGetFlagBool(utils.CREATE_DB) {
+	if !MustGetFlagBool(utils.CREATE_DB) && !MustGetFlagBool(utils.ON_ERROR_CONTINUE) {
 		ValidateRelationsInRestoreDatabase(connectionPool, MustGetFlagStringSlice(utils.INCLUDE_RELATION))
 	}
 }

--- a/restore/restore_suite_test.go
+++ b/restore/restore_suite_test.go
@@ -62,4 +62,5 @@ var _ = BeforeEach(func() {
 	restore.SetCmdFlags(cmdFlags)
 
 	cmdFlags.Bool(utils.ON_ERROR_CONTINUE, false, "")
+	cmdFlags.Bool(utils.DATA_ONLY, false, "")
 })

--- a/restore/validate_test.go
+++ b/restore/validate_test.go
@@ -1,6 +1,8 @@
 package restore_test
 
 import (
+	"regexp"
+
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup/restore"
 	"github.com/greenplum-db/gpbackup/testutils"
@@ -8,10 +10,14 @@ import (
 	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
 )
 
 var _ = Describe("restore/validate tests", func() {
 	var filterList []string
+	var toc *utils.TOC
+	var backupfile *utils.FileWithByteCount
 	AfterEach(func() {
 		filterList = []string{}
 	})
@@ -22,8 +28,6 @@ var _ = Describe("restore/validate tests", func() {
 		table1Len := uint64(len(table1.Statement))
 		table2 := utils.StatementWithType{ObjectType: "TABLE", Statement: "CREATE TABLE schema2.table2"}
 		table2Len := uint64(len(table2.Statement))
-		var toc *utils.TOC
-		var backupfile *utils.FileWithByteCount
 		BeforeEach(func() {
 			toc, backupfile = testutils.InitializeTestTOC(buffer, "predata")
 			backupfile.ByteCount = table1Len
@@ -59,31 +63,140 @@ var _ = Describe("restore/validate tests", func() {
 			restore.ValidateFilterSchemasInBackupSet(filterList)
 		})
 	})
-	Describe("ValidateFilterRelationsInRestoreDatabase", func() {
-		It("passes if there are no filter relations", func() {
-			restore.ValidateFilterRelationsInRestoreDatabase(connection, filterList)
+	Describe("ValidateRelationsInRestoreDatabase", func() {
+		BeforeEach(func() {
+			cmdFlags.Set(utils.DATA_ONLY, "false")
+			cmdFlags.Set(utils.ON_ERROR_CONTINUE, "false")
+			toc, _ = testutils.InitializeTestTOC(buffer, "metadata")
+			toc.AddMasterDataEntry("public", "table1", 1, "(j)", 0)
+			toc.AddMasterDataEntry("public", "table2", 2, "(j)", 0)
+			restore.SetTOC(toc)
 		})
-		It("passes if table is not present in database", func() {
-			no_table_rows := sqlmock.NewRows([]string{"string"})
-			mock.ExpectQuery("SELECT (.*)").WillReturnRows(no_table_rows)
-			filterList = []string{"public.table2"}
-			restore.ValidateFilterRelationsInRestoreDatabase(connection, filterList)
+		Context("data-only", func() {
+			BeforeEach(func() {
+				cmdFlags.Set(utils.DATA_ONLY, "true")
+			})
+			Context("on error continue", func() {
+				It("logs an error message, but does not panic with on-error-continue", func() {
+					cmdFlags.Set(utils.ON_ERROR_CONTINUE, "true")
+					no_table_rows := sqlmock.NewRows([]string{"string"})
+					mock.ExpectQuery("SELECT (.*)").WillReturnRows(no_table_rows)
+					filterList = []string{"public.table2"}
+					restore.ValidateRelationsInRestoreDatabase(connection, filterList)
+					Expect(stderr).To(gbytes.Say(regexp.QuoteMeta("[ERROR]:-Relation public.table2 must exist for data-only restore")))
+				})
+			})
+			Context("with filtering", func() {
+				It("panics if all tables missing from database", func() {
+					no_table_rows := sqlmock.NewRows([]string{"string"})
+					mock.ExpectQuery("SELECT (.*)").WillReturnRows(no_table_rows)
+					filterList = []string{"public.table2"}
+					defer testhelper.ShouldPanicWithMessage("Relation public.table2 must exist for data-only restore")
+					restore.ValidateRelationsInRestoreDatabase(connection, filterList)
+				})
+				It("panics if some tables missing from database", func() {
+					single_table_row := sqlmock.NewRows([]string{"string"}).
+						AddRow("public.table1")
+					mock.ExpectQuery("SELECT (.*)").WillReturnRows(single_table_row)
+					filterList = []string{"public.table1", "public.table2"}
+					defer testhelper.ShouldPanicWithMessage("Relation public.table2 must exist for data-only restore")
+					restore.ValidateRelationsInRestoreDatabase(connection, filterList)
+				})
+				It("passes if all tables are present in database", func() {
+					two_table_rows := sqlmock.NewRows([]string{"string"}).
+						AddRow("public.table1").AddRow("public.table2")
+					mock.ExpectQuery("SELECT (.*)").WillReturnRows(two_table_rows)
+					filterList = []string{"public.table1", "public.table2"}
+					restore.ValidateRelationsInRestoreDatabase(connection, filterList)
+				})
+				It("logs an error message, but does not panic with on-error-continue", func() {
+					cmdFlags.Set(utils.ON_ERROR_CONTINUE, "true")
+					no_table_rows := sqlmock.NewRows([]string{"string"})
+					mock.ExpectQuery("SELECT (.*)").WillReturnRows(no_table_rows)
+					filterList = []string{"public.table2"}
+					restore.ValidateRelationsInRestoreDatabase(connection, filterList)
+					Expect(stderr).To(gbytes.Say(regexp.QuoteMeta("[ERROR]:-Relation public.table2 must exist for data-only restore")))
+				})
+			})
+			Context("without filtering", func() {
+				It("panics if all tables missing from database", func() {
+					no_table_rows := sqlmock.NewRows([]string{"string"})
+					mock.ExpectQuery("SELECT (.*)").WillReturnRows(no_table_rows)
+					defer testhelper.ShouldPanicWithMessage("Relation public.table2 must exist for data-only restore")
+					restore.ValidateRelationsInRestoreDatabase(connection, filterList)
+				})
+				It("panics if some tables missing from database", func() {
+					single_table_row := sqlmock.NewRows([]string{"string"}).
+						AddRow("public.table1")
+					mock.ExpectQuery("SELECT (.*)").WillReturnRows(single_table_row)
+					defer testhelper.ShouldPanicWithMessage("Relation public.table2 must exist for data-only restore")
+					restore.ValidateRelationsInRestoreDatabase(connection, filterList)
+				})
+				It("passes if all tables are present in database", func() {
+					two_table_rows := sqlmock.NewRows([]string{"string"}).
+						AddRow("public.table1").AddRow("public.view1")
+					mock.ExpectQuery("SELECT (.*)").WillReturnRows(two_table_rows)
+					restore.ValidateRelationsInRestoreDatabase(connection, filterList)
+				})
+			})
 		})
-		It("panics if single table is present in database", func() {
-			single_table_row := sqlmock.NewRows([]string{"string"}).
-				AddRow("public.table1")
-			mock.ExpectQuery("SELECT (.*)").WillReturnRows(single_table_row)
-			filterList = []string{"public.table1"}
-			defer testhelper.ShouldPanicWithMessage("Relation public.table1 already exists")
-			restore.ValidateFilterRelationsInRestoreDatabase(connection, filterList)
-		})
-		It("panics if multiple tables are present in database", func() {
-			two_table_rows := sqlmock.NewRows([]string{"string"}).
-				AddRow("public.table1").AddRow("public.view1")
-			mock.ExpectQuery("SELECT (.*)").WillReturnRows(two_table_rows)
-			filterList = []string{"public.table1", "public.view1"}
-			defer testhelper.ShouldPanicWithMessage("Relation public.table1 already exists")
-			restore.ValidateFilterRelationsInRestoreDatabase(connection, filterList)
+		Context("all stages restore", func() {
+			Context("on error continue", func() {
+				It("logs an error message, but does not panic with on-error-continue", func() {
+					cmdFlags.Set(utils.ON_ERROR_CONTINUE, "true")
+					two_table_rows := sqlmock.NewRows([]string{"string"}).
+						AddRow("public.table1").AddRow("public.view1")
+					mock.ExpectQuery("SELECT (.*)").WillReturnRows(two_table_rows)
+					filterList = []string{"public.table1", "public.view1"}
+					restore.ValidateRelationsInRestoreDatabase(connection, filterList)
+					Expect(stderr).To(gbytes.Say(regexp.QuoteMeta("[ERROR]:-Relation public.table1 already exists")))
+				})
+			})
+			Context("with filtering", func() {
+				It("passes if table is not present in database", func() {
+					no_table_rows := sqlmock.NewRows([]string{"string"})
+					mock.ExpectQuery("SELECT (.*)").WillReturnRows(no_table_rows)
+					filterList = []string{"public.table2"}
+					restore.ValidateRelationsInRestoreDatabase(connection, filterList)
+				})
+				It("panics if single table is present in database", func() {
+					single_table_row := sqlmock.NewRows([]string{"string"}).
+						AddRow("public.table1")
+					mock.ExpectQuery("SELECT (.*)").WillReturnRows(single_table_row)
+					filterList = []string{"public.table1"}
+					defer testhelper.ShouldPanicWithMessage("Relation public.table1 already exists")
+					restore.ValidateRelationsInRestoreDatabase(connection, filterList)
+				})
+				It("panics if multiple tables are present in database", func() {
+					two_table_rows := sqlmock.NewRows([]string{"string"}).
+						AddRow("public.table1").AddRow("public.view1")
+					mock.ExpectQuery("SELECT (.*)").WillReturnRows(two_table_rows)
+					filterList = []string{"public.table1", "public.view1"}
+					defer testhelper.ShouldPanicWithMessage("Relation public.table1 already exists")
+					restore.ValidateRelationsInRestoreDatabase(connection, filterList)
+				})
+			})
+			Context("without filtering", func() {
+				It("passes if table is not present in database", func() {
+					no_table_rows := sqlmock.NewRows([]string{"string"})
+					mock.ExpectQuery("SELECT (.*)").WillReturnRows(no_table_rows)
+					restore.ValidateRelationsInRestoreDatabase(connection, filterList)
+				})
+				It("panics if single table is present in database", func() {
+					single_table_row := sqlmock.NewRows([]string{"string"}).
+						AddRow("public.table1")
+					mock.ExpectQuery("SELECT (.*)").WillReturnRows(single_table_row)
+					defer testhelper.ShouldPanicWithMessage("Relation public.table1 already exists")
+					restore.ValidateRelationsInRestoreDatabase(connection, filterList)
+				})
+				It("panics if multiple tables are present in database", func() {
+					two_table_rows := sqlmock.NewRows([]string{"string"}).
+						AddRow("public.table1").AddRow("public.table2")
+					mock.ExpectQuery("SELECT (.*)").WillReturnRows(two_table_rows)
+					defer testhelper.ShouldPanicWithMessage("Relation public.table1 already exists")
+					restore.ValidateRelationsInRestoreDatabase(connection, filterList)
+				})
+			})
 		})
 	})
 	Describe("ValidateFilterRelationsInBackupSet", func() {


### PR DESCRIPTION
For a data only restore, we want to validate that all tables we will
attempt to restore data to already exist in the database.

For a metadata restore, we want to validate that the tables we will
attempt to restore are not already in the database. We were previously
only checking this for a filtered restore.

Authored-by: Karen Huddleston <khuddleston@pivotal.io>