### PR TITLE
Add support for serialfunc and deserialfunc attributes for aggregates

### DIFF
--- a/backup/predata_functions.go
+++ b/backup/predata_functions.go
@@ -121,6 +121,12 @@ func PrintCreateAggregateStatements(metadataFile *utils.FileWithByteCount, toc *
 		if aggDef.CombineFunction != 0 {
 			metadataFile.MustPrintf(",\n\tCOMBINEFUNC = %s", funcInfoMap[aggDef.CombineFunction].QualifiedName)
 		}
+		if aggDef.SerialFunction != 0 {
+			metadataFile.MustPrintf(",\n\tSERIALFUNC = %s", funcInfoMap[aggDef.SerialFunction].QualifiedName)
+		}
+		if aggDef.DeserialFunction != 0 {
+			metadataFile.MustPrintf(",\n\tDESERIALFUNC = %s", funcInfoMap[aggDef.DeserialFunction].QualifiedName)
+		}
 		if aggDef.FinalFunction != 0 {
 			metadataFile.MustPrintf(",\n\tFINALFUNC = %s", funcInfoMap[aggDef.FinalFunction].QualifiedName)
 		}

--- a/backup/predata_functions_test.go
+++ b/backup/predata_functions_test.go
@@ -326,6 +326,24 @@ $_$`)
 	COMBINEFUNC = public.mypfunc
 );`)
 		})
+		It("prints an aggregate with a serial function", func() {
+			aggDefs[0].SerialFunction = 2
+			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(integer, integer) (
+	SFUNC = public.mysfunc,
+	STYPE = integer,
+	SERIALFUNC = public.mypfunc
+);`)
+		})
+		It("prints an aggregate with a deserial function", func() {
+			aggDefs[0].DeserialFunction = 2
+			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(integer, integer) (
+	SFUNC = public.mysfunc,
+	STYPE = integer,
+	DESERIALFUNC = public.mypfunc
+);`)
+		})
 		It("prints an aggregate with a final function", func() {
 			aggDefs[0].FinalFunction = 3
 			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)

--- a/backup/queries_functions.go
+++ b/backup/queries_functions.go
@@ -260,6 +260,8 @@ type Aggregate struct {
 	TransitionFunction  uint32 `db:"aggtransfn"`
 	PreliminaryFunction uint32 `db:"aggprelimfn"`
 	CombineFunction     uint32 `db:"aggcombinefn"`
+	SerialFunction      uint32 `db:"aggserialfn"`
+	DeserialFunction    uint32 `db:"aggdeserialfn"`
 	FinalFunction       uint32 `db:"aggfinalfn"`
 	FinalFuncExtra      bool
 	SortOperator        uint32 `db:"aggsortop"`
@@ -322,6 +324,8 @@ SELECT
 	pg_catalog.pg_get_function_identity_arguments(p.oid) AS identargs,
 	a.aggtransfn::regproc::oid,
 	a.aggcombinefn::regproc::oid,
+	a.aggserialfn::regproc::oid,
+	a.aggdeserialfn::regproc::oid,
 	a.aggfinalfn::regproc::oid,
 	a.aggfinalextra AS finalfuncextra,
 	a.aggsortop::regproc::oid,


### PR DESCRIPTION
This feature was introduced in GPDB6 as a backport for PG 9.6

Authored-by: Chris Hajas <chajas@pivotal.io>