### PR TITLE
Update tablespace location syntax for GPDB6

### DIFF
--- a/backup/metadata_globals.go
+++ b/backup/metadata_globals.go
@@ -288,12 +288,15 @@ func PrintRoleMembershipStatements(metadataFile *utils.FileWithByteCount, toc *u
 func PrintCreateTablespaceStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, tablespaces []Tablespace, tablespaceMetadata MetadataMap) {
 	for _, tablespace := range tablespaces {
 		start := metadataFile.ByteCount
-		if tablespace.SegmentLocations != nil {
-			metadataFile.MustPrintf("\n\nCREATE TABLESPACE %s LOCATION %s\n\tOPTIONS (%s);",
-				tablespace.Tablespace, tablespace.FileLocation, strings.Join(tablespace.SegmentLocations, ", "))
+		locationStr := ""
+		if tablespace.SegmentLocations == nil {
+			locationStr = fmt.Sprintf("FILESPACE %s", tablespace.FileLocation)
+		} else if len(tablespace.SegmentLocations) == 0 {
+			locationStr = fmt.Sprintf("LOCATION %s", tablespace.FileLocation)
 		} else {
-			metadataFile.MustPrintf("\n\nCREATE TABLESPACE %s FILESPACE %s;", tablespace.Tablespace, tablespace.FileLocation)
+			locationStr = fmt.Sprintf("LOCATION %s\n\tWITH (%s)", tablespace.FileLocation, strings.Join(tablespace.SegmentLocations, ", "))
 		}
+		metadataFile.MustPrintf("\n\nCREATE TABLESPACE %s %s;", tablespace.Tablespace, locationStr)
 		toc.AddGlobalEntry("", tablespace.Tablespace, "TABLESPACE", start, metadataFile)
 		start = metadataFile.ByteCount
 		PrintObjectMetadata(metadataFile, tablespaceMetadata[tablespace.GetUniqueID()], tablespace.Tablespace, "TABLESPACE")

--- a/backup/queries_globals.go
+++ b/backup/queries_globals.go
@@ -384,7 +384,7 @@ AND spcname != 'pg_global';`
 func GetSegmentTablespaces(connectionPool *dbconn.DBConn, Oid uint32) []string {
 	query := fmt.Sprintf(`
 SELECT
-	'content' || gp_segment_id || ' ''' || tblspc_loc || '''' AS string
+	'content' || gp_segment_id || '=''' || tblspc_loc || '''' AS string
 FROM gp_tablespace_segment_location(%d) WHERE tblspc_loc != pg_tablespace_location(%d)
 ORDER BY gp_segment_id;`, Oid, Oid)
 

--- a/integration/metadata_globals_create_test.go
+++ b/integration/metadata_globals_create_test.go
@@ -331,7 +331,7 @@ var _ = Describe("backup integration create statement tests", func() {
 
 			expectedTablespace = backup.Tablespace{
 				Oid: 1, Tablespace: "test_tablespace", FileLocation: "'/tmp/test_dir'",
-				SegmentLocations: []string{"content0 '/tmp/test_dir1'", "content1 '/tmp/test_dir2'"},
+				SegmentLocations: []string{"content0='/tmp/test_dir1'", "content1='/tmp/test_dir2'"},
 			}
 			numTablespaces := len(backup.GetTablespaces(connectionPool))
 			emptyMetadataMap := backup.MetadataMap{}

--- a/integration/metadata_globals_queries_test.go
+++ b/integration/metadata_globals_queries_test.go
@@ -348,10 +348,10 @@ CREATEEXTTABLE (protocol='gphdfs', type='writable')`)
 		It("returns a tablespace with segment locations", func() {
 			testutils.SkipIfBefore6(connectionPool)
 
-			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLESPACE test_tablespace LOCATION '/tmp/test_dir' OPTIONS (content0 '/tmp/test_dir1')")
+			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLESPACE test_tablespace LOCATION '/tmp/test_dir' WITH (content0='/tmp/test_dir1')")
 			expectedTablespace := backup.Tablespace{
 				Oid: 0, Tablespace: "test_tablespace", FileLocation: "'/tmp/test_dir'",
-				SegmentLocations: []string{"content0 '/tmp/test_dir1'"},
+				SegmentLocations: []string{"content0='/tmp/test_dir1'"},
 			}
 
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLESPACE test_tablespace")


### PR DESCRIPTION
The GPDB6 tablespace syntax has been modified to use WITH instead of
OPTIONS for the segment filespace locations. Additionally, when only the
default filespace is used, we don't print the WITH clause as this now
invalid syntax.

Authored-by: Chris Hajas <chajas@pivotal.io>