### PR TITLE
Change allow_system_table_mods to boolean for GPDB master

### DIFF
--- a/backup/statistics.go
+++ b/backup/statistics.go
@@ -14,9 +14,6 @@ import (
 )
 
 func PrintStatisticsStatements(statisticsFile *utils.FileWithByteCount, toc *utils.TOC, tables []Relation, attStats map[uint32][]AttributeStatistic, tupleStats map[uint32]TupleStatistic) {
-	start := statisticsFile.ByteCount
-	statisticsFile.MustPrintf(`SET allow_system_table_mods="DML";`)
-	toc.AddStatisticsEntry("", "", "STATISTICS GUC", start, statisticsFile)
 	for _, table := range tables {
 		PrintStatisticsStatementsForTable(statisticsFile, toc, table, attStats[table.Oid], tupleStats[table.Oid])
 	}

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -53,6 +53,10 @@ SET default_with_oids = off;
 	}
 	if connectionPool.Version.Before("6") {
 		setupQuery += "SET gp_max_csv_line_length = 4194304;\n"
+		setupQuery += "SET allow_system_table_mods = 'DML';\n"
+	}
+	if connectionPool.Version.AtLeast("6") {
+		setupQuery += "SET allow_system_table_mods = true;\n"
 	}
 	for i := 0; i < connectionPool.NumConns; i++ {
 		connectionPool.MustExec(setupQuery, i)


### PR DESCRIPTION
The allow_system_table_mods GUC was changed to a boolean in GPDB master.
Instead of setting this GUC in the backup, set it during the restore to
allow for better compatibility between major GPDB versions.

Authored-by: Chris Hajas <chajas@pivotal.io>