### PR TITLE
Fix type storage being printed in backup

### DIFF
--- a/backup/predata_types.go
+++ b/backup/predata_types.go
@@ -95,11 +95,11 @@ func PrintCreateBaseTypeStatement(metadataFile *utils.FileWithByteCount, toc *ut
 	if base.Storage != "" {
 		switch base.Storage {
 		case "e":
-			metadataFile.MustPrintf(",\n\tSTORAGE = extended")
+			metadataFile.MustPrintf(",\n\tSTORAGE = external")
 		case "m":
 			metadataFile.MustPrintf(",\n\tSTORAGE = main")
 		case "x":
-			metadataFile.MustPrintf(",\n\tSTORAGE = external")
+			metadataFile.MustPrintf(",\n\tSTORAGE = extended")
 		case "p": // Default case, don't print anything else
 		}
 	}

--- a/backup/predata_types_test.go
+++ b/backup/predata_types_test.go
@@ -146,7 +146,7 @@ COMMENT ON COLUMN public.composite_type.foo IS 'attribute comment';`)
 	INTERNALLENGTH = 16,
 	PASSEDBYVALUE,
 	ALIGNMENT = int2,
-	STORAGE = extended,
+	STORAGE = external,
 	DEFAULT = '42',
 	ELEMENT = int4,
 	DELIMITER = ',',
@@ -173,7 +173,7 @@ ALTER TYPE public.base_type
 	INPUT = input_fn,
 	OUTPUT = output_fn,
 	ALIGNMENT = int4,
-	STORAGE = external
+	STORAGE = extended
 );`)
 		})
 		It("prints a base type with comment and owner", func() {


### PR DESCRIPTION
We were previously using the wrong values for storage type 'e' and 'x'.
We are now using the correct values. 'e' is external, and 'x' is
extended.

This would have been caught if we used create tests for all the
permutations, but I don't think we chose to do that due to the
overhead. Unfortunately, this one slipped through.

Authored-by: Chris Hajas <chajas@pivotal.io>