### PR TITLE
Use unique identifier as key in metadata map

### DIFF
--- a/backup/dependencies.go
+++ b/backup/dependencies.go
@@ -60,7 +60,7 @@ var (
 	PG_PROC_OID                 uint32 = 1255
 	PG_RESGROUP_OID             uint32 = 6436
 	PG_RESQUEUE_OID             uint32 = 6026
-	PG_RULE_OID                 uint32 = 2618
+	PG_REWRITE_OID              uint32 = 2618
 	PG_TABLESPACE_OID           uint32 = 1213
 	PG_TRIGGER_OID              uint32 = 2620
 	PG_TS_CONFIG_OID            uint32 = 3602

--- a/backup/dependencies.go
+++ b/backup/dependencies.go
@@ -19,18 +19,18 @@ import (
  *   - Protocols
  */
 func AddProtocolDependenciesForGPDB4(depMap DependencyMap, tables []Relation, tableDefs map[uint32]TableDefinition, protocols []ExternalProtocol) {
-	protocolMap := make(map[string]DepEntry, len(protocols))
+	protocolMap := make(map[string]UniqueID, len(protocols))
 	for _, p := range protocols {
-		protocolMap[p.Name] = p.GetDepEntry()
+		protocolMap[p.Name] = p.GetUniqueID()
 	}
 	for _, table := range tables {
 		extTableDef := tableDefs[table.Oid].ExtTableDef
 		if extTableDef.Location != "" {
 			protocolName := extTableDef.Location[0:strings.Index(extTableDef.Location, "://")]
 			if protocolEntry, ok := protocolMap[protocolName]; ok {
-				tableEntry := table.GetDepEntry()
+				tableEntry := table.GetUniqueID()
 				if _, ok := depMap[tableEntry]; !ok {
-					depMap[tableEntry] = make(map[DepEntry]bool, 0)
+					depMap[tableEntry] = make(map[UniqueID]bool, 0)
 				}
 				depMap[tableEntry][protocolEntry] = true
 			}
@@ -39,10 +39,36 @@ func AddProtocolDependenciesForGPDB4(depMap DependencyMap, tables []Relation, ta
 }
 
 var (
-	PG_PROC_OID        uint32 = 1255
-	PG_CLASS_OID       uint32 = 1259
-	PG_TYPE_OID        uint32 = 1247
-	PG_EXTPROTOCOL_OID uint32 = 7175
+	PG_AGGREGATE_OID            uint32 = 1255
+	PG_AUTHID_OID               uint32 = 1260
+	PG_CAST_OID                 uint32 = 2605
+	PG_CLASS_OID                uint32 = 1259
+	PG_COLLATION_OID            uint32 = 3456
+	PG_CONSTRAINT_OID           uint32 = 2606
+	PG_CONVERSION_OID           uint32 = 2607
+	PG_DATABASE_OID             uint32 = 1262
+	PG_EXTENSION_OID            uint32 = 3079
+	PG_EXTPROTOCOL_OID          uint32 = 7175
+	PG_FOREIGN_DATA_WRAPPER_OID uint32 = 2328
+	PG_FOREIGN_SERVER_OID       uint32 = 1417
+	PG_INDEX_OID                uint32 = 2610
+	PG_LANGUAGE_OID             uint32 = 2612
+	PG_NAMESPACE_OID            uint32 = 2615
+	PG_OPCLASS_OID              uint32 = 2616
+	PG_OPERATOR_OID             uint32 = 2617
+	PG_OPFAMILY_OID             uint32 = 2753
+	PG_PROC_OID                 uint32 = 1255
+	PG_RESGROUP_OID             uint32 = 6436
+	PG_RESQUEUE_OID             uint32 = 6026
+	PG_RULE_OID                 uint32 = 2618
+	PG_TABLESPACE_OID           uint32 = 1213
+	PG_TRIGGER_OID              uint32 = 2620
+	PG_TS_CONFIG_OID            uint32 = 3602
+	PG_TS_DICT_OID              uint32 = 3600
+	PG_TS_PARSER_OID            uint32 = 3601
+	PG_TS_TEMPLATE_OID          uint32 = 3764
+	PG_TYPE_OID                 uint32 = 1247
+	PG_USER_MAPPING_OID         uint32 = 1418
 )
 
 func ConstructDependentObjectMetadataMap(functions MetadataMap, types MetadataMap, tables MetadataMap, protocols MetadataMap) MetadataMap {
@@ -68,27 +94,27 @@ func ConstructDependentObjectMetadataMap(functions MetadataMap, types MetadataMa
 
 type Sortable interface {
 	FQN() string
-	GetDepEntry() DepEntry
+	GetUniqueID() UniqueID
 }
 
 func TopologicalSort(slice []Sortable, dependencies DependencyMap) []Sortable {
-	inDegrees := make(map[DepEntry]int, 0)
-	dependencyIndexes := make(map[DepEntry]int, 0)
-	isDependentOn := make(map[DepEntry][]DepEntry, 0)
+	inDegrees := make(map[UniqueID]int, 0)
+	dependencyIndexes := make(map[UniqueID]int, 0)
+	isDependentOn := make(map[UniqueID][]UniqueID, 0)
 	queue := make([]Sortable, 0)
 	sorted := make([]Sortable, 0)
-	notVisited := make(map[DepEntry]bool, 0)
-	nameForDepEntries := make(map[DepEntry]string, 0)
+	notVisited := make(map[UniqueID]bool, 0)
+	nameForUniqueID := make(map[UniqueID]string, 0)
 	for i, item := range slice {
-		depEntry := item.GetDepEntry()
-		nameForDepEntries[depEntry] = item.FQN()
-		deps := dependencies[depEntry]
-		notVisited[depEntry] = true
-		inDegrees[depEntry] = len(deps)
+		uniqueID := item.GetUniqueID()
+		nameForUniqueID[uniqueID] = item.FQN()
+		deps := dependencies[uniqueID]
+		notVisited[uniqueID] = true
+		inDegrees[uniqueID] = len(deps)
 		for dep := range deps {
-			isDependentOn[dep] = append(isDependentOn[dep], depEntry)
+			isDependentOn[dep] = append(isDependentOn[dep], uniqueID)
 		}
-		dependencyIndexes[depEntry] = i
+		dependencyIndexes[uniqueID] = i
 		if len(deps) == 0 {
 			queue = append(queue, item)
 		}
@@ -97,8 +123,8 @@ func TopologicalSort(slice []Sortable, dependencies DependencyMap) []Sortable {
 		item := queue[0]
 		queue = queue[1:]
 		sorted = append(sorted, item)
-		notVisited[item.GetDepEntry()] = false
-		for _, dep := range isDependentOn[item.GetDepEntry()] {
+		notVisited[item.GetUniqueID()] = false
+		for _, dep := range isDependentOn[item.GetUniqueID()] {
 			inDegrees[dep]--
 			if inDegrees[dep] == 0 {
 				queue = append(queue, slice[dependencyIndexes[dep]])
@@ -109,11 +135,11 @@ func TopologicalSort(slice []Sortable, dependencies DependencyMap) []Sortable {
 		gplog.Verbose("Failed to sort dependencies.")
 		gplog.Verbose("Not yet visited:")
 		for _, item := range slice {
-			if notVisited[item.GetDepEntry()] {
-				gplog.Verbose("Object: %s %+v ", item.FQN(), item.GetDepEntry())
+			if notVisited[item.GetUniqueID()] {
+				gplog.Verbose("Object: %s %+v ", item.FQN(), item.GetUniqueID())
 				gplog.Verbose("Dependencies: ")
-				for depEntry := range dependencies[item.GetDepEntry()] {
-					gplog.Verbose("\t%s %+v", nameForDepEntries[depEntry], depEntry)
+				for uniqueID := range dependencies[item.GetUniqueID()] {
+					gplog.Verbose("\t%s %+v", nameForUniqueID[uniqueID], uniqueID)
 				}
 			}
 		}
@@ -122,15 +148,15 @@ func TopologicalSort(slice []Sortable, dependencies DependencyMap) []Sortable {
 	return sorted
 }
 
-type DependencyMap map[DepEntry]map[DepEntry]bool
+type DependencyMap map[UniqueID]map[UniqueID]bool
 
-type DepEntry struct {
+type UniqueID struct {
 	Classid uint32
-	Objid   uint32
+	Oid     uint32
 }
 
 // This function only returns dependencies that are referenced in the backup set
-func GetDependencies(connectionPool *dbconn.DBConn, backupSet map[DepEntry]bool) DependencyMap {
+func GetDependencies(connectionPool *dbconn.DBConn, backupSet map[UniqueID]bool) DependencyMap {
 	query := fmt.Sprintf(`SELECT
 	coalesce(id1.refclassid, d.classid) AS classid,
 	coalesce(id1.refobjid, d.objid) AS objid,
@@ -167,13 +193,13 @@ AND typelem != 0`)
 
 	dependencyMap := make(DependencyMap, 0)
 	for _, dep := range pgDependDeps {
-		object := DepEntry{
+		object := UniqueID{
 			Classid: dep.ClassID,
-			Objid:   dep.ObjID,
+			Oid:     dep.ObjID,
 		}
-		referenceObject := DepEntry{
+		referenceObject := UniqueID{
 			Classid: dep.RefClassID,
-			Objid:   dep.RefObjID,
+			Oid:     dep.RefObjID,
 		}
 
 		_, objInBackup := backupSet[object]
@@ -184,7 +210,7 @@ AND typelem != 0`)
 		}
 
 		if _, ok := dependencyMap[object]; !ok {
-			dependencyMap[object] = make(map[DepEntry]bool, 0)
+			dependencyMap[object] = make(map[UniqueID]bool, 0)
 		}
 
 		dependencyMap[object][referenceObject] = true

--- a/backup/dependencies.go
+++ b/backup/dependencies.go
@@ -151,7 +151,7 @@ func TopologicalSort(slice []Sortable, dependencies DependencyMap) []Sortable {
 type DependencyMap map[UniqueID]map[UniqueID]bool
 
 type UniqueID struct {
-	Classid uint32
+	ClassID uint32
 	Oid     uint32
 }
 
@@ -194,11 +194,11 @@ AND typelem != 0`)
 	dependencyMap := make(DependencyMap, 0)
 	for _, dep := range pgDependDeps {
 		object := UniqueID{
-			Classid: dep.ClassID,
+			ClassID: dep.ClassID,
 			Oid:     dep.ObjID,
 		}
 		referenceObject := UniqueID{
-			Classid: dep.RefClassID,
+			ClassID: dep.RefClassID,
 			Oid:     dep.RefObjID,
 		}
 
@@ -224,7 +224,7 @@ AND typelem != 0`)
 func breakCircularDependencies(depMap DependencyMap) {
 	for entry, deps := range depMap {
 		for dep := range deps {
-			if _, ok := depMap[dep]; ok && entry.Classid == PG_TYPE_OID && dep.Classid == PG_PROC_OID {
+			if _, ok := depMap[dep]; ok && entry.ClassID == PG_TYPE_OID && dep.ClassID == PG_PROC_OID {
 				if _, ok := depMap[dep][entry]; ok {
 					if len(depMap[dep]) == 1 {
 						delete(depMap, dep)

--- a/backup/dependencies_test.go
+++ b/backup/dependencies_test.go
@@ -33,7 +33,7 @@ var _ = Describe("backup/dependencies tests", func() {
 			Expect(relations[2].FQN()).To(Equal("public.relation3"))
 		})
 		It("sorts the slice correctly if there is an object dependent on one other object", func() {
-			depMap[backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: 1}] = map[backup.UniqueID]bool{{Classid: backup.PG_CLASS_OID, Oid: 3}: true}
+			depMap[backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: 1}] = map[backup.UniqueID]bool{{ClassID: backup.PG_CLASS_OID, Oid: 3}: true}
 			relations := []backup.Sortable{relation1, relation2, relation3}
 
 			relations = backup.TopologicalSort(relations, depMap)
@@ -43,8 +43,8 @@ var _ = Describe("backup/dependencies tests", func() {
 			Expect(relations[2].FQN()).To(Equal("public.relation1"))
 		})
 		It("sorts the slice correctly if there are two objects dependent on one other object", func() {
-			depMap[backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: 1}] = map[backup.UniqueID]bool{{Classid: backup.PG_CLASS_OID, Oid: 2}: true}
-			depMap[backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: 3}] = map[backup.UniqueID]bool{{Classid: backup.PG_CLASS_OID, Oid: 2}: true}
+			depMap[backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: 1}] = map[backup.UniqueID]bool{{ClassID: backup.PG_CLASS_OID, Oid: 2}: true}
+			depMap[backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: 3}] = map[backup.UniqueID]bool{{ClassID: backup.PG_CLASS_OID, Oid: 2}: true}
 			relations := []backup.Sortable{relation1, relation2, relation3}
 
 			relations = backup.TopologicalSort(relations, depMap)
@@ -54,7 +54,7 @@ var _ = Describe("backup/dependencies tests", func() {
 			Expect(relations[2].FQN()).To(Equal("public.relation3"))
 		})
 		It("sorts the slice correctly if there is one object dependent on two other objects", func() {
-			depMap[backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: 2}] = map[backup.UniqueID]bool{{Classid: backup.PG_CLASS_OID, Oid: 1}: true, {Classid: backup.PG_CLASS_OID, Oid: 1}: true}
+			depMap[backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: 2}] = map[backup.UniqueID]bool{{ClassID: backup.PG_CLASS_OID, Oid: 1}: true, {ClassID: backup.PG_CLASS_OID, Oid: 1}: true}
 			relations := []backup.Sortable{relation1, relation2, relation3}
 
 			relations = backup.TopologicalSort(relations, depMap)
@@ -64,28 +64,28 @@ var _ = Describe("backup/dependencies tests", func() {
 			Expect(relations[2].FQN()).To(Equal("public.relation2"))
 		})
 		It("aborts if dependency loop (this shouldn't be possible)", func() {
-			depMap[backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: 1}] = map[backup.UniqueID]bool{{Classid: backup.PG_CLASS_OID, Oid: 3}: true}
-			depMap[backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: 2}] = map[backup.UniqueID]bool{{Classid: backup.PG_CLASS_OID, Oid: 1}: true}
-			depMap[backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: 3}] = map[backup.UniqueID]bool{{Classid: backup.PG_CLASS_OID, Oid: 2}: true}
+			depMap[backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: 1}] = map[backup.UniqueID]bool{{ClassID: backup.PG_CLASS_OID, Oid: 3}: true}
+			depMap[backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: 2}] = map[backup.UniqueID]bool{{ClassID: backup.PG_CLASS_OID, Oid: 1}: true}
+			depMap[backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: 3}] = map[backup.UniqueID]bool{{ClassID: backup.PG_CLASS_OID, Oid: 2}: true}
 
 			sortable := []backup.Sortable{relation1, relation2, relation3}
 			defer func() {
-				testhelper.ExpectRegexp(logfile, "Object: public.relation1 {Classid:1259 Oid:1}")
+				testhelper.ExpectRegexp(logfile, "Object: public.relation1 {ClassID:1259 Oid:1}")
 				testhelper.ExpectRegexp(logfile, "Dependencies:")
-				testhelper.ExpectRegexp(logfile, "\tpublic.relation3 {Classid:1259 Oid:3}")
-				testhelper.ExpectRegexp(logfile, "Object: public.relation2 {Classid:1259 Oid:2}")
+				testhelper.ExpectRegexp(logfile, "\tpublic.relation3 {ClassID:1259 Oid:3}")
+				testhelper.ExpectRegexp(logfile, "Object: public.relation2 {ClassID:1259 Oid:2}")
 				testhelper.ExpectRegexp(logfile, "Dependencies:")
-				testhelper.ExpectRegexp(logfile, "\tpublic.relation1 {Classid:1259 Oid:1}")
-				testhelper.ExpectRegexp(logfile, "Object: public.relation3 {Classid:1259 Oid:3}")
+				testhelper.ExpectRegexp(logfile, "\tpublic.relation1 {ClassID:1259 Oid:1}")
+				testhelper.ExpectRegexp(logfile, "Object: public.relation3 {ClassID:1259 Oid:3}")
 				testhelper.ExpectRegexp(logfile, "Dependencies:")
-				testhelper.ExpectRegexp(logfile, "\tpublic.relation2 {Classid:1259 Oid:2}")
+				testhelper.ExpectRegexp(logfile, "\tpublic.relation2 {ClassID:1259 Oid:2}")
 			}()
 			defer testhelper.ShouldPanicWithMessage("Dependency resolution failed; see log file gbytes.Buffer for details. This is a bug, please report.")
 			sortable = backup.TopologicalSort(sortable, depMap)
 		})
 		It("aborts if dependencies are not met", func() {
-			depMap[backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: 1}] = map[backup.UniqueID]bool{{Classid: backup.PG_CLASS_OID, Oid: 2}: true}
-			depMap[backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: 1}] = map[backup.UniqueID]bool{{Classid: backup.PG_CLASS_OID, Oid: 4}: true}
+			depMap[backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: 1}] = map[backup.UniqueID]bool{{ClassID: backup.PG_CLASS_OID, Oid: 2}: true}
+			depMap[backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: 1}] = map[backup.UniqueID]bool{{ClassID: backup.PG_CLASS_OID, Oid: 4}: true}
 			sortable := []backup.Sortable{relation1, relation2}
 
 			defer testhelper.ShouldPanicWithMessage("Dependency resolution failed; see log file gbytes.Buffer for details. This is a bug, please report.")

--- a/backup/dependencies_test.go
+++ b/backup/dependencies_test.go
@@ -13,14 +13,14 @@ var _ = Describe("backup/dependencies tests", func() {
 		relation1 backup.Relation
 		relation2 backup.Relation
 		relation3 backup.Relation
-		depMap    map[backup.DepEntry]map[backup.DepEntry]bool
+		depMap    map[backup.UniqueID]map[backup.UniqueID]bool
 	)
 
 	BeforeEach(func() {
 		relation1 = backup.Relation{Schema: "public", Name: "relation1", Oid: 1}
 		relation2 = backup.Relation{Schema: "public", Name: "relation2", Oid: 2}
 		relation3 = backup.Relation{Schema: "public", Name: "relation3", Oid: 3}
-		depMap = make(map[backup.DepEntry]map[backup.DepEntry]bool, 0)
+		depMap = make(map[backup.UniqueID]map[backup.UniqueID]bool, 0)
 	})
 	Describe("TopologicalSort", func() {
 		It("returns the original slice if there are no dependencies among objects", func() {
@@ -33,7 +33,7 @@ var _ = Describe("backup/dependencies tests", func() {
 			Expect(relations[2].FQN()).To(Equal("public.relation3"))
 		})
 		It("sorts the slice correctly if there is an object dependent on one other object", func() {
-			depMap[backup.DepEntry{Classid: backup.PG_CLASS_OID, Objid: 1}] = map[backup.DepEntry]bool{{Classid: backup.PG_CLASS_OID, Objid: 3}: true}
+			depMap[backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: 1}] = map[backup.UniqueID]bool{{Classid: backup.PG_CLASS_OID, Oid: 3}: true}
 			relations := []backup.Sortable{relation1, relation2, relation3}
 
 			relations = backup.TopologicalSort(relations, depMap)
@@ -43,8 +43,8 @@ var _ = Describe("backup/dependencies tests", func() {
 			Expect(relations[2].FQN()).To(Equal("public.relation1"))
 		})
 		It("sorts the slice correctly if there are two objects dependent on one other object", func() {
-			depMap[backup.DepEntry{Classid: backup.PG_CLASS_OID, Objid: 1}] = map[backup.DepEntry]bool{{Classid: backup.PG_CLASS_OID, Objid: 2}: true}
-			depMap[backup.DepEntry{Classid: backup.PG_CLASS_OID, Objid: 3}] = map[backup.DepEntry]bool{{Classid: backup.PG_CLASS_OID, Objid: 2}: true}
+			depMap[backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: 1}] = map[backup.UniqueID]bool{{Classid: backup.PG_CLASS_OID, Oid: 2}: true}
+			depMap[backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: 3}] = map[backup.UniqueID]bool{{Classid: backup.PG_CLASS_OID, Oid: 2}: true}
 			relations := []backup.Sortable{relation1, relation2, relation3}
 
 			relations = backup.TopologicalSort(relations, depMap)
@@ -54,7 +54,7 @@ var _ = Describe("backup/dependencies tests", func() {
 			Expect(relations[2].FQN()).To(Equal("public.relation3"))
 		})
 		It("sorts the slice correctly if there is one object dependent on two other objects", func() {
-			depMap[backup.DepEntry{Classid: backup.PG_CLASS_OID, Objid: 2}] = map[backup.DepEntry]bool{{Classid: backup.PG_CLASS_OID, Objid: 1}: true, {Classid: backup.PG_CLASS_OID, Objid: 1}: true}
+			depMap[backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: 2}] = map[backup.UniqueID]bool{{Classid: backup.PG_CLASS_OID, Oid: 1}: true, {Classid: backup.PG_CLASS_OID, Oid: 1}: true}
 			relations := []backup.Sortable{relation1, relation2, relation3}
 
 			relations = backup.TopologicalSort(relations, depMap)
@@ -64,28 +64,28 @@ var _ = Describe("backup/dependencies tests", func() {
 			Expect(relations[2].FQN()).To(Equal("public.relation2"))
 		})
 		It("aborts if dependency loop (this shouldn't be possible)", func() {
-			depMap[backup.DepEntry{Classid: backup.PG_CLASS_OID, Objid: 1}] = map[backup.DepEntry]bool{{Classid: backup.PG_CLASS_OID, Objid: 3}: true}
-			depMap[backup.DepEntry{Classid: backup.PG_CLASS_OID, Objid: 2}] = map[backup.DepEntry]bool{{Classid: backup.PG_CLASS_OID, Objid: 1}: true}
-			depMap[backup.DepEntry{Classid: backup.PG_CLASS_OID, Objid: 3}] = map[backup.DepEntry]bool{{Classid: backup.PG_CLASS_OID, Objid: 2}: true}
+			depMap[backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: 1}] = map[backup.UniqueID]bool{{Classid: backup.PG_CLASS_OID, Oid: 3}: true}
+			depMap[backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: 2}] = map[backup.UniqueID]bool{{Classid: backup.PG_CLASS_OID, Oid: 1}: true}
+			depMap[backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: 3}] = map[backup.UniqueID]bool{{Classid: backup.PG_CLASS_OID, Oid: 2}: true}
 
 			sortable := []backup.Sortable{relation1, relation2, relation3}
 			defer func() {
-				testhelper.ExpectRegexp(logfile, "Object: public.relation1 {Classid:1259 Objid:1}")
+				testhelper.ExpectRegexp(logfile, "Object: public.relation1 {Classid:1259 Oid:1}")
 				testhelper.ExpectRegexp(logfile, "Dependencies:")
-				testhelper.ExpectRegexp(logfile, "\tpublic.relation3 {Classid:1259 Objid:3}")
-				testhelper.ExpectRegexp(logfile, "Object: public.relation2 {Classid:1259 Objid:2}")
+				testhelper.ExpectRegexp(logfile, "\tpublic.relation3 {Classid:1259 Oid:3}")
+				testhelper.ExpectRegexp(logfile, "Object: public.relation2 {Classid:1259 Oid:2}")
 				testhelper.ExpectRegexp(logfile, "Dependencies:")
-				testhelper.ExpectRegexp(logfile, "\tpublic.relation1 {Classid:1259 Objid:1}")
-				testhelper.ExpectRegexp(logfile, "Object: public.relation3 {Classid:1259 Objid:3}")
+				testhelper.ExpectRegexp(logfile, "\tpublic.relation1 {Classid:1259 Oid:1}")
+				testhelper.ExpectRegexp(logfile, "Object: public.relation3 {Classid:1259 Oid:3}")
 				testhelper.ExpectRegexp(logfile, "Dependencies:")
-				testhelper.ExpectRegexp(logfile, "\tpublic.relation2 {Classid:1259 Objid:2}")
+				testhelper.ExpectRegexp(logfile, "\tpublic.relation2 {Classid:1259 Oid:2}")
 			}()
 			defer testhelper.ShouldPanicWithMessage("Dependency resolution failed; see log file gbytes.Buffer for details. This is a bug, please report.")
 			sortable = backup.TopologicalSort(sortable, depMap)
 		})
 		It("aborts if dependencies are not met", func() {
-			depMap[backup.DepEntry{Classid: backup.PG_CLASS_OID, Objid: 1}] = map[backup.DepEntry]bool{{Classid: backup.PG_CLASS_OID, Objid: 2}: true}
-			depMap[backup.DepEntry{Classid: backup.PG_CLASS_OID, Objid: 1}] = map[backup.DepEntry]bool{{Classid: backup.PG_CLASS_OID, Objid: 4}: true}
+			depMap[backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: 1}] = map[backup.UniqueID]bool{{Classid: backup.PG_CLASS_OID, Oid: 2}: true}
+			depMap[backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: 1}] = map[backup.UniqueID]bool{{Classid: backup.PG_CLASS_OID, Oid: 4}: true}
 			sortable := []backup.Sortable{relation1, relation2}
 
 			defer testhelper.ShouldPanicWithMessage("Dependency resolution failed; see log file gbytes.Buffer for details. This is a bug, please report.")
@@ -94,16 +94,16 @@ var _ = Describe("backup/dependencies tests", func() {
 	})
 	Describe("ConstructDependentObjectMetadataMap", func() {
 		It("composes metadata maps for functions, types, and tables into one map", func() {
-			funcMap := backup.MetadataMap{1: backup.ObjectMetadata{Comment: "function"}}
-			typeMap := backup.MetadataMap{2: backup.ObjectMetadata{Comment: "type"}}
-			tableMap := backup.MetadataMap{3: backup.ObjectMetadata{Comment: "relation"}}
-			protoMap := backup.MetadataMap{4: backup.ObjectMetadata{Comment: "protocol"}}
+			funcMap := backup.MetadataMap{backup.UniqueID{Oid: 1}: backup.ObjectMetadata{Comment: "function"}}
+			typeMap := backup.MetadataMap{backup.UniqueID{Oid: 2}: backup.ObjectMetadata{Comment: "type"}}
+			tableMap := backup.MetadataMap{backup.UniqueID{Oid: 3}: backup.ObjectMetadata{Comment: "relation"}}
+			protoMap := backup.MetadataMap{backup.UniqueID{Oid: 4}: backup.ObjectMetadata{Comment: "protocol"}}
 			result := backup.ConstructDependentObjectMetadataMap(funcMap, typeMap, tableMap, protoMap)
 			expected := backup.MetadataMap{
-				1: backup.ObjectMetadata{Comment: "function"},
-				2: backup.ObjectMetadata{Comment: "type"},
-				3: backup.ObjectMetadata{Comment: "relation"},
-				4: backup.ObjectMetadata{Comment: "protocol"},
+				backup.UniqueID{Oid: 1}: backup.ObjectMetadata{Comment: "function"},
+				backup.UniqueID{Oid: 2}: backup.ObjectMetadata{Comment: "type"},
+				backup.UniqueID{Oid: 3}: backup.ObjectMetadata{Comment: "relation"},
+				backup.UniqueID{Oid: 4}: backup.ObjectMetadata{Comment: "protocol"},
 			}
 			Expect(result).To(Equal(expected))
 		})

--- a/backup/metadata_globals.go
+++ b/backup/metadata_globals.go
@@ -42,7 +42,7 @@ func PrintCreateDatabaseStatement(metadataFile *utils.FileWithByteCount, toc *ut
 	metadataFile.MustPrintf(";")
 	toc.AddGlobalEntry("", dbname, "DATABASE", start, metadataFile)
 	start = metadataFile.ByteCount
-	PrintObjectMetadata(metadataFile, dbMetadata[db.Oid], dbname, "DATABASE")
+	PrintObjectMetadata(metadataFile, dbMetadata[db.GetUniqueID()], dbname, "DATABASE")
 	if metadataFile.ByteCount > start {
 		toc.AddGlobalEntry("", dbname, "DATABASE METADATA", start, metadataFile)
 	}
@@ -87,7 +87,7 @@ func PrintCreateResourceQueueStatements(metadataFile *utils.FileWithByteCount, t
 			action = "ALTER"
 		}
 		metadataFile.MustPrintf("\n\n%s RESOURCE QUEUE %s WITH (%s);", action, resQueue.Name, strings.Join(attributes, ", "))
-		PrintObjectMetadata(metadataFile, resQueueMetadata[resQueue.Oid], resQueue.Name, "RESOURCE QUEUE")
+		PrintObjectMetadata(metadataFile, resQueueMetadata[resQueue.GetUniqueID()], resQueue.Name, "RESOURCE QUEUE")
 		toc.AddGlobalEntry("", resQueue.Name, "RESOURCE QUEUE", start, metadataFile)
 	}
 }
@@ -140,7 +140,7 @@ func PrintCreateResourceGroupStatements(metadataFile *utils.FileWithByteCount, t
 				/* cpuset mode */
 				metadataFile.MustPrintf("\n\nALTER RESOURCE GROUP %s SET CPUSET '%s';", resGroup.Name, resGroup.Cpuset)
 			}
-			PrintObjectMetadata(metadataFile, resGroupMetadata[resGroup.Oid], resGroup.Name, "RESOURCE GROUP")
+			PrintObjectMetadata(metadataFile, resGroupMetadata[resGroup.GetUniqueID()], resGroup.Name, "RESOURCE GROUP")
 			toc.AddGlobalEntry("", resGroup.Name, "RESOURCE GROUP", start, metadataFile)
 		} else {
 			start = metadataFile.ByteCount
@@ -173,7 +173,7 @@ func PrintCreateResourceGroupStatements(metadataFile *utils.FileWithByteCount, t
 			attributes = append(attributes, fmt.Sprintf("MEMORY_SPILL_RATIO=%d", resGroup.MemorySpillRatio))
 			attributes = append(attributes, fmt.Sprintf("CONCURRENCY=%d", resGroup.Concurrency))
 			metadataFile.MustPrintf("\n\nCREATE RESOURCE GROUP %s WITH (%s);", resGroup.Name, strings.Join(attributes, ", "))
-			PrintObjectMetadata(metadataFile, resGroupMetadata[resGroup.Oid], resGroup.Name, "RESOURCE GROUP")
+			PrintObjectMetadata(metadataFile, resGroupMetadata[resGroup.GetUniqueID()], resGroup.Name, "RESOURCE GROUP")
 			toc.AddGlobalEntry("", resGroup.Name, "RESOURCE GROUP", start, metadataFile)
 		}
 	}
@@ -267,7 +267,7 @@ ALTER ROLE %s %s;`, role.Name, roleGUC)
 				metadataFile.MustPrintf("\nALTER ROLE %s DENY BETWEEN DAY %d TIME '%s' AND DAY %d TIME '%s';", role.Name, timeConstraint.StartDay, timeConstraint.StartTime, timeConstraint.EndDay, timeConstraint.EndTime)
 			}
 		}
-		PrintObjectMetadata(metadataFile, roleMetadata[role.Oid], role.Name, "ROLE")
+		PrintObjectMetadata(metadataFile, roleMetadata[role.GetUniqueID()], role.Name, "ROLE")
 		toc.AddGlobalEntry("", role.Name, "ROLE", start, metadataFile)
 	}
 }
@@ -296,7 +296,7 @@ func PrintCreateTablespaceStatements(metadataFile *utils.FileWithByteCount, toc 
 		}
 		toc.AddGlobalEntry("", tablespace.Tablespace, "TABLESPACE", start, metadataFile)
 		start = metadataFile.ByteCount
-		PrintObjectMetadata(metadataFile, tablespaceMetadata[tablespace.Oid], tablespace.Tablespace, "TABLESPACE")
+		PrintObjectMetadata(metadataFile, tablespaceMetadata[tablespace.GetUniqueID()], tablespace.Tablespace, "TABLESPACE")
 		if metadataFile.ByteCount > start {
 			toc.AddGlobalEntry("", tablespace.Tablespace, "TABLESPACE METADATA", start, metadataFile)
 		}

--- a/backup/metadata_globals_test.go
+++ b/backup/metadata_globals_test.go
@@ -38,11 +38,11 @@ var _ = Describe("backup/metadata_globals tests", func() {
 			testutils.AssertBufferContents(toc.GlobalEntries, buffer, `CREATE DATABASE "table" TEMPLATE template0;`)
 		})
 		It("prints a CREATE DATABASE statement with privileges, an owner, and a comment", func() {
-			dbMetadataMap := testutils.DefaultMetadataMap("DATABASE", true, true, true)
-			dbMetadata := dbMetadataMap[1]
-			dbMetadata.Privileges[0].Create = false
-			dbMetadataMap[1] = dbMetadata
 			db := backup.Database{Oid: 1, Name: "testdb", Tablespace: "pg_default"}
+			dbMetadataMap := testutils.DefaultMetadataMap("DATABASE", true, true, true)
+			dbMetadata := dbMetadataMap[db.GetUniqueID()]
+			dbMetadata.Privileges[0].Create = false
+			dbMetadataMap[db.GetUniqueID()] = dbMetadata
 			backup.PrintCreateDatabaseStatement(backupfile, toc, db, dbMetadataMap)
 			testutils.AssertBufferContents(toc.GlobalEntries, buffer, `CREATE DATABASE testdb TEMPLATE template0;`,
 				`COMMENT ON DATABASE testdb IS 'This is a database comment.';
@@ -86,7 +86,7 @@ GRANT TEMPORARY,CONNECT ON DATABASE testdb TO testrole;`)
 		})
 	})
 	Describe("PrintCreateResourceQueueStatements", func() {
-		var emptyResQueueMetadata = map[uint32]backup.ObjectMetadata{}
+		var emptyResQueueMetadata = backup.MetadataMap{}
 		It("prints resource queues", func() {
 			someQueue := backup.ResourceQueue{Oid: 1, Name: "some_queue", ActiveStatements: 1, MaxCost: "-1.00", CostOvercommit: false, MinCost: "0.00", Priority: "medium", MemoryLimit: "-1"}
 			maxCostQueue := backup.ResourceQueue{Oid: 1, Name: `"someMaxCostQueue"`, ActiveStatements: -1, MaxCost: "99.9", CostOvercommit: true, MinCost: "0.00", Priority: "medium", MemoryLimit: "-1"}
@@ -131,7 +131,7 @@ COMMENT ON RESOURCE QUEUE "commentQueue" IS 'This is a resource queue comment.';
 		})
 	})
 	Describe("PrintCreateResourceGroupStatements", func() {
-		var emptyResGroupMetadata = map[uint32]backup.ObjectMetadata{}
+		var emptyResGroupMetadata = backup.MetadataMap{}
 		It("prints resource groups", func() {
 			someGroup := backup.ResourceGroup{Oid: 1, Name: "some_group", CPURateLimit: 10, MemoryLimit: 20, Concurrency: 15, MemorySharedQuota: 25, MemorySpillRatio: 30}
 			someGroup2 := backup.ResourceGroup{Oid: 2, Name: "some_group2", CPURateLimit: 20, MemoryLimit: 30, Concurrency: 25, MemorySharedQuota: 35, MemorySpillRatio: 10}

--- a/backup/postdata.go
+++ b/backup/postdata.go
@@ -22,7 +22,7 @@ func PrintCreateIndexStatements(metadataFile *utils.FileWithByteCount, toc *util
 		if index.IsClustered {
 			metadataFile.MustPrintf("\nALTER TABLE %s CLUSTER ON %s;", tableFQN, index.Name)
 		}
-		PrintObjectMetadata(metadataFile, indexMetadata[index.Oid], indexFQN, "INDEX")
+		PrintObjectMetadata(metadataFile, indexMetadata[index.GetUniqueID()], indexFQN, "INDEX")
 		toc.AddPostdataEntry(index.OwningSchema, index.Name, "INDEX", tableFQN, start, metadataFile)
 	}
 }
@@ -32,7 +32,7 @@ func PrintCreateRuleStatements(metadataFile *utils.FileWithByteCount, toc *utils
 		start := metadataFile.ByteCount
 		metadataFile.MustPrintf("\n\n%s", rule.Def)
 		tableFQN := utils.MakeFQN(rule.OwningSchema, rule.OwningTable)
-		PrintObjectMetadata(metadataFile, ruleMetadata[rule.Oid], rule.Name, "RULE", tableFQN)
+		PrintObjectMetadata(metadataFile, ruleMetadata[rule.GetUniqueID()], rule.Name, "RULE", tableFQN)
 		toc.AddPostdataEntry(rule.OwningSchema, rule.Name, "RULE", tableFQN, start, metadataFile)
 	}
 }
@@ -42,7 +42,7 @@ func PrintCreateTriggerStatements(metadataFile *utils.FileWithByteCount, toc *ut
 		start := metadataFile.ByteCount
 		metadataFile.MustPrintf("\n\n%s;", trigger.Def)
 		tableFQN := utils.MakeFQN(trigger.OwningSchema, trigger.OwningTable)
-		PrintObjectMetadata(metadataFile, triggerMetadata[trigger.Oid], trigger.Name, "TRIGGER", tableFQN)
+		PrintObjectMetadata(metadataFile, triggerMetadata[trigger.GetUniqueID()], trigger.Name, "TRIGGER", tableFQN)
 		toc.AddPostdataEntry(trigger.OwningSchema, trigger.Name, "TRIGGER", tableFQN, start, metadataFile)
 	}
 }

--- a/backup/postdata_test.go
+++ b/backup/postdata_test.go
@@ -48,7 +48,7 @@ COMMENT ON INDEX public.testindex IS 'This is an index comment.';`)
 		})
 	})
 	Context("PrintCreateRuleStatements", func() {
-		rule := backup.QuerySimpleDefinition{Oid: 1, Name: "testrule", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE RULE update_notify AS ON UPDATE TO testtable DO NOTIFY testtable;"}
+		rule := backup.QuerySimpleDefinition{Classid: backup.PG_REWRITE_OID, Oid: 1, Name: "testrule", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE RULE update_notify AS ON UPDATE TO testtable DO NOTIFY testtable;"}
 		It("can print a basic rule", func() {
 			rules := []backup.QuerySimpleDefinition{rule}
 			emptyMetadataMap := backup.MetadataMap{}
@@ -66,7 +66,7 @@ COMMENT ON RULE testrule ON public.testtable IS 'This is a rule comment.';`)
 		})
 	})
 	Context("PrintCreateTriggerStatements", func() {
-		trigger := backup.QuerySimpleDefinition{Oid: 1, Name: "testtrigger", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON testtable FOR EACH STATEMENT EXECUTE PROCEDURE flatfile_update_trigger()"}
+		trigger := backup.QuerySimpleDefinition{Classid: backup.PG_TRIGGER_OID, Oid: 1, Name: "testtrigger", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON testtable FOR EACH STATEMENT EXECUTE PROCEDURE flatfile_update_trigger()"}
 		It("can print a basic trigger", func() {
 			triggers := []backup.QuerySimpleDefinition{trigger}
 			emptyMetadataMap := backup.MetadataMap{}

--- a/backup/postdata_test.go
+++ b/backup/postdata_test.go
@@ -48,7 +48,7 @@ COMMENT ON INDEX public.testindex IS 'This is an index comment.';`)
 		})
 	})
 	Context("PrintCreateRuleStatements", func() {
-		rule := backup.QuerySimpleDefinition{Classid: backup.PG_REWRITE_OID, Oid: 1, Name: "testrule", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE RULE update_notify AS ON UPDATE TO testtable DO NOTIFY testtable;"}
+		rule := backup.QuerySimpleDefinition{ClassID: backup.PG_REWRITE_OID, Oid: 1, Name: "testrule", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE RULE update_notify AS ON UPDATE TO testtable DO NOTIFY testtable;"}
 		It("can print a basic rule", func() {
 			rules := []backup.QuerySimpleDefinition{rule}
 			emptyMetadataMap := backup.MetadataMap{}
@@ -66,7 +66,7 @@ COMMENT ON RULE testrule ON public.testtable IS 'This is a rule comment.';`)
 		})
 	})
 	Context("PrintCreateTriggerStatements", func() {
-		trigger := backup.QuerySimpleDefinition{Classid: backup.PG_TRIGGER_OID, Oid: 1, Name: "testtrigger", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON testtable FOR EACH STATEMENT EXECUTE PROCEDURE flatfile_update_trigger()"}
+		trigger := backup.QuerySimpleDefinition{ClassID: backup.PG_TRIGGER_OID, Oid: 1, Name: "testtrigger", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON testtable FOR EACH STATEMENT EXECUTE PROCEDURE flatfile_update_trigger()"}
 		It("can print a basic trigger", func() {
 			triggers := []backup.QuerySimpleDefinition{trigger}
 			emptyMetadataMap := backup.MetadataMap{}

--- a/backup/postdata_test.go
+++ b/backup/postdata_test.go
@@ -8,35 +8,39 @@ import (
 )
 
 var _ = Describe("backup/postdata tests", func() {
+	var emptyMetadataMap = backup.MetadataMap{}
 	BeforeEach(func() {
 		toc, backupfile = testutils.InitializeTestTOC(buffer, "postdata")
 	})
 	Context("PrintCreateIndexStatements", func() {
+		var index backup.IndexDefinition
+		BeforeEach(func() {
+			index = backup.IndexDefinition{Oid: 1, Name: "testindex", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE INDEX testindex ON public.testtable USING btree(i)"}
+		})
 		It("can print a basic index", func() {
-			indexes := []backup.IndexDefinition{{Oid: 1, Name: "testindex", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE INDEX testindex ON public.testtable USING btree(i)"}}
-			emptyMetadataMap := backup.MetadataMap{}
+			indexes := []backup.IndexDefinition{index}
 			backup.PrintCreateIndexStatements(backupfile, toc, indexes, emptyMetadataMap)
 			testutils.ExpectEntry(toc.PostdataEntries, 0, "public", "public.testtable", "testindex", "INDEX")
 			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE INDEX testindex ON public.testtable USING btree(i);`)
 		})
 		It("can print an index used for clustering", func() {
-			indexes := []backup.IndexDefinition{{Oid: 1, Name: "testindex", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE INDEX testindex ON public.testtable USING btree(i)", IsClustered: true}}
-			emptyMetadataMap := backup.MetadataMap{}
+			index.IsClustered = true
+			indexes := []backup.IndexDefinition{index}
 			backup.PrintCreateIndexStatements(backupfile, toc, indexes, emptyMetadataMap)
 			testutils.ExpectEntry(toc.PostdataEntries, 0, "public", "public.testtable", "testindex", "INDEX")
 			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE INDEX testindex ON public.testtable USING btree(i);
 ALTER TABLE public.testtable CLUSTER ON testindex;`)
 		})
 		It("can print an index with a tablespace", func() {
-			indexes := []backup.IndexDefinition{{Oid: 1, Name: "testindex", OwningSchema: "public", OwningTable: "testtable", Tablespace: "test_tablespace", Def: "CREATE INDEX testindex ON public.testtable USING btree(i)"}}
-			emptyMetadataMap := backup.MetadataMap{}
+			index.Tablespace = "test_tablespace"
+			indexes := []backup.IndexDefinition{index}
 			backup.PrintCreateIndexStatements(backupfile, toc, indexes, emptyMetadataMap)
 			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE INDEX testindex ON public.testtable USING btree(i);
 ALTER INDEX public.testindex SET TABLESPACE test_tablespace;`)
 		})
 		It("can print an index with a comment", func() {
-			indexes := []backup.IndexDefinition{{Oid: 1, Name: "testindex", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE INDEX testindex ON public.testtable USING btree(i)"}}
-			indexMetadataMap := backup.MetadataMap{1: {Comment: "This is an index comment."}}
+			indexes := []backup.IndexDefinition{index}
+			indexMetadataMap := backup.MetadataMap{index.GetUniqueID(): {Comment: "This is an index comment."}}
 			backup.PrintCreateIndexStatements(backupfile, toc, indexes, indexMetadataMap)
 			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE INDEX testindex ON public.testtable USING btree(i);
 
@@ -44,16 +48,17 @@ COMMENT ON INDEX public.testindex IS 'This is an index comment.';`)
 		})
 	})
 	Context("PrintCreateRuleStatements", func() {
+		rule := backup.QuerySimpleDefinition{Oid: 1, Name: "testrule", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE RULE update_notify AS ON UPDATE TO testtable DO NOTIFY testtable;"}
 		It("can print a basic rule", func() {
-			rules := []backup.QuerySimpleDefinition{{Oid: 1, Name: "testrule", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE RULE update_notify AS ON UPDATE TO testtable DO NOTIFY testtable;"}}
+			rules := []backup.QuerySimpleDefinition{rule}
 			emptyMetadataMap := backup.MetadataMap{}
 			backup.PrintCreateRuleStatements(backupfile, toc, rules, emptyMetadataMap)
 			testutils.ExpectEntry(toc.PostdataEntries, 0, "public", "public.testtable", "testrule", "RULE")
 			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE RULE update_notify AS ON UPDATE TO testtable DO NOTIFY testtable;`)
 		})
 		It("can print a rule with a comment", func() {
-			rules := []backup.QuerySimpleDefinition{{Oid: 1, Name: "testrule", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE RULE update_notify AS ON UPDATE TO testtable DO NOTIFY testtable;"}}
-			ruleMetadataMap := backup.MetadataMap{1: {Comment: "This is a rule comment."}}
+			rules := []backup.QuerySimpleDefinition{rule}
+			ruleMetadataMap := backup.MetadataMap{rule.GetUniqueID(): {Comment: "This is a rule comment."}}
 			backup.PrintCreateRuleStatements(backupfile, toc, rules, ruleMetadataMap)
 			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE RULE update_notify AS ON UPDATE TO testtable DO NOTIFY testtable;
 
@@ -61,16 +66,17 @@ COMMENT ON RULE testrule ON public.testtable IS 'This is a rule comment.';`)
 		})
 	})
 	Context("PrintCreateTriggerStatements", func() {
+		trigger := backup.QuerySimpleDefinition{Oid: 1, Name: "testtrigger", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON testtable FOR EACH STATEMENT EXECUTE PROCEDURE flatfile_update_trigger()"}
 		It("can print a basic trigger", func() {
-			triggers := []backup.QuerySimpleDefinition{{Oid: 1, Name: "testtrigger", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON testtable FOR EACH STATEMENT EXECUTE PROCEDURE flatfile_update_trigger()"}}
+			triggers := []backup.QuerySimpleDefinition{trigger}
 			emptyMetadataMap := backup.MetadataMap{}
 			backup.PrintCreateTriggerStatements(backupfile, toc, triggers, emptyMetadataMap)
 			testutils.ExpectEntry(toc.PostdataEntries, 0, "public", "public.testtable", "testtrigger", "TRIGGER")
 			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON testtable FOR EACH STATEMENT EXECUTE PROCEDURE flatfile_update_trigger();`)
 		})
 		It("can print a trigger with a comment", func() {
-			triggers := []backup.QuerySimpleDefinition{{Oid: 1, Name: "testtrigger", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON testtable FOR EACH STATEMENT EXECUTE PROCEDURE flatfile_update_trigger()"}}
-			triggerMetadataMap := backup.MetadataMap{1: {Comment: "This is a trigger comment."}}
+			triggers := []backup.QuerySimpleDefinition{trigger}
+			triggerMetadataMap := backup.MetadataMap{trigger.GetUniqueID(): {Comment: "This is a trigger comment."}}
 			backup.PrintCreateTriggerStatements(backupfile, toc, triggers, triggerMetadataMap)
 			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON testtable FOR EACH STATEMENT EXECUTE PROCEDURE flatfile_update_trigger();
 

--- a/backup/predata_functions.go
+++ b/backup/predata_functions.go
@@ -171,7 +171,7 @@ func PrintCreateAggregateStatements(metadataFile *utils.FileWithByteCount, toc *
 		}
 		aggFQN = fmt.Sprintf("%s(%s)", aggFQN, identArgumentsStr)
 		aggWithArgs := fmt.Sprintf("%s(%s)", aggDef.Name, identArgumentsStr)
-		PrintObjectMetadata(metadataFile, aggMetadata[aggDef.Oid], aggFQN, "AGGREGATE")
+		PrintObjectMetadata(metadataFile, aggMetadata[aggDef.GetUniqueID()], aggFQN, "AGGREGATE")
 		toc.AddPredataEntry(aggDef.Schema, aggWithArgs, "AGGREGATE", "", start, metadataFile)
 	}
 }
@@ -198,7 +198,7 @@ func PrintCreateCastStatements(metadataFile *utils.FileWithByteCount, toc *utils
 		case "e": // Default case, don't print anything else
 		}
 		metadataFile.MustPrintf(";")
-		PrintObjectMetadata(metadataFile, castMetadata[castDef.Oid], castStr, "CAST")
+		PrintObjectMetadata(metadataFile, castMetadata[castDef.GetUniqueID()], castStr, "CAST")
 		filterSchema := "pg_catalog"
 		if castDef.CastMethod == "f" {
 			filterSchema = castDef.FunctionSchema // Use the function's schema to allow restore filtering
@@ -211,7 +211,7 @@ func PrintCreateExtensionStatements(metadataFile *utils.FileWithByteCount, toc *
 	for _, extensionDef := range extensionDefs {
 		start := metadataFile.ByteCount
 		metadataFile.MustPrintf("\n\nSET search_path=%s,pg_catalog;\nCREATE EXTENSION IF NOT EXISTS %s WITH SCHEMA %s;\nSET search_path=pg_catalog;", extensionDef.Schema, extensionDef.Name, extensionDef.Schema)
-		PrintObjectMetadata(metadataFile, extensionMetadata[extensionDef.Oid], extensionDef.Name, "EXTENSION")
+		PrintObjectMetadata(metadataFile, extensionMetadata[extensionDef.GetUniqueID()], extensionDef.Name, "EXTENSION")
 		toc.AddPredataEntry("", extensionDef.Name, "EXTENSION", "", start, metadataFile)
 	}
 }
@@ -279,7 +279,7 @@ func PrintCreateLanguageStatements(metadataFile *utils.FileWithByteCount, toc *u
 		}
 		metadataFile.MustPrintf("%s;", paramsStr)
 		metadataFile.MustPrintf(alterStr)
-		PrintObjectMetadata(metadataFile, procLangMetadata[procLang.Oid], procLang.Name, "LANGUAGE")
+		PrintObjectMetadata(metadataFile, procLangMetadata[procLang.GetUniqueID()], procLang.Name, "LANGUAGE")
 		metadataFile.MustPrintln()
 		toc.AddPredataEntry("", procLang.Name, "PROCEDURAL LANGUAGE", "", start, metadataFile)
 	}
@@ -295,7 +295,7 @@ func PrintCreateConversionStatements(metadataFile *utils.FileWithByteCount, toc 
 		}
 		metadataFile.MustPrintf("\n\nCREATE%s CONVERSION %s FOR '%s' TO '%s' FROM %s;",
 			defaultStr, convFQN, conversion.ForEncoding, conversion.ToEncoding, conversion.ConversionFunction)
-		PrintObjectMetadata(metadataFile, conversionMetadata[conversion.Oid], convFQN, "CONVERSION")
+		PrintObjectMetadata(metadataFile, conversionMetadata[conversion.GetUniqueID()], convFQN, "CONVERSION")
 		metadataFile.MustPrintln()
 		toc.AddPredataEntry(conversion.Schema, conversion.Name, "CONVERSION", "", start, metadataFile)
 	}
@@ -317,7 +317,7 @@ func PrintCreateForeignDataWrapperStatements(metadataFile *utils.FileWithByteCou
 			metadataFile.MustPrintf("\n\tOPTIONS (%s)", fdw.Options)
 		}
 		metadataFile.MustPrintf(";")
-		PrintObjectMetadata(metadataFile, fdwMetadata[fdw.Oid], fdw.Name, "FOREIGN DATA WRAPPER")
+		PrintObjectMetadata(metadataFile, fdwMetadata[fdw.GetUniqueID()], fdw.Name, "FOREIGN DATA WRAPPER")
 		toc.AddPredataEntry("", fdw.Name, "FOREIGN DATA WRAPPER", "", start, metadataFile)
 	}
 }
@@ -339,7 +339,7 @@ func PrintCreateServerStatements(metadataFile *utils.FileWithByteCount, toc *uti
 		metadataFile.MustPrintf(";")
 
 		//NOTE: We must specify SERVER when creating and dropping, but FOREIGN SERVER when granting and revoking
-		PrintObjectMetadata(metadataFile, serverMetadata[server.Oid], server.Name, "FOREIGN SERVER")
+		PrintObjectMetadata(metadataFile, serverMetadata[server.GetUniqueID()], server.Name, "FOREIGN SERVER")
 		toc.AddPredataEntry("", server.Name, "FOREIGN SERVER", "", start, metadataFile)
 	}
 }

--- a/backup/predata_functions_test.go
+++ b/backup/predata_functions_test.go
@@ -262,8 +262,10 @@ $_$`)
 
 	})
 	Describe("PrintCreateAggregateStatements", func() {
-		aggDefs := make([]backup.Aggregate, 1)
-		aggDefinition := backup.Aggregate{Oid: 1, Schema: "public", Name: "agg_name", Arguments: "integer, integer", IdentArgs: "integer, integer", TransitionFunction: 1, TransitionDataType: "integer", InitValIsNull: true, MInitValIsNull: true}
+		var (
+			aggDefinition  backup.Aggregate
+			aggMetadataMap backup.MetadataMap
+		)
 		funcInfoMap := map[uint32]backup.FunctionInfo{
 			1: {QualifiedName: "public.mysfunc", Arguments: "integer"},
 			2: {QualifiedName: "public.mypfunc", Arguments: "numeric, numeric"},
@@ -272,14 +274,13 @@ $_$`)
 			5: {QualifiedName: "pg_catalog.ordered_set_transition_multi", Arguments: `internal, VARIADIC "any"`},
 			6: {QualifiedName: "pg_catalog.rank_final", Arguments: `internal, VARIADIC "any"`},
 		}
-		aggMetadataMap := backup.MetadataMap{}
 		BeforeEach(func() {
-			aggDefs[0] = aggDefinition
+			aggDefinition = backup.Aggregate{Oid: 1, Schema: "public", Name: "agg_name", Arguments: "integer, integer", IdentArgs: "integer, integer", TransitionFunction: 1, TransitionDataType: "integer", InitValIsNull: true, MInitValIsNull: true}
 			aggMetadataMap = backup.MetadataMap{}
 		})
 
 		It("prints an aggregate definition for an unordered aggregate with no optional specifications", func() {
-			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{aggDefinition}, funcInfoMap, aggMetadataMap)
 			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "agg_name(integer, integer)", "AGGREGATE")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(integer, integer) (
 	SFUNC = public.mysfunc,
@@ -287,25 +288,25 @@ $_$`)
 );`)
 		})
 		It("prints an aggregate definition for an ordered aggregate with no optional specifications", func() {
-			aggDefs[0].IsOrdered = true
-			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			aggDefinition.IsOrdered = true
+			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{aggDefinition}, funcInfoMap, aggMetadataMap)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE ORDERED AGGREGATE public.agg_name(integer, integer) (
 	SFUNC = public.mysfunc,
 	STYPE = integer
 );`)
 		})
 		It("prints an aggregate definition for an unordered aggregate with no arguments", func() {
-			aggDefs[0].Arguments = ""
-			aggDefs[0].IdentArgs = ""
-			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			aggDefinition.Arguments = ""
+			aggDefinition.IdentArgs = ""
+			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{aggDefinition}, funcInfoMap, aggMetadataMap)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(*) (
 	SFUNC = public.mysfunc,
 	STYPE = integer
 );`)
 		})
 		It("prints an aggregate with a preliminary function", func() {
-			aggDefs[0].PreliminaryFunction = 2
-			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			aggDefinition.PreliminaryFunction = 2
+			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{aggDefinition}, funcInfoMap, aggMetadataMap)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(integer, integer) (
 	SFUNC = public.mysfunc,
 	STYPE = integer,
@@ -313,8 +314,8 @@ $_$`)
 );`)
 		})
 		It("prints an aggregate with a combine function", func() {
-			aggDefs[0].CombineFunction = 2
-			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			aggDefinition.CombineFunction = 2
+			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{aggDefinition}, funcInfoMap, aggMetadataMap)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(integer, integer) (
 	SFUNC = public.mysfunc,
 	STYPE = integer,
@@ -322,8 +323,8 @@ $_$`)
 );`)
 		})
 		It("prints an aggregate with a serial function", func() {
-			aggDefs[0].SerialFunction = 2
-			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			aggDefinition.SerialFunction = 2
+			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{aggDefinition}, funcInfoMap, aggMetadataMap)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(integer, integer) (
 	SFUNC = public.mysfunc,
 	STYPE = integer,
@@ -331,8 +332,8 @@ $_$`)
 );`)
 		})
 		It("prints an aggregate with a deserial function", func() {
-			aggDefs[0].DeserialFunction = 2
-			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			aggDefinition.DeserialFunction = 2
+			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{aggDefinition}, funcInfoMap, aggMetadataMap)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(integer, integer) (
 	SFUNC = public.mysfunc,
 	STYPE = integer,
@@ -340,8 +341,8 @@ $_$`)
 );`)
 		})
 		It("prints an aggregate with a final function", func() {
-			aggDefs[0].FinalFunction = 3
-			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			aggDefinition.FinalFunction = 3
+			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{aggDefinition}, funcInfoMap, aggMetadataMap)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(integer, integer) (
 	SFUNC = public.mysfunc,
 	STYPE = integer,
@@ -349,8 +350,8 @@ $_$`)
 );`)
 		})
 		It("prints an aggregate with a final function extra attribute", func() {
-			aggDefs[0].FinalFuncExtra = true
-			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			aggDefinition.FinalFuncExtra = true
+			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{aggDefinition}, funcInfoMap, aggMetadataMap)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(integer, integer) (
 	SFUNC = public.mysfunc,
 	STYPE = integer,
@@ -358,9 +359,9 @@ $_$`)
 );`)
 		})
 		It("prints an aggregate with an initial condition", func() {
-			aggDefs[0].InitialValue = "0"
-			aggDefs[0].InitValIsNull = false
-			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			aggDefinition.InitialValue = "0"
+			aggDefinition.InitValIsNull = false
+			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{aggDefinition}, funcInfoMap, aggMetadataMap)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(integer, integer) (
 	SFUNC = public.mysfunc,
 	STYPE = integer,
@@ -368,8 +369,8 @@ $_$`)
 );`)
 		})
 		It("prints an aggregate with a sort operator", func() {
-			aggDefs[0].SortOperator = 4
-			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			aggDefinition.SortOperator = 4
+			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{aggDefinition}, funcInfoMap, aggMetadataMap)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(integer, integer) (
 	SFUNC = public.mysfunc,
 	STYPE = integer,
@@ -377,8 +378,8 @@ $_$`)
 );`)
 		})
 		It("prints an aggregate with a specified transition data size", func() {
-			aggDefs[0].TransitionDataSize = 1000
-			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			aggDefinition.TransitionDataSize = 1000
+			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{aggDefinition}, funcInfoMap, aggMetadataMap)
 			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "agg_name(integer, integer)", "AGGREGATE")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(integer, integer) (
 	SFUNC = public.mysfunc,
@@ -387,8 +388,8 @@ $_$`)
 );`)
 		})
 		It("prints an aggregate with a specified moving transition function", func() {
-			aggDefs[0].MTransitionFunction = 1
-			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			aggDefinition.MTransitionFunction = 1
+			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{aggDefinition}, funcInfoMap, aggMetadataMap)
 			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "agg_name(integer, integer)", "AGGREGATE")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(integer, integer) (
 	SFUNC = public.mysfunc,
@@ -397,8 +398,8 @@ $_$`)
 );`)
 		})
 		It("prints an aggregate with a specified moving inverse transition function", func() {
-			aggDefs[0].MInverseTransitionFunction = 1
-			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			aggDefinition.MInverseTransitionFunction = 1
+			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{aggDefinition}, funcInfoMap, aggMetadataMap)
 			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "agg_name(integer, integer)", "AGGREGATE")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(integer, integer) (
 	SFUNC = public.mysfunc,
@@ -407,8 +408,8 @@ $_$`)
 );`)
 		})
 		It("prints an aggregate with a specified moving state type", func() {
-			aggDefs[0].MTransitionDataType = "numeric"
-			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			aggDefinition.MTransitionDataType = "numeric"
+			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{aggDefinition}, funcInfoMap, aggMetadataMap)
 			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "agg_name(integer, integer)", "AGGREGATE")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(integer, integer) (
 	SFUNC = public.mysfunc,
@@ -417,8 +418,8 @@ $_$`)
 );`)
 		})
 		It("prints an aggregate with a specified moving transition size", func() {
-			aggDefs[0].MTransitionDataSize = 100
-			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			aggDefinition.MTransitionDataSize = 100
+			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{aggDefinition}, funcInfoMap, aggMetadataMap)
 			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "agg_name(integer, integer)", "AGGREGATE")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(integer, integer) (
 	SFUNC = public.mysfunc,
@@ -427,8 +428,8 @@ $_$`)
 );`)
 		})
 		It("prints an aggregate with a specified moving final function", func() {
-			aggDefs[0].MFinalFunction = 3
-			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			aggDefinition.MFinalFunction = 3
+			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{aggDefinition}, funcInfoMap, aggMetadataMap)
 			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "agg_name(integer, integer)", "AGGREGATE")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(integer, integer) (
 	SFUNC = public.mysfunc,
@@ -437,8 +438,8 @@ $_$`)
 );`)
 		})
 		It("prints an aggregate with a moving final function extra attribute", func() {
-			aggDefs[0].MFinalFuncExtra = true
-			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			aggDefinition.MFinalFuncExtra = true
+			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{aggDefinition}, funcInfoMap, aggMetadataMap)
 			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "agg_name(integer, integer)", "AGGREGATE")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(integer, integer) (
 	SFUNC = public.mysfunc,
@@ -447,9 +448,9 @@ $_$`)
 );`)
 		})
 		It("prints an aggregate with a moving initial condition", func() {
-			aggDefs[0].MInitialValue = "0"
-			aggDefs[0].MInitValIsNull = false
-			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			aggDefinition.MInitialValue = "0"
+			aggDefinition.MInitValIsNull = false
+			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{aggDefinition}, funcInfoMap, aggMetadataMap)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(integer, integer) (
 	SFUNC = public.mysfunc,
 	STYPE = integer,
@@ -457,9 +458,9 @@ $_$`)
 );`)
 		})
 		It("prints an aggregate with multiple specifications", func() {
-			aggDefs[0].FinalFunction = 3
-			aggDefs[0].SortOperator = 4
-			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			aggDefinition.FinalFunction = 3
+			aggDefinition.SortOperator = 4
+			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{aggDefinition}, funcInfoMap, aggMetadataMap)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(integer, integer) (
 	SFUNC = public.mysfunc,
 	STYPE = integer,
@@ -473,8 +474,8 @@ $_$`)
 				IdentArgs: `VARIADIC "any" ORDER BY VARIADIC "any"`, TransitionFunction: 5, FinalFunction: 6,
 				TransitionDataType: "internal", InitValIsNull: true, MInitValIsNull: true, FinalFuncExtra: true, Hypothetical: true,
 			}
