### PR TITLE
Rename relation and view ToString() methods to FQN()

### DIFF
--- a/backup/data.go
+++ b/backup/data.go
@@ -73,7 +73,7 @@ func CopyTableOut(connectionPool *dbconn.DBConn, table Relation, destinationToWr
 
 	copyCommand := fmt.Sprintf("PROGRAM '%s%s %s %s'", checkPipeExistsCommand, customPipeThroughCommand, sendToDestinationCommand, destinationToWrite)
 
-	query := fmt.Sprintf("COPY %s TO %s WITH CSV DELIMITER '%s' ON SEGMENT IGNORE EXTERNAL PARTITIONS;", table.ToString(), copyCommand, tableDelim)
+	query := fmt.Sprintf("COPY %s TO %s WITH CSV DELIMITER '%s' ON SEGMENT IGNORE EXTERNAL PARTITIONS;", table.FQN(), copyCommand, tableDelim)
 	result, err := connectionPool.Exec(query, connNum)
 	if err != nil {
 		return 0, err
@@ -90,9 +90,9 @@ func BackupSingleTableData(tableDef TableDefinition, table Relation, rowsCopiedM
 		counters.mutex.Unlock()
 		if gplog.GetVerbosity() > gplog.LOGINFO {
 			// No progress bar at this log level, so we note table count here
-			gplog.Verbose("Writing data for table %s to file (table %d of %d)", table.ToString(), numTables, counters.TotalRegTables)
+			gplog.Verbose("Writing data for table %s to file (table %d of %d)", table.FQN(), numTables, counters.TotalRegTables)
 		} else {
-			gplog.Verbose("Writing data for table %s to file", table.ToString())
+			gplog.Verbose("Writing data for table %s to file", table.FQN())
 		}
 
 		destinationToWrite := ""
@@ -108,7 +108,7 @@ func BackupSingleTableData(tableDef TableDefinition, table Relation, rowsCopiedM
 		rowsCopiedMap[table.Oid] = rowsCopied
 		counters.ProgressBar.Increment()
 	} else {
-		gplog.Verbose("Skipping data backup of table %s because it is an external table.", table.ToString())
+		gplog.Verbose("Skipping data backup of table %s because it is an external table.", table.FQN())
 	}
 	return nil
 }

--- a/backup/dependencies.go
+++ b/backup/dependencies.go
@@ -86,7 +86,7 @@ type Sortable interface {
 }
 
 func (r Relation) FQN() string {
-	return r.ToString()
+	return utils.MakeFQN(r.Schema, r.Name)
 }
 
 func (v View) FQN() string {

--- a/backup/dependencies.go
+++ b/backup/dependencies.go
@@ -1,7 +1,6 @@
 package backup
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
@@ -83,30 +82,6 @@ func ConstructDependentObjectMetadataMap(functions MetadataMap, types MetadataMa
 type Sortable interface {
 	FQN() string
 	Dependencies() []string
-}
-
-func (r Relation) FQN() string {
-	return utils.MakeFQN(r.Schema, r.Name)
-}
-
-func (v View) FQN() string {
-	return utils.MakeFQN(v.Schema, v.Name)
-}
-
-func (f Function) FQN() string {
-	/*
-	 * We need to include arguments to differentiate functions with the same name;
-	 * we don't use IdentArgs because we already have Arguments in the funcInfoMap.
-	 */
-	return fmt.Sprintf("%s(%s)", utils.MakeFQN(f.Schema, f.Name), f.Arguments)
-}
-
-func (t Type) FQN() string {
-	return utils.MakeFQN(t.Schema, t.Name)
-}
-
-func (p ExternalProtocol) FQN() string {
-	return p.Name
 }
 
 func (r Relation) Dependencies() []string {

--- a/backup/incremental.go
+++ b/backup/incremental.go
@@ -9,12 +9,12 @@ import (
 func FilterTablesForIncremental(lastBackupTOC, currentTOC *utils.TOC, tables []Relation) []Relation {
 	var filteredTables []Relation
 	for _, table := range tables {
-		currentAOEntry, isAOTable := currentTOC.IncrementalMetadata.AO[table.ToString()]
+		currentAOEntry, isAOTable := currentTOC.IncrementalMetadata.AO[table.FQN()]
 		if !isAOTable {
 			filteredTables = append(filteredTables, table)
 			continue
 		}
-		previousAOEntry := lastBackupTOC.IncrementalMetadata.AO[table.ToString()]
+		previousAOEntry := lastBackupTOC.IncrementalMetadata.AO[table.FQN()]
 
 		if previousAOEntry.Modcount != currentAOEntry.Modcount || previousAOEntry.LastDDLTimestamp != currentAOEntry.LastDDLTimestamp {
 			filteredTables = append(filteredTables, table)
@@ -77,19 +77,19 @@ func PopulateRestorePlan(changedTables []Relation,
 	}
 
 	for _, changedTable := range changedTables {
-		changedTableFQN := changedTable.ToString()
+		changedTableFQN := changedTable.FQN()
 		currBackupRestorePlanEntry.TableFQNs = append(currBackupRestorePlanEntry.TableFQNs, changedTableFQN)
 	}
 
 	changedTableFQNs := make(map[string]bool)
 	for _, changedTable := range changedTables {
-		changedTableFQN := changedTable.ToString()
+		changedTableFQN := changedTable.FQN()
 		changedTableFQNs[changedTableFQN] = true
 	}
 
 	allTableFQNs := make(map[string]bool)
 	for _, table := range allTables {
-		tableFQN := table.ToString()
+		tableFQN := table.FQN()
 		allTableFQNs[tableFQN] = true
 	}
 

--- a/backup/predata_externals.go
+++ b/backup/predata_externals.go
@@ -57,7 +57,7 @@ func PrintExternalTableCreateStatement(metadataFile *utils.FileWithByteCount, to
 	}
 	extTableDef := tableDef.ExtTableDef
 	extTableDef.Type, extTableDef.Protocol = DetermineExternalTableCharacteristics(extTableDef)
-	metadataFile.MustPrintf("\n\nCREATE %s TABLE %s (\n", tableTypeStrMap[extTableDef.Type], table.ToString())
+	metadataFile.MustPrintf("\n\nCREATE %s TABLE %s (\n", tableTypeStrMap[extTableDef.Type], table.FQN())
 	printColumnDefinitions(metadataFile, tableDef.ColumnDefs, "")
 	metadataFile.MustPrintf(") ")
 	PrintExternalTableStatements(metadataFile, table, extTableDef)
@@ -193,7 +193,7 @@ func PrintExternalTableStatements(metadataFile *utils.FileWithByteCount, table R
 		 * the value of pg_exttable.fmterrtbl will match the table's own name.
 		 */
 		errTableFQN := utils.MakeFQN(extTableDef.ErrTableSchema, extTableDef.ErrTableName)
-		if errTableFQN == table.ToString() {
+		if errTableFQN == table.FQN() {
 			metadataFile.MustPrintf("\nLOG ERRORS")
 		} else if extTableDef.ErrTableName != "" {
 			metadataFile.MustPrintf("\nLOG ERRORS INTO %s", errTableFQN)

--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -16,15 +16,6 @@ import (
 	"github.com/greenplum-db/gpbackup/utils"
 )
 
-type Relation struct {
-	SchemaOid   uint32
-	Oid         uint32
-	Schema      string
-	Name        string
-	DependsUpon []string // Used for dependency sorting
-	Inherits    []string // Only used for printing INHERITS statement
-}
-
 /*
  * Given a list of Relations, this function returns a sorted list of their Schemas.
  * It assumes that the Relation list is sorted by schema and then by table, so it

--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -26,14 +26,6 @@ type Relation struct {
 }
 
 /*
- * This function prints a table in fully-qualified schema.table format, with
- * everything quoted and escaped appropriately.
- */
-func (t Relation) ToString() string {
-	return utils.MakeFQN(t.Schema, t.Name)
-}
-
-/*
  * Given a list of Relations, this function returns a sorted list of their Schemas.
  * It assumes that the Relation list is sorted by schema and then by table, so it
  * doesn't need to do any sorting itself.
@@ -82,7 +74,7 @@ func SplitTablesByPartitionType(tables []Relation, tableDefs map[uint32]TableDef
 					dataTables = append(dataTables, table)
 				}
 			} else if len(includeList) > 0 {
-				if includeSet.MatchesFilter(table.ToString()) {
+				if includeSet.MatchesFilter(table.FQN()) {
 					dataTables = append(dataTables, table)
 				}
 			}
@@ -271,7 +263,7 @@ func PrintRegularTableCreateStatement(metadataFile *utils.FileWithByteCount, toc
 		unloggedStr = "UNLOGGED "
 	}
 
-	metadataFile.MustPrintf("\n\nCREATE %sTABLE %s %s(\n", unloggedStr, table.ToString(), typeStr)
+	metadataFile.MustPrintf("\n\nCREATE %sTABLE %s %s(\n", unloggedStr, table.FQN(), typeStr)
 
 	printColumnDefinitions(metadataFile, tableDef.ColumnDefs, tableDef.TableType)
 	metadataFile.MustPrintf(") ")
@@ -328,13 +320,13 @@ func printColumnDefinitions(metadataFile *utils.FileWithByteCount, columnDefs []
 func printAlterColumnStatements(metadataFile *utils.FileWithByteCount, table Relation, columnDefs []ColumnDefinition) {
 	for _, column := range columnDefs {
 		if column.StatTarget > -1 {
-			metadataFile.MustPrintf("\nALTER TABLE ONLY %s ALTER COLUMN %s SET STATISTICS %d;", table.ToString(), column.Name, column.StatTarget)
+			metadataFile.MustPrintf("\nALTER TABLE ONLY %s ALTER COLUMN %s SET STATISTICS %d;", table.FQN(), column.Name, column.StatTarget)
 		}
 		if column.StorageType != "" {
-			metadataFile.MustPrintf("\nALTER TABLE ONLY %s ALTER COLUMN %s SET STORAGE %s;", table.ToString(), column.Name, column.StorageType)
+			metadataFile.MustPrintf("\nALTER TABLE ONLY %s ALTER COLUMN %s SET STORAGE %s;", table.FQN(), column.Name, column.StorageType)
 		}
 		if column.Options != "" {
-			metadataFile.MustPrintf("\nALTER TABLE ONLY %s ALTER COLUMN %s SET (%s);", table.ToString(), column.Name, column.Options)
+			metadataFile.MustPrintf("\nALTER TABLE ONLY %s ALTER COLUMN %s SET (%s);", table.FQN(), column.Name, column.Options)
 		}
 	}
 }
@@ -344,16 +336,16 @@ func printAlterColumnStatements(metadataFile *utils.FileWithByteCount, table Rel
  * statement for both regular and external tables.
  */
 func PrintPostCreateTableStatements(metadataFile *utils.FileWithByteCount, table Relation, tableDef TableDefinition, tableMetadata ObjectMetadata) {
-	PrintObjectMetadata(metadataFile, tableMetadata, table.ToString(), "TABLE")
+	PrintObjectMetadata(metadataFile, tableMetadata, table.FQN(), "TABLE")
 
 	for _, att := range tableDef.ColumnDefs {
 		if att.Comment != "" {
 			escapedComment := utils.EscapeSingleQuotes(att.Comment)
-			metadataFile.MustPrintf("\n\nCOMMENT ON COLUMN %s.%s IS '%s';\n", table.ToString(), att.Name, escapedComment)
+			metadataFile.MustPrintf("\n\nCOMMENT ON COLUMN %s.%s IS '%s';\n", table.FQN(), att.Name, escapedComment)
 		}
 		if len(att.ACL) > 0 {
 			columnMetadata := ObjectMetadata{Privileges: att.ACL, Owner: tableMetadata.Owner}
-			columnPrivileges := columnMetadata.GetPrivilegesStatements(table.ToString(), "COLUMN", att.Name)
+			columnPrivileges := columnMetadata.GetPrivilegesStatements(table.FQN(), "COLUMN", att.Name)
 			metadataFile.MustPrintln(columnPrivileges)
 		}
 	}
@@ -368,8 +360,8 @@ func GetAllSequences(connection *dbconn.DBConn, sequenceOwnerTables map[string]s
 	sequenceRelations := GetAllSequenceRelations(connection)
 	sequences := make([]Sequence, 0)
 	for _, seqRelation := range sequenceRelations {
-		seqDef := GetSequenceDefinition(connection, seqRelation.ToString())
-		seqDef.OwningTable = sequenceOwnerTables[seqRelation.ToString()]
+		seqDef := GetSequenceDefinition(connection, seqRelation.FQN())
+		seqDef.OwningTable = sequenceOwnerTables[seqRelation.FQN()]
 		sequence := Sequence{seqRelation, seqDef}
 		sequences = append(sequences, sequence)
 	}
@@ -385,7 +377,7 @@ func PrintCreateSequenceStatements(metadataFile *utils.FileWithByteCount, toc *u
 	minVal := int64(math.MinInt64)
 	for _, sequence := range sequences {
 		start := metadataFile.ByteCount
-		seqFQN := sequence.ToString()
+		seqFQN := sequence.FQN()
 		metadataFile.MustPrintln("\n\nCREATE SEQUENCE", seqFQN)
 		if connectionPool.Version.AtLeast("6") {
 			metadataFile.MustPrintln("\tSTART WITH", sequence.StartVal)
@@ -420,7 +412,7 @@ func PrintCreateSequenceStatements(metadataFile *utils.FileWithByteCount, toc *u
 func PrintAlterSequenceStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, sequences []Sequence, sequenceColumnOwners map[string]string) {
 	gplog.Verbose("Writing ALTER SEQUENCE statements to metadata file")
 	for _, sequence := range sequences {
-		seqFQN := sequence.ToString()
+		seqFQN := sequence.FQN()
 		// owningColumn is quoted when the map is constructed in GetSequenceColumnOwnerMap() and doesn't need to be quoted again
 		if owningColumn, hasColumnOwner := sequenceColumnOwners[seqFQN]; hasColumnOwner {
 			start := metadataFile.ByteCount

--- a/backup/queries_externals.go
+++ b/backup/queries_externals.go
@@ -111,6 +111,10 @@ type ExternalProtocol struct {
 	FuncMap       map[uint32]string
 }
 
+func (p ExternalProtocol) FQN() string {
+	return p.Name
+}
+
 func GetExternalProtocols(connection *dbconn.DBConn) []ExternalProtocol {
 	results := make([]ExternalProtocol, 0)
 	query := `

--- a/backup/queries_functions.go
+++ b/backup/queries_functions.go
@@ -38,6 +38,14 @@ type Function struct {
 	ExecLocation      string `db:"proexeclocation"`
 }
 
+func (f Function) FQN() string {
+	/*
+	 * We need to include arguments to differentiate functions with the same name;
+	 * we don't use IdentArgs because we already have Arguments in the funcInfoMap.
+	 */
+	return fmt.Sprintf("%s(%s)", utils.MakeFQN(f.Schema, f.Name), f.Arguments)
+}
+
 /*
  * The functions pg_get_function_arguments, pg_getfunction_identity_arguments,
  * and pg_get_function_result were introduced in GPDB 5, so we can use those

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -46,6 +46,19 @@ func GetAllUserTables(connection *dbconn.DBConn) []Relation {
 	return GetUserTables(connection)
 }
 
+type Relation struct {
+	SchemaOid   uint32
+	Oid         uint32
+	Schema      string
+	Name        string
+	DependsUpon []string // Used for dependency sorting
+	Inherits    []string // Only used for printing INHERITS statement
+}
+
+func (r Relation) FQN() string {
+	return utils.MakeFQN(r.Schema, r.Name)
+}
+
 /*
  * This function also handles exclude table filtering since the way we do
  * it is currently much simpler than the include case.
@@ -656,6 +669,10 @@ type View struct {
 	Name        string
 	Definition  string
 	DependsUpon []string
+}
+
+func (v View) FQN() string {
+	return utils.MakeFQN(v.Schema, v.Name)
 }
 
 func GetViews(connection *dbconn.DBConn) []View {

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -496,7 +496,7 @@ func ConstructTableDependencies(connection *dbconn.DBConn, tables []Relation, ta
 		tableNameSet = utils.NewIncludeSet([]string{})
 		tableOidList = make([]string, len(tables))
 		for i, table := range tables {
-			tableNameSet.Add(table.ToString())
+			tableNameSet.Add(table.FQN())
 			tableOidList[i] = fmt.Sprintf("%d", table.Oid)
 		}
 	}
@@ -658,10 +658,6 @@ type View struct {
 	DependsUpon []string
 }
 
-func (v View) ToString() string {
-	return utils.MakeFQN(v.Schema, v.Name)
-}
-
 func GetViews(connection *dbconn.DBConn) []View {
 	results := make([]View, 0)
 
@@ -716,7 +712,7 @@ func LockTables(connection *dbconn.DBConn, tables []Relation) {
 	progressBar := utils.NewProgressBar(len(tables), "Locks acquired: ", utils.PB_VERBOSE)
 	progressBar.Start()
 	for _, table := range tables {
-		connection.MustExec(fmt.Sprintf("LOCK TABLE %s IN ACCESS SHARE MODE", table.ToString()))
+		connection.MustExec(fmt.Sprintf("LOCK TABLE %s IN ACCESS SHARE MODE", table.FQN()))
 		progressBar.Increment()
 	}
 	progressBar.Finish()

--- a/backup/queries_statistics.go
+++ b/backup/queries_statistics.go
@@ -61,7 +61,7 @@ func GetAttributeStatistics(connection *dbconn.DBConn, tables []Relation) map[ui
 	}
 	tablenames := make([]string, 0)
 	for _, table := range tables {
-		tablenames = append(tablenames, table.ToString())
+		tablenames = append(tablenames, table.FQN())
 	}
 	query := fmt.Sprintf(`
 SELECT
@@ -123,7 +123,7 @@ type TupleStatistic struct {
 func GetTupleStatistics(connection *dbconn.DBConn, tables []Relation) map[uint32]TupleStatistic {
 	tablenames := make([]string, 0)
 	for _, table := range tables {
-		tablenames = append(tablenames, table.ToString())
+		tablenames = append(tablenames, table.FQN())
 	}
 	query := fmt.Sprintf(`
 SELECT

--- a/backup/queries_types.go
+++ b/backup/queries_types.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/lib/pq"
 )
 
@@ -116,6 +117,10 @@ type Type struct {
 	StorageOptions  string
 	Collatable      bool
 	Collation       string
+}
+
+func (t Type) FQN() string {
+	return utils.MakeFQN(t.Schema, t.Name)
 }
 
 func GetBaseTypes(connection *dbconn.DBConn) []Type {

--- a/backup/statistics.go
+++ b/backup/statistics.go
@@ -52,7 +52,7 @@ func GenerateAttributeStatisticsQuery(table Relation, attStat AttributeStatistic
 	 * from the name to an OID in the below statements, rather than backing up the
 	 * OID in the source database.
 	 */
-	starelidStr := fmt.Sprintf("'%s'::regclass::oid", utils.EscapeSingleQuotes(table.ToString()))
+	starelidStr := fmt.Sprintf("'%s'::regclass::oid", utils.EscapeSingleQuotes(table.FQN()))
 	// The entry may or may not already exist, so we can't either just UPDATE or just INSERT without a DELETE.
 	inheritStr := ""
 	attributeSlotsQueryStr := ""


### PR DESCRIPTION
This cleans up some duplicate functionality and makes the method names
more descriptive of what they're actually returning (a fully qualified
relation/view name)

Authored-by: Chris Hajas <chajas@pivotal.io>