### PR TITLE
Only select database config that is not role specific

### DIFF
--- a/backup/queries_globals.go
+++ b/backup/queries_globals.go
@@ -77,7 +77,7 @@ FROM pg_options_to_table(
 		subquery := fmt.Sprintf("SELECT datconfig FROM pg_database WHERE datname = '%s'", utils.EscapeSingleQuotes(connectionPool.DBName))
 		query = fmt.Sprintf(query, subquery)
 	} else {
-		subquery := fmt.Sprintf("SELECT setconfig FROM pg_db_role_setting WHERE setdatabase = (SELECT oid FROM pg_database WHERE datname = '%s')", utils.EscapeSingleQuotes(connectionPool.DBName))
+		subquery := fmt.Sprintf("SELECT setconfig FROM pg_db_role_setting WHERE setrole = 0 AND setdatabase = (SELECT oid FROM pg_database WHERE datname = '%s')", utils.EscapeSingleQuotes(connectionPool.DBName))
 		query = fmt.Sprintf(query, subquery)
 	}
 	return dbconn.MustSelectStringSlice(connectionPool, query)


### PR DESCRIPTION
The pg_db_role_setting table was introduced in PG 9.0 which allows for
role-specific database settings instead of having a single datconfig
column in pg_database. setrole = 0 in this new table indicates settings
that are not role specific, so those are the only ones we want to
select.

Authored-by: Karen Huddleston <khuddleston@pivotal.io>