### PR TITLE
Simplify GetRestoreMetadataStatements logic

### DIFF
--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -163,8 +163,8 @@ func RecoverMetadataFilesUsingPlugin() {
 func GetRestoreMetadataStatements(section string, filename string, includeObjectTypes []string, excludeObjectTypes []string, filterSchemas bool, filterRelations bool) []utils.StatementWithType {
 	metadataFile := iohelper.MustOpenFileForReading(filename)
 	var statements []utils.StatementWithType
+	var inSchemas, exSchemas, inRelations, exRelations []string
 	if len(includeObjectTypes) > 0 || len(excludeObjectTypes) > 0 || filterSchemas || filterRelations {
-		var inSchemas, exSchemas, inRelations, exRelations []string
 		if filterSchemas {
 			inSchemas = MustGetFlagStringSlice(utils.INCLUDE_SCHEMA)
 			exSchemas = MustGetFlagStringSlice(utils.EXCLUDE_SCHEMA)
@@ -173,10 +173,8 @@ func GetRestoreMetadataStatements(section string, filename string, includeObject
 			inRelations = MustGetFlagStringSlice(utils.INCLUDE_RELATION)
 			exRelations = MustGetFlagStringSlice(utils.EXCLUDE_RELATION)
 		}
-		statements = globalTOC.GetSQLStatementForObjectTypes(section, metadataFile, includeObjectTypes, excludeObjectTypes, inSchemas, exSchemas, inRelations, exRelations)
-	} else {
-		statements = globalTOC.GetAllSQLStatements(section, metadataFile)
 	}
+	statements = globalTOC.GetSQLStatementForObjectTypes(section, metadataFile, includeObjectTypes, excludeObjectTypes, inSchemas, exSchemas, inRelations, exRelations)
 	return statements
 }
 

--- a/utils/toc.go
+++ b/utils/toc.go
@@ -102,6 +102,9 @@ type StatementWithType struct {
 }
 
 func GetPartitionRootData(tocDataEntries []MasterDataEntry, includeRelations []string) []string {
+	if len(includeRelations) == 0 {
+		return []string{}
+	}
 	rootPartitions := make([]string, 0)
 
 	FQNToPartitionRoot := make(map[string]string, 0)
@@ -167,18 +170,6 @@ func shouldIncludeStatement(entry MetadataEntry, objectSet *FilterSet, schemaSet
 		(entry.ReferenceObject != "" && relationSet.MatchesFilter(entry.ReferenceObject)) // Include relations that filtered tables depend on
 
 	return shouldIncludeObject && shouldIncludeSchema && shouldIncludeRelation
-}
-
-func (toc *TOC) GetAllSQLStatements(section string, metadataFile io.ReaderAt) []StatementWithType {
-	entries := *toc.metadataEntryMap[section]
-	statements := make([]StatementWithType, 0)
-	for _, entry := range entries {
-		contents := make([]byte, entry.EndByte-entry.StartByte)
-		_, err := metadataFile.ReadAt(contents, int64(entry.StartByte))
-		gplog.FatalOnError(err)
-		statements = append(statements, StatementWithType{Schema: entry.Schema, Name: entry.Name, ObjectType: entry.ObjectType, ReferenceObject: entry.ReferenceObject, Statement: string(contents)})
-	}
-	return statements
 }
 
 func getLeafPartitions(tableFQNs []string, tocDataEntries []MasterDataEntry) (leafPartitions []string) {

--- a/utils/toc_test.go
+++ b/utils/toc_test.go
@@ -226,7 +226,6 @@ var _ = Describe("utils/toc tests", func() {
 			toc.AddMasterDataEntry("schema3", "table3_partition1", 1, "(i)", 0, "table3")
 			toc.AddMasterDataEntry("schema3", "table3_partition2", 1, "(i)", 0, "table3")
 		})
-
 		Context("Non-empty restore plan", func() {
 			restorePlanTableFQNs := []string{"schema1.table1", "schema2.table2", "schema3.table3", "schema3.table3_partition1", "schema3.table3_partition2"}
 
@@ -365,37 +364,6 @@ var _ = Describe("utils/toc tests", func() {
 
 				Expect(matchingEntries).To(BeEmpty())
 			})
-		})
-	})
-
-	Describe("GetAllSqlStatements", func() {
-		It("returns statement for a single object type", func() {
-			backupfile.ByteCount = createLen
-			toc.AddMetadataEntry("", "somedatabase", "DATABASE", "", 0, backupfile, "global")
-
-			metadataFile := bytes.NewReader([]byte(create.Statement))
-			statements := toc.GetAllSQLStatements("global", metadataFile)
-
-			Expect(statements).To(Equal([]utils.StatementWithType{create}))
-		})
-		It("returns statement for a multiple object types", func() {
-			backupfile.ByteCount = createLen
-			toc.AddMetadataEntry("", "somedatabase", "DATABASE", "", 0, backupfile, "global")
-			backupfile.ByteCount += role1Len
-			toc.AddMetadataEntry("", "somerole1", "ROLE", "", createLen, backupfile, "global")
-			backupfile.ByteCount += role2Len
-			toc.AddMetadataEntry("", "somerole2", "ROLE", "", createLen+role1Len, backupfile, "global")
-
-			metadataFile := bytes.NewReader([]byte(create.Statement + role1.Statement + role2.Statement))
-			statements := toc.GetAllSQLStatements("global", metadataFile)
-
-			Expect(statements).To(Equal([]utils.StatementWithType{create, role1, role2}))
-		})
-		It("returns empty statement when no object types are found", func() {
-			metadataFile := bytes.NewReader([]byte(create.Statement))
-			statements := toc.GetAllSQLStatements("global", metadataFile)
-
-			Expect(statements).To(Equal([]utils.StatementWithType{}))
 		})
 	})
 	Describe("SubstituteRedirectDatabaseInStatements", func() {


### PR DESCRIPTION
The logic in globalTOC.GetAllSQLStatements and
GetSQLStatementForObjectTypes was nearly identical. This
removes GetAllSQLStatements() and thereby removes a branch in the logic.

Authored-by: Chris Hajas <chajas@pivotal.io>