### PR TITLE
Support the SSPACE parameter for aggregates in 6

### DIFF
--- a/backup/predata_functions.go
+++ b/backup/predata_functions.go
@@ -112,6 +112,9 @@ func PrintCreateAggregateStatements(metadataFile *utils.FileWithByteCount, toc *
 		metadataFile.MustPrintf("\tSFUNC = %s,\n", funcInfoMap[aggDef.TransitionFunction].QualifiedName)
 		metadataFile.MustPrintf("\tSTYPE = %s", aggDef.TransitionDataType)
 
+		if aggDef.TransitionDataSize != 0 {
+			metadataFile.MustPrintf(",\n\tSSPACE = %d", aggDef.TransitionDataSize)
+		}
 		if aggDef.PreliminaryFunction != 0 {
 			metadataFile.MustPrintf(",\n\tPREFUNC = %s", funcInfoMap[aggDef.PreliminaryFunction].QualifiedName)
 		}

--- a/backup/predata_functions_test.go
+++ b/backup/predata_functions_test.go
@@ -354,6 +354,16 @@ $_$`)
 	SORTOP = public.mysortop
 );`)
 		})
+		It("prints an aggregate with a specified transition data size", func() {
+			aggDefs[0].TransitionDataSize = 1000
+			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "agg_name(integer, integer)", "AGGREGATE")
+			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(integer, integer) (
+	SFUNC = public.mysfunc,
+	STYPE = integer,
+	SSPACE = 1000
+);`)
+		})
 		It("prints an aggregate with multiple specifications", func() {
 			aggDefs[0].FinalFunction = 3
 			aggDefs[0].SortOperator = 4

--- a/backup/queries_functions.go
+++ b/backup/queries_functions.go
@@ -257,6 +257,7 @@ type Aggregate struct {
 	SortOperator        uint32 `db:"aggsortop"`
 	Hypothetical        bool
 	TransitionDataType  string
+	TransitionDataSize  int `db:"aggtransspace"`
 	InitialValue        string
 	InitValIsNull       bool
 	IsOrdered           bool `db:"aggordered"`
@@ -318,6 +319,7 @@ SELECT
 	a.aggsortop::regproc::oid,
 	(a.aggkind = 'h') AS hypothetical,
 	format_type(a.aggtranstype, NULL) as transitiondatatype,
+	aggtransspace,
 	coalesce(a.agginitval, '') AS initialvalue,
 	(a.agginitval IS NULL) AS initvalisnull
 FROM pg_aggregate a

--- a/integration/predata_functions_queries_test.go
+++ b/integration/predata_functions_queries_test.go
@@ -373,6 +373,7 @@ CREATE FUNCTION public.mycombine_accum(numeric, numeric)
 CREATE AGGREGATE public.agg_combinefunc(numeric, numeric) (
 	SFUNC = public.mysfunc_accum,
 	STYPE = numeric,
+	SSPACE = 1000,
 	COMBINEFUNC = public.mycombine_accum,
 	INITCOND = 0 );
 `)
@@ -386,7 +387,8 @@ CREATE AGGREGATE public.agg_combinefunc(numeric, numeric) (
 			aggregateDef := backup.Aggregate{
 				Schema: "public", Name: "agg_combinefunc", Arguments: "numeric, numeric",
 				IdentArgs: "numeric, numeric", TransitionFunction: transitionOid, CombineFunction: combineOid,
-				FinalFunction: 0, SortOperator: 0, TransitionDataType: "numeric", InitialValue: "0", IsOrdered: false,
+				FinalFunction: 0, SortOperator: 0, TransitionDataType: "numeric", TransitionDataSize: 1000,
+				InitialValue: "0", IsOrdered: false,
 			}
 
 			Expect(len(result)).To(Equal(1))


### PR DESCRIPTION
This allows a user to estimate the data size of the aggregate's state
value. It can be used by the planner for query optimization.