### PR TITLE
Update versioning logic after dbconn/version update

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -19,7 +19,7 @@
     "structmatcher",
     "testhelper"
   ]
-  revision = "bcd40cae9af9f3c6829b61fe78e56d1cd0080b5e"
+  revision = "6ae0bc3408913019c4d3520f761858a4ef6c6979"
 
 [[projects]]
   name = "github.com/inconshreveable/mousetrap"

--- a/backup/dependencies_test.go
+++ b/backup/dependencies_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup/backup"
-	"github.com/greenplum-db/gpbackup/testutils"
 	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 
 	. "github.com/onsi/ginkgo"
@@ -156,7 +155,7 @@ var _ = Describe("backup/dependencies tests", func() {
 	})
 	Describe("ConstructFunctionDependencies", func() {
 		It("queries function dependencies in GPDB 5", func() {
-			testutils.SetDBVersion(connectionPool, "5.0.0")
+			testhelper.SetDBVersion(connectionPool, "5.0.0")
 			header := []string{"oid", "referencedobject"}
 			functionRows := sqlmock.NewRows(header).AddRow([]driver.Value{"1", "public.type"}...)
 
@@ -169,7 +168,7 @@ var _ = Describe("backup/dependencies tests", func() {
 			Expect(functions[0].DependsUpon).To(Equal([]string{"public.type"}))
 		})
 		It("queries function dependencies in GPDB 4.3", func() {
-			testutils.SetDBVersion(connectionPool, "4.3.0")
+			testhelper.SetDBVersion(connectionPool, "4.3.0")
 			header := []string{"oid", "referencedobject"}
 			functionRows := sqlmock.NewRows(header).AddRow([]driver.Value{"1", "public.type"}...)
 
@@ -184,7 +183,7 @@ var _ = Describe("backup/dependencies tests", func() {
 	})
 	Describe("ConstructBaseTypeDependencies", func() {
 		It("queries base type dependencies in GPDB 5", func() {
-			testutils.SetDBVersion(connectionPool, "5.0.0")
+			testhelper.SetDBVersion(connectionPool, "5.0.0")
 			header := []string{"oid", "referencedobject"}
 			baseTypeRows := sqlmock.NewRows(header).AddRow([]driver.Value{"2", "public.func(integer, integer)"}...)
 
@@ -198,7 +197,7 @@ var _ = Describe("backup/dependencies tests", func() {
 			Expect(types[0].DependsUpon).To(Equal([]string{"public.func(integer, integer)"}))
 		})
 		It("queries base type dependencies in GPDB 4.3", func() {
-			testutils.SetDBVersion(connectionPool, "4.3.0")
+			testhelper.SetDBVersion(connectionPool, "4.3.0")
 			funcInfoMap := map[uint32]backup.FunctionInfo{
 				5: {QualifiedName: "public.func", Arguments: "integer, integer"},
 			}
@@ -217,7 +216,7 @@ var _ = Describe("backup/dependencies tests", func() {
 	})
 	Describe("ConstructCompositeTypeDependencies", func() {
 		It("queries composite type dependencies in GPDB 5", func() {
-			testutils.SetDBVersion(connectionPool, "5.0.0")
+			testhelper.SetDBVersion(connectionPool, "5.0.0")
 			header := []string{"oid", "referencedobject"}
 			compTypeRows := sqlmock.NewRows(header).AddRow([]driver.Value{"3", "public.othertype"}...)
 
@@ -231,7 +230,7 @@ var _ = Describe("backup/dependencies tests", func() {
 			Expect(types[0].DependsUpon).To(Equal([]string{"public.othertype"}))
 		})
 		It("queries composite type dependencies in GPDB 4.3", func() {
-			testutils.SetDBVersion(connectionPool, "4.3.0")
+			testhelper.SetDBVersion(connectionPool, "4.3.0")
 			header := []string{"oid", "referencedobject"}
 			compTypeRows := sqlmock.NewRows(header).AddRow([]driver.Value{"3", "public.othertype"}...)
 
@@ -248,7 +247,7 @@ var _ = Describe("backup/dependencies tests", func() {
 	})
 	Describe("ConstructDomainDependencies", func() {
 		It("queries domain dependencies in GPDB 5", func() {
-			testutils.SetDBVersion(connectionPool, "5.0.0")
+			testhelper.SetDBVersion(connectionPool, "5.0.0")
 			header := []string{"oid", "referencedobject"}
 			domainRows := sqlmock.NewRows(header).AddRow([]driver.Value{"4", "public.builtin"}...)
 
@@ -263,7 +262,7 @@ var _ = Describe("backup/dependencies tests", func() {
 			Expect(types[0].DependsUpon).To(Equal([]string{"public.builtin"}))
 		})
 		It("queries domain dependencies in GPDB 4.3", func() {
-			testutils.SetDBVersion(connectionPool, "4.3.0")
+			testhelper.SetDBVersion(connectionPool, "4.3.0")
 			header := []string{"oid", "referencedobject"}
 			domainRows := sqlmock.NewRows(header).AddRow([]driver.Value{"4", "public.builtin"}...)
 

--- a/backup/metadata_globals_test.go
+++ b/backup/metadata_globals_test.go
@@ -14,7 +14,7 @@ var _ = Describe("backup/metadata_globals tests", func() {
 	})
 	Describe("PrintSessionGUCs", func() {
 		It("prints session GUCs", func() {
-			testutils.SetDBVersion(connectionPool, "4.3.0")
+			testhelper.SetDBVersion(connectionPool, "4.3.0")
 			gucs := backup.SessionGUCs{ClientEncoding: "UTF8"}
 
 			backup.PrintSessionGUCs(backupfile, toc, gucs)

--- a/backup/predata_relations_test.go
+++ b/backup/predata_relations_test.go
@@ -679,7 +679,7 @@ SELECT pg_catalog.setval('public.seq_name', 7, false);`)
 SELECT pg_catalog.setval('public.seq_''name', 7, true);`)
 		})
 		It("can print a sequence with privileges, an owner, and a comment for version < 6", func() {
-			testutils.SetDBVersion(connectionPool, "5.0.0")
+			testhelper.SetDBVersion(connectionPool, "5.0.0")
 			sequenceMetadataMap := testutils.DefaultMetadataMap("SEQUENCE", true, true, true)
 			sequenceMetadata := sequenceMetadataMap[1]
 			sequenceMetadata.Privileges[0].Update = false
@@ -704,10 +704,10 @@ ALTER TABLE public.seq_name OWNER TO testrole;
 REVOKE ALL ON SEQUENCE public.seq_name FROM PUBLIC;
 REVOKE ALL ON SEQUENCE public.seq_name FROM testrole;
 GRANT SELECT,USAGE ON SEQUENCE public.seq_name TO testrole;`)
-			testutils.SetDBVersion(connectionPool, "5.1.0")
+			testhelper.SetDBVersion(connectionPool, "5.1.0")
 		})
 		It("can print a sequence with privileges, an owner, and a comment for version >= 6", func() {
-			testutils.SetDBVersion(connectionPool, "6.0.0")
+			testhelper.SetDBVersion(connectionPool, "6.0.0")
 			sequenceMetadataMap := testutils.DefaultMetadataMap("SEQUENCE", true, true, true)
 			sequenceMetadata := sequenceMetadataMap[1]
 			sequenceMetadata.Privileges[0].Update = false
@@ -733,7 +733,7 @@ ALTER SEQUENCE public.seq_name OWNER TO testrole;
 REVOKE ALL ON SEQUENCE public.seq_name FROM PUBLIC;
 REVOKE ALL ON SEQUENCE public.seq_name FROM testrole;
 GRANT SELECT,USAGE ON SEQUENCE public.seq_name TO testrole;`)
-			testutils.SetDBVersion(connectionPool, "5.1.0")
+			testhelper.SetDBVersion(connectionPool, "5.1.0")
 		})
 		It("can print a sequence with privileges WITH GRANT OPTION", func() {
 			sequenceMetadataMap := backup.MetadataMap{
@@ -768,8 +768,8 @@ GRANT SELECT,USAGE ON SEQUENCE public.seq_name TO testrole WITH GRANT OPTION;`)
 				`CREATE VIEW shamwow.shazam AS SELECT count(*) FROM pg_tables;`)
 		})
 		It("can print a view with privileges, an owner, and a comment for version < 6", func() {
-			testutils.SetDBVersion(connectionPool, "5.0.0")
-			defer testutils.SetDBVersion(connectionPool, "5.1.0")
+			testhelper.SetDBVersion(connectionPool, "5.0.0")
+			defer testhelper.SetDBVersion(connectionPool, "5.1.0")
 
 			viewOne := backup.View{Oid: 0, Schema: "public", Name: `"WowZa"`, Definition: "SELECT rolname FROM pg_role;", DependsUpon: []string{}}
 			viewTwo := backup.View{Oid: 1, Schema: "shamwow", Name: "shazam", Definition: "SELECT count(*) FROM pg_tables;", DependsUpon: []string{}}
@@ -791,8 +791,8 @@ REVOKE ALL ON shamwow.shazam FROM testrole;
 GRANT ALL ON shamwow.shazam TO testrole;`)
 		})
 		It("can print a view with privileges, an owner, and a comment for version >= 6", func() {
-			testutils.SetDBVersion(connectionPool, "6.0.0")
-			defer testutils.SetDBVersion(connectionPool, "5.1.0")
+			testhelper.SetDBVersion(connectionPool, "6.0.0")
+			defer testhelper.SetDBVersion(connectionPool, "5.1.0")
 
 			viewOne := backup.View{Oid: 0, Schema: "public", Name: `"WowZa"`, Definition: "SELECT rolname FROM pg_role;", DependsUpon: []string{}}
 			viewTwo := backup.View{Oid: 1, Schema: "shamwow", Name: "shazam", Definition: "SELECT count(*) FROM pg_tables;", DependsUpon: []string{}}

--- a/backup/predata_shared_test.go
+++ b/backup/predata_shared_test.go
@@ -350,31 +350,31 @@ GRANT ALL ON FOREIGN SERVER foreignserver TO testrole;`)
 		Context("Views and sequences have owners", func() {
 			objectMetadata := backup.ObjectMetadata{Owner: "testrole"}
 			AfterEach(func() {
-				testutils.SetDBVersion(connectionPool, "5.1.0")
+				testhelper.SetDBVersion(connectionPool, "5.1.0")
 			})
 			It("prints an ALTER TABLE ... OWNER TO statement to set the owner for a sequence if version < 6", func() {
-				testutils.SetDBVersion(connectionPool, "5.0.0")
+				testhelper.SetDBVersion(connectionPool, "5.0.0")
 				backup.PrintObjectMetadata(backupfile, objectMetadata, "public.sequencename", "SEQUENCE")
 				testhelper.ExpectRegexp(buffer, `
 
 ALTER TABLE public.sequencename OWNER TO testrole;`)
 			})
 			It("prints an ALTER TABLE ... OWNER TO statement to set the owner for a view if version < 6", func() {
-				testutils.SetDBVersion(connectionPool, "5.0.0")
+				testhelper.SetDBVersion(connectionPool, "5.0.0")
 				backup.PrintObjectMetadata(backupfile, objectMetadata, "public.viewname", "VIEW")
 				testhelper.ExpectRegexp(buffer, `
 
 ALTER TABLE public.viewname OWNER TO testrole;`)
 			})
 			It("prints an ALTER SEQUENCE ... OWNER TO statement to set the owner for a sequence if version >= 6", func() {
-				testutils.SetDBVersion(connectionPool, "6.0.0")
+				testhelper.SetDBVersion(connectionPool, "6.0.0")
 				backup.PrintObjectMetadata(backupfile, objectMetadata, "public.sequencename", "SEQUENCE")
 				testhelper.ExpectRegexp(buffer, `
 
 ALTER SEQUENCE public.sequencename OWNER TO testrole;`)
 			})
 			It("prints an ALTER VIEW ... OWNER TO statement to set the owner for a view if version >= 6", func() {
-				testutils.SetDBVersion(connectionPool, "6.0.0")
+				testhelper.SetDBVersion(connectionPool, "6.0.0")
 				backup.PrintObjectMetadata(backupfile, objectMetadata, "public.viewname", "VIEW")
 				testhelper.ExpectRegexp(buffer, `
 

--- a/backup/statistics_test.go
+++ b/backup/statistics_test.go
@@ -1,6 +1,7 @@
 package backup_test
 
 import (
+	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup/backup"
 	"github.com/greenplum-db/gpbackup/testutils"
 	"github.com/lib/pq"
@@ -123,7 +124,7 @@ AND relnamespace = 0;`))
 				AttNumber: 3, NullFraction: .4, Width: 10, Distinct: .5, Kind1: 20, Kind5: 10, Operator1: 10, Operator5: 12,
 				Numbers1: pq.StringArray([]string{"1", "2", "3"}), Values1: pq.StringArray([]string{"4", "5", "6"})}
 			It("generates attribute statistics query for array type for GPDB master", func() {
-				testutils.SetDBVersion(connectionPool, "6.0.0")
+				testhelper.SetDBVersion(connectionPool, "6.0.0")
 				attStats.Type = "_array"
 				attStatsQuery := backup.GenerateAttributeStatisticsQuery(tableTestTable, attStats)
 				Expect(attStatsQuery).To(Equal(`DELETE FROM pg_statistic WHERE starelid = 'testschema."test''table"'::regclass::oid AND staattnum = 3;
@@ -158,7 +159,7 @@ INSERT INTO pg_statistic VALUES (
 );`))
 			})
 			It("generates attribute statistics query for non-array type for GPDB master", func() {
-				testutils.SetDBVersion(connectionPool, "6.0.0")
+				testhelper.SetDBVersion(connectionPool, "6.0.0")
 				attStats.Type = "testtype"
 				attStatsQuery := backup.GenerateAttributeStatisticsQuery(tableTestTable, attStats)
 				Expect(attStatsQuery).To(Equal(`DELETE FROM pg_statistic WHERE starelid = 'testschema."test''table"'::regclass::oid AND staattnum = 3;
@@ -199,7 +200,7 @@ INSERT INTO pg_statistic VALUES (
 				AttNumber: 3, NullFraction: .4, Width: 10, Distinct: .5, Kind1: 20, Operator1: 10,
 				Numbers1: pq.StringArray([]string{"1", "2", "3"}), Values1: pq.StringArray([]string{"4", "5", "6"})}
 			It("generates attribute statistics query for array type for GPDB4/5", func() {
-				testutils.SetDBVersion(connectionPool, "5.1.0")
+				testhelper.SetDBVersion(connectionPool, "5.1.0")
 				attStats.Type = "_array"
 				attStatsQuery := backup.GenerateAttributeStatisticsQuery(tableTestTable, attStats)
 				Expect(attStatsQuery).To(Equal(`DELETE FROM pg_statistic WHERE starelid = 'testschema."test''table"'::regclass::oid AND staattnum = 3;
@@ -229,7 +230,7 @@ INSERT INTO pg_statistic VALUES (
 );`))
 			})
 			It("generates attribute statistics query for non-array type for GPDB4/5", func() {
-				testutils.SetDBVersion(connectionPool, "5.1.0")
+				testhelper.SetDBVersion(connectionPool, "5.1.0")
 				attStats.Type = "testtype"
 				attStatsQuery := backup.GenerateAttributeStatisticsQuery(tableTestTable, attStats)
 				Expect(attStatsQuery).To(Equal(`DELETE FROM pg_statistic WHERE starelid = 'testschema."test''table"'::regclass::oid AND staattnum = 3;

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -37,7 +37,7 @@ func SetLoggerVerbosity() {
 func InitializeConnectionPool() {
 	connectionPool = dbconn.NewDBConnFromEnvironment(MustGetFlagString(utils.DBNAME))
 	connectionPool.MustConnect(MustGetFlagInt(utils.JOBS))
-	utils.SetDatabaseVersion(connectionPool)
+	utils.ValidateGPDBVersionCompatibility(connectionPool)
 	InitializeMetadataParams(connectionPool)
 	for connNum := 0; connNum < connectionPool.NumConns; connNum++ {
 		connectionPool.MustExec("SET application_name TO 'gpbackup'", connNum)

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -50,7 +50,6 @@ var _ = BeforeSuite(func() {
 	// We can't use AssertQueryRuns since if a role already exists it will error
 	connection.Exec("CREATE ROLE testrole SUPERUSER")
 	connection.Exec("CREATE ROLE anothertestrole SUPERUSER")
-	utils.SetDatabaseVersion(connection)
 	backup.InitializeMetadataParams(connection)
 	backup.SetConnection(connection)
 	segConfig := cluster.MustGetSegmentConfiguration(connection)

--- a/integration/parallel_queries_test.go
+++ b/integration/parallel_queries_test.go
@@ -22,7 +22,6 @@ var _ = Describe("backup, utils, and restore integration tests related to parall
 		BeforeEach(func() {
 			tempConn = dbconn.NewDBConnFromEnvironment("testdb")
 			tempConn.MustConnect(2)
-			utils.SetDatabaseVersion(tempConn)
 		})
 		AfterEach(func() {
 			tempConn.Close()

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -34,7 +34,7 @@ func SetLoggerVerbosity() {
 func InitializeConnection(dbname string) {
 	connectionPool = dbconn.NewDBConnFromEnvironment(dbname)
 	connectionPool.MustConnect(MustGetFlagInt(utils.JOBS))
-	utils.SetDatabaseVersion(connectionPool)
+	utils.ValidateGPDBVersionCompatibility(connectionPool)
 	setupQuery := `
 SET application_name TO 'gprestore';
 SET search_path TO pg_catalog;

--- a/testutils/functions.go
+++ b/testutils/functions.go
@@ -51,7 +51,6 @@ func SetupTestCluster() {
 func SetupTestDbConn(dbname string) *dbconn.DBConn {
 	conn := dbconn.NewDBConnFromEnvironment(dbname)
 	conn.MustConnect(1)
-	utils.SetDatabaseVersion(conn)
 	return conn
 }
 

--- a/testutils/functions.go
+++ b/testutils/functions.go
@@ -6,7 +6,6 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/blang/semver"
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/structmatcher"
@@ -34,7 +33,6 @@ func SetupTestEnvironment() (*dbconn.DBConn, sqlmock.Sqlmock, *gbytes.Buffer, *g
 
 func CreateAndConnectMockDB(numConns int) (*dbconn.DBConn, sqlmock.Sqlmock) {
 	connection, mock := testhelper.CreateAndConnectMockDB(numConns)
-	SetDBVersion(connection, "5.1.0")
 	backup.SetConnection(connection)
 	restore.SetConnection(connection)
 	backup.InitializeMetadataParams(connection)
@@ -345,8 +343,4 @@ func InitializeTestTOC(buffer io.Writer, which string) (*utils.TOC, *utils.FileW
 	backupfile := utils.NewFileWithByteCount(buffer)
 	backupfile.Filename = which
 	return toc, backupfile
-}
-
-func SetDBVersion(connection *dbconn.DBConn, versionStr string) {
-	connection.Version = dbconn.GPDBVersion{VersionString: versionStr, SemVer: semver.MustParse(versionStr)}
 }

--- a/utils/util.go
+++ b/utils/util.go
@@ -94,12 +94,7 @@ AND procpid <> pg_backend_pid()`, appName, copyFileName)
 	_, _ = connection.Exec(query)
 }
 
-func SetDatabaseVersion(connection *dbconn.DBConn) {
-	connection.Version.Initialize(connection)
-	validateGPDBVersionCompatibility(connection)
-}
-
-func validateGPDBVersionCompatibility(connection *dbconn.DBConn) {
+func ValidateGPDBVersionCompatibility(connection *dbconn.DBConn) {
 	if connection.Version.Before(MINIMUM_GPDB4_VERSION) {
 		gplog.Fatal(errors.Errorf(`GPDB version %s is not supported. Please upgrade to GPDB %s.0 or later.`, connection.Version.VersionString, MINIMUM_GPDB4_VERSION), "")
 	} else if connection.Version.Is("5") && connection.Version.Before(MINIMUM_GPDB5_VERSION) {

--- a/utils/util_test.go
+++ b/utils/util_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/operating"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup/utils"
-	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -100,45 +99,28 @@ var _ = Describe("utils/util tests", func() {
 			utils.ValidateFullPath(path)
 		})
 	})
-	Describe("SetDatabaseVersion", func() {
-		BeforeEach(func() {
-			operating.System.Now = func() time.Time { return time.Date(2017, time.January, 1, 1, 1, 1, 1, time.Local) }
-		})
-		It("parses GPDB version string", func() {
-			versionString := sqlmock.NewRows([]string{"versionstring"}).AddRow(" PostgreSQL 8.3.23 (Greenplum Database 5.1.0-beta.5+dev.65.g2a47ec9bfa build dev) on x86_64-apple-darwin16.5.0, compiled by GCC Apple LLVM version 8.1.0 (clang-802.0.42) compiled on Aug  4 2017 11:36:54")
-			mock.ExpectQuery("SELECT (.*)").WillReturnRows(versionString)
-
-			utils.SetDatabaseVersion(connection)
-
-			Expect(connection.Version.VersionString).To(Equal("5.1.0-beta.5+dev.65.g2a47ec9bfa build dev"))
-
-		})
+	Describe("ValidateGPDBVersionCompatibility", func() {
 		It("panics if GPDB version is less than 4.3.17", func() {
-			defer testhelper.ShouldPanicWithMessage("GPDB version 4.3.14.1+dev.83.ga57d1b7 build 1 is not supported. Please upgrade to GPDB 4.3.17.0 or later.")
-			versionString := sqlmock.NewRows([]string{"versionstring"}).AddRow(" PostgreSQL 8.2.15 (Greenplum Database 4.3.14.1+dev.83.ga57d1b7 build 1) on x86_64-unknown-linux-gnu, compiled by GCC gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-18) compiled on Sep 15 2017 17:31:20")
-			mock.ExpectQuery("SELECT (.*)").WillReturnRows(versionString)
-			utils.SetDatabaseVersion(connection)
+			testhelper.SetDBVersion(connection, "4.3.14")
+			defer testhelper.ShouldPanicWithMessage("GPDB version 4.3.14 is not supported. Please upgrade to GPDB 4.3.17.0 or later.")
+			utils.ValidateGPDBVersionCompatibility(connection)
 		})
 		It("panics if GPDB 5 version is less than 5.1.0", func() {
-			defer testhelper.ShouldPanicWithMessage("GPDB version 5.0.0+dev.92.g010f702 build dev 1 is not supported. Please upgrade to GPDB 5.1.0 or later.")
-			versionString := sqlmock.NewRows([]string{"versionstring"}).AddRow(" PostgreSQL 8.3.23 (Greenplum Database 5.0.0+dev.92.g010f702 build dev 1) on x86_64-apple-darwin14.5.0, compiled by GCC Apple LLVM version 6.0 (clang-600.0.57) (based on LLVM 3.5svn) compiled on Sep 27 2017 14:40:25")
-			mock.ExpectQuery("SELECT (.*)").WillReturnRows(versionString)
-			utils.SetDatabaseVersion(connection)
+			testhelper.SetDBVersion(connection, "5.0.0")
+			defer testhelper.ShouldPanicWithMessage("GPDB version 5.0.0 is not supported. Please upgrade to GPDB 5.1.0 or later.")
+			utils.ValidateGPDBVersionCompatibility(connection)
 		})
-		It("does not panic if GPDB version is at least than 4.3.17", func() {
-			versionString := sqlmock.NewRows([]string{"versionstring"}).AddRow(" PostgreSQL 8.2.15 (Greenplum Database 4.3.17.1+dev.83.ga57d1b7 build 1) on x86_64-unknown-linux-gnu, compiled by GCC gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-18) compiled on Sep 15 2017 17:31:20")
-			mock.ExpectQuery("SELECT (.*)").WillReturnRows(versionString)
-			utils.SetDatabaseVersion(connection)
+		It("does not panic if GPDB version is at least 4.3.17", func() {
+			testhelper.SetDBVersion(connection, "4.3.17")
+			utils.ValidateGPDBVersionCompatibility(connection)
 		})
 		It("does not panic if GPDB version is at least 5.1.0", func() {
-			versionString := sqlmock.NewRows([]string{"versionstring"}).AddRow(" PostgreSQL 8.3.23 (Greenplum Database 5.1.0-beta.9+dev.129.g4bd4e41 build dev) on x86_64-apple-darwin14.5.0, compiled by GCC Apple LLVM version 6.0 (clang-600.0.57) (based on LLVM 3.5svn) compiled on Sep  1 2017 16:57:41")
-			mock.ExpectQuery("SELECT (.*)").WillReturnRows(versionString)
-			utils.SetDatabaseVersion(connection)
+			testhelper.SetDBVersion(connection, "5.1.0")
+			utils.ValidateGPDBVersionCompatibility(connection)
 		})
 		It("does not panic if GPDB version is at least 6.0.0", func() {
-			versionString := sqlmock.NewRows([]string{"versionstring"}).AddRow(" PostgreSQL 8.4.23 (Greenplum Database 6.0.0-beta.9+dev.129.g4bd4e41 build dev) on x86_64-apple-darwin14.5.0, compiled by GCC Apple LLVM version 6.0 (clang-600.0.57) (based on LLVM 3.5svn) compiled on Sep  1 2017 16:57:41")
-			mock.ExpectQuery("SELECT (.*)").WillReturnRows(versionString)
-			utils.SetDatabaseVersion(connection)
+			testhelper.SetDBVersion(connection, "6.0.0")
+			utils.ValidateGPDBVersionCompatibility(connection)
 		})
 	})
 })


### PR DESCRIPTION
This PR makes some minor updates to version-related code now that `dbconn.Connect` has been changed to automatically retrieve the GPDB version of the target database.  There are no changes in functionality, just a bit of cleanup; see individual commit messages for details.