### PR TITLE
Back up range types

### DIFF
--- a/backup/predata_shared.go
+++ b/backup/predata_shared.go
@@ -465,6 +465,8 @@ func PrintDependentObjectStatements(metadataFile *utils.FileWithByteCount, toc *
 			case "d":
 				domainName := utils.MakeFQN(obj.Schema, obj.Name)
 				PrintCreateDomainStatement(metadataFile, toc, obj, objMetadata, conMap[domainName])
+			case "r":
+				PrintCreateRangeTypeStatement(metadataFile, toc, obj, objMetadata)
 			}
 		case Function:
 			PrintCreateFunctionStatement(metadataFile, toc, obj, objMetadata)

--- a/backup/predata_types.go
+++ b/backup/predata_types.go
@@ -24,7 +24,7 @@ func PrintCreateShellTypeStatements(metadataFile *utils.FileWithByteCount, toc *
 	start := metadataFile.ByteCount
 	metadataFile.MustPrintf("\n\n")
 	for _, typ := range types {
-		if typ.Type == "b" || typ.Type == "p" {
+		if typ.Type == "b" || typ.Type == "p" || typ.Type == "r" {
 			typeFQN := utils.MakeFQN(typ.Schema, typ.Name)
 			metadataFile.MustPrintf("CREATE TYPE %s;\n", typeFQN)
 			toc.AddPredataEntry(typ.Schema, typ.Name, "TYPE", "", start, metadataFile)
@@ -165,6 +165,29 @@ func PrintCreateEnumTypeStatements(metadataFile *utils.FileWithByteCount, toc *u
 		PrintObjectMetadata(metadataFile, typeMetadata[enum.GetUniqueID()], typeFQN, "TYPE")
 		toc.AddPredataEntry(enum.Schema, enum.Name, "TYPE", "", start, metadataFile)
 	}
+}
+
+func PrintCreateRangeTypeStatement(metadataFile *utils.FileWithByteCount, toc *utils.TOC, rangeType Type, typeMetadata ObjectMetadata) {
+	start := metadataFile.ByteCount
+	typeFQN := utils.MakeFQN(rangeType.Schema, rangeType.Name)
+	metadataFile.MustPrintf("\n\nCREATE TYPE %s AS RANGE (\n\tSUBTYPE = %s", typeFQN, rangeType.SubType)
+
+	if rangeType.SubTypeOpClass != "" {
+		metadataFile.MustPrintf(",\n\tSUBTYPE_OPCLASS = %s", rangeType.SubTypeOpClass)
+	}
+	if rangeType.Collation != "" {
+		metadataFile.MustPrintf(",\n\tCOLLATION = %s", rangeType.Collation)
+	}
+	if rangeType.Canonical != "" {
+		metadataFile.MustPrintf(",\n\tCANONICAL = %s", rangeType.Canonical)
+	}
+	if rangeType.SubTypeDiff != "" {
+		metadataFile.MustPrintf(",\n\tSUBTYPE_DIFF = %s", rangeType.SubTypeDiff)
+	}
+	metadataFile.MustPrintf("\n);\n")
+
+	PrintObjectMetadata(metadataFile, typeMetadata, typeFQN, "TYPE")
+	toc.AddPredataEntry(rangeType.Schema, rangeType.Name, "TYPE", "", start, metadataFile)
 }
 
 func PrintCreateCollationStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, collations []Collation, collationMetadata MetadataMap) {

--- a/backup/queries_types.go
+++ b/backup/queries_types.go
@@ -115,6 +115,10 @@ type Type struct {
 	StorageOptions  string
 	Collatable      bool
 	Collation       string
+	SubType         string
+	SubTypeOpClass  string
+	Canonical       string
+	SubTypeDiff     string
 }
 
 func (t Type) GetUniqueID() UniqueID {
@@ -349,6 +353,48 @@ WHERE %s
 AND t.typtype = 'e'
 AND %s
 ORDER BY n.nspname, t.typname;`, enumSortClause, SchemaFilterClause("n"), ExtensionFilterClause("t"))
+
+	results := make([]Type, 0)
+	err := connectionPool.Select(&results, query)
+	gplog.FatalOnError(err)
+	return results
+}
+
+func GetRangeTypes(connectionPool *dbconn.DBConn) []Type {
+	query := fmt.Sprintf(`
+SELECT
+	t.oid,
+	n.nspname AS schema,
+	t.typname AS name,
+	t.typtype,
+	format_type(st.oid, st.typtypmod) AS subtype,
+	CASE
+		WHEN c.collname IS NULL THEN ''
+		ELSE nc.nspname || '.' || c.collname
+	END AS collation,
+	CASE
+		WHEN opc.opcname IS NULL THEN ''
+		ELSE nopc.nspname || '.' || opc.opcname
+	END AS subtypeopclass,
+	CASE
+		WHEN r.rngcanonical = '-'::regproc THEN ''
+		ELSE r.rngcanonical::regproc::text
+	END AS canonical,
+	CASE
+		WHEN r.rngsubdiff = '-'::regproc THEN ''
+		ELSE r.rngsubdiff::regproc::text
+	END AS subtypediff
+FROM pg_range r
+JOIN pg_type t ON t.oid = r.rngtypid
+JOIN pg_namespace n ON t.typnamespace = n.oid
+JOIN pg_type st ON st.oid = r.rngsubtype
+LEFT JOIN pg_collation c ON c.oid = r.rngcollation
+LEFT JOIN pg_namespace nc ON nc.oid = c.collnamespace
+LEFT JOIN pg_opclass opc ON opc.oid = r.rngsubopc
+LEFT JOIN pg_namespace nopc ON nopc.oid = opc.opcnamespace
+WHERE %s
+AND t.typtype = 'r'
+AND %s;`, SchemaFilterClause("n"), ExtensionFilterClause("t"))
 
 	results := make([]Type, 0)
 	err := connectionPool.Select(&results, query)

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -167,6 +167,10 @@ func RetrieveTypes(sortables *[]Sortable, metadataMap MetadataMap) ([]Type, Meta
 	types = append(types, composites...)
 	domains := GetDomainTypes(connectionPool)
 	types = append(types, domains...)
+	if connectionPool.Version.AtLeast("6") {
+		ranges := GetRangeTypes(connectionPool)
+		types = append(types, ranges...)
+	}
 	objectCounts["Types"] = len(types)
 	typeMetadata := GetMetadataForObjectType(connectionPool, TYPE_TYPE)
 

--- a/end_to_end/gpdb4_objects.sql
+++ b/end_to_end/gpdb4_objects.sql
@@ -114,6 +114,9 @@ CREATE OPERATOR CLASS testclass
 	FUNCTION 1 abs(integer),
 	FUNCTION 2 int4out(integer);
 
+CREATE OPERATOR CLASS range_class
+	FOR TYPE text USING btree AS
+	STORAGE text;
 
 SET default_tablespace = '';
 

--- a/end_to_end/gpdb6_objects.sql
+++ b/end_to_end/gpdb6_objects.sql
@@ -51,3 +51,11 @@ $$;
 CREATE EVENT TRIGGER nothing_ddl ON ddl_command_start
    WHEN TAG IN ('ALTER SERVER')
    EXECUTE PROCEDURE do_nothing();
+
+CREATE COLLATION public.some_coll (lc_collate = 'POSIX', lc_ctype = 'POSIX');
+
+CREATE TYPE public.textrange AS RANGE (
+	SUBTYPE_OPCLASS = public.range_class,
+	SUBTYPE = pg_catalog.text,
+	COLLATION = public.some_coll
+);

--- a/integration/predata_types_create_test.go
+++ b/integration/predata_types_create_test.go
@@ -154,6 +154,55 @@ var _ = Describe("backup integration create statement tests", func() {
 			structmatcher.ExpectStructsToMatchIncluding(&domainType, &resultTypes[0], "Schema", "Name", "Type", "DefaultVal", "BaseType", "NotNull", "Collation")
 		})
 	})
+	Describe("PrintCreateRangeTypeStatement", func() {
+		typeMetadata := backup.ObjectMetadata{}
+		It("creates a range type with a collation and opclass", func() {
+			rangeType := backup.Type{
+				Oid:            0,
+				Schema:         "public",
+				Name:           "textrange",
+				Type:           "r",
+				SubType:        "text",
+				Collation:      "public.some_coll",
+				SubTypeOpClass: "pg_catalog.text_ops",
+			}
+			testhelper.AssertQueryRuns(connectionPool, "CREATE COLLATION public.some_coll (lc_collate = 'POSIX', lc_ctype = 'POSIX');")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP COLLATION public.some_coll")
+
+			backup.PrintCreateRangeTypeStatement(backupfile, toc, rangeType, typeMetadata)
+
+			testhelper.AssertQueryRuns(connectionPool, buffer.String())
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP TYPE public.textrange")
+
+			resultTypes := backup.GetRangeTypes(connectionPool)
+
+			Expect(len(resultTypes)).To(Equal(1))
+			structmatcher.ExpectStructsToMatchExcluding(&rangeType, &resultTypes[0], "Oid")
+		})
+		It("creates a range type in a specific schema with a subtype diff function", func() {
+			rangeType := backup.Type{
+				Oid:            0,
+				Schema:         "testschema",
+				Name:           "timerange",
+				Type:           "r",
+				SubType:        "time without time zone",
+				SubTypeOpClass: "pg_catalog.time_ops",
+				SubTypeDiff:    "testschema.time_subtype_diff",
+			}
+			testhelper.AssertQueryRuns(connectionPool, "CREATE SCHEMA testschema;")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP SCHEMA testschema CASCADE;")
+			testhelper.AssertQueryRuns(connectionPool, "CREATE FUNCTION testschema.time_subtype_diff(x time, y time) RETURNS float8 AS 'SELECT EXTRACT(EPOCH FROM (x - y))' LANGUAGE sql STRICT IMMUTABLE;")
+
+			backup.PrintCreateRangeTypeStatement(backupfile, toc, rangeType, typeMetadata)
+
+			testhelper.AssertQueryRuns(connectionPool, buffer.String())
+
+			resultTypes := backup.GetRangeTypes(connectionPool)
+
+			Expect(len(resultTypes)).To(Equal(1))
+			structmatcher.ExpectStructsToMatchExcluding(&rangeType, &resultTypes[0], "Oid")
+		})
+	})
 	Describe("PrintCreateCollationStatement", func() {
 		collation := backup.Collation{Oid: 1, Schema: "public", Name: "testcollation", Collate: "POSIX", Ctype: "POSIX"}
 		It("creates a basic collation", func() {


### PR DESCRIPTION
Range types have some slightly complex dependencies to be aware of:
* They can depend on
    - other types
    - operator classes
    - collations
    - functions
* They create implicit functions that need to be excluded from
GetFunctions
* The can potentially have circular dependencies with canonical
functions, similar to base types

Co-authored-by: Kevin Yeap <kyeap@pivotal.io>
Co-authored-by: Karen Huddleston <khuddleston@pivotal.io>