-			aggDefs[0] = complexAggDefinition
-			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			aggDefinition = complexAggDefinition
+			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{aggDefinition}, funcInfoMap, aggMetadataMap)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_hypo_ord(VARIADIC "any" ORDER BY VARIADIC "any") (
 	SFUNC = pg_catalog.ordered_set_transition_multi,
 	STYPE = internal,
@@ -484,8 +485,8 @@ $_$`)
 );`)
 		})
 		It("prints an aggregate with owner and comment", func() {
-			aggMetadataMap[backup.UniqueID{Classid: backup.PG_AGGREGATE_OID, Oid: 1}] = backup.ObjectMetadata{Privileges: []backup.ACL{}, Owner: "testrole", Comment: "This is an aggregate comment."}
-			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			aggMetadataMap[aggDefinition.GetUniqueID()] = backup.ObjectMetadata{Privileges: []backup.ACL{}, Owner: "testrole", Comment: "This is an aggregate comment."}
+			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{aggDefinition}, funcInfoMap, aggMetadataMap)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(integer, integer) (
 	SFUNC = public.mysfunc,
 	STYPE = integer
@@ -498,10 +499,10 @@ COMMENT ON AGGREGATE public.agg_name(integer, integer) IS 'This is an aggregate 
 ALTER AGGREGATE public.agg_name(integer, integer) OWNER TO testrole;`)
 		})
 		It("prints an aggregate with owner, comment, and no arguments", func() {
-			aggDefs[0].Arguments = ""
-			aggDefs[0].IdentArgs = ""
-			aggMetadataMap[backup.UniqueID{Classid: backup.PG_AGGREGATE_OID, Oid: 1}] = backup.ObjectMetadata{Privileges: []backup.ACL{}, Owner: "testrole", Comment: "This is an aggregate comment."}
-			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
+			aggDefinition.Arguments = ""
+			aggDefinition.IdentArgs = ""
+			aggMetadataMap[aggDefinition.GetUniqueID()] = backup.ObjectMetadata{Privileges: []backup.ACL{}, Owner: "testrole", Comment: "This is an aggregate comment."}
+			backup.PrintCreateAggregateStatements(backupfile, toc, []backup.Aggregate{aggDefinition}, funcInfoMap, aggMetadataMap)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(*) (
 	SFUNC = public.mysfunc,
 	STYPE = integer

--- a/backup/predata_functions_test.go
+++ b/backup/predata_functions_test.go
@@ -484,7 +484,7 @@ $_$`)
 );`)
 		})
 		It("prints an aggregate with owner and comment", func() {
-			aggMetadataMap[1] = backup.ObjectMetadata{Privileges: []backup.ACL{}, Owner: "testrole", Comment: "This is an aggregate comment."}
+			aggMetadataMap[backup.UniqueID{Classid: backup.PG_AGGREGATE_OID, Oid: 1}] = backup.ObjectMetadata{Privileges: []backup.ACL{}, Owner: "testrole", Comment: "This is an aggregate comment."}
 			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(integer, integer) (
 	SFUNC = public.mysfunc,
@@ -500,7 +500,7 @@ ALTER AGGREGATE public.agg_name(integer, integer) OWNER TO testrole;`)
 		It("prints an aggregate with owner, comment, and no arguments", func() {
 			aggDefs[0].Arguments = ""
 			aggDefs[0].IdentArgs = ""
-			aggMetadataMap[1] = backup.ObjectMetadata{Privileges: []backup.ACL{}, Owner: "testrole", Comment: "This is an aggregate comment."}
+			aggMetadataMap[backup.UniqueID{Classid: backup.PG_AGGREGATE_OID, Oid: 1}] = backup.ObjectMetadata{Privileges: []backup.ACL{}, Owner: "testrole", Comment: "This is an aggregate comment."}
 			backup.PrintCreateAggregateStatements(backupfile, toc, aggDefs, funcInfoMap, aggMetadataMap)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(*) (
 	SFUNC = public.mysfunc,

--- a/backup/predata_operators.go
+++ b/backup/predata_operators.go
@@ -55,7 +55,7 @@ CREATE OPERATOR %s (
 	%s
 );`, operatorFQN, operator.Procedure, strings.Join(optionalFields, ",\n\t"))
 		operatorStr := fmt.Sprintf("%s (%s, %s)", operatorFQN, leftArg, rightArg)
-		PrintObjectMetadata(metadataFile, operatorMetadata[operator.Oid], operatorStr, "OPERATOR")
+		PrintObjectMetadata(metadataFile, operatorMetadata[operator.GetUniqueID()], operatorStr, "OPERATOR")
 		toc.AddPredataEntry(operator.Schema, operator.Name, "OPERATOR", "", start, metadataFile)
 	}
 }
@@ -70,7 +70,7 @@ func PrintCreateOperatorFamilyStatements(metadataFile *utils.FileWithByteCount, 
 		operatorFamilyFQN := utils.MakeFQN(operatorFamily.Schema, operatorFamily.Name)
 		operatorFamilyStr := fmt.Sprintf("%s USING %s", operatorFamilyFQN, operatorFamily.IndexMethod)
 		metadataFile.MustPrintf("\n\nCREATE OPERATOR FAMILY %s;", operatorFamilyStr)
-		PrintObjectMetadata(metadataFile, operatorFamilyMetadata[operatorFamily.Oid], operatorFamilyStr, "OPERATOR FAMILY")
+		PrintObjectMetadata(metadataFile, operatorFamilyMetadata[operatorFamily.GetUniqueID()], operatorFamilyStr, "OPERATOR FAMILY")
 		toc.AddPredataEntry(operatorFamily.Schema, operatorFamily.Name, "OPERATOR FAMILY", "", start, metadataFile)
 	}
 }
@@ -122,7 +122,7 @@ func PrintCreateOperatorClassStatements(metadataFile *utils.FileWithByteCount, t
 		metadataFile.MustPrintf(" AS\n\t%s;", strings.Join(opClassClauses, ",\n\t"))
 
 		operatorClassStr := fmt.Sprintf("%s USING %s", operatorClassFQN, operatorClass.IndexMethod)
-		PrintObjectMetadata(metadataFile, operatorClassMetadata[operatorClass.Oid], operatorClassStr, "OPERATOR CLASS")
+		PrintObjectMetadata(metadataFile, operatorClassMetadata[operatorClass.GetUniqueID()], operatorClassStr, "OPERATOR CLASS")
 		toc.AddPredataEntry(operatorClass.Schema, operatorClass.Name, "OPERATOR CLASS", "", start, metadataFile)
 	}
 }

--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -429,7 +429,7 @@ func PrintCreateSequenceStatements(metadataFile *utils.FileWithByteCount, toc *u
 
 		metadataFile.MustPrintf("\n\nSELECT pg_catalog.setval('%s', %d, %v);\n", utils.EscapeSingleQuotes(seqFQN), sequence.LastVal, sequence.IsCalled)
 
-		PrintObjectMetadata(metadataFile, sequenceMetadata[sequence.Oid], seqFQN, "SEQUENCE")
+		PrintObjectMetadata(metadataFile, sequenceMetadata[sequence.Relation.GetUniqueID()], seqFQN, "SEQUENCE")
 		toc.AddPredataEntry(sequence.Relation.Schema, sequence.Relation.Name, "SEQUENCE", sequence.OwningTable, start, metadataFile)
 	}
 }

--- a/backup/predata_relations_test.go
+++ b/backup/predata_relations_test.go
@@ -733,9 +733,9 @@ SELECT pg_catalog.setval('public.seq_''name', 7, true);`)
 		It("can print a sequence with privileges, an owner, and a comment for version < 6", func() {
 			testhelper.SetDBVersion(connectionPool, "5.0.0")
 			sequenceMetadataMap := testutils.DefaultMetadataMap("SEQUENCE", true, true, true)
-			sequenceMetadata := sequenceMetadataMap[1]
+			sequenceMetadata := sequenceMetadataMap[seqDefault.GetUniqueID()]
 			sequenceMetadata.Privileges[0].Update = false
-			sequenceMetadataMap[1] = sequenceMetadata
+			sequenceMetadataMap[seqDefault.GetUniqueID()] = sequenceMetadata
 			sequences := []backup.Sequence{seqDefault}
 			backup.PrintCreateSequenceStatements(backupfile, toc, sequences, sequenceMetadataMap)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE SEQUENCE public.seq_name
@@ -761,9 +761,9 @@ GRANT SELECT,USAGE ON SEQUENCE public.seq_name TO testrole;`)
 		It("can print a sequence with privileges, an owner, and a comment for version >= 6", func() {
 			testhelper.SetDBVersion(connectionPool, "6.0.0")
 			sequenceMetadataMap := testutils.DefaultMetadataMap("SEQUENCE", true, true, true)
-			sequenceMetadata := sequenceMetadataMap[1]
+			sequenceMetadata := sequenceMetadataMap[seqDefault.GetUniqueID()]
 			sequenceMetadata.Privileges[0].Update = false
-			sequenceMetadataMap[1] = sequenceMetadata
+			sequenceMetadataMap[seqDefault.GetUniqueID()] = sequenceMetadata
 			sequences := []backup.Sequence{seqDefault}
 			backup.PrintCreateSequenceStatements(backupfile, toc, sequences, sequenceMetadataMap)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE SEQUENCE public.seq_name
@@ -788,11 +788,8 @@ GRANT SELECT,USAGE ON SEQUENCE public.seq_name TO testrole;`)
 			testhelper.SetDBVersion(connectionPool, "5.1.0")
 		})
 		It("can print a sequence with privileges WITH GRANT OPTION", func() {
-			sequenceMetadataMap := backup.MetadataMap{
-				1: {Privileges: []backup.ACL{testutils.DefaultACLWithGrantWithout("testrole", "SEQUENCE", "UPDATE")}}}
-			sequenceMetadata := sequenceMetadataMap[1]
-			sequenceMetadata.Privileges[0].Update = false
-			sequenceMetadataMap[1] = sequenceMetadata
+			sequenceMetadata := backup.ObjectMetadata{Privileges: []backup.ACL{testutils.DefaultACLWithGrantWithout("testrole", "SEQUENCE", "UPDATE")}}
+			sequenceMetadataMap := backup.MetadataMap{seqDefault.GetUniqueID(): sequenceMetadata}
 			sequences := []backup.Sequence{seqDefault}
 			backup.PrintCreateSequenceStatements(backupfile, toc, sequences, sequenceMetadataMap)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE SEQUENCE public.seq_name
@@ -817,7 +814,7 @@ GRANT SELECT,USAGE ON SEQUENCE public.seq_name TO testrole WITH GRANT OPTION;`)
 		BeforeEach(func() {
 			view = backup.View{Oid: 1, Schema: "shamwow", Name: "shazam", Definition: "SELECT count(*) FROM pg_tables;"}
 			emptyMetadata = backup.ObjectMetadata{}
-			viewMetadata = testutils.DefaultMetadataMap("VIEW", true, true, true)[1]
+			viewMetadata = testutils.DefaultMetadata("VIEW", true, true, true)
 		})
 		It("can print a basic view", func() {
 			backup.PrintCreateViewStatement(backupfile, toc, view, emptyMetadata)

--- a/backup/predata_shared_test.go
+++ b/backup/predata_shared_test.go
@@ -382,11 +382,11 @@ ALTER VIEW public.viewname OWNER TO testrole;`)
 		})
 	})
 	Describe("ConstructMetadataMap", func() {
-		object1A := backup.MetadataQueryStruct{Oid: 1, Privileges: sql.NullString{String: "gpadmin=r/gpadmin", Valid: true}, Kind: "", Owner: "testrole", Comment: ""}
-		object1B := backup.MetadataQueryStruct{Oid: 1, Privileges: sql.NullString{String: "testrole=r/testrole", Valid: true}, Kind: "", Owner: "testrole", Comment: ""}
-		object2 := backup.MetadataQueryStruct{Oid: 2, Privileges: sql.NullString{String: "testrole=r/testrole", Valid: true}, Kind: "", Owner: "testrole", Comment: "this is a comment"}
-		objectDefaultKind := backup.MetadataQueryStruct{Oid: 3, Privileges: sql.NullString{String: "", Valid: false}, Kind: "Default", Owner: "testrole", Comment: ""}
-		objectEmptyKind := backup.MetadataQueryStruct{Oid: 4, Privileges: sql.NullString{String: "", Valid: false}, Kind: "Empty", Owner: "testrole", Comment: ""}
+		object1A := backup.MetadataQueryStruct{UniqueID: backup.UniqueID{Oid: 1}, Privileges: sql.NullString{String: "gpadmin=r/gpadmin", Valid: true}, Kind: "", Owner: "testrole", Comment: ""}
+		object1B := backup.MetadataQueryStruct{UniqueID: backup.UniqueID{Oid: 1}, Privileges: sql.NullString{String: "testrole=r/testrole", Valid: true}, Kind: "", Owner: "testrole", Comment: ""}
+		object2 := backup.MetadataQueryStruct{UniqueID: backup.UniqueID{Oid: 2}, Privileges: sql.NullString{String: "testrole=r/testrole", Valid: true}, Kind: "", Owner: "testrole", Comment: "this is a comment"}
+		objectDefaultKind := backup.MetadataQueryStruct{UniqueID: backup.UniqueID{Oid: 3}, Privileges: sql.NullString{String: "", Valid: false}, Kind: "Default", Owner: "testrole", Comment: ""}
+		objectEmptyKind := backup.MetadataQueryStruct{UniqueID: backup.UniqueID{Oid: 4}, Privileges: sql.NullString{String: "", Valid: false}, Kind: "Empty", Owner: "testrole", Comment: ""}
 		var metadataList []backup.MetadataQueryStruct
 		BeforeEach(func() {
 			rolnames := sqlmock.NewRows([]string{"rolename", "quotedrolename"}).
@@ -405,14 +405,14 @@ ALTER VIEW public.viewname OWNER TO testrole;`)
 			metadataMap := backup.ConstructMetadataMap(metadataList)
 			expectedObjectMetadata := backup.ObjectMetadata{Privileges: []backup.ACL{{Grantee: "testrole", Select: true}}, Owner: "testrole", Comment: "this is a comment"}
 			Expect(metadataMap).To(HaveLen(1))
-			Expect(metadataMap[2]).To(Equal(expectedObjectMetadata))
+			Expect(metadataMap[backup.UniqueID{Oid: 2}]).To(Equal(expectedObjectMetadata))
 		})
 		It("One object with two ACL entries", func() {
 			metadataList = []backup.MetadataQueryStruct{object1A, object1B}
 			metadataMap := backup.ConstructMetadataMap(metadataList)
 			expectedObjectMetadata := backup.ObjectMetadata{Privileges: []backup.ACL{{Grantee: "gpadmin", Select: true}, {Grantee: "testrole", Select: true}}, Owner: "testrole"}
 			Expect(metadataMap).To(HaveLen(1))
-			Expect(metadataMap[1]).To(Equal(expectedObjectMetadata))
+			Expect(metadataMap[backup.UniqueID{Oid: 1}]).To(Equal(expectedObjectMetadata))
 		})
 		It("Multiple objects", func() {
 			metadataList = []backup.MetadataQueryStruct{object1A, object1B, object2}
@@ -420,22 +420,22 @@ ALTER VIEW public.viewname OWNER TO testrole;`)
 			expectedObjectMetadataOne := backup.ObjectMetadata{Privileges: []backup.ACL{{Grantee: "gpadmin", Select: true}, {Grantee: "testrole", Select: true}}, Owner: "testrole"}
 			expectedObjectMetadataTwo := backup.ObjectMetadata{Privileges: []backup.ACL{{Grantee: "testrole", Select: true}}, Owner: "testrole", Comment: "this is a comment"}
 			Expect(metadataMap).To(HaveLen(2))
-			Expect(metadataMap[1]).To(Equal(expectedObjectMetadataOne))
-			Expect(metadataMap[2]).To(Equal(expectedObjectMetadataTwo))
+			Expect(metadataMap[backup.UniqueID{Oid: 1}]).To(Equal(expectedObjectMetadataOne))
+			Expect(metadataMap[backup.UniqueID{Oid: 2}]).To(Equal(expectedObjectMetadataTwo))
 		})
 		It("Default Kind", func() {
 			metadataList = []backup.MetadataQueryStruct{objectDefaultKind}
 			metadataMap := backup.ConstructMetadataMap(metadataList)
 			expectedObjectMetadata := backup.ObjectMetadata{Privileges: []backup.ACL{}, Owner: "testrole"}
 			Expect(metadataMap).To(HaveLen(1))
-			Expect(metadataMap[3]).To(Equal(expectedObjectMetadata))
+			Expect(metadataMap[backup.UniqueID{Oid: 3}]).To(Equal(expectedObjectMetadata))
 		})
 		It("'Empty' Kind", func() {
 			metadataList = []backup.MetadataQueryStruct{objectEmptyKind}
 			metadataMap := backup.ConstructMetadataMap(metadataList)
 			expectedObjectMetadata := backup.ObjectMetadata{Privileges: []backup.ACL{{Grantee: "GRANTEE"}}, Owner: "testrole"}
 			Expect(metadataMap).To(HaveLen(1))
-			Expect(metadataMap[4]).To(Equal(expectedObjectMetadata))
+			Expect(metadataMap[backup.UniqueID{Oid: 4}]).To(Equal(expectedObjectMetadata))
 		})
 	})
 	Describe("ParseACL", func() {
@@ -518,12 +518,12 @@ ALTER VIEW public.viewname OWNER TO testrole;`)
 				},
 			}
 			metadataMap = backup.MetadataMap{
-				1: backup.ObjectMetadata{Comment: "function"},
-				2: backup.ObjectMetadata{Comment: "base type"},
-				3: backup.ObjectMetadata{Comment: "composite type"},
-				4: backup.ObjectMetadata{Comment: "domain"},
-				5: backup.ObjectMetadata{Comment: "relation"},
-				6: backup.ObjectMetadata{Comment: "protocol"},
+				backup.UniqueID{Classid: backup.PG_PROC_OID, Oid: 1}:        backup.ObjectMetadata{Comment: "function"},
+				backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: 2}:        backup.ObjectMetadata{Comment: "base type"},
+				backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: 3}:        backup.ObjectMetadata{Comment: "composite type"},
+				backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: 4}:        backup.ObjectMetadata{Comment: "domain"},
+				backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: 5}:       backup.ObjectMetadata{Comment: "relation"},
+				backup.UniqueID{Classid: backup.PG_EXTPROTOCOL_OID, Oid: 6}: backup.ObjectMetadata{Comment: "protocol"},
 			}
 			tableDefsMap = map[uint32]backup.TableDefinition{
 				5: {DistPolicy: "DISTRIBUTED RANDOMLY", ColumnDefs: []backup.ColumnDefinition{}},

--- a/backup/predata_shared_test.go
+++ b/backup/predata_shared_test.go
@@ -518,12 +518,12 @@ ALTER VIEW public.viewname OWNER TO testrole;`)
 				},
 			}
 			metadataMap = backup.MetadataMap{
-				backup.UniqueID{Classid: backup.PG_PROC_OID, Oid: 1}:        backup.ObjectMetadata{Comment: "function"},
-				backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: 2}:        backup.ObjectMetadata{Comment: "base type"},
-				backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: 3}:        backup.ObjectMetadata{Comment: "composite type"},
-				backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: 4}:        backup.ObjectMetadata{Comment: "domain"},
-				backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: 5}:       backup.ObjectMetadata{Comment: "relation"},
-				backup.UniqueID{Classid: backup.PG_EXTPROTOCOL_OID, Oid: 6}: backup.ObjectMetadata{Comment: "protocol"},
+				backup.UniqueID{ClassID: backup.PG_PROC_OID, Oid: 1}:        backup.ObjectMetadata{Comment: "function"},
+				backup.UniqueID{ClassID: backup.PG_TYPE_OID, Oid: 2}:        backup.ObjectMetadata{Comment: "base type"},
+				backup.UniqueID{ClassID: backup.PG_TYPE_OID, Oid: 3}:        backup.ObjectMetadata{Comment: "composite type"},
+				backup.UniqueID{ClassID: backup.PG_TYPE_OID, Oid: 4}:        backup.ObjectMetadata{Comment: "domain"},
+				backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: 5}:       backup.ObjectMetadata{Comment: "relation"},
+				backup.UniqueID{ClassID: backup.PG_EXTPROTOCOL_OID, Oid: 6}: backup.ObjectMetadata{Comment: "protocol"},
 			}
 			tableDefsMap = map[uint32]backup.TableDefinition{
 				5: {DistPolicy: "DISTRIBUTED RANDOMLY", ColumnDefs: []backup.ColumnDefinition{}},

--- a/backup/predata_textsearch.go
+++ b/backup/predata_textsearch.go
@@ -29,7 +29,7 @@ func PrintCreateTextSearchParserStatements(metadataFile *utils.FileWithByteCount
 			metadataFile.MustPrintf(",\n\tHEADLINE = %s", parser.HeadlineFunc)
 		}
 		metadataFile.MustPrintf("\n);")
-		PrintObjectMetadata(metadataFile, parserMetadata[parser.Oid], parserFQN, "TEXT SEARCH PARSER")
+		PrintObjectMetadata(metadataFile, parserMetadata[parser.GetUniqueID()], parserFQN, "TEXT SEARCH PARSER")
 		toc.AddPredataEntry(parser.Schema, parser.Name, "TEXT SEARCH PARSER", "", start, metadataFile)
 	}
 }
