### PR TITLE
Fix newlines to work with more aggressive linter in go 1.11

### DIFF
--- a/backup/metadata_globals.go
+++ b/backup/metadata_globals.go
@@ -273,7 +273,7 @@ ALTER ROLE %s %s;`, role.Name, roleGUC)
 }
 
 func PrintRoleMembershipStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, roleMembers []RoleMember) {
-	metadataFile.MustPrintln("\n")
+	metadataFile.MustPrintf("\n\n")
 	for _, roleMember := range roleMembers {
 		start := metadataFile.ByteCount
 		metadataFile.MustPrintf("\nGRANT %s TO %s", roleMember.Role, roleMember.Member)

--- a/backup/predata_types.go
+++ b/backup/predata_types.go
@@ -21,7 +21,7 @@ import (
  */
 func PrintCreateShellTypeStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, types []Type) {
 	start := metadataFile.ByteCount
-	metadataFile.MustPrintln("\n")
+	metadataFile.MustPrintf("\n\n")
 	for _, typ := range types {
 		if typ.Type == "b" || typ.Type == "p" {
 			typeFQN := utils.MakeFQN(typ.Schema, typ.Name)


### PR DESCRIPTION
Fixes "FileWithByteCount.MustPrintln arg list ends with redundant newline"
linting errors.

Authored-by: Chris Hajas <chajas@pivotal.io>