### PR TITLE
Fix gprestore properly restore filtered leaf partitions for incremental backups

### DIFF
--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -291,9 +291,7 @@ var _ = Describe("backup end to end integration tests", func() {
 				os.Remove("/tmp/include-tables.txt")
 			})
 			It("runs gpbackup and gprestore with include-table restore flag against a leaf partition", func() {
-				if useOldBackupVersion {
-					Skip("Feature not supported in gpbackup 1.0.0")
-				}
+				skipIfOldBackupVersionBefore("1.7.2")
 				timestamp := gpbackup(gpbackupPath, backupHelperPath, "--leaf-partition-data")
 				gprestore(gprestorePath, restoreHelperPath, timestamp, "--redirect-db", "restoredb", "--include-table", "public.sales_1_prt_jan17")
 

--- a/restore/validate.go
+++ b/restore/validate.go
@@ -127,8 +127,12 @@ func ValidateFilterRelationsInBackupSet(relationList []string) {
 			return
 		}
 	}
-	for _, entry := range globalTOC.DataEntries {
-		fqn := utils.MakeFQN(entry.Schema, entry.Name)
+
+	dataEntries := make([]string, 0)
+	for _, restorePlanEntry := range backupConfig.RestorePlan {
+		dataEntries = append(dataEntries, restorePlanEntry.TableFQNs...)
+	}
+	for _, fqn := range dataEntries {
 		if _, ok := relationMap[fqn]; ok {
 			delete(relationMap, fqn)
 		}

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -172,6 +172,12 @@ func GetRestoreMetadataStatements(section string, filename string, includeObject
 		if filterRelations {
 			inRelations = MustGetFlagStringSlice(utils.INCLUDE_RELATION)
 			exRelations = MustGetFlagStringSlice(utils.EXCLUDE_RELATION)
+			fpInfoList := GetBackupFPInfoListFromRestorePlan()
+			for _, fpInfo := range fpInfoList {
+				tocFilename := fpInfo.GetTOCFilePath()
+				toc := utils.NewTOC(tocFilename)
+				inRelations = append(inRelations, utils.GetPartitionRootData(toc.DataEntries, inRelations)...)
+			}
 		}
 	}
 	statements = globalTOC.GetSQLStatementForObjectTypes(section, metadataFile, includeObjectTypes, excludeObjectTypes, inSchemas, exSchemas, inRelations, exRelations)

--- a/utils/toc.go
+++ b/utils/toc.go
@@ -126,8 +126,6 @@ func GetPartitionRootData(tocDataEntries []MasterDataEntry, includeRelations []s
 func (toc *TOC) GetSQLStatementForObjectTypes(section string, metadataFile io.ReaderAt, includeObjectTypes []string, excludeObjectTypes []string, includeSchemas []string, excludeSchemas []string, includeRelations []string, excludeRelations []string) []StatementWithType {
 	entries := *toc.metadataEntryMap[section]
 
-	includeRelations = append(includeRelations, GetPartitionRootData(toc.DataEntries, includeRelations)...)
-
 	objectSet, schemaSet, relationSet := constructFilterSets(includeObjectTypes, excludeObjectTypes, includeSchemas, excludeSchemas, includeRelations, excludeRelations)
 	statements := make([]StatementWithType, 0)
 	for _, entry := range entries {

--- a/utils/toc_test.go
+++ b/utils/toc_test.go
@@ -34,7 +34,7 @@ var _ = Describe("utils/toc tests", func() {
 	BeforeEach(func() {
 		toc, backupfile = testutils.InitializeTestTOC(buffer, "global")
 	})
-	Describe("GetSqlStatementForObjectTypes", func() {
+	Describe("GetSQLStatementForObjectTypes", func() {
 		// Dummy variables to help clarify which arguments are non-empty in a given test
 		var noInObj, noExObj, noInSchema, noExSchema, noInRelation, noExRelation []string
 		It("returns statement for a single object type", func() {


### PR DESCRIPTION
Previously, gprestore would fail in validation if a user attempted a
filtered restore of a partition that was not in the most recent restore
plan entry. Now, gprestore will look through all restore plan entries to
determine whether a partition leaf is present in the restore set.

Additionally, when restoring a leaf partition, the root partition table
schema would not get restored if it no leaf partitions were in the most
recent restore plan entry. Now, we iterate through restore plans to and
add all roots to the include list.