### PR TITLE
Add support for options on views

### DIFF
--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -434,7 +434,7 @@ func PrintCreateViewStatements(metadataFile *utils.FileWithByteCount, toc *utils
 	for _, view := range views {
 		start := metadataFile.ByteCount
 		viewFQN := utils.MakeFQN(view.Schema, view.Name)
-		metadataFile.MustPrintf("\n\nCREATE VIEW %s AS %s\n", viewFQN, view.Definition)
+		metadataFile.MustPrintf("\n\nCREATE VIEW %s%s AS %s\n", viewFQN, view.Options, view.Definition)
 		PrintObjectMetadata(metadataFile, viewMetadata[view.Oid], viewFQN, "VIEW")
 		toc.AddPredataEntry(view.Schema, view.Name, "VIEW", "", start, metadataFile)
 	}

--- a/backup/predata_relations_test.go
+++ b/backup/predata_relations_test.go
@@ -813,6 +813,14 @@ REVOKE ALL ON shamwow.shazam FROM PUBLIC;
 REVOKE ALL ON shamwow.shazam FROM testrole;
 GRANT ALL ON shamwow.shazam TO testrole;`)
 		})
+		It("can print a view with options", func() {
+			viewOne := backup.View{Oid: 0, Schema: "public", Name: `"WowZa"`, Definition: "SELECT rolname FROM pg_role;", Options: " WITH (security_barrier=true)", DependsUpon: []string{}}
+			viewMetadataMap := backup.MetadataMap{}
+			backup.PrintCreateViewStatements(backupfile, toc, []backup.View{viewOne}, viewMetadataMap)
+			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", `"WowZa"`, "VIEW")
+			testutils.AssertBufferContents(toc.PredataEntries, buffer,
+				`CREATE VIEW public."WowZa" WITH (security_barrier=true) AS SELECT rolname FROM pg_role;`)
+		})
 	})
 	Describe("PrintAlterSequenceStatements", func() {
 		baseSequence := backup.Relation{Schema: "public", Name: "seq_name"}

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -654,6 +654,7 @@ type View struct {
 	Oid         uint32
 	Schema      string
 	Name        string
+	Options     string
 	Definition  string
 	DependsUpon []string
 }
@@ -664,18 +665,22 @@ func (v View) ToString() string {
 
 func GetViews(connection *dbconn.DBConn) []View {
 	results := make([]View, 0)
-
+	optionsStr := ""
+	if connection.Version.AtLeast("6") {
+		optionsStr = "coalesce(' WITH (' || array_to_string(reloptions, ', ') || ')', '') AS options,"
+	}
 	query := fmt.Sprintf(`
 SELECT
 	c.oid,
 	quote_ident(n.nspname) AS schema,
 	quote_ident(c.relname) AS name,
+	%s
 	pg_get_viewdef(c.oid) AS definition
 FROM pg_class c
 LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
 WHERE c.relkind = 'v'::"char"
 AND %s
-AND %s;`, relationAndSchemaFilterClause(), ExtensionFilterClause("c"))
+AND %s;`, optionsStr, relationAndSchemaFilterClause(), ExtensionFilterClause("c"))
 	err := connection.Select(&results, query)
 	gplog.FatalOnError(err)
 	return results

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -667,7 +667,7 @@ func GetViews(connection *dbconn.DBConn) []View {
 	results := make([]View, 0)
 	optionsStr := ""
 	if connection.Version.AtLeast("6") {
-		optionsStr = "coalesce(' WITH (' || array_to_string(reloptions, ', ') || ')', '') AS options,"
+		optionsStr = "coalesce(' WITH (' || array_to_string(c.reloptions, ', ') || ')', '') AS options,"
 	}
 	query := fmt.Sprintf(`
 SELECT

--- a/integration/predata_relations_queries_test.go
+++ b/integration/predata_relations_queries_test.go
@@ -1040,6 +1040,18 @@ SET SUBPARTITION TEMPLATE
 			Expect(results).To(HaveLen(1))
 			structmatcher.ExpectStructsToMatchExcluding(&viewDef, &results[0], "Oid")
 		})
+		It("returns a slice for a view with options", func() {
+			testutils.SkipIfBefore6(connection)
+			testhelper.AssertQueryRuns(connection, "CREATE VIEW public.simpleview WITH (security_barrier=true) AS SELECT rolname FROM pg_roles")
+			defer testhelper.AssertQueryRuns(connection, "DROP VIEW public.simpleview")
+
+			results := backup.GetViews(connection)
+
+			viewDef := backup.View{Oid: 1, Schema: "public", Name: "simpleview", Definition: "SELECT pg_roles.rolname FROM pg_roles;", DependsUpon: nil, Options: " WITH (security_barrier=true)"}
+
+			Expect(results).To(HaveLen(1))
+			structmatcher.ExpectStructsToMatchExcluding(&viewDef, &results[0], "Oid")
+		})
 	})
 	Describe("ConstructTableDependencies", func() {
 		child := backup.Relation{Schema: "public", Name: "child"}


### PR DESCRIPTION
The postgres 9.2 introduced options on views. We now back up and restore
these options for GPDB6 and later.

Authored-by: Chris Hajas <chajas@pivotal.io>