@@ -44,7 +44,7 @@ func PrintCreateTextSearchTemplateStatements(metadataFile *utils.FileWithByteCou
 		}
 		metadataFile.MustPrintf("\n\tLEXIZE = %s", template.LexizeFunc)
 		metadataFile.MustPrintf("\n);")
-		PrintObjectMetadata(metadataFile, templateMetadata[template.Oid], templateFQN, "TEXT SEARCH TEMPLATE")
+		PrintObjectMetadata(metadataFile, templateMetadata[template.GetUniqueID()], templateFQN, "TEXT SEARCH TEMPLATE")
 		toc.AddPredataEntry(template.Schema, template.Name, "TEXT SEARCH TEMPLATE", "", start, metadataFile)
 	}
 }
@@ -59,7 +59,7 @@ func PrintCreateTextSearchDictionaryStatements(metadataFile *utils.FileWithByteC
 			metadataFile.MustPrintf(",\n\t%s", dictionary.InitOption)
 		}
 		metadataFile.MustPrintf("\n);")
-		PrintObjectMetadata(metadataFile, dictionaryMetadata[dictionary.Oid], dictionaryFQN, "TEXT SEARCH DICTIONARY")
+		PrintObjectMetadata(metadataFile, dictionaryMetadata[dictionary.GetUniqueID()], dictionaryFQN, "TEXT SEARCH DICTIONARY")
 		toc.AddPredataEntry(dictionary.Schema, dictionary.Name, "TEXT SEARCH DICTIONARY", "", start, metadataFile)
 	}
 }
@@ -81,7 +81,7 @@ func PrintCreateTextSearchConfigurationStatements(metadataFile *utils.FileWithBy
 			metadataFile.MustPrintf("\n\nALTER TEXT SEARCH CONFIGURATION %s", configurationFQN)
 			metadataFile.MustPrintf("\n\tADD MAPPING FOR \"%s\" WITH %s;", token, strings.Join(dicts, ", "))
 		}
-		PrintObjectMetadata(metadataFile, configurationMetadata[configuration.Oid], configurationFQN, "TEXT SEARCH CONFIGURATION")
+		PrintObjectMetadata(metadataFile, configurationMetadata[configuration.GetUniqueID()], configurationFQN, "TEXT SEARCH CONFIGURATION")
 		toc.AddPredataEntry(configuration.Schema, configuration.Name, "TEXT SEARCH CONFIGURATION", "", start, metadataFile)
 	}
 }

--- a/backup/predata_types.go
+++ b/backup/predata_types.go
@@ -162,7 +162,7 @@ func PrintCreateEnumTypeStatements(metadataFile *utils.FileWithByteCount, toc *u
 	for _, enum := range enums {
 		typeFQN := utils.MakeFQN(enum.Schema, enum.Name)
 		metadataFile.MustPrintf("\n\nCREATE TYPE %s AS ENUM (\n\t%s\n);\n", typeFQN, enum.EnumLabels)
-		PrintObjectMetadata(metadataFile, typeMetadata[enum.Oid], typeFQN, "TYPE")
+		PrintObjectMetadata(metadataFile, typeMetadata[enum.GetUniqueID()], typeFQN, "TYPE")
 		toc.AddPredataEntry(enum.Schema, enum.Name, "TYPE", "", start, metadataFile)
 	}
 }
@@ -172,7 +172,7 @@ func PrintCreateCollationStatements(metadataFile *utils.FileWithByteCount, toc *
 		collationFQN := utils.MakeFQN(collation.Schema, collation.Name)
 		start := metadataFile.ByteCount
 		metadataFile.MustPrintf("\nCREATE COLLATION %s (LC_COLLATE = '%s', LC_CTYPE = '%s');", collationFQN, collation.Collate, collation.Ctype)
-		PrintObjectMetadata(metadataFile, collationMetadata[collation.Oid], collationFQN, "COLLATION")
+		PrintObjectMetadata(metadataFile, collationMetadata[collation.GetUniqueID()], collationFQN, "COLLATION")
 		toc.AddPredataEntry(collation.Schema, collation.Name, "COLLATION", "", start, metadataFile)
 	}
 }

--- a/backup/predata_types_test.go
+++ b/backup/predata_types_test.go
@@ -81,7 +81,7 @@ ALTER TYPE public.enum_type OWNER TO testrole;`)
 		})
 		It("prints a composite type with comment and owner", func() {
 			compType.Attributes = twoAtts
-			typeMetadata = testutils.DefaultMetadataMap("TYPE", false, true, true)[1]
+			typeMetadata = testutils.DefaultMetadata("TYPE", false, true, true)
 			backup.PrintCreateCompositeTypeStatement(backupfile, toc, compType, typeMetadata)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TYPE public.composite_type AS (
 	foo integer,
@@ -219,7 +219,7 @@ ALTER TYPE public.base_type
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE DOMAIN public.domain1 AS numeric DEFAULT 4 COLLATE public.mycollation NOT NULL;`)
 		})
 		It("prints a domain without constraint with comment and owner", func() {
-			typeMetadata = testutils.DefaultMetadataMap("DOMAIN", false, true, true)[1]
+			typeMetadata = testutils.DefaultMetadata("DOMAIN", false, true, true)
 			backup.PrintCreateDomainStatement(backupfile, toc, domainTwo, typeMetadata, emptyConstraint)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE DOMAIN public.domain2 AS varchar;
 

--- a/backup/queries_externals.go
+++ b/backup/queries_externals.go
@@ -111,7 +111,7 @@ type ExternalProtocol struct {
 }
 
 func (p ExternalProtocol) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_EXTPROTOCOL_OID, Oid: p.Oid}
+	return UniqueID{ClassID: PG_EXTPROTOCOL_OID, Oid: p.Oid}
 }
 
 func (p ExternalProtocol) FQN() string {

--- a/backup/queries_externals.go
+++ b/backup/queries_externals.go
@@ -110,8 +110,8 @@ type ExternalProtocol struct {
 	FuncMap       map[uint32]string
 }
 
-func (p ExternalProtocol) GetDepEntry() DepEntry {
-	return DepEntry{Classid: PG_EXTPROTOCOL_OID, Objid: p.Oid}
+func (p ExternalProtocol) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_EXTPROTOCOL_OID, Oid: p.Oid}
 }
 
 func (p ExternalProtocol) FQN() string {

--- a/backup/queries_functions.go
+++ b/backup/queries_functions.go
@@ -38,7 +38,7 @@ type Function struct {
 }
 
 func (f Function) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_PROC_OID, Oid: f.Oid}
+	return UniqueID{ClassID: PG_PROC_OID, Oid: f.Oid}
 }
 
 func (f Function) FQN() string {
@@ -287,7 +287,7 @@ type Aggregate struct {
 }
 
 func (a Aggregate) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_AGGREGATE_OID, Oid: a.Oid}
+	return UniqueID{ClassID: PG_AGGREGATE_OID, Oid: a.Oid}
 }
 
 func GetAggregates(connectionPool *dbconn.DBConn) []Aggregate {
@@ -463,7 +463,7 @@ type Cast struct {
 }
 
 func (c Cast) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_CAST_OID, Oid: c.Oid}
+	return UniqueID{ClassID: PG_CAST_OID, Oid: c.Oid}
 }
 
 func GetCasts(connectionPool *dbconn.DBConn) []Cast {
@@ -526,7 +526,7 @@ type Extension struct {
 }
 
 func (e Extension) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_EXTENSION_OID, Oid: e.Oid}
+	return UniqueID{ClassID: PG_EXTENSION_OID, Oid: e.Oid}
 }
 
 func GetExtensions(connectionPool *dbconn.DBConn) []Extension {
@@ -557,7 +557,7 @@ type ProceduralLanguage struct {
 }
 
 func (pl ProceduralLanguage) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_LANGUAGE_OID, Oid: pl.Oid}
+	return UniqueID{ClassID: PG_LANGUAGE_OID, Oid: pl.Oid}
 }
 
 func GetProceduralLanguages(connectionPool *dbconn.DBConn) []ProceduralLanguage {
@@ -612,7 +612,7 @@ type Conversion struct {
 }
 
 func (c Conversion) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_CONVERSION_OID, Oid: c.Oid}
+	return UniqueID{ClassID: PG_CONVERSION_OID, Oid: c.Oid}
 }
 
 func GetConversions(connectionPool *dbconn.DBConn) []Conversion {
@@ -648,7 +648,7 @@ type ForeignDataWrapper struct {
 }
 
 func (fdw ForeignDataWrapper) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_FOREIGN_DATA_WRAPPER_OID, Oid: fdw.Oid}
+	return UniqueID{ClassID: PG_FOREIGN_DATA_WRAPPER_OID, Oid: fdw.Oid}
 }
 
 func GetForeignDataWrappers(connectionPool *dbconn.DBConn) []ForeignDataWrapper {
@@ -682,7 +682,7 @@ type ForeignServer struct {
 }
 
 func (fs ForeignServer) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_FOREIGN_SERVER_OID, Oid: fs.Oid}
+	return UniqueID{ClassID: PG_FOREIGN_SERVER_OID, Oid: fs.Oid}
 }
 
 func GetForeignServers(connectionPool *dbconn.DBConn) []ForeignServer {
@@ -716,7 +716,7 @@ type UserMapping struct {
 }
 
 func (um UserMapping) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_USER_MAPPING_OID, Oid: um.Oid}
+	return UniqueID{ClassID: PG_USER_MAPPING_OID, Oid: um.Oid}
 }
 
 func GetUserMappings(connectionPool *dbconn.DBConn) []UserMapping {

--- a/backup/queries_functions.go
+++ b/backup/queries_functions.go
@@ -37,8 +37,8 @@ type Function struct {
 	ExecLocation      string `db:"proexeclocation"`
 }
 
-func (f Function) GetDepEntry() DepEntry {
-	return DepEntry{Classid: PG_PROC_OID, Objid: f.Oid}
+func (f Function) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_PROC_OID, Oid: f.Oid}
 }
 
 func (f Function) FQN() string {
@@ -286,6 +286,10 @@ type Aggregate struct {
 	MInitValIsNull             bool
 }
 
+func (a Aggregate) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_AGGREGATE_OID, Oid: a.Oid}
+}
+
 func GetAggregates(connectionPool *dbconn.DBConn) []Aggregate {
 	version4query := fmt.Sprintf(`
 SELECT
@@ -458,6 +462,10 @@ type Cast struct {
 	CastMethod     string
 }
 
+func (c Cast) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_CAST_OID, Oid: c.Oid}
+}
+
 func GetCasts(connectionPool *dbconn.DBConn) []Cast {
 	/* This query retrieves all casts where either the source type, the target
 	 * type, or the cast function is user-defined.
@@ -517,6 +525,10 @@ type Extension struct {
 	Schema string
 }
 
+func (e Extension) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_EXTENSION_OID, Oid: e.Oid}
+}
+
 func GetExtensions(connectionPool *dbconn.DBConn) []Extension {
 	results := make([]Extension, 0)
 
@@ -542,6 +554,10 @@ type ProceduralLanguage struct {
 	Handler   uint32 `db:"lanplcallfoid"`
 	Inline    uint32 `db:"laninline"`
 	Validator uint32 `db:"lanvalidator"`
+}
+
+func (pl ProceduralLanguage) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_LANGUAGE_OID, Oid: pl.Oid}
 }
 
 func GetProceduralLanguages(connectionPool *dbconn.DBConn) []ProceduralLanguage {
@@ -595,6 +611,10 @@ type Conversion struct {
 	IsDefault          bool `db:"condefault"`
 }
 
+func (c Conversion) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_CONVERSION_OID, Oid: c.Oid}
+}
+
 func GetConversions(connectionPool *dbconn.DBConn) []Conversion {
 	results := make([]Conversion, 0)
 	query := fmt.Sprintf(`
@@ -627,6 +647,10 @@ type ForeignDataWrapper struct {
 	Options   string
 }
 
+func (fdw ForeignDataWrapper) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_FOREIGN_DATA_WRAPPER_OID, Oid: fdw.Oid}
+}
+
 func GetForeignDataWrappers(connectionPool *dbconn.DBConn) []ForeignDataWrapper {
 	results := make([]ForeignDataWrapper, 0)
 	query := fmt.Sprintf(`
@@ -657,6 +681,10 @@ type ForeignServer struct {
 	Options            string
 }
 
+func (fs ForeignServer) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_FOREIGN_SERVER_OID, Oid: fs.Oid}
+}
+
 func GetForeignServers(connectionPool *dbconn.DBConn) []ForeignServer {
 	results := make([]ForeignServer, 0)
 	query := fmt.Sprintf(`
@@ -685,6 +713,10 @@ type UserMapping struct {
 	User    string
 	Server  string
 	Options string
+}
+
+func (um UserMapping) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_USER_MAPPING_OID, Oid: um.Oid}
 }
 
 func GetUserMappings(connectionPool *dbconn.DBConn) []UserMapping {

--- a/backup/queries_globals.go
+++ b/backup/queries_globals.go
@@ -34,6 +34,10 @@ type Database struct {
 	Encoding   string
 }
 
+func (db Database) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_DATABASE_OID, Oid: db.Oid}
+}
+
 func GetDatabaseInfo(connectionPool *dbconn.DBConn) Database {
 	lcQuery := ""
 	if connectionPool.Version.AtLeast("6") {
@@ -89,6 +93,10 @@ type ResourceQueue struct {
 	MemoryLimit      string
 }
 
+func (rq ResourceQueue) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_RESQUEUE_OID, Oid: rq.Oid}
+}
+
 func GetResourceQueues(connectionPool *dbconn.DBConn) []ResourceQueue {
 	/*
 	 * maxcost and mincost are represented as real types in the database, but we round to two decimals
@@ -129,6 +137,10 @@ type ResourceGroup struct {
 	MemorySpillRatio  int
 	MemoryAuditor     int
 	Cpuset            string
+}
+
+func (rg ResourceGroup) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_RESGROUP_OID, Oid: rg.Oid}
 }
 
 func GetResourceGroups(connectionPool *dbconn.DBConn) []ResourceGroup {
@@ -191,6 +203,10 @@ type Role struct {
 	Createrexthdfs  bool `db:"rolcreaterexthdfs"`
 	Createwexthdfs  bool `db:"rolcreatewexthdfs"`
 	TimeConstraints []TimeConstraint
+}
+
+func (r Role) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_AUTHID_OID, Oid: r.Oid}
 }
 
 /*
@@ -325,6 +341,10 @@ type Tablespace struct {
 	Tablespace       string
 	FileLocation     string // FILESPACE in 4.3 and 5, LOCATION in 6 and later
 	SegmentLocations []string
+}
+
+func (t Tablespace) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_TABLESPACE_OID, Oid: t.Oid}
 }
 
 func GetTablespaces(connectionPool *dbconn.DBConn) []Tablespace {

--- a/backup/queries_globals.go
+++ b/backup/queries_globals.go
@@ -35,7 +35,7 @@ type Database struct {
 }
 
 func (db Database) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_DATABASE_OID, Oid: db.Oid}
+	return UniqueID{ClassID: PG_DATABASE_OID, Oid: db.Oid}
 }
 
 func GetDatabaseInfo(connectionPool *dbconn.DBConn) Database {
@@ -94,7 +94,7 @@ type ResourceQueue struct {
 }
 
 func (rq ResourceQueue) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_RESQUEUE_OID, Oid: rq.Oid}
+	return UniqueID{ClassID: PG_RESQUEUE_OID, Oid: rq.Oid}
 }
 
 func GetResourceQueues(connectionPool *dbconn.DBConn) []ResourceQueue {
@@ -140,7 +140,7 @@ type ResourceGroup struct {
 }
 
 func (rg ResourceGroup) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_RESGROUP_OID, Oid: rg.Oid}
+	return UniqueID{ClassID: PG_RESGROUP_OID, Oid: rg.Oid}
 }
 
 func GetResourceGroups(connectionPool *dbconn.DBConn) []ResourceGroup {
@@ -206,7 +206,7 @@ type Role struct {
 }
 
 func (r Role) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_AUTHID_OID, Oid: r.Oid}
+	return UniqueID{ClassID: PG_AUTHID_OID, Oid: r.Oid}
 }
 
 /*
@@ -344,7 +344,7 @@ type Tablespace struct {
 }
 
 func (t Tablespace) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_TABLESPACE_OID, Oid: t.Oid}
+	return UniqueID{ClassID: PG_TABLESPACE_OID, Oid: t.Oid}
 }
 
 func GetTablespaces(connectionPool *dbconn.DBConn) []Tablespace {

--- a/backup/queries_operators.go
+++ b/backup/queries_operators.go
@@ -28,7 +28,7 @@ type Operator struct {
 }
 
 func (o Operator) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_OPERATOR_OID, Oid: o.Oid}
+	return UniqueID{ClassID: PG_OPERATOR_OID, Oid: o.Oid}
 }
 
 func GetOperators(connectionPool *dbconn.DBConn) []Operator {
@@ -92,7 +92,7 @@ type OperatorFamily struct {
 }
 
 func (opf OperatorFamily) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_OPFAMILY_OID, Oid: opf.Oid}
+	return UniqueID{ClassID: PG_OPFAMILY_OID, Oid: opf.Oid}
 }
 
 func GetOperatorFamilies(connectionPool *dbconn.DBConn) []OperatorFamily {
@@ -127,7 +127,7 @@ type OperatorClass struct {
 }
 
 func (opc OperatorClass) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_OPCLASS_OID, Oid: opc.Oid}
+	return UniqueID{ClassID: PG_OPCLASS_OID, Oid: opc.Oid}
 }
 
 func GetOperatorClasses(connectionPool *dbconn.DBConn) []OperatorClass {

--- a/backup/queries_operators.go
+++ b/backup/queries_operators.go
@@ -27,11 +27,15 @@ type Operator struct {
 	CanMerge         bool
 }
 
+func (o Operator) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_OPERATOR_OID, Oid: o.Oid}
+}
+
 func GetOperators(connectionPool *dbconn.DBConn) []Operator {
 	results := make([]Operator, 0)
 	version4query := fmt.Sprintf(`
 SELECT
-	o.oid,
+	o.oid AS oid,
 	quote_ident(n.nspname) AS schema,
 	oprname AS name,
 	oprcode::regproc AS procedure,
@@ -48,7 +52,7 @@ WHERE %s AND oprcode != 0`, SchemaFilterClause("n"))
 
 	masterQuery := fmt.Sprintf(`
 SELECT
-	o.oid,
+	o.oid AS oid,
 	quote_ident(n.nspname) AS schema,
 	oprname AS name,
 	oprcode::regproc AS procedure,
@@ -87,11 +91,15 @@ type OperatorFamily struct {
 	IndexMethod string
 }
 
+func (opf OperatorFamily) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_OPFAMILY_OID, Oid: opf.Oid}
+}
+
 func GetOperatorFamilies(connectionPool *dbconn.DBConn) []OperatorFamily {
 	results := make([]OperatorFamily, 0)
 	query := fmt.Sprintf(`
 SELECT
-	o.oid,
+	o.oid AS oid,
 	quote_ident(n.nspname) AS schema,
 	quote_ident(opfname) AS name,
 	(SELECT quote_ident(amname) FROM pg_am WHERE oid = opfmethod) AS indexMethod
@@ -118,6 +126,10 @@ type OperatorClass struct {
 	Functions    []OperatorClassFunction
 }
 
+func (opc OperatorClass) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_OPCLASS_OID, Oid: opc.Oid}
+}
+
 func GetOperatorClasses(connectionPool *dbconn.DBConn) []OperatorClass {
 	results := make([]OperatorClass, 0)
 	/*
@@ -128,7 +140,7 @@ func GetOperatorClasses(connectionPool *dbconn.DBConn) []OperatorClass {
 	 */
 	version4query := fmt.Sprintf(`
 SELECT
-	c.oid,
+	c.oid AS oid,
 	quote_ident(cls_ns.nspname) AS schema,
 	quote_ident(opcname) AS name,
 	'' AS familyschema,
@@ -143,7 +155,7 @@ WHERE %s`, SchemaFilterClause("cls_ns"))
 
 	masterQuery := fmt.Sprintf(`
 SELECT
-	c.oid,
+	c.oid AS oid,
 	quote_ident(cls_ns.nspname) AS schema,
 	quote_ident(opcname) AS name,
 	quote_ident(fam_ns.nspname) AS familyschema,

--- a/backup/queries_postdata.go
+++ b/backup/queries_postdata.go
@@ -55,6 +55,10 @@ type IndexDefinition struct {
 	IsClustered  bool
 }
 
+func (i IndexDefinition) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_INDEX_OID, Oid: i.Oid}
+}
+
 func GetIndexes(connectionPool *dbconn.DBConn) []IndexDefinition {
 	resultIndexes := make([]IndexDefinition, 0)
 	if connectionPool.Version.Before("6") {
@@ -140,11 +144,16 @@ ORDER BY name;`, relationAndSchemaFilterClause(), ExtensionFilterClause("c")) //
  * statements can require it.
  */
 type QuerySimpleDefinition struct {
+	Classid      uint32
 	Oid          uint32
 	Name         string
 	OwningSchema string
 	OwningTable  string
 	Def          string
+}
+
+func (sd QuerySimpleDefinition) GetUniqueID() UniqueID {
+	return UniqueID{Classid: sd.Classid, Oid: sd.Oid}
 }
 
 /*
@@ -155,7 +164,8 @@ type QuerySimpleDefinition struct {
 func GetRules(connectionPool *dbconn.DBConn) []QuerySimpleDefinition {
 	query := fmt.Sprintf(`
 SELECT
-	r.oid,
+	'pg_rewrite'::regclass::oid AS classid,
+	r.oid AS oid,
 	quote_ident(r.rulename) AS name,
 	quote_ident(n.nspname) AS owningschema,
 	quote_ident(c.relname) AS owningtable,
@@ -184,7 +194,8 @@ func GetTriggers(connectionPool *dbconn.DBConn) []QuerySimpleDefinition {
 	}
 	query := fmt.Sprintf(`
 SELECT
-	t.oid,
+	'pg_trigger'::regclass::oid AS classid,
+	t.oid AS oid,
 	quote_ident(t.tgname) AS name,
 	quote_ident(n.nspname) AS owningschema,
 	quote_ident(c.relname) AS owningtable,

--- a/backup/queries_postdata.go
+++ b/backup/queries_postdata.go
@@ -56,7 +56,7 @@ type IndexDefinition struct {
 }
 
 func (i IndexDefinition) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_INDEX_OID, Oid: i.Oid}
+	return UniqueID{ClassID: PG_INDEX_OID, Oid: i.Oid}
 }
 
 func GetIndexes(connectionPool *dbconn.DBConn) []IndexDefinition {
@@ -144,7 +144,7 @@ ORDER BY name;`, relationAndSchemaFilterClause(), ExtensionFilterClause("c")) //
  * statements can require it.
  */
 type QuerySimpleDefinition struct {
-	Classid      uint32
+	ClassID      uint32
 	Oid          uint32
 	Name         string
 	OwningSchema string
@@ -153,7 +153,7 @@ type QuerySimpleDefinition struct {
 }
 
 func (sd QuerySimpleDefinition) GetUniqueID() UniqueID {
-	return UniqueID{Classid: sd.Classid, Oid: sd.Oid}
+	return UniqueID{ClassID: sd.ClassID, Oid: sd.Oid}
 }
 
 /*

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -58,7 +58,7 @@ func (r Relation) FQN() string {
 }
 
 func (r Relation) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_CLASS_OID, Oid: r.Oid}
+	return UniqueID{ClassID: PG_CLASS_OID, Oid: r.Oid}
 }
 
 /*
@@ -677,7 +677,7 @@ type View struct {
 }
 
 func (v View) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_CLASS_OID, Oid: v.Oid}
+	return UniqueID{ClassID: PG_CLASS_OID, Oid: v.Oid}
 }
 
 func (v View) FQN() string {

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -57,8 +57,8 @@ func (r Relation) FQN() string {
 	return utils.MakeFQN(r.Schema, r.Name)
 }
 
-func (r Relation) GetDepEntry() DepEntry {
-	return DepEntry{Classid: PG_CLASS_OID, Objid: r.Oid}
+func (r Relation) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_CLASS_OID, Oid: r.Oid}
 }
 
 /*
@@ -676,8 +676,8 @@ type View struct {
 	Definition string
 }
 
-func (v View) GetDepEntry() DepEntry {
-	return DepEntry{Classid: PG_CLASS_OID, Objid: v.Oid}
+func (v View) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_CLASS_OID, Oid: v.Oid}
 }
 
 func (v View) FQN() string {
@@ -692,7 +692,7 @@ func GetViews(connectionPool *dbconn.DBConn) []View {
 	}
 	query := fmt.Sprintf(`
 SELECT
-	c.oid,
+	c.oid AS oid,
 	quote_ident(n.nspname) AS schema,
 	quote_ident(c.relname) AS name,
 	%s

--- a/backup/queries_shared.go
+++ b/backup/queries_shared.go
@@ -28,6 +28,14 @@ import (
  * for use with the functions immediately following them.  Structs in the utils
  * package (especially Table and Schema) are intended for more general use.
  */
+type Schema struct {
+	Oid  uint32
+	Name string
+}
+
+func (s Schema) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_NAMESPACE_OID, Oid: s.Oid}
+}
 
 func GetAllUserSchemas(connectionPool *dbconn.DBConn) []Schema {
 	/*
@@ -60,6 +68,10 @@ type Constraint struct {
 	OwningObject       string
 	IsDomainConstraint bool
 	IsPartitionParent  bool
+}
+
+func (c Constraint) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_CONSTRAINT_OID, Oid: c.Oid}
 }
 
 func GetConstraints(connectionPool *dbconn.DBConn, includeTables ...Relation) []Constraint {
@@ -233,7 +245,7 @@ func ExtensionFilterClause(namespace string) string {
 }
 
 type MetadataQueryStruct struct {
-	Oid        uint32
+	UniqueID
 	Privileges sql.NullString
 	Kind       string
 	Owner      string
@@ -274,6 +286,7 @@ WHERE %s`, params.SchemaField, SchemaFilterClause("n"))
 
 	query := fmt.Sprintf(`
 SELECT
+	'%s'::regclass::oid AS classid,
 	o.oid,
 	%s AS privileges,
 	%s AS kind,
@@ -283,7 +296,7 @@ FROM %s o LEFT JOIN %s d ON (d.objoid = o.oid AND d.classoid = '%s'::regclass%s)
 %s
 AND o.oid NOT IN (SELECT objid FROM pg_depend WHERE deptype='e')
 ORDER BY o.oid;
-`, aclStr, kindStr, ownerStr, params.CatalogTable, descFunc, params.CatalogTable, subidStr, schemaStr)
+`, params.CatalogTable, aclStr, kindStr, ownerStr, params.CatalogTable, descFunc, params.CatalogTable, subidStr, schemaStr)
 
 	results := make([]MetadataQueryStruct, 0)
 	err := connectionPool.Select(&results, query)
@@ -334,13 +347,14 @@ func GetCommentsForObjectType(connectionPool *dbconn.DBConn, params MetadataQuer
 	}
 	query := fmt.Sprintf(`
 SELECT
+	'%s'::regclass::oid AS classid,
 	o.%s AS oid,
 	coalesce(description,'') AS comment
 	FROM %s o JOIN %s d ON (d.objoid = %s AND d.classoid = '%s'::regclass%s)%s;
-`, params.OidField, params.CatalogTable, descTable, params.OidField, commentTable, subidStr, schemaStr)
+`, params.CatalogTable, params.OidField, params.CatalogTable, descTable, params.OidField, commentTable, subidStr, schemaStr)
 
 	results := make([]struct {
-		Oid     uint32
+		UniqueID
 		Comment string
 	}, 0)
 	err := connectionPool.Select(&results, query)
@@ -349,7 +363,7 @@ SELECT
 	metadataMap := make(MetadataMap)
 	if len(results) > 0 {
 		for _, result := range results {
-			metadataMap[result.Oid] = ObjectMetadata{[]ACL{}, "", result.Comment}
+			metadataMap[result.UniqueID] = ObjectMetadata{[]ACL{}, "", result.Comment}
 		}
 	}
 	return metadataMap

--- a/backup/queries_shared.go
+++ b/backup/queries_shared.go
@@ -34,7 +34,7 @@ type Schema struct {
 }
 
 func (s Schema) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_NAMESPACE_OID, Oid: s.Oid}
+	return UniqueID{ClassID: PG_NAMESPACE_OID, Oid: s.Oid}
 }
 
 func GetAllUserSchemas(connectionPool *dbconn.DBConn) []Schema {
@@ -71,7 +71,7 @@ type Constraint struct {
 }
 
 func (c Constraint) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_CONSTRAINT_OID, Oid: c.Oid}
+	return UniqueID{ClassID: PG_CONSTRAINT_OID, Oid: c.Oid}
 }
 
 func GetConstraints(connectionPool *dbconn.DBConn, includeTables ...Relation) []Constraint {

--- a/backup/queries_shared_test.go
+++ b/backup/queries_shared_test.go
@@ -23,6 +23,7 @@ var _ = Describe("backup/queries_shared tests", func() {
 		})
 		It("queries metadata for an object with default params", func() {
 			mock.ExpectQuery(regexp.QuoteMeta(`SELECT
+	'table'::regclass::oid AS classid,
 	o.oid,
 	'' AS privileges,
 	'' AS kind,
@@ -35,6 +36,7 @@ ORDER BY o.oid;`)).WillReturnRows(emptyRows)
 		})
 		It("queries metadata for an object with a schema field", func() {
 			mock.ExpectQuery(regexp.QuoteMeta(`SELECT
+	'table'::regclass::oid AS classid,
 	o.oid,
 	'' AS privileges,
 	'' AS kind,
@@ -50,6 +52,7 @@ ORDER BY o.oid;`)).WillReturnRows(emptyRows)
 		})
 		It("queries metadata for an object with an ACL field", func() {
 			mock.ExpectQuery(regexp.QuoteMeta(`SELECT
+	'table'::regclass::oid AS classid,
 	o.oid,
 	CASE
 		WHEN acl IS NULL OR array_upper(acl, 1) = 0 THEN acl[0]
@@ -69,6 +72,7 @@ ORDER BY o.oid;`)).WillReturnRows(emptyRows)
 		})
 		It("queries metadata for a shared object", func() {
 			mock.ExpectQuery(regexp.QuoteMeta(`SELECT
+	'table'::regclass::oid AS classid,
 	o.oid,
 	'' AS privileges,
 	'' AS kind,
@@ -99,8 +103,8 @@ ORDER BY o.oid;`)).WillReturnRows(emptyRows)
 				{Grantee: "testrole", Insert: true},
 			}, Owner: "testrole"}
 			expectedTwo := backup.ObjectMetadata{Privileges: []backup.ACL{}, Owner: "testrole", Comment: "This is a metadata comment."}
-			resultOne := resultMetadataMap[1]
-			resultTwo := resultMetadataMap[2]
+			resultOne := resultMetadataMap[backup.UniqueID{Oid: 1}]
+			resultTwo := resultMetadataMap[backup.UniqueID{Oid: 2}]
 			Expect(resultMetadataMap).To(HaveLen(2))
 			structmatcher.ExpectStructsToMatch(&expectedOne, &resultOne)
 			structmatcher.ExpectStructsToMatch(&expectedTwo, &resultTwo)
@@ -116,6 +120,7 @@ ORDER BY o.oid;`)).WillReturnRows(emptyRows)
 		})
 		It("returns comment for object with default params", func() {
 			mock.ExpectQuery(regexp.QuoteMeta(`SELECT
+	'table'::regclass::oid AS classid,
 	o.oid AS oid,
 	coalesce(description,'') AS comment
 FROM table o JOIN pg_description d ON (d.objoid = oid AND d.classoid = 'table'::regclass AND d.objsubid = 0);`)).WillReturnRows(emptyRows)
@@ -124,6 +129,7 @@ FROM table o JOIN pg_description d ON (d.objoid = oid AND d.classoid = 'table'::
 		It("returns comment for object with different comment table", func() {
 			params.CommentTable = "comment_table"
 			mock.ExpectQuery(regexp.QuoteMeta(`SELECT
+	'table'::regclass::oid AS classid,
 	o.oid AS oid,
 	coalesce(description,'') AS comment
 FROM table o JOIN pg_description d ON (d.objoid = oid AND d.classoid = 'comment_table'::regclass AND d.objsubid = 0);`)).WillReturnRows(emptyRows)
@@ -132,6 +138,7 @@ FROM table o JOIN pg_description d ON (d.objoid = oid AND d.classoid = 'comment_
 		It("returns comment for a shared object", func() {
 			params.Shared = true
 			mock.ExpectQuery(regexp.QuoteMeta(`SELECT
+	'table'::regclass::oid AS classid,
 	o.oid AS oid,
 	coalesce(description,'') AS comment
 FROM table o JOIN pg_shdescription d ON (d.objoid = oid AND d.classoid = 'table'::regclass);`)).WillReturnRows(emptyRows)
@@ -146,8 +153,8 @@ FROM table o JOIN pg_shdescription d ON (d.objoid = oid AND d.classoid = 'table'
 
 			expectedOne := backup.ObjectMetadata{Privileges: []backup.ACL{}, Comment: "This is a metadata comment."}
 			expectedTwo := backup.ObjectMetadata{Privileges: []backup.ACL{}, Comment: "This is also a metadata comment."}
-			resultOne := resultMetadataMap[1]
-			resultTwo := resultMetadataMap[2]
+			resultOne := resultMetadataMap[backup.UniqueID{Oid: 1}]
+			resultTwo := resultMetadataMap[backup.UniqueID{Oid: 2}]
 			Expect(resultMetadataMap).To(HaveLen(2))
 			structmatcher.ExpectStructsToMatch(&expectedOne, &resultOne)
 			structmatcher.ExpectStructsToMatch(&expectedTwo, &resultTwo)

--- a/backup/queries_textsearch.go
+++ b/backup/queries_textsearch.go
@@ -27,7 +27,7 @@ type TextSearchParser struct {
 }
 
 func (tsp TextSearchParser) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_TS_PARSER_OID, Oid: tsp.Oid}
+	return UniqueID{ClassID: PG_TS_PARSER_OID, Oid: tsp.Oid}
 }
 
 func GetTextSearchParsers(connectionPool *dbconn.DBConn) []TextSearchParser {
@@ -62,7 +62,7 @@ type TextSearchTemplate struct {
 }
 
 func (tst TextSearchTemplate) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_TS_TEMPLATE_OID, Oid: tst.Oid}
+	return UniqueID{ClassID: PG_TS_TEMPLATE_OID, Oid: tst.Oid}
 }
 
 func GetTextSearchTemplates(connectionPool *dbconn.DBConn) []TextSearchTemplate {
@@ -94,7 +94,7 @@ type TextSearchDictionary struct {
 }
 
 func (tsd TextSearchDictionary) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_TS_DICT_OID, Oid: tsd.Oid}
+	return UniqueID{ClassID: PG_TS_DICT_OID, Oid: tsd.Oid}
 }
 
 func GetTextSearchDictionaries(connectionPool *dbconn.DBConn) []TextSearchDictionary {
@@ -128,7 +128,7 @@ type TextSearchConfiguration struct {
 }
 
 func (tsc TextSearchConfiguration) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_TS_CONFIG_OID, Oid: tsc.Oid}
+	return UniqueID{ClassID: PG_TS_CONFIG_OID, Oid: tsc.Oid}
 }
 
 func GetTextSearchConfigurations(connectionPool *dbconn.DBConn) []TextSearchConfiguration {

--- a/backup/queries_textsearch.go
+++ b/backup/queries_textsearch.go
@@ -26,6 +26,10 @@ type TextSearchParser struct {
 	HeadlineFunc string
 }
 
+func (tsp TextSearchParser) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_TS_PARSER_OID, Oid: tsp.Oid}
+}
+
 func GetTextSearchParsers(connectionPool *dbconn.DBConn) []TextSearchParser {
 	query := fmt.Sprintf(`
 SELECT
@@ -57,6 +61,10 @@ type TextSearchTemplate struct {
 	LexizeFunc string
 }
 
+func (tst TextSearchTemplate) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_TS_TEMPLATE_OID, Oid: tst.Oid}
+}
+
 func GetTextSearchTemplates(connectionPool *dbconn.DBConn) []TextSearchTemplate {
 	query := fmt.Sprintf(`
 SELECT
@@ -83,6 +91,10 @@ type TextSearchDictionary struct {
 	Name       string
 	Template   string
 	InitOption string
+}
+
+func (tsd TextSearchDictionary) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_TS_DICT_OID, Oid: tsd.Oid}
 }
 
 func GetTextSearchDictionaries(connectionPool *dbconn.DBConn) []TextSearchDictionary {
@@ -113,6 +125,10 @@ type TextSearchConfiguration struct {
 	Name         string
 	Parser       string
 	TokenToDicts map[string][]string
+}
+
+func (tsc TextSearchConfiguration) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_TS_CONFIG_OID, Oid: tsc.Oid}
 }
 
 func GetTextSearchConfigurations(connectionPool *dbconn.DBConn) []TextSearchConfiguration {

--- a/backup/queries_types.go
+++ b/backup/queries_types.go
@@ -117,8 +117,8 @@ type Type struct {
 	Collation       string
 }
 
-func (t Type) GetDepEntry() DepEntry {
-	return DepEntry{Classid: PG_TYPE_OID, Objid: t.Oid}
+func (t Type) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_TYPE_OID, Oid: t.Oid}
 }
 
 func (t Type) FQN() string {
@@ -382,6 +382,10 @@ type Collation struct {
 	Name    string
 	Collate string
 	Ctype   string
+}
+
+func (c Collation) GetUniqueID() UniqueID {
+	return UniqueID{Classid: PG_COLLATION_OID, Oid: c.Oid}
 }
 
 func GetCollations(connectionPool *dbconn.DBConn) []Collation {

--- a/backup/queries_types.go
+++ b/backup/queries_types.go
@@ -118,7 +118,7 @@ type Type struct {
 }
 
 func (t Type) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_TYPE_OID, Oid: t.Oid}
+	return UniqueID{ClassID: PG_TYPE_OID, Oid: t.Oid}
 }
 
 func (t Type) FQN() string {
@@ -385,7 +385,7 @@ type Collation struct {
 }
 
 func (c Collation) GetUniqueID() UniqueID {
-	return UniqueID{Classid: PG_COLLATION_OID, Oid: c.Oid}
+	return UniqueID{ClassID: PG_COLLATION_OID, Oid: c.Oid}
 }
 
 func GetCollations(connectionPool *dbconn.DBConn) []Collation {

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -287,7 +287,7 @@ func BackupProceduralLanguages(metadataFile *utils.FileWithByteCount, procLangs 
 	gplog.Verbose("Writing CREATE PROCEDURAL LANGUAGE statements to metadata file")
 	objectCounts["Procedural Languages"] = len(procLangs)
 	for _, langFunc := range langFuncs {
-		PrintCreateFunctionStatement(metadataFile, globalTOC, langFunc, functionMetadata[langFunc.Oid])
+		PrintCreateFunctionStatement(metadataFile, globalTOC, langFunc, functionMetadata[langFunc.GetUniqueID()])
 	}
 	procLangMetadata := GetMetadataForObjectType(connectionPool, TYPE_PROCLANGUAGE)
 	PrintCreateLanguageStatements(metadataFile, globalTOC, procLangs, funcInfoMap, procLangMetadata)
@@ -334,10 +334,10 @@ func BackupCreateSequences(metadataFile *utils.FileWithByteCount, sequences []Se
 	PrintCreateSequenceStatements(metadataFile, globalTOC, sequences, relationMetadata)
 }
 
-func createBackupSet(objSlice []Sortable) (backupSet map[DepEntry]bool) {
-	backupSet = make(map[DepEntry]bool, 0)
+func createBackupSet(objSlice []Sortable) (backupSet map[UniqueID]bool) {
+	backupSet = make(map[UniqueID]bool, 0)
 	for _, obj := range objSlice {
-		backupSet[obj.GetDepEntry()] = true
+		backupSet[obj.GetUniqueID()] = true
 	}
 
 	return backupSet

--- a/integration/dependency_queries_test.go
+++ b/integration/dependency_queries_test.go
@@ -18,9 +18,9 @@ var _ = Describe("backup integration tests", func() {
 
 			oidFoo := testutils.OidFromObjectName(connectionPool, "public", "foo", backup.TYPE_RELATION)
 			oidBar := testutils.OidFromObjectName(connectionPool, "public", "bar", backup.TYPE_RELATION)
-			fooEntry := backup.DepEntry{Classid: backup.PG_CLASS_OID, Objid: oidFoo}
-			barEntry := backup.DepEntry{Classid: backup.PG_CLASS_OID, Objid: oidBar}
-			backupSet := map[backup.DepEntry]bool{fooEntry: true, barEntry: true}
+			fooEntry := backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: oidFoo}
+			barEntry := backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: oidBar}
+			backupSet := map[backup.UniqueID]bool{fooEntry: true, barEntry: true}
 
 			deps := backup.GetDependencies(connectionPool, backupSet)
 
@@ -48,10 +48,10 @@ var _ = Describe("backup integration tests", func() {
 			protocolOid := testutils.OidFromObjectName(connectionPool, "", "s3", backup.TYPE_PROTOCOL)
 			functionOid := testutils.OidFromObjectName(connectionPool, "public", "read_from_s3", backup.TYPE_FUNCTION)
 
-			tableEntry := backup.DepEntry{Classid: backup.PG_CLASS_OID, Objid: tableOid}
-			protocolEntry := backup.DepEntry{Classid: backup.PG_EXTPROTOCOL_OID, Objid: protocolOid}
-			functionEntry := backup.DepEntry{Classid: backup.PG_PROC_OID, Objid: functionOid}
-			backupSet := map[backup.DepEntry]bool{tableEntry: true, protocolEntry: true, functionEntry: true}
+			tableEntry := backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: tableOid}
+			protocolEntry := backup.UniqueID{Classid: backup.PG_EXTPROTOCOL_OID, Oid: protocolOid}
+			functionEntry := backup.UniqueID{Classid: backup.PG_PROC_OID, Oid: functionOid}
+			backupSet := map[backup.UniqueID]bool{tableEntry: true, protocolEntry: true, functionEntry: true}
 
 			deps := backup.GetDependencies(connectionPool, backupSet)
 			if connectionPool.Version.Is("4") {
@@ -79,10 +79,10 @@ var _ = Describe("backup integration tests", func() {
 			parent2Oid := testutils.OidFromObjectName(connectionPool, "public", "parent2", backup.TYPE_RELATION)
 			childOid := testutils.OidFromObjectName(connectionPool, "public", "child", backup.TYPE_RELATION)
 
-			parent1Entry := backup.DepEntry{Classid: backup.PG_CLASS_OID, Objid: parent1Oid}
-			parent2Entry := backup.DepEntry{Classid: backup.PG_CLASS_OID, Objid: parent2Oid}
-			childEntry := backup.DepEntry{Classid: backup.PG_CLASS_OID, Objid: childOid}
-			backupSet := map[backup.DepEntry]bool{parent1Entry: true, parent2Entry: true, childEntry: true}
+			parent1Entry := backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: parent1Oid}
+			parent2Entry := backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: parent2Oid}
+			childEntry := backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: childOid}
+			backupSet := map[backup.UniqueID]bool{parent1Entry: true, parent2Entry: true, childEntry: true}
 
 			deps := backup.GetDependencies(connectionPool, backupSet)
 
@@ -92,11 +92,11 @@ var _ = Describe("backup integration tests", func() {
 			Expect(deps[childEntry]).To(HaveKey(parent2Entry))
 		})
 		Describe("function dependencies", func() {
-			var compositeEntry backup.DepEntry
+			var compositeEntry backup.UniqueID
 			BeforeEach(func() {
 				testhelper.AssertQueryRuns(connectionPool, "CREATE TYPE public.composite_ints AS (one integer, two integer)")
 				compositeOid := testutils.OidFromObjectName(connectionPool, "public", "composite_ints", backup.TYPE_TYPE)
-				compositeEntry = backup.DepEntry{Classid: backup.PG_TYPE_OID, Objid: compositeOid}
+				compositeEntry = backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: compositeOid}
 			})
 			AfterEach(func() {
 				testhelper.AssertQueryRuns(connectionPool, "DROP TYPE public.composite_ints CASCADE")
@@ -106,8 +106,8 @@ var _ = Describe("backup integration tests", func() {
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP FUNCTION public.add(public.composite_ints)")
 
 				functionOid := testutils.OidFromObjectName(connectionPool, "public", "add", backup.TYPE_FUNCTION)
-				funcEntry := backup.DepEntry{Classid: backup.PG_PROC_OID, Objid: functionOid}
-				backupSet := map[backup.DepEntry]bool{funcEntry: true, compositeEntry: true}
+				funcEntry := backup.UniqueID{Classid: backup.PG_PROC_OID, Oid: functionOid}
+				backupSet := map[backup.UniqueID]bool{funcEntry: true, compositeEntry: true}
 
 				functionDeps := backup.GetDependencies(connectionPool, backupSet)
 
@@ -120,8 +120,8 @@ var _ = Describe("backup integration tests", func() {
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP FUNCTION public.compose(integer, integer)")
 
 				functionOid := testutils.OidFromObjectName(connectionPool, "public", "compose", backup.TYPE_FUNCTION)
-				funcEntry := backup.DepEntry{Classid: backup.PG_PROC_OID, Objid: functionOid}
-				backupSet := map[backup.DepEntry]bool{funcEntry: true, compositeEntry: true}
+				funcEntry := backup.UniqueID{Classid: backup.PG_PROC_OID, Oid: functionOid}
+				backupSet := map[backup.UniqueID]bool{funcEntry: true, compositeEntry: true}
 
 				functionDeps := backup.GetDependencies(connectionPool, backupSet)
 
@@ -139,10 +139,10 @@ var _ = Describe("backup integration tests", func() {
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP FUNCTION public.compose(public.base_type[], public.composite_ints)")
 
 				functionOid := testutils.OidFromObjectName(connectionPool, "public", "compose", backup.TYPE_FUNCTION)
-				funcEntry := backup.DepEntry{Classid: backup.PG_PROC_OID, Objid: functionOid}
+				funcEntry := backup.UniqueID{Classid: backup.PG_PROC_OID, Oid: functionOid}
 				baseOid := testutils.OidFromObjectName(connectionPool, "public", "base_type", backup.TYPE_TYPE)
-				baseEntry := backup.DepEntry{Classid: backup.PG_TYPE_OID, Objid: baseOid}
-				backupSet := map[backup.DepEntry]bool{funcEntry: true, compositeEntry: true, baseEntry: true}
+				baseEntry := backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: baseOid}
+				backupSet := map[backup.UniqueID]bool{funcEntry: true, compositeEntry: true, baseEntry: true}
 
 				functionDeps := backup.GetDependencies(connectionPool, backupSet)
 
@@ -155,7 +155,7 @@ var _ = Describe("backup integration tests", func() {
 		Describe("type dependencies", func() {
 			var (
 				baseOid   uint32
-				baseEntry backup.DepEntry
+				baseEntry backup.UniqueID
 			)
 			BeforeEach(func() {
 				testhelper.AssertQueryRuns(connectionPool, "CREATE TYPE public.base_type")
@@ -164,7 +164,7 @@ var _ = Describe("backup integration tests", func() {
 				testhelper.AssertQueryRuns(connectionPool, "CREATE TYPE public.base_type(INPUT=public.base_fn_in, OUTPUT=public.base_fn_out)")
 
 				baseOid = testutils.OidFromObjectName(connectionPool, "public", "base_type", backup.TYPE_TYPE)
-				baseEntry = backup.DepEntry{Classid: backup.PG_TYPE_OID, Objid: baseOid}
+				baseEntry = backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: baseOid}
 			})
 			AfterEach(func() {
 				testhelper.AssertQueryRuns(connectionPool, "DROP TYPE public.base_type CASCADE")
@@ -178,9 +178,9 @@ var _ = Describe("backup integration tests", func() {
 				domainOid := testutils.OidFromObjectName(connectionPool, "public", "parent_domain", backup.TYPE_TYPE)
 				domain2Oid := testutils.OidFromObjectName(connectionPool, "public", "domain_type", backup.TYPE_TYPE)
 
-				domainEntry := backup.DepEntry{Classid: backup.PG_TYPE_OID, Objid: domainOid}
-				domain2Entry := backup.DepEntry{Classid: backup.PG_TYPE_OID, Objid: domain2Oid}
-				backupSet := map[backup.DepEntry]bool{domainEntry: true, domain2Entry: true}
+				domainEntry := backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: domainOid}
+				domain2Entry := backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: domain2Oid}
+				backupSet := map[backup.UniqueID]bool{domainEntry: true, domain2Entry: true}
 
 				deps := backup.GetDependencies(connectionPool, backupSet)
 
@@ -193,9 +193,9 @@ var _ = Describe("backup integration tests", func() {
 				baseInOid := testutils.OidFromObjectName(connectionPool, "public", "base_fn_in", backup.TYPE_FUNCTION)
 				baseOutOid := testutils.OidFromObjectName(connectionPool, "public", "base_fn_out", backup.TYPE_FUNCTION)
 
-				baseInEntry := backup.DepEntry{Classid: backup.PG_PROC_OID, Objid: baseInOid}
-				baseOutEntry := backup.DepEntry{Classid: backup.PG_PROC_OID, Objid: baseOutOid}
-				backupSet := map[backup.DepEntry]bool{baseEntry: true, baseInEntry: true, baseOutEntry: true}
+				baseInEntry := backup.UniqueID{Classid: backup.PG_PROC_OID, Oid: baseInOid}
+				baseOutEntry := backup.UniqueID{Classid: backup.PG_PROC_OID, Oid: baseOutOid}
+				backupSet := map[backup.UniqueID]bool{baseEntry: true, baseInEntry: true, baseOutEntry: true}
 
 				deps := backup.GetDependencies(connectionPool, backupSet)
 
@@ -209,8 +209,8 @@ var _ = Describe("backup integration tests", func() {
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP TYPE public.comp_type")
 
 				compositeOid := testutils.OidFromObjectName(connectionPool, "public", "comp_type", backup.TYPE_TYPE)
-				compositeEntry := backup.DepEntry{Classid: backup.PG_TYPE_OID, Objid: compositeOid}
-				backupSet := map[backup.DepEntry]bool{baseEntry: true, compositeEntry: true}
+				compositeEntry := backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: compositeOid}
+				backupSet := map[backup.UniqueID]bool{baseEntry: true, compositeEntry: true}
 
 				deps := backup.GetDependencies(connectionPool, backupSet)
 
@@ -229,10 +229,10 @@ var _ = Describe("backup integration tests", func() {
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP TYPE public.comp_type")
 
 				base2Oid := testutils.OidFromObjectName(connectionPool, "public", "base_type2", backup.TYPE_TYPE)
-				base2Entry := backup.DepEntry{Classid: backup.PG_TYPE_OID, Objid: base2Oid}
+				base2Entry := backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: base2Oid}
 				compositeOid := testutils.OidFromObjectName(connectionPool, "public", "comp_type", backup.TYPE_TYPE)
-				compositeEntry := backup.DepEntry{Classid: backup.PG_TYPE_OID, Objid: compositeOid}
-				backupSet := map[backup.DepEntry]bool{baseEntry: true, base2Entry: true, compositeEntry: true}
+				compositeEntry := backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: compositeOid}
+				backupSet := map[backup.UniqueID]bool{baseEntry: true, base2Entry: true, compositeEntry: true}
 
 				deps := backup.GetDependencies(connectionPool, backupSet)
 
@@ -246,8 +246,8 @@ var _ = Describe("backup integration tests", func() {
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP TYPE public.comp_type")
 
 				compositeOid := testutils.OidFromObjectName(connectionPool, "public", "comp_type", backup.TYPE_TYPE)
-				compositeEntry := backup.DepEntry{Classid: backup.PG_TYPE_OID, Objid: compositeOid}
-				backupSet := map[backup.DepEntry]bool{baseEntry: true, compositeEntry: true}
+				compositeEntry := backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: compositeOid}
+				backupSet := map[backup.UniqueID]bool{baseEntry: true, compositeEntry: true}
 
 				deps := backup.GetDependencies(connectionPool, backupSet)
 
@@ -264,9 +264,9 @@ var _ = Describe("backup integration tests", func() {
 				tableOid := testutils.OidFromObjectName(connectionPool, "public", "my_table", backup.TYPE_RELATION)
 				typeOid := testutils.OidFromObjectName(connectionPool, "public", "my_type", backup.TYPE_TYPE)
 
-				tableEntry := backup.DepEntry{Classid: backup.PG_CLASS_OID, Objid: tableOid}
-				typeEntry := backup.DepEntry{Classid: backup.PG_TYPE_OID, Objid: typeOid}
-				backupSet := map[backup.DepEntry]bool{tableEntry: true, typeEntry: true}
+				tableEntry := backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: tableOid}
+				typeEntry := backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: typeOid}
+				backupSet := map[backup.UniqueID]bool{tableEntry: true, typeEntry: true}
 
 				deps := backup.GetDependencies(connectionPool, backupSet)
 

--- a/integration/dependency_queries_test.go
+++ b/integration/dependency_queries_test.go
@@ -18,8 +18,8 @@ var _ = Describe("backup integration tests", func() {
 
 			oidFoo := testutils.OidFromObjectName(connectionPool, "public", "foo", backup.TYPE_RELATION)
 			oidBar := testutils.OidFromObjectName(connectionPool, "public", "bar", backup.TYPE_RELATION)
-			fooEntry := backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: oidFoo}
-			barEntry := backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: oidBar}
+			fooEntry := backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: oidFoo}
+			barEntry := backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: oidBar}
 			backupSet := map[backup.UniqueID]bool{fooEntry: true, barEntry: true}
 
 			deps := backup.GetDependencies(connectionPool, backupSet)
@@ -48,9 +48,9 @@ var _ = Describe("backup integration tests", func() {
 			protocolOid := testutils.OidFromObjectName(connectionPool, "", "s3", backup.TYPE_PROTOCOL)
 			functionOid := testutils.OidFromObjectName(connectionPool, "public", "read_from_s3", backup.TYPE_FUNCTION)
 
-			tableEntry := backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: tableOid}
-			protocolEntry := backup.UniqueID{Classid: backup.PG_EXTPROTOCOL_OID, Oid: protocolOid}
-			functionEntry := backup.UniqueID{Classid: backup.PG_PROC_OID, Oid: functionOid}
+			tableEntry := backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: tableOid}
+			protocolEntry := backup.UniqueID{ClassID: backup.PG_EXTPROTOCOL_OID, Oid: protocolOid}
+			functionEntry := backup.UniqueID{ClassID: backup.PG_PROC_OID, Oid: functionOid}
 			backupSet := map[backup.UniqueID]bool{tableEntry: true, protocolEntry: true, functionEntry: true}
 
 			deps := backup.GetDependencies(connectionPool, backupSet)
@@ -79,9 +79,9 @@ var _ = Describe("backup integration tests", func() {
 			parent2Oid := testutils.OidFromObjectName(connectionPool, "public", "parent2", backup.TYPE_RELATION)
 			childOid := testutils.OidFromObjectName(connectionPool, "public", "child", backup.TYPE_RELATION)
 
-			parent1Entry := backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: parent1Oid}
-			parent2Entry := backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: parent2Oid}
-			childEntry := backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: childOid}
+			parent1Entry := backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: parent1Oid}
+			parent2Entry := backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: parent2Oid}
+			childEntry := backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: childOid}
 			backupSet := map[backup.UniqueID]bool{parent1Entry: true, parent2Entry: true, childEntry: true}
 
 			deps := backup.GetDependencies(connectionPool, backupSet)
@@ -96,7 +96,7 @@ var _ = Describe("backup integration tests", func() {
 			BeforeEach(func() {
 				testhelper.AssertQueryRuns(connectionPool, "CREATE TYPE public.composite_ints AS (one integer, two integer)")
 				compositeOid := testutils.OidFromObjectName(connectionPool, "public", "composite_ints", backup.TYPE_TYPE)
-				compositeEntry = backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: compositeOid}
+				compositeEntry = backup.UniqueID{ClassID: backup.PG_TYPE_OID, Oid: compositeOid}
 			})
 			AfterEach(func() {
 				testhelper.AssertQueryRuns(connectionPool, "DROP TYPE public.composite_ints CASCADE")
@@ -106,7 +106,7 @@ var _ = Describe("backup integration tests", func() {
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP FUNCTION public.add(public.composite_ints)")
 
 				functionOid := testutils.OidFromObjectName(connectionPool, "public", "add", backup.TYPE_FUNCTION)
-				funcEntry := backup.UniqueID{Classid: backup.PG_PROC_OID, Oid: functionOid}
+				funcEntry := backup.UniqueID{ClassID: backup.PG_PROC_OID, Oid: functionOid}
 				backupSet := map[backup.UniqueID]bool{funcEntry: true, compositeEntry: true}
 
 				functionDeps := backup.GetDependencies(connectionPool, backupSet)
@@ -120,7 +120,7 @@ var _ = Describe("backup integration tests", func() {
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP FUNCTION public.compose(integer, integer)")
 
 				functionOid := testutils.OidFromObjectName(connectionPool, "public", "compose", backup.TYPE_FUNCTION)
-				funcEntry := backup.UniqueID{Classid: backup.PG_PROC_OID, Oid: functionOid}
+				funcEntry := backup.UniqueID{ClassID: backup.PG_PROC_OID, Oid: functionOid}
 				backupSet := map[backup.UniqueID]bool{funcEntry: true, compositeEntry: true}
 
 				functionDeps := backup.GetDependencies(connectionPool, backupSet)
@@ -139,9 +139,9 @@ var _ = Describe("backup integration tests", func() {
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP FUNCTION public.compose(public.base_type[], public.composite_ints)")
 
 				functionOid := testutils.OidFromObjectName(connectionPool, "public", "compose", backup.TYPE_FUNCTION)
-				funcEntry := backup.UniqueID{Classid: backup.PG_PROC_OID, Oid: functionOid}
+				funcEntry := backup.UniqueID{ClassID: backup.PG_PROC_OID, Oid: functionOid}
 				baseOid := testutils.OidFromObjectName(connectionPool, "public", "base_type", backup.TYPE_TYPE)
-				baseEntry := backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: baseOid}
+				baseEntry := backup.UniqueID{ClassID: backup.PG_TYPE_OID, Oid: baseOid}
 				backupSet := map[backup.UniqueID]bool{funcEntry: true, compositeEntry: true, baseEntry: true}
 
 				functionDeps := backup.GetDependencies(connectionPool, backupSet)
@@ -164,7 +164,7 @@ var _ = Describe("backup integration tests", func() {
 				testhelper.AssertQueryRuns(connectionPool, "CREATE TYPE public.base_type(INPUT=public.base_fn_in, OUTPUT=public.base_fn_out)")
 
 				baseOid = testutils.OidFromObjectName(connectionPool, "public", "base_type", backup.TYPE_TYPE)
-				baseEntry = backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: baseOid}
+				baseEntry = backup.UniqueID{ClassID: backup.PG_TYPE_OID, Oid: baseOid}
 			})
 			AfterEach(func() {
 				testhelper.AssertQueryRuns(connectionPool, "DROP TYPE public.base_type CASCADE")
@@ -178,8 +178,8 @@ var _ = Describe("backup integration tests", func() {
 				domainOid := testutils.OidFromObjectName(connectionPool, "public", "parent_domain", backup.TYPE_TYPE)
 				domain2Oid := testutils.OidFromObjectName(connectionPool, "public", "domain_type", backup.TYPE_TYPE)
 
-				domainEntry := backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: domainOid}
-				domain2Entry := backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: domain2Oid}
+				domainEntry := backup.UniqueID{ClassID: backup.PG_TYPE_OID, Oid: domainOid}
+				domain2Entry := backup.UniqueID{ClassID: backup.PG_TYPE_OID, Oid: domain2Oid}
 				backupSet := map[backup.UniqueID]bool{domainEntry: true, domain2Entry: true}
 
 				deps := backup.GetDependencies(connectionPool, backupSet)
@@ -193,8 +193,8 @@ var _ = Describe("backup integration tests", func() {
 				baseInOid := testutils.OidFromObjectName(connectionPool, "public", "base_fn_in", backup.TYPE_FUNCTION)
 				baseOutOid := testutils.OidFromObjectName(connectionPool, "public", "base_fn_out", backup.TYPE_FUNCTION)
 
-				baseInEntry := backup.UniqueID{Classid: backup.PG_PROC_OID, Oid: baseInOid}
-				baseOutEntry := backup.UniqueID{Classid: backup.PG_PROC_OID, Oid: baseOutOid}
+				baseInEntry := backup.UniqueID{ClassID: backup.PG_PROC_OID, Oid: baseInOid}
+				baseOutEntry := backup.UniqueID{ClassID: backup.PG_PROC_OID, Oid: baseOutOid}
 				backupSet := map[backup.UniqueID]bool{baseEntry: true, baseInEntry: true, baseOutEntry: true}
 
 				deps := backup.GetDependencies(connectionPool, backupSet)
@@ -209,7 +209,7 @@ var _ = Describe("backup integration tests", func() {
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP TYPE public.comp_type")
 
 				compositeOid := testutils.OidFromObjectName(connectionPool, "public", "comp_type", backup.TYPE_TYPE)
-				compositeEntry := backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: compositeOid}
+				compositeEntry := backup.UniqueID{ClassID: backup.PG_TYPE_OID, Oid: compositeOid}
 				backupSet := map[backup.UniqueID]bool{baseEntry: true, compositeEntry: true}
 
 				deps := backup.GetDependencies(connectionPool, backupSet)
@@ -229,9 +229,9 @@ var _ = Describe("backup integration tests", func() {
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP TYPE public.comp_type")
 
 				base2Oid := testutils.OidFromObjectName(connectionPool, "public", "base_type2", backup.TYPE_TYPE)
-				base2Entry := backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: base2Oid}
+				base2Entry := backup.UniqueID{ClassID: backup.PG_TYPE_OID, Oid: base2Oid}
 				compositeOid := testutils.OidFromObjectName(connectionPool, "public", "comp_type", backup.TYPE_TYPE)
-				compositeEntry := backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: compositeOid}
+				compositeEntry := backup.UniqueID{ClassID: backup.PG_TYPE_OID, Oid: compositeOid}
 				backupSet := map[backup.UniqueID]bool{baseEntry: true, base2Entry: true, compositeEntry: true}
 
 				deps := backup.GetDependencies(connectionPool, backupSet)
@@ -246,7 +246,7 @@ var _ = Describe("backup integration tests", func() {
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP TYPE public.comp_type")
 
 				compositeOid := testutils.OidFromObjectName(connectionPool, "public", "comp_type", backup.TYPE_TYPE)
-				compositeEntry := backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: compositeOid}
+				compositeEntry := backup.UniqueID{ClassID: backup.PG_TYPE_OID, Oid: compositeOid}
 				backupSet := map[backup.UniqueID]bool{baseEntry: true, compositeEntry: true}
 
 				deps := backup.GetDependencies(connectionPool, backupSet)
@@ -264,8 +264,8 @@ var _ = Describe("backup integration tests", func() {
 				tableOid := testutils.OidFromObjectName(connectionPool, "public", "my_table", backup.TYPE_RELATION)
 				typeOid := testutils.OidFromObjectName(connectionPool, "public", "my_type", backup.TYPE_TYPE)
 
-				tableEntry := backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: tableOid}
-				typeEntry := backup.UniqueID{Classid: backup.PG_TYPE_OID, Oid: typeOid}
+				tableEntry := backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: tableOid}
+				typeEntry := backup.UniqueID{ClassID: backup.PG_TYPE_OID, Oid: typeOid}
 				backupSet := map[backup.UniqueID]bool{tableEntry: true, typeEntry: true}
 
 				deps := backup.GetDependencies(connectionPool, backupSet)

--- a/integration/metadata_globals_create_test.go
+++ b/integration/metadata_globals_create_test.go
@@ -38,7 +38,7 @@ var _ = Describe("backup integration create statement tests", func() {
 		It("creates a basic resource queue with a comment", func() {
 			basicQueue := backup.ResourceQueue{Oid: 1, Name: `"basicQueue"`, ActiveStatements: -1, MaxCost: "32.80", CostOvercommit: false, MinCost: "0.00", Priority: "medium", MemoryLimit: "-1"}
 			resQueueMetadataMap := testutils.DefaultMetadataMap("RESOURCE QUEUE", false, false, true)
-			resQueueMetadata := resQueueMetadataMap[backup.UniqueID{Oid: 1}]
+			resQueueMetadata := resQueueMetadataMap[basicQueue.GetUniqueID()]
 
 			backup.PrintCreateResourceQueueStatements(backupfile, toc, []backup.ResourceQueue{basicQueue}, resQueueMetadataMap)
 
@@ -50,9 +50,9 @@ var _ = Describe("backup integration create statement tests", func() {
 			testhelper.AssertQueryRuns(connectionPool, hunks[1])
 
 			resultResourceQueues := backup.GetResourceQueues(connectionPool)
-			resQueueOid := testutils.OidFromObjectName(connectionPool, "", "basicQueue", backup.TYPE_RESOURCEQUEUE)
+			resQueueUniqueID := testutils.UniqueIDFromObjectName(connectionPool, "", "basicQueue", backup.TYPE_RESOURCEQUEUE)
 			resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_RESOURCEQUEUE)
-			resultMetadata := resultMetadataMap[backup.UniqueID{Oid: resQueueOid}]
+			resultMetadata := resultMetadataMap[resQueueUniqueID]
 			structmatcher.ExpectStructsToMatch(&resultMetadata, &resQueueMetadata)
 
 			for _, resultQueue := range resultResourceQueues {

--- a/integration/metadata_globals_create_test.go
+++ b/integration/metadata_globals_create_test.go
@@ -38,7 +38,7 @@ var _ = Describe("backup integration create statement tests", func() {
 		It("creates a basic resource queue with a comment", func() {
 			basicQueue := backup.ResourceQueue{Oid: 1, Name: `"basicQueue"`, ActiveStatements: -1, MaxCost: "32.80", CostOvercommit: false, MinCost: "0.00", Priority: "medium", MemoryLimit: "-1"}
 			resQueueMetadataMap := testutils.DefaultMetadataMap("RESOURCE QUEUE", false, false, true)
-			resQueueMetadata := resQueueMetadataMap[1]
+			resQueueMetadata := resQueueMetadataMap[backup.UniqueID{Oid: 1}]
 
 			backup.PrintCreateResourceQueueStatements(backupfile, toc, []backup.ResourceQueue{basicQueue}, resQueueMetadataMap)
 
@@ -52,7 +52,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultResourceQueues := backup.GetResourceQueues(connectionPool)
 			resQueueOid := testutils.OidFromObjectName(connectionPool, "", "basicQueue", backup.TYPE_RESOURCEQUEUE)
 			resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_RESOURCEQUEUE)
-			resultMetadata := resultMetadataMap[resQueueOid]
+			resultMetadata := resultMetadataMap[backup.UniqueID{Oid: resQueueOid}]
 			structmatcher.ExpectStructsToMatch(&resultMetadata, &resQueueMetadata)
 
 			for _, resultQueue := range resultResourceQueues {
@@ -64,7 +64,7 @@ var _ = Describe("backup integration create statement tests", func() {
 		})
 		It("creates a resource queue with all attributes", func() {
 			everythingQueue := backup.ResourceQueue{Oid: 1, Name: `"everythingQueue"`, ActiveStatements: 7, MaxCost: "32.80", CostOvercommit: true, MinCost: "22.80", Priority: "low", MemoryLimit: "2GB"}
-			emptyMetadataMap := map[uint32]backup.ObjectMetadata{}
+			emptyMetadataMap := map[backup.UniqueID]backup.ObjectMetadata{}
 
 			backup.PrintCreateResourceQueueStatements(backupfile, toc, []backup.ResourceQueue{everythingQueue}, emptyMetadataMap)
 
@@ -88,7 +88,7 @@ var _ = Describe("backup integration create statement tests", func() {
 		})
 		It("creates a basic resource group", func() {
 			someGroup := backup.ResourceGroup{Oid: 1, Name: "some_group", CPURateLimit: 10, MemoryLimit: 20, Concurrency: 15, MemorySharedQuota: 25, MemorySpillRatio: 30, MemoryAuditor: 0, Cpuset: "-1"}
-			emptyMetadataMap := map[uint32]backup.ObjectMetadata{}
+			emptyMetadataMap := map[backup.UniqueID]backup.ObjectMetadata{}
 
 			backup.PrintCreateResourceGroupStatements(backupfile, toc, []backup.ResourceGroup{someGroup}, emptyMetadataMap)
 
@@ -107,7 +107,7 @@ var _ = Describe("backup integration create statement tests", func() {
 		})
 		It("alters a default resource group", func() {
 			defaultGroup := backup.ResourceGroup{Oid: 1, Name: "default_group", CPURateLimit: 10, MemoryLimit: 20, Concurrency: 15, MemorySharedQuota: 25, MemorySpillRatio: 30, MemoryAuditor: 0, Cpuset: "-1"}
-			emptyMetadataMap := map[uint32]backup.ObjectMetadata{}
+			emptyMetadataMap := map[backup.UniqueID]backup.ObjectMetadata{}
 
 			backup.PrintCreateResourceGroupStatements(backupfile, toc, []backup.ResourceGroup{defaultGroup}, emptyMetadataMap)
 
@@ -128,7 +128,7 @@ var _ = Describe("backup integration create statement tests", func() {
 	})
 	Describe("PrintCreateRoleStatements", func() {
 		role1 := backup.Role{
-			Oid:             0,
+			Oid:             1,
 			Name:            "role1",
 			Super:           true,
 			Inherit:         false,
@@ -353,7 +353,7 @@ var _ = Describe("backup integration create statement tests", func() {
 		It("creates a tablespace with permissions, an owner, and a comment", func() {
 			numTablespaces := len(backup.GetTablespaces(connectionPool))
 			tablespaceMetadataMap := testutils.DefaultMetadataMap("TABLESPACE", true, true, true)
-			tablespaceMetadata := tablespaceMetadataMap[1]
+			tablespaceMetadata := tablespaceMetadataMap[expectedTablespace.GetUniqueID()]
 			backup.PrintCreateTablespaceStatements(backupfile, toc, []backup.Tablespace{expectedTablespace}, tablespaceMetadataMap)
 
 			if connectionPool.Version.AtLeast("6") {
@@ -374,8 +374,7 @@ var _ = Describe("backup integration create statement tests", func() {
 
 			resultTablespaces := backup.GetTablespaces(connectionPool)
 			resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TABLESPACE)
-			oid := testutils.OidFromObjectName(connectionPool, "", "test_tablespace", backup.TYPE_TABLESPACE)
-			resultMetadata := resultMetadataMap[oid]
+			resultMetadata := resultMetadataMap[resultTablespaces[0].GetUniqueID()]
 			structmatcher.ExpectStructsToMatchExcluding(&tablespaceMetadata, &resultMetadata, "Oid")
 			Expect(resultTablespaces).To(HaveLen(numTablespaces + 1))
 			for _, tablespace := range resultTablespaces {

--- a/integration/postdata_create_test.go
+++ b/integration/postdata_create_test.go
@@ -61,7 +61,6 @@ var _ = Describe("backup integration create statement tests", func() {
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 
-			indexes[0].Oid = testutils.OidFromObjectName(connectionPool, "", "index1", backup.TYPE_INDEX)
 			resultIndexes := backup.GetIndexes(connectionPool)
 			resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_INDEX)
 			resultMetadata := resultMetadataMap[resultIndexes[0].GetUniqueID()]
@@ -119,7 +118,7 @@ var _ = Describe("backup integration create statement tests", func() {
 		It("creates a rule with a comment", func() {
 			rules := []backup.QuerySimpleDefinition{{ClassID: backup.PG_REWRITE_OID, Oid: 1, Name: "update_notify", OwningSchema: "public", OwningTable: "testtable", Def: ruleDef}}
 			ruleMetadataMap = testutils.DefaultMetadataMap("RULE", false, false, true)
-			ruleMetadata := ruleMetadataMap[backup.UniqueID{Oid: 1}]
+			ruleMetadata := ruleMetadataMap[rules[0].GetUniqueID()]
 			backup.PrintCreateRuleStatements(backupfile, toc, rules, ruleMetadataMap)
 
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.testtable(i int)")
@@ -130,7 +129,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			rules[0].Oid = testutils.OidFromObjectName(connectionPool, "", "update_notify", backup.TYPE_RULE)
 			resultRules := backup.GetRules(connectionPool)
 			resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_RULE)
-			resultMetadata := resultMetadataMap[backup.UniqueID{Oid: rules[0].Oid}]
+			resultMetadata := resultMetadataMap[resultRules[0].GetUniqueID()]
 			Expect(resultRules).To(HaveLen(1))
 			structmatcher.ExpectStructsToMatchExcluding(&resultRules[0], &rules[0], "Oid")
 			structmatcher.ExpectStructsToMatch(&resultMetadata, &ruleMetadata)
@@ -159,7 +158,7 @@ var _ = Describe("backup integration create statement tests", func() {
 		It("creates a trigger with a comment", func() {
 			triggers := []backup.QuerySimpleDefinition{{ClassID: backup.PG_TRIGGER_OID, Oid: 1, Name: "sync_testtable", OwningSchema: "public", OwningTable: "testtable", Def: `CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON public.testtable FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}}
 			triggerMetadataMap = testutils.DefaultMetadataMap("RULE", false, false, true)
-			triggerMetadata := triggerMetadataMap[backup.UniqueID{Oid: 1}]
+			triggerMetadata := triggerMetadataMap[triggers[0].GetUniqueID()]
 			backup.PrintCreateTriggerStatements(backupfile, toc, triggers, triggerMetadataMap)
 
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.testtable(i int)")
@@ -170,7 +169,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			triggers[0].Oid = testutils.OidFromObjectName(connectionPool, "", "sync_testtable", backup.TYPE_TRIGGER)
 			resultTriggers := backup.GetTriggers(connectionPool)
 			resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_TRIGGER)
-			resultMetadata := resultMetadataMap[backup.UniqueID{Oid: triggers[0].Oid}]
+			resultMetadata := resultMetadataMap[resultTriggers[0].GetUniqueID()]
 			Expect(resultTriggers).To(HaveLen(1))
 			structmatcher.ExpectStructsToMatchExcluding(&resultTriggers[0], &triggers[0], "Oid")
 			structmatcher.ExpectStructsToMatch(&resultMetadata, &triggerMetadata)

--- a/integration/postdata_create_test.go
+++ b/integration/postdata_create_test.go
@@ -104,7 +104,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			}
 		})
 		It("creates a basic rule", func() {
-			rules := []backup.QuerySimpleDefinition{{Classid: backup.PG_RULE_OID, Oid: 0, Name: "update_notify", OwningSchema: "public", OwningTable: "testtable", Def: ruleDef}}
+			rules := []backup.QuerySimpleDefinition{{Classid: backup.PG_REWRITE_OID, Oid: 0, Name: "update_notify", OwningSchema: "public", OwningTable: "testtable", Def: ruleDef}}
 			backup.PrintCreateRuleStatements(backupfile, toc, rules, ruleMetadataMap)
 
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.testtable(i int)")
@@ -117,7 +117,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&resultRules[0], &rules[0], "Oid")
 		})
 		It("creates a rule with a comment", func() {
-			rules := []backup.QuerySimpleDefinition{{Classid: backup.PG_RULE_OID, Oid: 1, Name: "update_notify", OwningSchema: "public", OwningTable: "testtable", Def: ruleDef}}
+			rules := []backup.QuerySimpleDefinition{{Classid: backup.PG_REWRITE_OID, Oid: 1, Name: "update_notify", OwningSchema: "public", OwningTable: "testtable", Def: ruleDef}}
 			ruleMetadataMap = testutils.DefaultMetadataMap("RULE", false, false, true)
 			ruleMetadata := ruleMetadataMap[backup.UniqueID{Oid: 1}]
 			backup.PrintCreateRuleStatements(backupfile, toc, rules, ruleMetadataMap)

--- a/integration/postdata_create_test.go
+++ b/integration/postdata_create_test.go
@@ -104,7 +104,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			}
 		})
 		It("creates a basic rule", func() {
-			rules := []backup.QuerySimpleDefinition{{Classid: backup.PG_REWRITE_OID, Oid: 0, Name: "update_notify", OwningSchema: "public", OwningTable: "testtable", Def: ruleDef}}
+			rules := []backup.QuerySimpleDefinition{{ClassID: backup.PG_REWRITE_OID, Oid: 0, Name: "update_notify", OwningSchema: "public", OwningTable: "testtable", Def: ruleDef}}
 			backup.PrintCreateRuleStatements(backupfile, toc, rules, ruleMetadataMap)
 
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.testtable(i int)")
@@ -117,7 +117,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&resultRules[0], &rules[0], "Oid")
 		})
 		It("creates a rule with a comment", func() {
-			rules := []backup.QuerySimpleDefinition{{Classid: backup.PG_REWRITE_OID, Oid: 1, Name: "update_notify", OwningSchema: "public", OwningTable: "testtable", Def: ruleDef}}
+			rules := []backup.QuerySimpleDefinition{{ClassID: backup.PG_REWRITE_OID, Oid: 1, Name: "update_notify", OwningSchema: "public", OwningTable: "testtable", Def: ruleDef}}
 			ruleMetadataMap = testutils.DefaultMetadataMap("RULE", false, false, true)
 			ruleMetadata := ruleMetadataMap[backup.UniqueID{Oid: 1}]
 			backup.PrintCreateRuleStatements(backupfile, toc, rules, ruleMetadataMap)
@@ -144,7 +144,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			triggerMetadataMap = backup.MetadataMap{}
 		})
 		It("creates a basic trigger", func() {
-			triggers := []backup.QuerySimpleDefinition{{Classid: backup.PG_TRIGGER_OID, Oid: 0, Name: "sync_testtable", OwningSchema: "public", OwningTable: "testtable", Def: `CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON public.testtable FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}}
+			triggers := []backup.QuerySimpleDefinition{{ClassID: backup.PG_TRIGGER_OID, Oid: 0, Name: "sync_testtable", OwningSchema: "public", OwningTable: "testtable", Def: `CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON public.testtable FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}}
 			backup.PrintCreateTriggerStatements(backupfile, toc, triggers, triggerMetadataMap)
 
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.testtable(i int)")
@@ -157,7 +157,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&resultTriggers[0], &triggers[0], "Oid")
 		})
 		It("creates a trigger with a comment", func() {
-			triggers := []backup.QuerySimpleDefinition{{Classid: backup.PG_TRIGGER_OID, Oid: 1, Name: "sync_testtable", OwningSchema: "public", OwningTable: "testtable", Def: `CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON public.testtable FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}}
+			triggers := []backup.QuerySimpleDefinition{{ClassID: backup.PG_TRIGGER_OID, Oid: 1, Name: "sync_testtable", OwningSchema: "public", OwningTable: "testtable", Def: `CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON public.testtable FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}}
 			triggerMetadataMap = testutils.DefaultMetadataMap("RULE", false, false, true)
 			triggerMetadata := triggerMetadataMap[backup.UniqueID{Oid: 1}]
 			backup.PrintCreateTriggerStatements(backupfile, toc, triggers, triggerMetadataMap)

--- a/integration/postdata_queries_test.go
+++ b/integration/postdata_queries_test.go
@@ -207,8 +207,8 @@ PARTITION BY RANGE (date)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP RULE update_notify ON public.rule_table1")
 			testhelper.AssertQueryRuns(connectionPool, "COMMENT ON RULE update_notify ON public.rule_table1 IS 'This is a rule comment.'")
 
-			rule1 := backup.QuerySimpleDefinition{Classid: backup.PG_RULE_OID, Oid: 0, Name: "double_insert", OwningSchema: "public", OwningTable: "rule_table1", Def: ruleDef1}
-			rule2 := backup.QuerySimpleDefinition{Classid: backup.PG_RULE_OID, Oid: 1, Name: "update_notify", OwningSchema: "public", OwningTable: "rule_table1", Def: ruleDef2}
+			rule1 := backup.QuerySimpleDefinition{Classid: backup.PG_REWRITE_OID, Oid: 0, Name: "double_insert", OwningSchema: "public", OwningTable: "rule_table1", Def: ruleDef1}
+			rule2 := backup.QuerySimpleDefinition{Classid: backup.PG_REWRITE_OID, Oid: 1, Name: "update_notify", OwningSchema: "public", OwningTable: "rule_table1", Def: ruleDef2}
 
 			results := backup.GetRules(connectionPool)
 
@@ -229,7 +229,7 @@ PARTITION BY RANGE (date)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP RULE double_insert ON testschema.rule_table1")
 			backupCmdFlags.Set(utils.INCLUDE_SCHEMA, "public")
 
-			rule1 := backup.QuerySimpleDefinition{Classid: backup.PG_RULE_OID, Oid: 0, Name: "double_insert", OwningSchema: "public", OwningTable: "rule_table1", Def: ruleDef1}
+			rule1 := backup.QuerySimpleDefinition{Classid: backup.PG_REWRITE_OID, Oid: 0, Name: "double_insert", OwningSchema: "public", OwningTable: "rule_table1", Def: ruleDef1}
 
 			results := backup.GetRules(connectionPool)
 
@@ -249,7 +249,7 @@ PARTITION BY RANGE (date)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP RULE double_insert ON testschema.rule_table1")
 			backupCmdFlags.Set(utils.INCLUDE_RELATION, "public.rule_table1")
 
-			rule1 := backup.QuerySimpleDefinition{Classid: backup.PG_RULE_OID, Oid: 0, Name: "double_insert", OwningSchema: "public", OwningTable: "rule_table1", Def: ruleDef1}
+			rule1 := backup.QuerySimpleDefinition{Classid: backup.PG_REWRITE_OID, Oid: 0, Name: "double_insert", OwningSchema: "public", OwningTable: "rule_table1", Def: ruleDef1}
 
 			results := backup.GetRules(connectionPool)
 

--- a/integration/postdata_queries_test.go
+++ b/integration/postdata_queries_test.go
@@ -207,8 +207,8 @@ PARTITION BY RANGE (date)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP RULE update_notify ON public.rule_table1")
 			testhelper.AssertQueryRuns(connectionPool, "COMMENT ON RULE update_notify ON public.rule_table1 IS 'This is a rule comment.'")
 
-			rule1 := backup.QuerySimpleDefinition{Oid: 0, Name: "double_insert", OwningSchema: "public", OwningTable: "rule_table1", Def: ruleDef1}
-			rule2 := backup.QuerySimpleDefinition{Oid: 1, Name: "update_notify", OwningSchema: "public", OwningTable: "rule_table1", Def: ruleDef2}
+			rule1 := backup.QuerySimpleDefinition{Classid: backup.PG_RULE_OID, Oid: 0, Name: "double_insert", OwningSchema: "public", OwningTable: "rule_table1", Def: ruleDef1}
+			rule2 := backup.QuerySimpleDefinition{Classid: backup.PG_RULE_OID, Oid: 1, Name: "update_notify", OwningSchema: "public", OwningTable: "rule_table1", Def: ruleDef2}
 
 			results := backup.GetRules(connectionPool)
 
@@ -229,7 +229,7 @@ PARTITION BY RANGE (date)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP RULE double_insert ON testschema.rule_table1")
 			backupCmdFlags.Set(utils.INCLUDE_SCHEMA, "public")
 
-			rule1 := backup.QuerySimpleDefinition{Oid: 0, Name: "double_insert", OwningSchema: "public", OwningTable: "rule_table1", Def: ruleDef1}
+			rule1 := backup.QuerySimpleDefinition{Classid: backup.PG_RULE_OID, Oid: 0, Name: "double_insert", OwningSchema: "public", OwningTable: "rule_table1", Def: ruleDef1}
 
 			results := backup.GetRules(connectionPool)
 
@@ -249,7 +249,7 @@ PARTITION BY RANGE (date)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP RULE double_insert ON testschema.rule_table1")
 			backupCmdFlags.Set(utils.INCLUDE_RELATION, "public.rule_table1")
 
-			rule1 := backup.QuerySimpleDefinition{Oid: 0, Name: "double_insert", OwningSchema: "public", OwningTable: "rule_table1", Def: ruleDef1}
+			rule1 := backup.QuerySimpleDefinition{Classid: backup.PG_RULE_OID, Oid: 0, Name: "double_insert", OwningSchema: "public", OwningTable: "rule_table1", Def: ruleDef1}
 
 			results := backup.GetRules(connectionPool)
 
@@ -274,8 +274,8 @@ PARTITION BY RANGE (date)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TRIGGER sync_trigger_table2 ON public.trigger_table2")
 			testhelper.AssertQueryRuns(connectionPool, "COMMENT ON TRIGGER sync_trigger_table2 ON public.trigger_table2 IS 'This is a trigger comment.'")
 
-			trigger1 := backup.QuerySimpleDefinition{Oid: 0, Name: "sync_trigger_table1", OwningSchema: "public", OwningTable: "trigger_table1", Def: `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}
-			trigger2 := backup.QuerySimpleDefinition{Oid: 1, Name: "sync_trigger_table2", OwningSchema: "public", OwningTable: "trigger_table2", Def: `CREATE TRIGGER sync_trigger_table2 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table2 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}
+			trigger1 := backup.QuerySimpleDefinition{Classid: backup.PG_TRIGGER_OID, Oid: 0, Name: "sync_trigger_table1", OwningSchema: "public", OwningTable: "trigger_table1", Def: `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}
+			trigger2 := backup.QuerySimpleDefinition{Classid: backup.PG_TRIGGER_OID, Oid: 1, Name: "sync_trigger_table2", OwningSchema: "public", OwningTable: "trigger_table2", Def: `CREATE TRIGGER sync_trigger_table2 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table2 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}
 
 			results := backup.GetTriggers(connectionPool)
 
@@ -307,7 +307,7 @@ PARTITION BY RANGE (date)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TRIGGER sync_trigger_table1 ON testschema.trigger_table1")
 			backupCmdFlags.Set(utils.INCLUDE_SCHEMA, "testschema")
 
-			trigger1 := backup.QuerySimpleDefinition{Oid: 0, Name: "sync_trigger_table1", OwningSchema: "testschema", OwningTable: "trigger_table1", Def: `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON testschema.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}
+			trigger1 := backup.QuerySimpleDefinition{Classid: backup.PG_TRIGGER_OID, Oid: 0, Name: "sync_trigger_table1", OwningSchema: "testschema", OwningTable: "trigger_table1", Def: `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON testschema.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}
 
 			results := backup.GetTriggers(connectionPool)
 
@@ -327,7 +327,7 @@ PARTITION BY RANGE (date)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TRIGGER sync_trigger_table1 ON testschema.trigger_table1")
 			backupCmdFlags.Set(utils.INCLUDE_RELATION, "testschema.trigger_table1")
 
-			trigger1 := backup.QuerySimpleDefinition{Oid: 0, Name: "sync_trigger_table1", OwningSchema: "testschema", OwningTable: "trigger_table1", Def: `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON testschema.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}
+			trigger1 := backup.QuerySimpleDefinition{Classid: backup.PG_TRIGGER_OID, Oid: 0, Name: "sync_trigger_table1", OwningSchema: "testschema", OwningTable: "trigger_table1", Def: `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON testschema.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}
 
 			results := backup.GetTriggers(connectionPool)
 

--- a/integration/postdata_queries_test.go
+++ b/integration/postdata_queries_test.go
@@ -207,8 +207,8 @@ PARTITION BY RANGE (date)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP RULE update_notify ON public.rule_table1")
 			testhelper.AssertQueryRuns(connectionPool, "COMMENT ON RULE update_notify ON public.rule_table1 IS 'This is a rule comment.'")
 
-			rule1 := backup.QuerySimpleDefinition{Classid: backup.PG_REWRITE_OID, Oid: 0, Name: "double_insert", OwningSchema: "public", OwningTable: "rule_table1", Def: ruleDef1}
-			rule2 := backup.QuerySimpleDefinition{Classid: backup.PG_REWRITE_OID, Oid: 1, Name: "update_notify", OwningSchema: "public", OwningTable: "rule_table1", Def: ruleDef2}
+			rule1 := backup.QuerySimpleDefinition{ClassID: backup.PG_REWRITE_OID, Oid: 0, Name: "double_insert", OwningSchema: "public", OwningTable: "rule_table1", Def: ruleDef1}
+			rule2 := backup.QuerySimpleDefinition{ClassID: backup.PG_REWRITE_OID, Oid: 1, Name: "update_notify", OwningSchema: "public", OwningTable: "rule_table1", Def: ruleDef2}
 
 			results := backup.GetRules(connectionPool)
 
@@ -229,7 +229,7 @@ PARTITION BY RANGE (date)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP RULE double_insert ON testschema.rule_table1")
 			backupCmdFlags.Set(utils.INCLUDE_SCHEMA, "public")
 
-			rule1 := backup.QuerySimpleDefinition{Classid: backup.PG_REWRITE_OID, Oid: 0, Name: "double_insert", OwningSchema: "public", OwningTable: "rule_table1", Def: ruleDef1}
+			rule1 := backup.QuerySimpleDefinition{ClassID: backup.PG_REWRITE_OID, Oid: 0, Name: "double_insert", OwningSchema: "public", OwningTable: "rule_table1", Def: ruleDef1}
 
 			results := backup.GetRules(connectionPool)
 
@@ -249,7 +249,7 @@ PARTITION BY RANGE (date)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP RULE double_insert ON testschema.rule_table1")
 			backupCmdFlags.Set(utils.INCLUDE_RELATION, "public.rule_table1")
 
-			rule1 := backup.QuerySimpleDefinition{Classid: backup.PG_REWRITE_OID, Oid: 0, Name: "double_insert", OwningSchema: "public", OwningTable: "rule_table1", Def: ruleDef1}
+			rule1 := backup.QuerySimpleDefinition{ClassID: backup.PG_REWRITE_OID, Oid: 0, Name: "double_insert", OwningSchema: "public", OwningTable: "rule_table1", Def: ruleDef1}
 
 			results := backup.GetRules(connectionPool)
 
@@ -274,8 +274,8 @@ PARTITION BY RANGE (date)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TRIGGER sync_trigger_table2 ON public.trigger_table2")
 			testhelper.AssertQueryRuns(connectionPool, "COMMENT ON TRIGGER sync_trigger_table2 ON public.trigger_table2 IS 'This is a trigger comment.'")
 
-			trigger1 := backup.QuerySimpleDefinition{Classid: backup.PG_TRIGGER_OID, Oid: 0, Name: "sync_trigger_table1", OwningSchema: "public", OwningTable: "trigger_table1", Def: `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}
-			trigger2 := backup.QuerySimpleDefinition{Classid: backup.PG_TRIGGER_OID, Oid: 1, Name: "sync_trigger_table2", OwningSchema: "public", OwningTable: "trigger_table2", Def: `CREATE TRIGGER sync_trigger_table2 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table2 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}
+			trigger1 := backup.QuerySimpleDefinition{ClassID: backup.PG_TRIGGER_OID, Oid: 0, Name: "sync_trigger_table1", OwningSchema: "public", OwningTable: "trigger_table1", Def: `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}
+			trigger2 := backup.QuerySimpleDefinition{ClassID: backup.PG_TRIGGER_OID, Oid: 1, Name: "sync_trigger_table2", OwningSchema: "public", OwningTable: "trigger_table2", Def: `CREATE TRIGGER sync_trigger_table2 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table2 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}
 
 			results := backup.GetTriggers(connectionPool)
 
@@ -307,7 +307,7 @@ PARTITION BY RANGE (date)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TRIGGER sync_trigger_table1 ON testschema.trigger_table1")
 			backupCmdFlags.Set(utils.INCLUDE_SCHEMA, "testschema")
 
-			trigger1 := backup.QuerySimpleDefinition{Classid: backup.PG_TRIGGER_OID, Oid: 0, Name: "sync_trigger_table1", OwningSchema: "testschema", OwningTable: "trigger_table1", Def: `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON testschema.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}
+			trigger1 := backup.QuerySimpleDefinition{ClassID: backup.PG_TRIGGER_OID, Oid: 0, Name: "sync_trigger_table1", OwningSchema: "testschema", OwningTable: "trigger_table1", Def: `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON testschema.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}
 
 			results := backup.GetTriggers(connectionPool)
 
@@ -327,7 +327,7 @@ PARTITION BY RANGE (date)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TRIGGER sync_trigger_table1 ON testschema.trigger_table1")
 			backupCmdFlags.Set(utils.INCLUDE_RELATION, "testschema.trigger_table1")
 
-			trigger1 := backup.QuerySimpleDefinition{Classid: backup.PG_TRIGGER_OID, Oid: 0, Name: "sync_trigger_table1", OwningSchema: "testschema", OwningTable: "trigger_table1", Def: `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON testschema.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}
+			trigger1 := backup.QuerySimpleDefinition{ClassID: backup.PG_TRIGGER_OID, Oid: 0, Name: "sync_trigger_table1", OwningSchema: "testschema", OwningTable: "trigger_table1", Def: `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON testschema.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`}
 
 			results := backup.GetTriggers(connectionPool)
 

--- a/integration/predata_operators_create_test.go
+++ b/integration/predata_operators_create_test.go
@@ -42,8 +42,8 @@ var _ = Describe("backup integration create statement tests", func() {
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP FUNCTION testschema.\"testFunc\" (path,path)")
 
 			operatorMetadataMap := testutils.DefaultMetadataMap("OPERATOR", false, false, true)
-			operatorMetadata := operatorMetadataMap[1]
 			operator := backup.Operator{Oid: 1, Schema: "testschema", Name: "##", Procedure: "testschema.\"testFunc\"", LeftArgType: "path", RightArgType: "path", CommutatorOp: "0", NegatorOp: "0", RestrictFunction: "-", JoinFunction: "-", CanHash: false, CanMerge: false}
+			operatorMetadata := operatorMetadataMap[operator.GetUniqueID()]
 			operators := []backup.Operator{operator}
 
 			backup.PrintCreateOperatorStatements(backupfile, toc, operators, operatorMetadataMap)
@@ -53,7 +53,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultOperators := backup.GetOperators(connectionPool)
 			Expect(resultOperators).To(HaveLen(1))
 			resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_OPERATOR)
-			resultMetadata := resultMetadataMap[resultOperators[0].Oid]
+			resultMetadata := resultMetadataMap[resultOperators[0].GetUniqueID()]
 			structmatcher.ExpectStructsToMatchExcluding(&operator, &resultOperators[0], "Oid")
 			structmatcher.ExpectStructsToMatchExcluding(&resultMetadata, &operatorMetadata, "Oid")
 		})
@@ -76,10 +76,10 @@ var _ = Describe("backup integration create statement tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&operatorFamily, &resultOperatorFamilies[0], "Oid")
 		})
 		It("creates operator family with owner and comment", func() {
-			operatorFamilyMetadataMap := testutils.DefaultMetadataMap("OPERATOR FAMILY", false, true, true)
-			operatorFamilyMetadata := operatorFamilyMetadataMap[1]
 			operatorFamily := backup.OperatorFamily{Oid: 1, Schema: "public", Name: "testfam", IndexMethod: "hash"}
 			operatorFamilies := []backup.OperatorFamily{operatorFamily}
+			operatorFamilyMetadataMap := testutils.DefaultMetadataMap("OPERATOR FAMILY", false, true, true)
+			operatorFamilyMetadata := operatorFamilyMetadataMap[operatorFamily.GetUniqueID()]
 
 			backup.PrintCreateOperatorFamilyStatements(backupfile, toc, operatorFamilies, operatorFamilyMetadataMap)
 
@@ -89,7 +89,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultOperatorFamilies := backup.GetOperatorFamilies(connectionPool)
 			Expect(resultOperatorFamilies).To(HaveLen(1))
 			resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_OPERATORFAMILY)
-			resultMetadata := resultMetadataMap[resultOperatorFamilies[0].Oid]
+			resultMetadata := resultMetadataMap[resultOperatorFamilies[0].GetUniqueID()]
 			structmatcher.ExpectStructsToMatchExcluding(&operatorFamily, &resultOperatorFamilies[0], "Oid")
 			structmatcher.ExpectStructsToMatchExcluding(&resultMetadata, &operatorFamilyMetadata, "Oid")
 		})
@@ -160,10 +160,9 @@ var _ = Describe("backup integration create statement tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&operatorClass, &resultOperatorClasses[0], "Oid", "Operators.ClassOid", "Functions.ClassOid")
 		})
 		It("creates basic operator class with a comment and owner", func() {
-			operatorClassMetadataMap := testutils.DefaultMetadataMap("OPERATOR CLASS", false, true, true)
-			operatorClassMetadata := operatorClassMetadataMap[1]
-
 			operatorClass := backup.OperatorClass{Oid: 1, Schema: "public", Name: "testclass", FamilySchema: "public", FamilyName: "testclass", IndexMethod: "hash", Type: "integer", Default: false, StorageType: "-", Operators: nil, Functions: nil}
+			operatorClassMetadataMap := testutils.DefaultMetadataMap("OPERATOR CLASS", false, true, true)
+			operatorClassMetadata := operatorClassMetadataMap[operatorClass.GetUniqueID()]
 			if connectionPool.Version.Before("5") { // Operator families do not exist prior to GPDB5
 				operatorClass.FamilySchema = ""
 				operatorClass.FamilyName = ""
@@ -183,7 +182,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&operatorClass, &resultOperatorClasses[0], "Oid")
 
 			resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_OPERATORCLASS)
-			resultMetadata := resultMetadataMap[resultOperatorClasses[0].Oid]
+			resultMetadata := resultMetadataMap[resultOperatorClasses[0].GetUniqueID()]
 			structmatcher.ExpectStructsToMatchExcluding(&resultMetadata, &operatorClassMetadata, "Oid")
 
 		})

--- a/integration/predata_relations_create_test.go
+++ b/integration/predata_relations_create_test.go
@@ -421,7 +421,7 @@ SET SUBPARTITION TEMPLATE  ` + `
 			}
 			sequenceDef.SequenceDefinition = backup.SequenceDefinition{Name: "my_sequence", LastVal: 1, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 1, StartVal: startValue}
 			sequenceMetadata := backup.ObjectMetadata{Privileges: []backup.ACL{testutils.DefaultACLWithout("testrole", "SEQUENCE", "UPDATE")}, Owner: "testrole", Comment: "This is a sequence comment."}
-			sequenceMetadataMap[backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: 1}] = sequenceMetadata
+			sequenceMetadataMap[backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: 1}] = sequenceMetadata
 			backup.PrintCreateSequenceStatements(backupfile, toc, []backup.Sequence{sequenceDef}, sequenceMetadataMap)
 			if connectionPool.Version.Before("5") {
 				sequenceDef.LogCnt = 1 // In GPDB 4.3, sequence log count is one-indexed

--- a/integration/predata_relations_create_test.go
+++ b/integration/predata_relations_create_test.go
@@ -285,7 +285,7 @@ SET SUBPARTITION TEMPLATE  ` + `
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 			testTableUniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "testtable", backup.TYPE_RELATION)
-			testTable.Oid = testutils.OidFromObjectName(connectionPool, "public", "testtable", backup.TYPE_RELATION)
+			testTable.Oid = testTableUniqueID.Oid
 
 			resultMetadata := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_RELATION)
 			resultTableMetadata := resultMetadata[testTableUniqueID]

--- a/integration/predata_relations_create_test.go
+++ b/integration/predata_relations_create_test.go
@@ -284,9 +284,12 @@ SET SUBPARTITION TEMPLATE  ` + `
 			backup.PrintPostCreateTableStatements(backupfile, testTable, tableDef, tableMetadata)
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
+			testTableUniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "testtable", backup.TYPE_RELATION)
 			testTable.Oid = testutils.OidFromObjectName(connectionPool, "public", "testtable", backup.TYPE_RELATION)
+
 			resultMetadata := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_RELATION)
-			resultTableMetadata := resultMetadata[testTable.Oid]
+			resultTableMetadata := resultMetadata[testTableUniqueID]
+
 			structmatcher.ExpectStructsToMatch(&tableMetadata, &resultTableMetadata)
 			resultTableDef := backup.ConstructDefinitionsForTables(connectionPool, []backup.Relation{testTable})[testTable.Oid]
 			structmatcher.ExpectStructsToMatchExcluding(&tableDef, &resultTableDef, "ColumnDefs.Oid", "ColumnDefs.ACL", "ExtTableDef")
@@ -298,11 +301,12 @@ SET SUBPARTITION TEMPLATE  ` + `
 			backup.PrintPostCreateTableStatements(backupfile, testTable, tableDef, tableMetadata)
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
+			testTableUniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "testtable", backup.TYPE_RELATION)
 			testTable.Oid = testutils.OidFromObjectName(connectionPool, "public", "testtable", backup.TYPE_RELATION)
 			resultTableDef := backup.ConstructDefinitionsForTables(connectionPool, []backup.Relation{testTable})[testTable.Oid]
 			structmatcher.ExpectStructsToMatchExcluding(&tableDef, &resultTableDef, "ColumnDefs.Oid", "ColumnDefs.ACL", "ExtTableDef")
 			resultMetadata := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_RELATION)
-			resultTableMetadata := resultMetadata[testTable.Oid]
+			resultTableMetadata := resultMetadata[testTableUniqueID]
 			structmatcher.ExpectStructsToMatch(&tableMetadata, &resultTableMetadata)
 		})
 		It("prints column level privileges", func() {
@@ -330,7 +334,7 @@ SET SUBPARTITION TEMPLATE  ` + `
 		})
 		It("creates a view with privileges and a comment and owner", func() {
 			view := backup.View{Oid: 1, Schema: "public", Name: "simpleview", Definition: viewDef}
-			viewMetadata := testutils.DefaultMetadataMap("VIEW", true, true, true)[1]
+			viewMetadata := testutils.DefaultMetadata("VIEW", true, true, true)
 
 			backup.PrintCreateViewStatement(backupfile, toc, view, viewMetadata)
 
@@ -342,7 +346,7 @@ SET SUBPARTITION TEMPLATE  ` + `
 
 			view.Oid = testutils.OidFromObjectName(connectionPool, "public", "simpleview", backup.TYPE_RELATION)
 			Expect(resultViews).To(HaveLen(1))
-			resultMetadata := resultMetadataMap[view.Oid]
+			resultMetadata := resultMetadataMap[view.GetUniqueID()]
 			structmatcher.ExpectStructsToMatch(&view, &resultViews[0])
 			structmatcher.ExpectStructsToMatch(&viewMetadata, &resultMetadata)
 		})
@@ -417,7 +421,7 @@ SET SUBPARTITION TEMPLATE  ` + `
 			}
 			sequenceDef.SequenceDefinition = backup.SequenceDefinition{Name: "my_sequence", LastVal: 1, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 1, StartVal: startValue}
 			sequenceMetadata := backup.ObjectMetadata{Privileges: []backup.ACL{testutils.DefaultACLWithout("testrole", "SEQUENCE", "UPDATE")}, Owner: "testrole", Comment: "This is a sequence comment."}
-			sequenceMetadataMap[1] = sequenceMetadata
+			sequenceMetadataMap[backup.UniqueID{Classid: backup.PG_CLASS_OID, Oid: 1}] = sequenceMetadata
 			backup.PrintCreateSequenceStatements(backupfile, toc, []backup.Sequence{sequenceDef}, sequenceMetadataMap)
 			if connectionPool.Version.Before("5") {
 				sequenceDef.LogCnt = 1 // In GPDB 4.3, sequence log count is one-indexed
@@ -430,8 +434,8 @@ SET SUBPARTITION TEMPLATE  ` + `
 
 			Expect(resultSequences).To(HaveLen(1))
 			resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_RELATION)
-			oid := testutils.OidFromObjectName(connectionPool, "public", "my_sequence", backup.TYPE_RELATION)
-			resultMetadata := resultMetadataMap[oid]
+			uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "my_sequence", backup.TYPE_RELATION)
+			resultMetadata := resultMetadataMap[uniqueID]
 			structmatcher.ExpectStructsToMatchExcluding(&sequence, &resultSequences[0].Relation, "SchemaOid", "Oid")
 			structmatcher.ExpectStructsToMatch(&sequenceDef.SequenceDefinition, &resultSequences[0].SequenceDefinition)
 			structmatcher.ExpectStructsToMatch(&sequenceMetadata, &resultMetadata)

--- a/integration/predata_shared_queries_test.go
+++ b/integration/predata_shared_queries_test.go
@@ -266,9 +266,9 @@ PARTITION BY RANGE (date)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_RELATION)
 
-				fooOid := testutils.OidFromObjectName(connectionPool, "public", "foo", backup.TYPE_RELATION)
-				barOid := testutils.OidFromObjectName(connectionPool, "public", "bar", backup.TYPE_RELATION)
-				bazOid := testutils.OidFromObjectName(connectionPool, "public", "baz", backup.TYPE_RELATION)
+				fooOid := testutils.UniqueIDFromObjectName(connectionPool, "public", "foo", backup.TYPE_RELATION)
+				barOid := testutils.UniqueIDFromObjectName(connectionPool, "public", "bar", backup.TYPE_RELATION)
+				bazOid := testutils.UniqueIDFromObjectName(connectionPool, "public", "baz", backup.TYPE_RELATION)
 				expectedFoo := backup.ObjectMetadata{Privileges: []backup.ACL{testutils.DefaultACLWithout("testrole", "TABLE", "DELETE")}, Owner: "testrole"}
 				expectedBar := backup.ObjectMetadata{Privileges: []backup.ACL{{Grantee: "GRANTEE"}}, Owner: "testrole"}
 				expectedBaz := backup.ObjectMetadata{Privileges: []backup.ACL{testutils.DefaultACLForType("anothertestrole", "TABLE"), testutils.DefaultACLForType("testrole", "TABLE")}, Owner: "testrole"}
@@ -291,7 +291,7 @@ PARTITION BY RANGE (date)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_DATABASE)
 
-				oid := testutils.OidFromObjectName(connectionPool, "", "testdb", backup.TYPE_DATABASE)
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "testdb", backup.TYPE_DATABASE)
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
@@ -304,7 +304,7 @@ PARTITION BY RANGE (date)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_RELATION)
 
-				oid := testutils.OidFromObjectName(connectionPool, "public", "testtable", backup.TYPE_RELATION)
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "testtable", backup.TYPE_RELATION)
 				expectedMetadata := backup.ObjectMetadata{Privileges: []backup.ACL{}, Owner: `"Role1"`}
 				Expect(resultMetadataMap).To(HaveLen(1))
 				resultMetadata := resultMetadataMap[oid]
@@ -318,8 +318,8 @@ PARTITION BY RANGE (date)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_RELATION)
 
-				oid := testutils.OidFromObjectName(connectionPool, "public", "testtable", backup.TYPE_RELATION)
-				expectedMetadata := testutils.DefaultMetadataMap("TABLE", true, true, true)[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "testtable", backup.TYPE_RELATION)
+				expectedMetadata := testutils.DefaultMetadata("TABLE", true, true, true)
 				Expect(resultMetadataMap).To(HaveLen(1))
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
@@ -332,8 +332,8 @@ PARTITION BY RANGE (date)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_RELATION)
 
-				oid := testutils.OidFromObjectName(connectionPool, "public", "testsequence", backup.TYPE_RELATION)
-				expectedMetadata := testutils.DefaultMetadataMap("SEQUENCE", true, true, true)[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "testsequence", backup.TYPE_RELATION)
+				expectedMetadata := testutils.DefaultMetadata("SEQUENCE", true, true, true)
 				Expect(resultMetadataMap).To(HaveLen(1))
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
@@ -349,8 +349,8 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_FUNCTION)
 
-				oid := testutils.OidFromObjectName(connectionPool, "public", "add", backup.TYPE_FUNCTION)
-				expectedMetadata := testutils.DefaultMetadataMap("FUNCTION", true, true, true)[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "add", backup.TYPE_FUNCTION)
+				expectedMetadata := testutils.DefaultMetadata("FUNCTION", true, true, true)
 				Expect(resultMetadataMap).To(HaveLen(1))
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
@@ -363,8 +363,8 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_RELATION)
 
-				oid := testutils.OidFromObjectName(connectionPool, "public", "testview", backup.TYPE_RELATION)
-				expectedMetadata := testutils.DefaultMetadataMap("VIEW", true, true, true)[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "testview", backup.TYPE_RELATION)
+				expectedMetadata := testutils.DefaultMetadata("VIEW", true, true, true)
 				Expect(resultMetadataMap).To(HaveLen(1))
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
@@ -377,8 +377,8 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_SCHEMA)
 
-				oid := testutils.OidFromObjectName(connectionPool, "", "testschema", backup.TYPE_SCHEMA)
-				expectedMetadata := testutils.DefaultMetadataMap("SCHEMA", true, true, true)[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "testschema", backup.TYPE_SCHEMA)
+				expectedMetadata := testutils.DefaultMetadata("SCHEMA", true, true, true)
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
@@ -412,8 +412,8 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_AGGREGATE)
 
-				oid := testutils.OidFromObjectName(connectionPool, "", "agg_prefunc", backup.TYPE_AGGREGATE)
-				expectedMetadata := testutils.DefaultMetadataMap("AGGREGATE", false, true, true)[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "agg_prefunc", backup.TYPE_AGGREGATE)
+				expectedMetadata := testutils.DefaultMetadata("AGGREGATE", false, true, true)
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
@@ -424,9 +424,9 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TYPE)
 
-				oid := testutils.OidFromObjectName(connectionPool, "", "testtype", backup.TYPE_TYPE)
-				expectedMetadata := testutils.DefaultMetadataMap("TYPE", false, true, true)[1]
-				resultMetadata := resultMetadataMap[oid]
+				typeUniqueID := testutils.UniqueIDFromObjectName(connectionPool, "", "testtype", backup.TYPE_TYPE)
+				expectedMetadata := testutils.DefaultMetadata("TYPE", false, true, true)
+				resultMetadata := resultMetadataMap[typeUniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a domain", func() {
@@ -436,8 +436,8 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TYPE)
 
-				oid := testutils.OidFromObjectName(connectionPool, "", "domain_type", backup.TYPE_TYPE)
-				expectedMetadata := testutils.DefaultMetadataMap("DOMAIN", false, true, true)[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "domain_type", backup.TYPE_TYPE)
+				expectedMetadata := testutils.DefaultMetadata("DOMAIN", false, true, true)
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
@@ -450,8 +450,8 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_PROTOCOL)
 
-				oid := testutils.OidFromObjectName(connectionPool, "", "s3_read", backup.TYPE_PROTOCOL)
-				expectedMetadata := testutils.DefaultMetadataMap("PROTOCOL", true, true, false)[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "s3_read", backup.TYPE_PROTOCOL)
+				expectedMetadata := testutils.DefaultMetadata("PROTOCOL", true, true, false)
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
@@ -467,8 +467,8 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TABLESPACE)
 
-				oid := testutils.OidFromObjectName(connectionPool, "", "test_tablespace", backup.TYPE_TABLESPACE)
-				expectedMetadata := testutils.DefaultMetadataMap("TABLESPACE", true, true, true)[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "test_tablespace", backup.TYPE_TABLESPACE)
+				expectedMetadata := testutils.DefaultMetadata("TABLESPACE", true, true, true)
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
@@ -480,8 +480,8 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_OPERATOR)
 
-				oid := testutils.OidFromObjectName(connectionPool, "", "####", backup.TYPE_OPERATOR)
-				expectedMetadata := testutils.DefaultMetadataMap("OPERATOR", false, true, true)[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "####", backup.TYPE_OPERATOR)
+				expectedMetadata := testutils.DefaultMetadata("OPERATOR", false, true, true)
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
@@ -494,8 +494,8 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_OPERATORFAMILY)
 
-				oid := testutils.OidFromObjectName(connectionPool, "public", "testfam", backup.TYPE_OPERATORFAMILY)
-				expectedMetadata := testutils.DefaultMetadataMap("OPERATOR FAMILY", false, true, true)[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "testfam", backup.TYPE_OPERATORFAMILY)
+				expectedMetadata := testutils.DefaultMetadata("OPERATOR FAMILY", false, true, true)
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
@@ -510,8 +510,8 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_OPERATORCLASS)
 
-				oid := testutils.OidFromObjectName(connectionPool, "public", "testclass", backup.TYPE_OPERATORCLASS)
-				expectedMetadata := testutils.DefaultMetadataMap("OPERATOR CLASS", false, true, true)[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "testclass", backup.TYPE_OPERATORCLASS)
+				expectedMetadata := testutils.DefaultMetadata("OPERATOR CLASS", false, true, true)
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
@@ -524,23 +524,21 @@ LANGUAGE SQL`)
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TSDICTIONARY)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
-				oid := testutils.OidFromObjectName(connectionPool, "public", "testdictionary", backup.TYPE_TSDICTIONARY)
-				dictionaryMetadataMap := testutils.DefaultMetadataMap("TEXT SEARCH DICTIONARY", false, true, true)
-				dictionaryMetadata := dictionaryMetadataMap[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "testdictionary", backup.TYPE_TSDICTIONARY)
+				dictionaryMetadata := testutils.DefaultMetadata("TEXT SEARCH DICTIONARY", false, true, true)
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatch(&dictionaryMetadata, &resultMetadata)
 			})
 			It("returns a slice of default metadata for a text search configuration", func() {
 				testutils.SkipIfBefore5(connectionPool)
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TSCONFIGURATION)
-				configurationMetadataMap := testutils.DefaultMetadataMap("TEXT SEARCH CONFIGURATION", false, true, true)
-				configurationMetadata := configurationMetadataMap[1]
+				configurationMetadata := testutils.DefaultMetadata("TEXT SEARCH CONFIGURATION", false, true, true)
 
 				testhelper.AssertQueryRuns(connectionPool, `CREATE TEXT SEARCH CONFIGURATION public.testconfiguration (PARSER = pg_catalog."default");`)
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP TEXT SEARCH CONFIGURATION public.testconfiguration")
 				testhelper.AssertQueryRuns(connectionPool, "COMMENT ON TEXT SEARCH CONFIGURATION public.testconfiguration IS 'This is a text search configuration comment.'")
 
-				oid := testutils.OidFromObjectName(connectionPool, "public", "testconfiguration", backup.TYPE_TSCONFIGURATION)
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "testconfiguration", backup.TYPE_TSCONFIGURATION)
 				resultMetadataMap = backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TSCONFIGURATION)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
@@ -556,8 +554,8 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_FOREIGNDATAWRAPPER)
 
-				oid := testutils.OidFromObjectName(connectionPool, "", "foreignwrapper", backup.TYPE_FOREIGNDATAWRAPPER)
-				expectedMetadata := testutils.DefaultMetadataMap("FOREIGN DATA WRAPPER", true, true, false)[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "foreignwrapper", backup.TYPE_FOREIGNDATAWRAPPER)
+				expectedMetadata := testutils.DefaultMetadata("FOREIGN DATA WRAPPER", true, true, false)
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
@@ -571,8 +569,8 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_FOREIGNSERVER)
 
-				oid := testutils.OidFromObjectName(connectionPool, "", "foreignserver", backup.TYPE_FOREIGNSERVER)
-				expectedMetadata := testutils.DefaultMetadataMap("FOREIGN SERVER", true, true, false)[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "foreignserver", backup.TYPE_FOREIGNSERVER)
+				expectedMetadata := testutils.DefaultMetadata("FOREIGN SERVER", true, true, false)
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
@@ -585,9 +583,8 @@ LANGUAGE SQL`)
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_COLLATION)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
-				oid := testutils.OidFromObjectName(connectionPool, "public", "some_coll", backup.TYPE_COLLATION)
-				collationMetadataMap := testutils.DefaultMetadataMap("COLLATION", false, true, true)
-				collationMetadata := collationMetadataMap[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "some_coll", backup.TYPE_COLLATION)
+				collationMetadata := testutils.DefaultMetadata("COLLATION", false, true, true)
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatch(&collationMetadata, &resultMetadata)
 			})
@@ -606,8 +603,8 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_RELATION)
 
-				oid := testutils.OidFromObjectName(connectionPool, "testschema", "testtable", backup.TYPE_RELATION)
-				expectedMetadata := testutils.DefaultMetadataMap("TABLE", true, true, true)[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testtable", backup.TYPE_RELATION)
+				expectedMetadata := testutils.DefaultMetadata("TABLE", true, true, true)
 				Expect(resultMetadataMap).To(HaveLen(1))
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
@@ -625,8 +622,8 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_RELATION)
 
-				oid := testutils.OidFromObjectName(connectionPool, "testschema", "testtable", backup.TYPE_RELATION)
-				expectedMetadata := testutils.DefaultMetadataMap("TABLE", true, true, true)[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testtable", backup.TYPE_RELATION)
+				expectedMetadata := testutils.DefaultMetadata("TABLE", true, true, true)
 				Expect(resultMetadataMap).To(HaveLen(1))
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
@@ -649,8 +646,8 @@ LANGUAGE SQL`)
 				backupCmdFlags.Set(utils.INCLUDE_SCHEMA, "testschema")
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_FUNCTION)
 
-				oid := testutils.OidFromObjectName(connectionPool, "testschema", "add", backup.TYPE_FUNCTION)
-				expectedMetadata := testutils.DefaultMetadataMap("FUNCTION", true, true, true)[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "add", backup.TYPE_FUNCTION)
+				expectedMetadata := testutils.DefaultMetadata("FUNCTION", true, true, true)
 				Expect(resultMetadataMap).To(HaveLen(1))
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
@@ -668,8 +665,8 @@ LANGUAGE SQL`)
 				backupCmdFlags.Set(utils.INCLUDE_SCHEMA, "testschema")
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_RELATION)
 
-				oid := testutils.OidFromObjectName(connectionPool, "testschema", "testview", backup.TYPE_RELATION)
-				expectedMetadata := testutils.DefaultMetadataMap("VIEW", true, true, true)[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testview", backup.TYPE_RELATION)
+				expectedMetadata := testutils.DefaultMetadata("VIEW", true, true, true)
 				Expect(resultMetadataMap).To(HaveLen(1))
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
@@ -715,8 +712,8 @@ LANGUAGE SQL`)
 				backupCmdFlags.Set(utils.INCLUDE_SCHEMA, "testschema")
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_AGGREGATE)
 
-				oid := testutils.OidFromObjectName(connectionPool, "testschema", "agg_prefunc", backup.TYPE_AGGREGATE)
-				expectedMetadata := testutils.DefaultMetadataMap("AGGREGATE", false, true, true)[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "agg_prefunc", backup.TYPE_AGGREGATE)
+				expectedMetadata := testutils.DefaultMetadata("AGGREGATE", false, true, true)
 				Expect(resultMetadataMap).To(HaveLen(1))
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
@@ -733,8 +730,8 @@ LANGUAGE SQL`)
 				backupCmdFlags.Set(utils.INCLUDE_SCHEMA, "testschema")
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TYPE)
 
-				oid := testutils.OidFromObjectName(connectionPool, "testschema", "testtype", backup.TYPE_TYPE)
-				expectedMetadata := testutils.DefaultMetadataMap("TYPE", false, true, true)[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testtype", backup.TYPE_TYPE)
+				expectedMetadata := testutils.DefaultMetadata("TYPE", false, true, true)
 				resultMetadata := resultMetadataMap[oid]
 				if connectionPool.Version.Before("5") {
 					// In 4.3, creating testtype does not generate a "_testtype" entry in pg_type
@@ -758,8 +755,8 @@ LANGUAGE SQL`)
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_OPERATOR)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
-				oid := testutils.OidFromObjectName(connectionPool, "testschema", "####", backup.TYPE_OPERATOR)
-				expectedMetadata := testutils.DefaultMetadataMap("OPERATOR", false, true, true)[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "####", backup.TYPE_OPERATOR)
+				expectedMetadata := testutils.DefaultMetadata("OPERATOR", false, true, true)
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
@@ -777,8 +774,8 @@ LANGUAGE SQL`)
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_OPERATORFAMILY)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
-				oid := testutils.OidFromObjectName(connectionPool, "testschema", "testfam", backup.TYPE_OPERATORFAMILY)
-				expectedMetadata := testutils.DefaultMetadataMap("OPERATOR FAMILY", false, true, true)[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testfam", backup.TYPE_OPERATORFAMILY)
+				expectedMetadata := testutils.DefaultMetadata("OPERATOR FAMILY", false, true, true)
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
@@ -803,8 +800,8 @@ LANGUAGE SQL`)
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_OPERATORCLASS)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
-				oid := testutils.OidFromObjectName(connectionPool, "testschema", "testclass", backup.TYPE_OPERATORCLASS)
-				expectedMetadata := testutils.DefaultMetadataMap("OPERATOR CLASS", false, true, true)[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testclass", backup.TYPE_OPERATORCLASS)
+				expectedMetadata := testutils.DefaultMetadata("OPERATOR CLASS", false, true, true)
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
@@ -822,17 +819,15 @@ LANGUAGE SQL`)
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TSDICTIONARY)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
-				oid := testutils.OidFromObjectName(connectionPool, "testschema", "testdictionary", backup.TYPE_TSDICTIONARY)
-				dictionaryMetadataMap := testutils.DefaultMetadataMap("TEXT SEARCH DICTIONARY", false, true, true)
-				dictionaryMetadata := dictionaryMetadataMap[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testdictionary", backup.TYPE_TSDICTIONARY)
+				dictionaryMetadata := testutils.DefaultMetadata("TEXT SEARCH DICTIONARY", false, true, true)
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatch(&dictionaryMetadata, &resultMetadata)
 			})
 			It("returns a slice of default metadata for a text search configuration in a specific schema", func() {
 				testutils.SkipIfBefore5(connectionPool)
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TSCONFIGURATION)
-				configurationMetadataMap := testutils.DefaultMetadataMap("TEXT SEARCH CONFIGURATION", false, true, true)
-				configurationMetadata := configurationMetadataMap[1]
+				configurationMetadata := testutils.DefaultMetadata("TEXT SEARCH CONFIGURATION", false, true, true)
 
 				testhelper.AssertQueryRuns(connectionPool, `CREATE TEXT SEARCH CONFIGURATION public.testconfiguration (PARSER = pg_catalog."default");`)
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP TEXT SEARCH CONFIGURATION public.testconfiguration")
@@ -846,7 +841,7 @@ LANGUAGE SQL`)
 				resultMetadataMap = backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TSCONFIGURATION)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
-				oid := testutils.OidFromObjectName(connectionPool, "testschema", "testconfiguration", backup.TYPE_TSCONFIGURATION)
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testconfiguration", backup.TYPE_TSCONFIGURATION)
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatch(&configurationMetadata, &resultMetadata)
 			})
@@ -864,9 +859,8 @@ LANGUAGE SQL`)
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_COLLATION)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
-				oid := testutils.OidFromObjectName(connectionPool, "testschema", "some_coll", backup.TYPE_COLLATION)
-				collationMetadataMap := testutils.DefaultMetadataMap("COLLATION", false, true, true)
-				collationMetadata := collationMetadataMap[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "some_coll", backup.TYPE_COLLATION)
+				collationMetadata := testutils.DefaultMetadata("COLLATION", false, true, true)
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatch(&collationMetadata, &resultMetadata)
 			})
@@ -885,9 +879,8 @@ LANGUAGE SQL`)
 
 				resultMetadataMap = backup.GetCommentsForObjectType(connectionPool, backup.TYPE_INDEX)
 
-				oid := testutils.OidFromObjectName(connectionPool, "", "testindex", backup.TYPE_INDEX)
-				expectedMetadataMap := testutils.DefaultMetadataMap("INDEX", false, false, true)
-				expectedMetadata := expectedMetadataMap[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "testindex", backup.TYPE_INDEX)
+				expectedMetadata := testutils.DefaultMetadata("INDEX", false, false, true)
 
 				Expect(resultMetadataMap).To(HaveLen(numIndexes + 1))
 				resultMetadata := resultMetadataMap[oid]
@@ -904,9 +897,8 @@ LANGUAGE SQL`)
 
 				resultMetadataMap = backup.GetCommentsForObjectType(connectionPool, backup.TYPE_RULE)
 
-				oid := testutils.OidFromObjectName(connectionPool, "", "update_notify", backup.TYPE_RULE)
-				expectedMetadataMap := testutils.DefaultMetadataMap("RULE", false, false, true)
-				expectedMetadata := expectedMetadataMap[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "update_notify", backup.TYPE_RULE)
+				expectedMetadata := testutils.DefaultMetadata("RULE", false, false, true)
 
 				Expect(resultMetadataMap).To(HaveLen(numRules + 1))
 				resultMetadata := resultMetadataMap[oid]
@@ -923,9 +915,8 @@ LANGUAGE SQL`)
 
 				resultMetadataMap = backup.GetCommentsForObjectType(connectionPool, backup.TYPE_TRIGGER)
 
-				oid := testutils.OidFromObjectName(connectionPool, "", "sync_testtable", backup.TYPE_TRIGGER)
-				expectedMetadataMap := testutils.DefaultMetadataMap("TRIGGER", false, false, true)
-				expectedMetadata := expectedMetadataMap[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "sync_testtable", backup.TYPE_TRIGGER)
+				expectedMetadata := testutils.DefaultMetadata("TRIGGER", false, false, true)
 
 				Expect(resultMetadataMap).To(HaveLen(numTriggers + 1))
 				resultMetadata := resultMetadataMap[oid]
@@ -946,11 +937,10 @@ LANGUAGE SQL`)
 				boolOid := testutils.OidFromObjectName(connectionPool, "", "bool", backup.TYPE_TYPE)
 				textOid := testutils.OidFromObjectName(connectionPool, "", "text", backup.TYPE_TYPE)
 				oid := testutils.OidFromCast(connectionPool, boolOid, textOid)
-				expectedMetadataMap := testutils.DefaultMetadataMap("CAST", false, false, true)
-				expectedMetadata := expectedMetadataMap[1]
+				expectedMetadata := testutils.DefaultMetadata("CAST", false, false, true)
 
 				Expect(resultMetadataMap).To(HaveLen(numCasts + 1))
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[backup.UniqueID{Classid: backup.PG_CAST_OID, Oid: oid}]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a cast in 5", func() {
@@ -968,11 +958,10 @@ LANGUAGE SQL`)
 				textOid := testutils.OidFromObjectName(connectionPool, "", "text", backup.TYPE_TYPE)
 				intOid := testutils.OidFromObjectName(connectionPool, "", "int4", backup.TYPE_TYPE)
 				oid := testutils.OidFromCast(connectionPool, textOid, intOid)
-				expectedMetadataMap := testutils.DefaultMetadataMap("CAST", false, false, true)
-				expectedMetadata := expectedMetadataMap[1]
+				expectedMetadata := testutils.DefaultMetadata("CAST", false, false, true)
 
 				Expect(resultMetadataMap).To(HaveLen(numCasts + 1))
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[backup.UniqueID{Classid: backup.PG_CAST_OID, Oid: oid}]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a resource queue", func() {
@@ -985,9 +974,8 @@ LANGUAGE SQL`)
 
 				resultMetadataMap = backup.GetCommentsForObjectType(connectionPool, backup.TYPE_RESOURCEQUEUE)
 
-				oid := testutils.OidFromObjectName(connectionPool, "", "res_queue", backup.TYPE_RESOURCEQUEUE)
-				expectedMetadataMap := testutils.DefaultMetadataMap("RESOURCE QUEUE", false, false, true)
-				expectedMetadata := expectedMetadataMap[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "res_queue", backup.TYPE_RESOURCEQUEUE)
+				expectedMetadata := testutils.DefaultMetadata("RESOURCE QUEUE", false, false, true)
 
 				Expect(resultMetadataMap).To(HaveLen(numResQueues + 1))
 				resultMetadata := resultMetadataMap[oid]
@@ -1003,9 +991,8 @@ LANGUAGE SQL`)
 
 				resultMetadataMap = backup.GetCommentsForObjectType(connectionPool, backup.TYPE_ROLE)
 
-				oid := testutils.OidFromObjectName(connectionPool, "", "testuser", backup.TYPE_ROLE)
-				expectedMetadataMap := testutils.DefaultMetadataMap("ROLE", false, false, true)
-				expectedMetadata := expectedMetadataMap[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "testuser", backup.TYPE_ROLE)
+				expectedMetadata := testutils.DefaultMetadata("ROLE", false, false, true)
 
 				Expect(resultMetadataMap).To(HaveLen(numRoles + 1))
 				resultMetadata := resultMetadataMap[oid]
@@ -1013,14 +1000,13 @@ LANGUAGE SQL`)
 			})
 			It("returns a slice of default metadata for a text search parser", func() {
 				testutils.SkipIfBefore5(connectionPool)
-				parserMetadataMap := testutils.DefaultMetadataMap("TEXT SEARCH PARSER", false, false, true)
-				parserMetadata := parserMetadataMap[1]
+				parserMetadata := testutils.DefaultMetadata("TEXT SEARCH PARSER", false, false, true)
 
 				testhelper.AssertQueryRuns(connectionPool, "CREATE TEXT SEARCH PARSER public.testparser(START = prsd_start, GETTOKEN = prsd_nexttoken, END = prsd_end, LEXTYPES = prsd_lextype);")
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP TEXT SEARCH PARSER public.testparser")
 				testhelper.AssertQueryRuns(connectionPool, "COMMENT ON TEXT SEARCH PARSER public.testparser IS 'This is a text search parser comment.'")
 
-				oid := testutils.OidFromObjectName(connectionPool, "public", "testparser", backup.TYPE_TSPARSER)
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "testparser", backup.TYPE_TSPARSER)
 				resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_TSPARSER)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
@@ -1029,14 +1015,13 @@ LANGUAGE SQL`)
 			})
 			It("returns a slice of default metadata for a text search template", func() {
 				testutils.SkipIfBefore5(connectionPool)
-				templateMetadataMap := testutils.DefaultMetadataMap("TEXT SEARCH TEMPLATE", false, false, true)
-				templateMetadata := templateMetadataMap[1]
+				templateMetadata := testutils.DefaultMetadata("TEXT SEARCH TEMPLATE", false, false, true)
 
 				testhelper.AssertQueryRuns(connectionPool, "CREATE TEXT SEARCH TEMPLATE public.testtemplate(LEXIZE = dsimple_lexize);")
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP TEXT SEARCH TEMPLATE public.testtemplate")
 				testhelper.AssertQueryRuns(connectionPool, "COMMENT ON TEXT SEARCH TEMPLATE public.testtemplate IS 'This is a text search template comment.'")
 
-				oid := testutils.OidFromObjectName(connectionPool, "public", "testtemplate", backup.TYPE_TSTEMPLATE)
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "testtemplate", backup.TYPE_TSTEMPLATE)
 				resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_TSTEMPLATE)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
@@ -1045,14 +1030,13 @@ LANGUAGE SQL`)
 			})
 			It("returns a slice of default metadata for an extension", func() {
 				testutils.SkipIfBefore5(connectionPool)
-				extensionMetadataMap := testutils.DefaultMetadataMap("EXTENSION", false, false, true)
-				extensionMetadata := extensionMetadataMap[1]
+				extensionMetadata := testutils.DefaultMetadata("EXTENSION", false, false, true)
 
 				testhelper.AssertQueryRuns(connectionPool, "CREATE EXTENSION plperl;")
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP EXTENSION plperl")
 				testhelper.AssertQueryRuns(connectionPool, "COMMENT ON EXTENSION plperl IS 'This is an extension comment.'")
 
-				oid := testutils.OidFromObjectName(connectionPool, "", "plperl", backup.TYPE_EXTENSION)
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "plperl", backup.TYPE_EXTENSION)
 				resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_EXTENSION)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
@@ -1076,9 +1060,8 @@ LANGUAGE SQL`)
 				backupCmdFlags.Set(utils.INCLUDE_SCHEMA, "testschema")
 				resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_INDEX)
 
-				oid := testutils.OidFromObjectName(connectionPool, "", "testindex1", backup.TYPE_INDEX)
-				expectedMetadataMap := testutils.DefaultMetadataMap("INDEX", false, false, true)
-				expectedMetadata := expectedMetadataMap[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "testindex1", backup.TYPE_INDEX)
+				expectedMetadata := testutils.DefaultMetadata("INDEX", false, false, true)
 
 				resultMetadata := resultMetadataMap[oid]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
@@ -1097,9 +1080,8 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_CONSTRAINT)
 
-				oid := testutils.OidFromObjectName(connectionPool, "testschema", "testtable_i_key", backup.TYPE_CONSTRAINT)
-				expectedMetadataMap := testutils.DefaultMetadataMap("CONSTRAINT", false, false, true)
-				expectedMetadata := expectedMetadataMap[1]
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testtable_i_key", backup.TYPE_CONSTRAINT)
+				expectedMetadata := testutils.DefaultMetadata("CONSTRAINT", false, false, true)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
 				resultMetadata := resultMetadataMap[oid]
@@ -1107,8 +1089,7 @@ LANGUAGE SQL`)
 			})
 			It("returns a slice of default metadata for a text search parser in a specific schema", func() {
 				testutils.SkipIfBefore5(connectionPool)
-				parserMetadataMap := testutils.DefaultMetadataMap("TEXT SEARCH PARSER", false, false, true)
-				parserMetadata := parserMetadataMap[1]
+				parserMetadata := testutils.DefaultMetadata("TEXT SEARCH PARSER", false, false, true)
 
 				testhelper.AssertQueryRuns(connectionPool, "CREATE TEXT SEARCH PARSER public.testparser(START = prsd_start, GETTOKEN = prsd_nexttoken, END = prsd_end, LEXTYPES = prsd_lextype);")
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP TEXT SEARCH PARSER public.testparser")
@@ -1118,7 +1099,7 @@ LANGUAGE SQL`)
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP TEXT SEARCH PARSER testschema.testparser")
 				testhelper.AssertQueryRuns(connectionPool, "COMMENT ON TEXT SEARCH PARSER testschema.testparser IS 'This is a text search parser comment.'")
 
-				oid := testutils.OidFromObjectName(connectionPool, "testschema", "testparser", backup.TYPE_TSPARSER)
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testparser", backup.TYPE_TSPARSER)
 				backupCmdFlags.Set(utils.INCLUDE_SCHEMA, "testschema")
 				resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_TSPARSER)
 
@@ -1128,8 +1109,7 @@ LANGUAGE SQL`)
 			})
 			It("returns a slice of default metadata for a text search template in a specific schema", func() {
 				testutils.SkipIfBefore5(connectionPool)
-				templateMetadataMap := testutils.DefaultMetadataMap("TEXT SEARCH TEMPLATE", false, false, true)
-				templateMetadata := templateMetadataMap[1]
+				templateMetadata := testutils.DefaultMetadata("TEXT SEARCH TEMPLATE", false, false, true)
 
 				testhelper.AssertQueryRuns(connectionPool, "CREATE TEXT SEARCH TEMPLATE public.testtemplate(LEXIZE = dsimple_lexize);")
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP TEXT SEARCH TEMPLATE public.testtemplate")
@@ -1139,7 +1119,7 @@ LANGUAGE SQL`)
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP TEXT SEARCH TEMPLATE testschema.testtemplate")
 				testhelper.AssertQueryRuns(connectionPool, "COMMENT ON TEXT SEARCH TEMPLATE testschema.testtemplate IS 'This is a text search template comment.'")
 
-				oid := testutils.OidFromObjectName(connectionPool, "testschema", "testtemplate", backup.TYPE_TSTEMPLATE)
+				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testtemplate", backup.TYPE_TSTEMPLATE)
 				backupCmdFlags.Set(utils.INCLUDE_SCHEMA, "testschema")
 				resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_TSTEMPLATE)
 

--- a/integration/predata_shared_queries_test.go
+++ b/integration/predata_shared_queries_test.go
@@ -266,16 +266,16 @@ PARTITION BY RANGE (date)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_RELATION)
 
-				fooOid := testutils.UniqueIDFromObjectName(connectionPool, "public", "foo", backup.TYPE_RELATION)
-				barOid := testutils.UniqueIDFromObjectName(connectionPool, "public", "bar", backup.TYPE_RELATION)
-				bazOid := testutils.UniqueIDFromObjectName(connectionPool, "public", "baz", backup.TYPE_RELATION)
+				fooUniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "foo", backup.TYPE_RELATION)
+				barUniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "bar", backup.TYPE_RELATION)
+				bazUniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "baz", backup.TYPE_RELATION)
 				expectedFoo := backup.ObjectMetadata{Privileges: []backup.ACL{testutils.DefaultACLWithout("testrole", "TABLE", "DELETE")}, Owner: "testrole"}
 				expectedBar := backup.ObjectMetadata{Privileges: []backup.ACL{{Grantee: "GRANTEE"}}, Owner: "testrole"}
 				expectedBaz := backup.ObjectMetadata{Privileges: []backup.ACL{testutils.DefaultACLForType("anothertestrole", "TABLE"), testutils.DefaultACLForType("testrole", "TABLE")}, Owner: "testrole"}
 				Expect(resultMetadataMap).To(HaveLen(3))
-				resultFoo := resultMetadataMap[fooOid]
-				resultBar := resultMetadataMap[barOid]
-				resultBaz := resultMetadataMap[bazOid]
+				resultFoo := resultMetadataMap[fooUniqueID]
+				resultBar := resultMetadataMap[barUniqueID]
+				resultBaz := resultMetadataMap[bazUniqueID]
 				structmatcher.ExpectStructsToMatch(&resultFoo, &expectedFoo)
 				structmatcher.ExpectStructsToMatch(&resultBar, &expectedBar)
 				structmatcher.ExpectStructsToMatch(&resultBaz, &expectedBaz)
@@ -291,8 +291,8 @@ PARTITION BY RANGE (date)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_DATABASE)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "testdb", backup.TYPE_DATABASE)
-				resultMetadata := resultMetadataMap[oid]
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "", "testdb", backup.TYPE_DATABASE)
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of metadata with the owner in quotes", func() {
@@ -304,10 +304,10 @@ PARTITION BY RANGE (date)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_RELATION)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "testtable", backup.TYPE_RELATION)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "testtable", backup.TYPE_RELATION)
 				expectedMetadata := backup.ObjectMetadata{Privileges: []backup.ACL{}, Owner: `"Role1"`}
 				Expect(resultMetadataMap).To(HaveLen(1))
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a table", func() {
@@ -318,10 +318,10 @@ PARTITION BY RANGE (date)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_RELATION)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "testtable", backup.TYPE_RELATION)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "testtable", backup.TYPE_RELATION)
 				expectedMetadata := testutils.DefaultMetadata("TABLE", true, true, true)
 				Expect(resultMetadataMap).To(HaveLen(1))
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a sequence", func() {
@@ -332,10 +332,10 @@ PARTITION BY RANGE (date)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_RELATION)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "testsequence", backup.TYPE_RELATION)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "testsequence", backup.TYPE_RELATION)
 				expectedMetadata := testutils.DefaultMetadata("SEQUENCE", true, true, true)
 				Expect(resultMetadataMap).To(HaveLen(1))
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a function", func() {
@@ -349,10 +349,10 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_FUNCTION)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "add", backup.TYPE_FUNCTION)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "add", backup.TYPE_FUNCTION)
 				expectedMetadata := testutils.DefaultMetadata("FUNCTION", true, true, true)
 				Expect(resultMetadataMap).To(HaveLen(1))
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a view", func() {
@@ -363,10 +363,10 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_RELATION)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "testview", backup.TYPE_RELATION)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "testview", backup.TYPE_RELATION)
 				expectedMetadata := testutils.DefaultMetadata("VIEW", true, true, true)
 				Expect(resultMetadataMap).To(HaveLen(1))
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a schema", func() {
@@ -377,9 +377,9 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_SCHEMA)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "testschema", backup.TYPE_SCHEMA)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "", "testschema", backup.TYPE_SCHEMA)
 				expectedMetadata := testutils.DefaultMetadata("SCHEMA", true, true, true)
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for an aggregate", func() {
@@ -412,9 +412,9 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_AGGREGATE)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "agg_prefunc", backup.TYPE_AGGREGATE)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "", "agg_prefunc", backup.TYPE_AGGREGATE)
 				expectedMetadata := testutils.DefaultMetadata("AGGREGATE", false, true, true)
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a type", func() {
@@ -436,9 +436,9 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TYPE)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "domain_type", backup.TYPE_TYPE)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "", "domain_type", backup.TYPE_TYPE)
 				expectedMetadata := testutils.DefaultMetadata("DOMAIN", false, true, true)
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for an external protocol", func() {
@@ -450,9 +450,9 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_PROTOCOL)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "s3_read", backup.TYPE_PROTOCOL)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "", "s3_read", backup.TYPE_PROTOCOL)
 				expectedMetadata := testutils.DefaultMetadata("PROTOCOL", true, true, false)
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a tablespace", func() {
@@ -467,9 +467,9 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TABLESPACE)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "test_tablespace", backup.TYPE_TABLESPACE)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "", "test_tablespace", backup.TYPE_TABLESPACE)
 				expectedMetadata := testutils.DefaultMetadata("TABLESPACE", true, true, true)
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for an operator", func() {
@@ -480,9 +480,9 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_OPERATOR)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "####", backup.TYPE_OPERATOR)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "", "####", backup.TYPE_OPERATOR)
 				expectedMetadata := testutils.DefaultMetadata("OPERATOR", false, true, true)
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for an operator family", func() {
@@ -494,9 +494,9 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_OPERATORFAMILY)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "testfam", backup.TYPE_OPERATORFAMILY)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "testfam", backup.TYPE_OPERATORFAMILY)
 				expectedMetadata := testutils.DefaultMetadata("OPERATOR FAMILY", false, true, true)
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for an operator class", func() {
@@ -510,9 +510,9 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_OPERATORCLASS)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "testclass", backup.TYPE_OPERATORCLASS)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "testclass", backup.TYPE_OPERATORCLASS)
 				expectedMetadata := testutils.DefaultMetadata("OPERATOR CLASS", false, true, true)
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a text search dictionary", func() {
@@ -524,9 +524,9 @@ LANGUAGE SQL`)
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TSDICTIONARY)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "testdictionary", backup.TYPE_TSDICTIONARY)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "testdictionary", backup.TYPE_TSDICTIONARY)
 				dictionaryMetadata := testutils.DefaultMetadata("TEXT SEARCH DICTIONARY", false, true, true)
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatch(&dictionaryMetadata, &resultMetadata)
 			})
 			It("returns a slice of default metadata for a text search configuration", func() {
@@ -538,11 +538,11 @@ LANGUAGE SQL`)
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP TEXT SEARCH CONFIGURATION public.testconfiguration")
 				testhelper.AssertQueryRuns(connectionPool, "COMMENT ON TEXT SEARCH CONFIGURATION public.testconfiguration IS 'This is a text search configuration comment.'")
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "testconfiguration", backup.TYPE_TSCONFIGURATION)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "testconfiguration", backup.TYPE_TSCONFIGURATION)
 				resultMetadataMap = backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TSCONFIGURATION)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatch(&configurationMetadata, &resultMetadata)
 			})
 			It("returns a slice of default metadata for a foreign data wrapper", func() {
@@ -554,9 +554,9 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_FOREIGNDATAWRAPPER)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "foreignwrapper", backup.TYPE_FOREIGNDATAWRAPPER)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "", "foreignwrapper", backup.TYPE_FOREIGNDATAWRAPPER)
 				expectedMetadata := testutils.DefaultMetadata("FOREIGN DATA WRAPPER", true, true, false)
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a foreign server", func() {
@@ -569,9 +569,9 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_FOREIGNSERVER)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "foreignserver", backup.TYPE_FOREIGNSERVER)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "", "foreignserver", backup.TYPE_FOREIGNSERVER)
 				expectedMetadata := testutils.DefaultMetadata("FOREIGN SERVER", true, true, false)
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a collation", func() {
@@ -583,9 +583,9 @@ LANGUAGE SQL`)
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_COLLATION)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "some_coll", backup.TYPE_COLLATION)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "some_coll", backup.TYPE_COLLATION)
 				collationMetadata := testutils.DefaultMetadata("COLLATION", false, true, true)
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatch(&collationMetadata, &resultMetadata)
 			})
 		})
@@ -603,10 +603,10 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_RELATION)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testtable", backup.TYPE_RELATION)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testtable", backup.TYPE_RELATION)
 				expectedMetadata := testutils.DefaultMetadata("TABLE", true, true, true)
 				Expect(resultMetadataMap).To(HaveLen(1))
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a table not in a specific schema", func() {
@@ -622,10 +622,10 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_RELATION)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testtable", backup.TYPE_RELATION)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testtable", backup.TYPE_RELATION)
 				expectedMetadata := testutils.DefaultMetadata("TABLE", true, true, true)
 				Expect(resultMetadataMap).To(HaveLen(1))
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a function in a specific schema", func() {
@@ -646,10 +646,10 @@ LANGUAGE SQL`)
 				backupCmdFlags.Set(utils.INCLUDE_SCHEMA, "testschema")
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_FUNCTION)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "add", backup.TYPE_FUNCTION)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "add", backup.TYPE_FUNCTION)
 				expectedMetadata := testutils.DefaultMetadata("FUNCTION", true, true, true)
 				Expect(resultMetadataMap).To(HaveLen(1))
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a view in a specific schema", func() {
@@ -665,10 +665,10 @@ LANGUAGE SQL`)
 				backupCmdFlags.Set(utils.INCLUDE_SCHEMA, "testschema")
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_RELATION)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testview", backup.TYPE_RELATION)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testview", backup.TYPE_RELATION)
 				expectedMetadata := testutils.DefaultMetadata("VIEW", true, true, true)
 				Expect(resultMetadataMap).To(HaveLen(1))
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for an aggregate in a specific schema", func() {
@@ -712,10 +712,10 @@ LANGUAGE SQL`)
 				backupCmdFlags.Set(utils.INCLUDE_SCHEMA, "testschema")
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_AGGREGATE)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "agg_prefunc", backup.TYPE_AGGREGATE)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "agg_prefunc", backup.TYPE_AGGREGATE)
 				expectedMetadata := testutils.DefaultMetadata("AGGREGATE", false, true, true)
 				Expect(resultMetadataMap).To(HaveLen(1))
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a type in a specific schema", func() {
@@ -730,9 +730,9 @@ LANGUAGE SQL`)
 				backupCmdFlags.Set(utils.INCLUDE_SCHEMA, "testschema")
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TYPE)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testtype", backup.TYPE_TYPE)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testtype", backup.TYPE_TYPE)
 				expectedMetadata := testutils.DefaultMetadata("TYPE", false, true, true)
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				if connectionPool.Version.Before("5") {
 					// In 4.3, creating testtype does not generate a "_testtype" entry in pg_type
 					Expect(resultMetadataMap).To(HaveLen(1))
@@ -755,9 +755,9 @@ LANGUAGE SQL`)
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_OPERATOR)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "####", backup.TYPE_OPERATOR)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "####", backup.TYPE_OPERATOR)
 				expectedMetadata := testutils.DefaultMetadata("OPERATOR", false, true, true)
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for an operator family in a specific schema", func() {
@@ -774,9 +774,9 @@ LANGUAGE SQL`)
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_OPERATORFAMILY)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testfam", backup.TYPE_OPERATORFAMILY)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testfam", backup.TYPE_OPERATORFAMILY)
 				expectedMetadata := testutils.DefaultMetadata("OPERATOR FAMILY", false, true, true)
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for an operator class in a specific schema", func() {
@@ -800,9 +800,9 @@ LANGUAGE SQL`)
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_OPERATORCLASS)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testclass", backup.TYPE_OPERATORCLASS)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testclass", backup.TYPE_OPERATORCLASS)
 				expectedMetadata := testutils.DefaultMetadata("OPERATOR CLASS", false, true, true)
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a text search dictionary in a specific schema", func() {
@@ -819,9 +819,9 @@ LANGUAGE SQL`)
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TSDICTIONARY)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testdictionary", backup.TYPE_TSDICTIONARY)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testdictionary", backup.TYPE_TSDICTIONARY)
 				dictionaryMetadata := testutils.DefaultMetadata("TEXT SEARCH DICTIONARY", false, true, true)
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatch(&dictionaryMetadata, &resultMetadata)
 			})
 			It("returns a slice of default metadata for a text search configuration in a specific schema", func() {
@@ -841,8 +841,8 @@ LANGUAGE SQL`)
 				resultMetadataMap = backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TSCONFIGURATION)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testconfiguration", backup.TYPE_TSCONFIGURATION)
-				resultMetadata := resultMetadataMap[oid]
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testconfiguration", backup.TYPE_TSCONFIGURATION)
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatch(&configurationMetadata, &resultMetadata)
 			})
 			It("returns a slice of default metadata for a collation in a specific schema", func() {
@@ -859,9 +859,9 @@ LANGUAGE SQL`)
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_COLLATION)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "some_coll", backup.TYPE_COLLATION)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "some_coll", backup.TYPE_COLLATION)
 				collationMetadata := testutils.DefaultMetadata("COLLATION", false, true, true)
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatch(&collationMetadata, &resultMetadata)
 			})
 		})
@@ -879,11 +879,11 @@ LANGUAGE SQL`)
 
 				resultMetadataMap = backup.GetCommentsForObjectType(connectionPool, backup.TYPE_INDEX)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "testindex", backup.TYPE_INDEX)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "", "testindex", backup.TYPE_INDEX)
 				expectedMetadata := testutils.DefaultMetadata("INDEX", false, false, true)
 
 				Expect(resultMetadataMap).To(HaveLen(numIndexes + 1))
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a rule", func() {
@@ -897,11 +897,11 @@ LANGUAGE SQL`)
 
 				resultMetadataMap = backup.GetCommentsForObjectType(connectionPool, backup.TYPE_RULE)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "update_notify", backup.TYPE_RULE)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "", "update_notify", backup.TYPE_RULE)
 				expectedMetadata := testutils.DefaultMetadata("RULE", false, false, true)
 
 				Expect(resultMetadataMap).To(HaveLen(numRules + 1))
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a trigger", func() {
@@ -915,11 +915,11 @@ LANGUAGE SQL`)
 
 				resultMetadataMap = backup.GetCommentsForObjectType(connectionPool, backup.TYPE_TRIGGER)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "sync_testtable", backup.TYPE_TRIGGER)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "", "sync_testtable", backup.TYPE_TRIGGER)
 				expectedMetadata := testutils.DefaultMetadata("TRIGGER", false, false, true)
 
 				Expect(resultMetadataMap).To(HaveLen(numTriggers + 1))
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a cast in 4.3", func() {
@@ -974,11 +974,11 @@ LANGUAGE SQL`)
 
 				resultMetadataMap = backup.GetCommentsForObjectType(connectionPool, backup.TYPE_RESOURCEQUEUE)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "res_queue", backup.TYPE_RESOURCEQUEUE)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "", "res_queue", backup.TYPE_RESOURCEQUEUE)
 				expectedMetadata := testutils.DefaultMetadata("RESOURCE QUEUE", false, false, true)
 
 				Expect(resultMetadataMap).To(HaveLen(numResQueues + 1))
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a role", func() {
@@ -991,11 +991,11 @@ LANGUAGE SQL`)
 
 				resultMetadataMap = backup.GetCommentsForObjectType(connectionPool, backup.TYPE_ROLE)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "testuser", backup.TYPE_ROLE)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "", "testuser", backup.TYPE_ROLE)
 				expectedMetadata := testutils.DefaultMetadata("ROLE", false, false, true)
 
 				Expect(resultMetadataMap).To(HaveLen(numRoles + 1))
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a text search parser", func() {
@@ -1006,11 +1006,11 @@ LANGUAGE SQL`)
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP TEXT SEARCH PARSER public.testparser")
 				testhelper.AssertQueryRuns(connectionPool, "COMMENT ON TEXT SEARCH PARSER public.testparser IS 'This is a text search parser comment.'")
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "testparser", backup.TYPE_TSPARSER)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "testparser", backup.TYPE_TSPARSER)
 				resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_TSPARSER)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatch(&parserMetadata, &resultMetadata)
 			})
 			It("returns a slice of default metadata for a text search template", func() {
@@ -1021,11 +1021,11 @@ LANGUAGE SQL`)
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP TEXT SEARCH TEMPLATE public.testtemplate")
 				testhelper.AssertQueryRuns(connectionPool, "COMMENT ON TEXT SEARCH TEMPLATE public.testtemplate IS 'This is a text search template comment.'")
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "testtemplate", backup.TYPE_TSTEMPLATE)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "testtemplate", backup.TYPE_TSTEMPLATE)
 				resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_TSTEMPLATE)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatch(&templateMetadata, &resultMetadata)
 			})
 			It("returns a slice of default metadata for an extension", func() {
@@ -1036,11 +1036,11 @@ LANGUAGE SQL`)
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP EXTENSION plperl")
 				testhelper.AssertQueryRuns(connectionPool, "COMMENT ON EXTENSION plperl IS 'This is an extension comment.'")
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "plperl", backup.TYPE_EXTENSION)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "", "plperl", backup.TYPE_EXTENSION)
 				resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_EXTENSION)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatch(&extensionMetadata, &resultMetadata)
 			})
 		})
@@ -1060,10 +1060,10 @@ LANGUAGE SQL`)
 				backupCmdFlags.Set(utils.INCLUDE_SCHEMA, "testschema")
 				resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_INDEX)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "", "testindex1", backup.TYPE_INDEX)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "", "testindex1", backup.TYPE_INDEX)
 				expectedMetadata := testutils.DefaultMetadata("INDEX", false, false, true)
 
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a constraint in a specific schema", func() {
@@ -1080,11 +1080,11 @@ LANGUAGE SQL`)
 
 				resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_CONSTRAINT)
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testtable_i_key", backup.TYPE_CONSTRAINT)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testtable_i_key", backup.TYPE_CONSTRAINT)
 				expectedMetadata := testutils.DefaultMetadata("CONSTRAINT", false, false, true)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a text search parser in a specific schema", func() {
@@ -1099,12 +1099,12 @@ LANGUAGE SQL`)
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP TEXT SEARCH PARSER testschema.testparser")
 				testhelper.AssertQueryRuns(connectionPool, "COMMENT ON TEXT SEARCH PARSER testschema.testparser IS 'This is a text search parser comment.'")
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testparser", backup.TYPE_TSPARSER)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testparser", backup.TYPE_TSPARSER)
 				backupCmdFlags.Set(utils.INCLUDE_SCHEMA, "testschema")
 				resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_TSPARSER)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatch(&parserMetadata, &resultMetadata)
 			})
 			It("returns a slice of default metadata for a text search template in a specific schema", func() {
@@ -1119,12 +1119,12 @@ LANGUAGE SQL`)
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP TEXT SEARCH TEMPLATE testschema.testtemplate")
 				testhelper.AssertQueryRuns(connectionPool, "COMMENT ON TEXT SEARCH TEMPLATE testschema.testtemplate IS 'This is a text search template comment.'")
 
-				oid := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testtemplate", backup.TYPE_TSTEMPLATE)
+				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "testschema", "testtemplate", backup.TYPE_TSTEMPLATE)
 				backupCmdFlags.Set(utils.INCLUDE_SCHEMA, "testschema")
 				resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_TSTEMPLATE)
 
 				Expect(resultMetadataMap).To(HaveLen(1))
-				resultMetadata := resultMetadataMap[oid]
+				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatch(&templateMetadata, &resultMetadata)
 			})
 		})

--- a/integration/predata_shared_queries_test.go
+++ b/integration/predata_shared_queries_test.go
@@ -940,7 +940,7 @@ LANGUAGE SQL`)
 				expectedMetadata := testutils.DefaultMetadata("CAST", false, false, true)
 
 				Expect(resultMetadataMap).To(HaveLen(numCasts + 1))
-				resultMetadata := resultMetadataMap[backup.UniqueID{Classid: backup.PG_CAST_OID, Oid: oid}]
+				resultMetadata := resultMetadataMap[backup.UniqueID{ClassID: backup.PG_CAST_OID, Oid: oid}]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a cast in 5", func() {
@@ -961,7 +961,7 @@ LANGUAGE SQL`)
 				expectedMetadata := testutils.DefaultMetadata("CAST", false, false, true)
 
 				Expect(resultMetadataMap).To(HaveLen(numCasts + 1))
-				resultMetadata := resultMetadataMap[backup.UniqueID{Classid: backup.PG_CAST_OID, Oid: oid}]
+				resultMetadata := resultMetadataMap[backup.UniqueID{ClassID: backup.PG_CAST_OID, Oid: oid}]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a resource queue", func() {

--- a/integration/predata_textsearch_create_test.go
+++ b/integration/predata_textsearch_create_test.go
@@ -129,7 +129,7 @@ var _ = Describe("backup integration create statement tests", func() {
 		It("creates a basic text search configuration with a comment and owner", func() {
 			configurations := []backup.TextSearchConfiguration{{Oid: 1, Schema: "public", Name: "testconfiguration", Parser: `pg_catalog."default"`, TokenToDicts: map[string][]string{}}}
 			configurationMetadataMap := testutils.DefaultMetadataMap("TEXT SEARCH CONFIGURATION", false, true, true)
-			configurationMetadata := configurationMetadataMap[backup.UniqueID{Classid: backup.PG_TS_CONFIG_OID, Oid: 1}]
+			configurationMetadata := configurationMetadataMap[backup.UniqueID{ClassID: backup.PG_TS_CONFIG_OID, Oid: 1}]
 
 			backup.PrintCreateTextSearchConfigurationStatements(backupfile, toc, configurations, configurationMetadataMap)
 

--- a/integration/predata_textsearch_create_test.go
+++ b/integration/predata_textsearch_create_test.go
@@ -31,7 +31,7 @@ var _ = Describe("backup integration create statement tests", func() {
 		It("creates a basic text search parser with a comment", func() {
 			parsers := []backup.TextSearchParser{{Oid: 1, Schema: "public", Name: "testparser", StartFunc: "prsd_start", TokenFunc: "prsd_nexttoken", EndFunc: "prsd_end", LexTypesFunc: "prsd_lextype", HeadlineFunc: "prsd_headline"}}
 			parserMetadataMap := testutils.DefaultMetadataMap("TEXT SEARCH PARSER", false, false, true)
-			parserMetadata := parserMetadataMap[1]
+			parserMetadata := parserMetadataMap[parsers[0].GetUniqueID()]
 
 			backup.PrintCreateTextSearchParserStatements(backupfile, toc, parsers, parserMetadataMap)
 
@@ -42,8 +42,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_TSPARSER)
 
 			Expect(resultParsers).To(HaveLen(1))
-			oid := testutils.OidFromObjectName(connectionPool, "public", "testparser", backup.TYPE_TSPARSER)
-			resultMetadata := resultMetadataMap[oid]
+			resultMetadata := resultMetadataMap[resultParsers[0].GetUniqueID()]
 			structmatcher.ExpectStructsToMatchExcluding(&parsers[0], &resultParsers[0], "Oid")
 			structmatcher.ExpectStructsToMatch(&parserMetadata, &resultMetadata)
 		})
@@ -64,7 +63,7 @@ var _ = Describe("backup integration create statement tests", func() {
 		It("creates a basic text search template with a comment", func() {
 			templates := []backup.TextSearchTemplate{{Oid: 1, Schema: "public", Name: "testtemplate", InitFunc: "dsimple_init", LexizeFunc: "dsimple_lexize"}}
 			templateMetadataMap := testutils.DefaultMetadataMap("TEXT SEARCH TEMPLATE", false, false, true)
-			templateMetadata := templateMetadataMap[1]
+			templateMetadata := templateMetadataMap[backup.UniqueID{Oid: 1}]
 
 			backup.PrintCreateTextSearchTemplateStatements(backupfile, toc, templates, templateMetadataMap)
 
@@ -75,8 +74,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_TSTEMPLATE)
 
 			Expect(resultTemplates).To(HaveLen(1))
-			oid := testutils.OidFromObjectName(connectionPool, "public", "testtemplate", backup.TYPE_TSTEMPLATE)
-			resultMetadata := resultMetadataMap[oid]
+			resultMetadata := resultMetadataMap[templates[0].GetUniqueID()]
 			structmatcher.ExpectStructsToMatchExcluding(&templates[0], &resultTemplates[0], "Oid")
 			structmatcher.ExpectStructsToMatch(&templateMetadata, &resultMetadata)
 		})
@@ -98,7 +96,7 @@ var _ = Describe("backup integration create statement tests", func() {
 		It("creates a basic text search dictionary with a comment and owner", func() {
 			dictionaries := []backup.TextSearchDictionary{{Oid: 1, Schema: "public", Name: "testdictionary", Template: "pg_catalog.snowball", InitOption: "language = 'russian', stopwords = 'russian'"}}
 			dictionaryMetadataMap := testutils.DefaultMetadataMap("TEXT SEARCH DICTIONARY", false, true, true)
-			dictionaryMetadata := dictionaryMetadataMap[1]
+			dictionaryMetadata := dictionaryMetadataMap[backup.UniqueID{Oid: 1}]
 
 			backup.PrintCreateTextSearchDictionaryStatements(backupfile, toc, dictionaries, dictionaryMetadataMap)
 
@@ -109,8 +107,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TSDICTIONARY)
 
 			Expect(resultDictionaries).To(HaveLen(1))
-			oid := testutils.OidFromObjectName(connectionPool, "public", "testdictionary", backup.TYPE_TSDICTIONARY)
-			resultMetadata := resultMetadataMap[oid]
+			resultMetadata := resultMetadataMap[dictionaries[0].GetUniqueID()]
 			structmatcher.ExpectStructsToMatchExcluding(&dictionaries[0], &resultDictionaries[0], "Oid")
 			structmatcher.ExpectStructsToMatch(&dictionaryMetadata, &resultMetadata)
 		})
@@ -132,7 +129,7 @@ var _ = Describe("backup integration create statement tests", func() {
 		It("creates a basic text search configuration with a comment and owner", func() {
 			configurations := []backup.TextSearchConfiguration{{Oid: 1, Schema: "public", Name: "testconfiguration", Parser: `pg_catalog."default"`, TokenToDicts: map[string][]string{}}}
 			configurationMetadataMap := testutils.DefaultMetadataMap("TEXT SEARCH CONFIGURATION", false, true, true)
-			configurationMetadata := configurationMetadataMap[1]
+			configurationMetadata := configurationMetadataMap[backup.UniqueID{Classid: backup.PG_TS_CONFIG_OID, Oid: 1}]
 
 			backup.PrintCreateTextSearchConfigurationStatements(backupfile, toc, configurations, configurationMetadataMap)
 
@@ -143,8 +140,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TSCONFIGURATION)
 
 			Expect(resultConfigurations).To(HaveLen(1))
-			oid := testutils.OidFromObjectName(connectionPool, "public", "testconfiguration", backup.TYPE_TSCONFIGURATION)
-			resultMetadata := resultMetadataMap[oid]
+			resultMetadata := resultMetadataMap[resultConfigurations[0].GetUniqueID()]
 			structmatcher.ExpectStructsToMatchExcluding(&configurations[0], &resultConfigurations[0], "Oid")
 			structmatcher.ExpectStructsToMatch(&configurationMetadata, &resultMetadata)
 		})

--- a/integration/predata_textsearch_create_test.go
+++ b/integration/predata_textsearch_create_test.go
@@ -16,9 +16,9 @@ var _ = Describe("backup integration create statement tests", func() {
 		toc, backupfile = testutils.InitializeTestTOC(buffer, "predata")
 	})
 	Describe("PrintCreateTextSearchParserStatements", func() {
+		parser := backup.TextSearchParser{Oid: 0, Schema: "public", Name: "testparser", StartFunc: "prsd_start", TokenFunc: "prsd_nexttoken", EndFunc: "prsd_end", LexTypesFunc: "prsd_lextype", HeadlineFunc: "prsd_headline"}
 		It("creates a basic text search parser", func() {
-			parsers := []backup.TextSearchParser{{Oid: 0, Schema: "public", Name: "testparser", StartFunc: "prsd_start", TokenFunc: "prsd_nexttoken", EndFunc: "prsd_end", LexTypesFunc: "prsd_lextype", HeadlineFunc: "prsd_headline"}}
-			backup.PrintCreateTextSearchParserStatements(backupfile, toc, parsers, backup.MetadataMap{})
+			backup.PrintCreateTextSearchParserStatements(backupfile, toc, []backup.TextSearchParser{parser}, backup.MetadataMap{})
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TEXT SEARCH PARSER public.testparser")
@@ -26,14 +26,13 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultParsers := backup.GetTextSearchParsers(connectionPool)
 
 			Expect(resultParsers).To(HaveLen(1))
-			structmatcher.ExpectStructsToMatchExcluding(&parsers[0], &resultParsers[0], "Oid")
+			structmatcher.ExpectStructsToMatchExcluding(&parser, &resultParsers[0], "Oid")
 		})
 		It("creates a basic text search parser with a comment", func() {
-			parsers := []backup.TextSearchParser{{Oid: 1, Schema: "public", Name: "testparser", StartFunc: "prsd_start", TokenFunc: "prsd_nexttoken", EndFunc: "prsd_end", LexTypesFunc: "prsd_lextype", HeadlineFunc: "prsd_headline"}}
 			parserMetadataMap := testutils.DefaultMetadataMap("TEXT SEARCH PARSER", false, false, true)
-			parserMetadata := parserMetadataMap[parsers[0].GetUniqueID()]
+			parserMetadata := parserMetadataMap[parser.GetUniqueID()]
 
-			backup.PrintCreateTextSearchParserStatements(backupfile, toc, parsers, parserMetadataMap)
+			backup.PrintCreateTextSearchParserStatements(backupfile, toc, []backup.TextSearchParser{parser}, parserMetadataMap)
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TEXT SEARCH PARSER public.testparser")
@@ -42,15 +41,16 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_TSPARSER)
 
 			Expect(resultParsers).To(HaveLen(1))
-			resultMetadata := resultMetadataMap[resultParsers[0].GetUniqueID()]
-			structmatcher.ExpectStructsToMatchExcluding(&parsers[0], &resultParsers[0], "Oid")
+			uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "testparser", backup.TYPE_TSPARSER)
+			resultMetadata := resultMetadataMap[uniqueID]
+			structmatcher.ExpectStructsToMatchExcluding(&parser, &resultParsers[0], "Oid")
 			structmatcher.ExpectStructsToMatch(&parserMetadata, &resultMetadata)
 		})
 	})
 	Describe("PrintCreateTextSearchTemplateStatements", func() {
+		template := backup.TextSearchTemplate{Oid: 1, Schema: "public", Name: "testtemplate", InitFunc: "dsimple_init", LexizeFunc: "dsimple_lexize"}
 		It("creates a basic text search template", func() {
-			templates := []backup.TextSearchTemplate{{Oid: 0, Schema: "public", Name: "testtemplate", InitFunc: "dsimple_init", LexizeFunc: "dsimple_lexize"}}
-			backup.PrintCreateTextSearchTemplateStatements(backupfile, toc, templates, backup.MetadataMap{})
+			backup.PrintCreateTextSearchTemplateStatements(backupfile, toc, []backup.TextSearchTemplate{template}, backup.MetadataMap{})
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TEXT SEARCH TEMPLATE public.testtemplate")
@@ -58,14 +58,13 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultTemplates := backup.GetTextSearchTemplates(connectionPool)
 
 			Expect(resultTemplates).To(HaveLen(1))
-			structmatcher.ExpectStructsToMatchExcluding(&templates[0], &resultTemplates[0], "Oid")
+			structmatcher.ExpectStructsToMatchExcluding(&template, &resultTemplates[0], "Oid")
 		})
 		It("creates a basic text search template with a comment", func() {
-			templates := []backup.TextSearchTemplate{{Oid: 1, Schema: "public", Name: "testtemplate", InitFunc: "dsimple_init", LexizeFunc: "dsimple_lexize"}}
 			templateMetadataMap := testutils.DefaultMetadataMap("TEXT SEARCH TEMPLATE", false, false, true)
-			templateMetadata := templateMetadataMap[backup.UniqueID{Oid: 1}]
+			templateMetadata := templateMetadataMap[template.GetUniqueID()]
 
-			backup.PrintCreateTextSearchTemplateStatements(backupfile, toc, templates, templateMetadataMap)
+			backup.PrintCreateTextSearchTemplateStatements(backupfile, toc, []backup.TextSearchTemplate{template}, templateMetadataMap)
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TEXT SEARCH TEMPLATE public.testtemplate")
@@ -74,16 +73,17 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_TSTEMPLATE)
 
 			Expect(resultTemplates).To(HaveLen(1))
-			resultMetadata := resultMetadataMap[templates[0].GetUniqueID()]
-			structmatcher.ExpectStructsToMatchExcluding(&templates[0], &resultTemplates[0], "Oid")
+			uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "testtemplate", backup.TYPE_TSTEMPLATE)
+			resultMetadata := resultMetadataMap[uniqueID]
+			structmatcher.ExpectStructsToMatchExcluding(&template, &resultTemplates[0], "Oid")
 			structmatcher.ExpectStructsToMatch(&templateMetadata, &resultMetadata)
 		})
 	})
 	Describe("PrintCreateTextSearchDictionaryStatements", func() {
+		dictionary := backup.TextSearchDictionary{Oid: 1, Schema: "public", Name: "testdictionary", Template: "pg_catalog.snowball", InitOption: "language = 'russian', stopwords = 'russian'"}
 		It("creates a basic text search dictionary", func() {
-			dictionaries := []backup.TextSearchDictionary{{Oid: 0, Schema: "public", Name: "testdictionary", Template: "pg_catalog.snowball", InitOption: "language = 'russian', stopwords = 'russian'"}}
 
-			backup.PrintCreateTextSearchDictionaryStatements(backupfile, toc, dictionaries, backup.MetadataMap{})
+			backup.PrintCreateTextSearchDictionaryStatements(backupfile, toc, []backup.TextSearchDictionary{dictionary}, backup.MetadataMap{})
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TEXT SEARCH DICTIONARY public.testdictionary")
@@ -91,14 +91,13 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultDictionaries := backup.GetTextSearchDictionaries(connectionPool)
 
 			Expect(resultDictionaries).To(HaveLen(1))
-			structmatcher.ExpectStructsToMatchExcluding(&dictionaries[0], &resultDictionaries[0], "Oid")
+			structmatcher.ExpectStructsToMatchExcluding(&dictionary, &resultDictionaries[0], "Oid")
 		})
 		It("creates a basic text search dictionary with a comment and owner", func() {
-			dictionaries := []backup.TextSearchDictionary{{Oid: 1, Schema: "public", Name: "testdictionary", Template: "pg_catalog.snowball", InitOption: "language = 'russian', stopwords = 'russian'"}}
 			dictionaryMetadataMap := testutils.DefaultMetadataMap("TEXT SEARCH DICTIONARY", false, true, true)
-			dictionaryMetadata := dictionaryMetadataMap[backup.UniqueID{Oid: 1}]
+			dictionaryMetadata := dictionaryMetadataMap[dictionary.GetUniqueID()]
 
-			backup.PrintCreateTextSearchDictionaryStatements(backupfile, toc, dictionaries, dictionaryMetadataMap)
+			backup.PrintCreateTextSearchDictionaryStatements(backupfile, toc, []backup.TextSearchDictionary{dictionary}, dictionaryMetadataMap)
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TEXT SEARCH DICTIONARY public.testdictionary")
@@ -107,16 +106,16 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TSDICTIONARY)
 
 			Expect(resultDictionaries).To(HaveLen(1))
-			resultMetadata := resultMetadataMap[dictionaries[0].GetUniqueID()]
-			structmatcher.ExpectStructsToMatchExcluding(&dictionaries[0], &resultDictionaries[0], "Oid")
+			uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "testdictionary", backup.TYPE_TSDICTIONARY)
+			resultMetadata := resultMetadataMap[uniqueID]
+			structmatcher.ExpectStructsToMatchExcluding(&dictionary, &resultDictionaries[0], "Oid")
 			structmatcher.ExpectStructsToMatch(&dictionaryMetadata, &resultMetadata)
 		})
 	})
 	Describe("PrintCreateTextSearchConfigurationStatements", func() {
+		configuration := backup.TextSearchConfiguration{Oid: 1, Schema: "public", Name: "testconfiguration", Parser: `pg_catalog."default"`, TokenToDicts: map[string][]string{}}
 		It("creates a basic text search configuration", func() {
-			configurations := []backup.TextSearchConfiguration{{Oid: 0, Schema: "public", Name: "testconfiguration", Parser: `pg_catalog."default"`, TokenToDicts: map[string][]string{}}}
-
-			backup.PrintCreateTextSearchConfigurationStatements(backupfile, toc, configurations, backup.MetadataMap{})
+			backup.PrintCreateTextSearchConfigurationStatements(backupfile, toc, []backup.TextSearchConfiguration{configuration}, backup.MetadataMap{})
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TEXT SEARCH CONFIGURATION public.testconfiguration")
@@ -124,14 +123,13 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultConfigurations := backup.GetTextSearchConfigurations(connectionPool)
 
 			Expect(resultConfigurations).To(HaveLen(1))
-			structmatcher.ExpectStructsToMatchExcluding(&configurations[0], &resultConfigurations[0], "Oid")
+			structmatcher.ExpectStructsToMatchExcluding(&configuration, &resultConfigurations[0], "Oid")
 		})
 		It("creates a basic text search configuration with a comment and owner", func() {
-			configurations := []backup.TextSearchConfiguration{{Oid: 1, Schema: "public", Name: "testconfiguration", Parser: `pg_catalog."default"`, TokenToDicts: map[string][]string{}}}
 			configurationMetadataMap := testutils.DefaultMetadataMap("TEXT SEARCH CONFIGURATION", false, true, true)
-			configurationMetadata := configurationMetadataMap[backup.UniqueID{ClassID: backup.PG_TS_CONFIG_OID, Oid: 1}]
+			configurationMetadata := configurationMetadataMap[configuration.GetUniqueID()]
 
-			backup.PrintCreateTextSearchConfigurationStatements(backupfile, toc, configurations, configurationMetadataMap)
+			backup.PrintCreateTextSearchConfigurationStatements(backupfile, toc, []backup.TextSearchConfiguration{configuration}, configurationMetadataMap)
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TEXT SEARCH CONFIGURATION public.testconfiguration")
@@ -140,8 +138,9 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_TSCONFIGURATION)
 
 			Expect(resultConfigurations).To(HaveLen(1))
-			resultMetadata := resultMetadataMap[resultConfigurations[0].GetUniqueID()]
-			structmatcher.ExpectStructsToMatchExcluding(&configurations[0], &resultConfigurations[0], "Oid")
+			uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "testconfiguration", backup.TYPE_TSCONFIGURATION)
+			resultMetadata := resultMetadataMap[uniqueID]
+			structmatcher.ExpectStructsToMatchExcluding(&configuration, &resultConfigurations[0], "Oid")
 			structmatcher.ExpectStructsToMatch(&configurationMetadata, &resultMetadata)
 		})
 	})

--- a/integration/predata_types_create_test.go
+++ b/integration/predata_types_create_test.go
@@ -173,7 +173,6 @@ var _ = Describe("backup integration create statement tests", func() {
 			testutils.SkipIfBefore6(connectionPool)
 			collations := []backup.Collation{{Oid: 1, Schema: "public", Name: "testcollation", Collate: "POSIX", Ctype: "POSIX"}}
 			collationMetadataMap := testutils.DefaultMetadataMap("COLLATION", false, true, true)
-			collationMetadata := collationMetadataMap[1]
 
 			backup.PrintCreateCollationStatements(backupfile, toc, collations, collationMetadataMap)
 
@@ -183,8 +182,9 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultCollations := backup.GetCollations(connectionPool)
 			resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_COLLATION)
 
+			collationMetadata := testutils.DefaultMetadata("COLLATION", false, true, true)
 			Expect(resultCollations).To(HaveLen(1))
-			oid := testutils.OidFromObjectName(connectionPool, "public", "testcollation", backup.TYPE_COLLATION)
+			oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "testcollation", backup.TYPE_COLLATION)
 			resultMetadata := resultMetadataMap[oid]
 			structmatcher.ExpectStructsToMatchExcluding(&collations[0], &resultCollations[0], "Oid")
 			structmatcher.ExpectStructsToMatch(&collationMetadata, &resultMetadata)

--- a/integration/predata_types_create_test.go
+++ b/integration/predata_types_create_test.go
@@ -155,11 +155,11 @@ var _ = Describe("backup integration create statement tests", func() {
 		})
 	})
 	Describe("PrintCreateCollationStatement", func() {
+		collation := backup.Collation{Oid: 1, Schema: "public", Name: "testcollation", Collate: "POSIX", Ctype: "POSIX"}
 		It("creates a basic collation", func() {
 			testutils.SkipIfBefore6(connectionPool)
-			collations := []backup.Collation{{Oid: 0, Schema: "public", Name: "testcollation", Collate: "POSIX", Ctype: "POSIX"}}
 
-			backup.PrintCreateCollationStatements(backupfile, toc, collations, backup.MetadataMap{})
+			backup.PrintCreateCollationStatements(backupfile, toc, []backup.Collation{collation}, backup.MetadataMap{})
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP COLLATION public.testcollation")
@@ -167,14 +167,14 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultCollations := backup.GetCollations(connectionPool)
 
 			Expect(resultCollations).To(HaveLen(1))
-			structmatcher.ExpectStructsToMatchExcluding(&collations[0], &resultCollations[0], "Oid")
+			structmatcher.ExpectStructsToMatchExcluding(&collation, &resultCollations[0], "Oid")
 		})
 		It("creates a basic collation with comment and owner", func() {
 			testutils.SkipIfBefore6(connectionPool)
-			collations := []backup.Collation{{Oid: 1, Schema: "public", Name: "testcollation", Collate: "POSIX", Ctype: "POSIX"}}
 			collationMetadataMap := testutils.DefaultMetadataMap("COLLATION", false, true, true)
+			collationMetadata := collationMetadataMap[collation.GetUniqueID()]
 
-			backup.PrintCreateCollationStatements(backupfile, toc, collations, collationMetadataMap)
+			backup.PrintCreateCollationStatements(backupfile, toc, []backup.Collation{collation}, collationMetadataMap)
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP COLLATION public.testcollation")
@@ -182,11 +182,10 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultCollations := backup.GetCollations(connectionPool)
 			resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_COLLATION)
 
-			collationMetadata := testutils.DefaultMetadata("COLLATION", false, true, true)
 			Expect(resultCollations).To(HaveLen(1))
 			uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "testcollation", backup.TYPE_COLLATION)
 			resultMetadata := resultMetadataMap[uniqueID]
-			structmatcher.ExpectStructsToMatchExcluding(&collations[0], &resultCollations[0], "Oid")
+			structmatcher.ExpectStructsToMatchExcluding(&collation, &resultCollations[0], "Oid")
 			structmatcher.ExpectStructsToMatch(&collationMetadata, &resultMetadata)
 
 		})

--- a/integration/predata_types_create_test.go
+++ b/integration/predata_types_create_test.go
@@ -184,8 +184,8 @@ var _ = Describe("backup integration create statement tests", func() {
 
 			collationMetadata := testutils.DefaultMetadata("COLLATION", false, true, true)
 			Expect(resultCollations).To(HaveLen(1))
-			oid := testutils.UniqueIDFromObjectName(connectionPool, "public", "testcollation", backup.TYPE_COLLATION)
-			resultMetadata := resultMetadataMap[oid]
+			uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "testcollation", backup.TYPE_COLLATION)
+			resultMetadata := resultMetadataMap[uniqueID]
 			structmatcher.ExpectStructsToMatchExcluding(&collations[0], &resultCollations[0], "Oid")
 			structmatcher.ExpectStructsToMatch(&collationMetadata, &resultMetadata)
 

--- a/testutils/functions.go
+++ b/testutils/functions.go
@@ -63,8 +63,7 @@ func SetDefaultSegmentConfiguration() *cluster.Cluster {
 	return cluster
 }
 
-// objType should be an all-caps string like TABLE, INDEX, etc.
-func DefaultMetadataMap(objType string, hasPrivileges bool, hasOwner bool, hasComment bool) backup.MetadataMap {
+func DefaultMetadata(objType string, hasPrivileges bool, hasOwner bool, hasComment bool) backup.ObjectMetadata {
 	privileges := []backup.ACL{}
 	if hasPrivileges {
 		privileges = []backup.ACL{DefaultACLForType("testrole", objType)}
@@ -82,11 +81,57 @@ func DefaultMetadataMap(objType string, hasPrivileges bool, hasOwner bool, hasCo
 		}
 		comment = fmt.Sprintf("This is a%s %s comment.", n, strings.ToLower(objType))
 	}
+	return backup.ObjectMetadata{Privileges: privileges, Owner: owner, Comment: comment}
+
+}
+
+// objType should be an all-caps string like TABLE, INDEX, etc.
+func DefaultMetadataMap(objType string, hasPrivileges bool, hasOwner bool, hasComment bool) backup.MetadataMap {
 	return backup.MetadataMap{
-		1: {Privileges: privileges, Owner: owner, Comment: comment},
+		backup.UniqueID{Classid: ClassIDFromObjectName(objType), Oid: 1}: DefaultMetadata(objType, hasPrivileges, hasOwner, hasComment),
 	}
 }
 
+var objNameToClassid = map[string]uint32{
+	"AGGREGATE":                 1255,
+	"CAST":                      2605,
+	"COLLATION":                 3456,
+	"CONVERSION":                2607,
+	"CONSTRAINT":                2606,
+	"DATABASE":                  1262,
+	"DOMAIN  ":                  1247,
+	"EXTENSION":                 3079,
+	"FOREIGN DATA WRAPPER":      2328,
+	"FOREIGN SERVER":            1417,
+	"FUNCTION":                  1255,
+	"INDEX":                     2610,
+	"LANGUAGE":                  2612,
+	"OPERATOR":                  2617,
+	"OPERATOR CLASS":            2616,
+	"OPERATOR FAMILY":           2753,
+	"PROTOCOL":                  7175,
+	"RESOURCE QUEUE":            6026,
+	"RESOURCE GROUP":            6436,
+	"ROLE":                      1260,
+	"RULE":                      2618,
+	"SCHEMA":                    2615,
+	"SEQUENCE":                  1259,
+	"TABLE":                     1259,
+	"TABLESPACE":                1213,
+	"TEXT SEARCH CONFIGURATION": 3602,
+	"TEXT SEARCH DICTIONARY":    3600,
+	"TEXT SEARCH PARSER":        3601,
+	"TEXT SEARCH TEMPLATE":      3764,
+	"TRIGGER":                   2620,
+	"TYPE":                      1247,
+	"USER MAPPING":              1418,
+	"VIEW":                      1259,
+}
+
+func ClassIDFromObjectName(objName string) uint32 {
+	return objNameToClassid[objName]
+
+}
 func DefaultACLForType(grantee string, objType string) backup.ACL {
 	return backup.ACL{
 		Grantee:    grantee,
@@ -322,6 +367,19 @@ func OidFromObjectName(connectionPool *dbconn.DBConn, schemaName string, objectN
 		Fail(fmt.Sprintf("Execution of query failed: %v", err))
 	}
 	return result.Oid
+}
+
+func UniqueIDFromObjectName(connectionPool *dbconn.DBConn, schemaName string, objectName string, params backup.MetadataQueryParams) backup.UniqueID {
+	query := fmt.Sprintf("SELECT '%s'::regclass::oid", params.CatalogTable)
+	result := struct {
+		Oid uint32
+	}{}
+	err := connectionPool.Get(&result, query)
+	if err != nil {
+		Fail(fmt.Sprintf("Execution of query failed: %v", err))
+	}
+
+	return backup.UniqueID{Classid: result.Oid, Oid: OidFromObjectName(connectionPool, schemaName, objectName, params)}
 }
 
 func GetUserByID(connectionPool *dbconn.DBConn, oid uint32) string {

--- a/testutils/functions.go
+++ b/testutils/functions.go
@@ -88,11 +88,11 @@ func DefaultMetadata(objType string, hasPrivileges bool, hasOwner bool, hasComme
 // objType should be an all-caps string like TABLE, INDEX, etc.
 func DefaultMetadataMap(objType string, hasPrivileges bool, hasOwner bool, hasComment bool) backup.MetadataMap {
 	return backup.MetadataMap{
-		backup.UniqueID{Classid: ClassIDFromObjectName(objType), Oid: 1}: DefaultMetadata(objType, hasPrivileges, hasOwner, hasComment),
+		backup.UniqueID{ClassID: ClassIDFromObjectName(objType), Oid: 1}: DefaultMetadata(objType, hasPrivileges, hasOwner, hasComment),
 	}
 }
 
-var objNameToClassid = map[string]uint32{
+var objNameToClassID = map[string]uint32{
 	"AGGREGATE":                 1255,
 	"CAST":                      2605,
 	"COLLATION":                 3456,
@@ -129,7 +129,7 @@ var objNameToClassid = map[string]uint32{
 }
 
 func ClassIDFromObjectName(objName string) uint32 {
-	return objNameToClassid[objName]
+	return objNameToClassID[objName]
 
 }
 func DefaultACLForType(grantee string, objType string) backup.ACL {
@@ -379,7 +379,7 @@ func UniqueIDFromObjectName(connectionPool *dbconn.DBConn, schemaName string, ob
 		Fail(fmt.Sprintf("Execution of query failed: %v", err))
 	}
 
-	return backup.UniqueID{Classid: result.Oid, Oid: OidFromObjectName(connectionPool, schemaName, objectName, params)}
+	return backup.UniqueID{ClassID: result.Oid, Oid: OidFromObjectName(connectionPool, schemaName, objectName, params)}
 }
 
 func GetUserByID(connectionPool *dbconn.DBConn, oid uint32) string {


### PR DESCRIPTION
Previously, only the oid was used in the metadata map. This works fine
when we dump each object type separately. When dumping multiple objects
referencing the same metadata map, it can produce incorrect backups
since it is possible for objects of different types to have the same
OID. We now use the classID and the object's oid to uniquely identify
each object.

Co-authored-by: Nadeem Ghani <nghani@pivotal.io>
Co-authored-by: Chris Hajas <chajas@pivotal.io>