### PR TITLE
Log stack trace for panics that don't come from gplog

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -3,6 +3,7 @@ package backup
 import (
 	"fmt"
 	"os"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -368,7 +369,13 @@ func DoTeardown() {
 
 	errStr := ""
 	if err := recover(); err != nil {
-		errStr = fmt.Sprintf("%v", err)
+		// Check if gplog.Fatal did not cause the panic
+		if gplog.GetErrorCode() != 2 {
+			gplog.Error(fmt.Sprintf("%v: %s", err, debug.Stack()))
+			gplog.SetErrorCode(2)
+		} else {
+			errStr = fmt.Sprintf("%v", err)
+		}
 	}
 	if wasTerminated {
 		/*

--- a/restore/data.go
+++ b/restore/data.go
@@ -60,22 +60,17 @@ func restoreSingleTableData(fpInfo *utils.FilePathInfo, entry utils.MasterDataEn
 		return err
 	}
 	numRowsBackedUp := entry.RowsCopied
-	CheckRowsRestored(numRowsRestored, numRowsBackedUp, name)
+	err = CheckRowsRestored(numRowsRestored, numRowsBackedUp, name)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
-func CheckRowsRestored(rowsRestored int64, rowsBackedUp int64, tableName string) {
+func CheckRowsRestored(rowsRestored int64, rowsBackedUp int64, tableName string) error {
 	if rowsRestored != rowsBackedUp {
 		rowsErrMsg := fmt.Sprintf("Expected to restore %d rows to table %s, but restored %d instead", rowsBackedUp, tableName, rowsRestored)
-		if MustGetFlagBool(utils.ON_ERROR_CONTINUE) {
-			gplog.Error(rowsErrMsg)
-		} else {
-			agentErr := CheckAgentErrorsOnSegments()
-			if agentErr != nil {
-				gplog.Error(rowsErrMsg)
-				gplog.Fatal(agentErr, "")
-			}
-			gplog.Fatal(errors.Errorf("%s", rowsErrMsg), "")
-		}
+		return errors.New(rowsErrMsg)
 	}
+	return nil
 }

--- a/restore/remote.go
+++ b/restore/remote.go
@@ -72,28 +72,3 @@ func VerifyMetadataFilePaths(withStats bool) {
 		gplog.Fatal(errors.Errorf("One or more metadata files do not exist or are not readable."), "Cannot proceed with restore")
 	}
 }
-
-func CheckAgentErrorsOnSegments() error {
-	remoteOutput := globalCluster.GenerateAndExecuteCommand("Checking whether segment agents had errors during restore", func(contentID int) string {
-		errorFile := fmt.Sprintf("%s_error", globalFPInfo.GetSegmentPipeFilePath(contentID))
-		/*
-		 * If an error file exists we want to indicate an error, as that means
-		 * the agent errored out.  If no file exists, the agent was successful.
-		 */
-		return fmt.Sprintf("if [[ -f %s ]]; then echo 'error'; fi; rm -f %s", errorFile, errorFile)
-	}, cluster.ON_SEGMENTS)
-
-	numErrors := 0
-	for contentID := range remoteOutput.Stdouts {
-		if strings.TrimSpace(remoteOutput.Stdouts[contentID]) == "error" {
-			gplog.Verbose("Error occurred with restore agent on segment %d on host %s.", contentID, globalCluster.GetHostForContent(contentID))
-			numErrors++
-		}
-	}
-	if numErrors > 0 {
-		helperLogName := globalFPInfo.GetHelperLogPath()
-		return errors.Errorf("Encountered errors with %d restore agent(s).  See %s for a complete list of segments with errors, and see %s on the corresponding hosts for detailed error messages.",
-			numErrors, gplog.GetLogFilePath(), helperLogName)
-	}
-	return nil
-}

--- a/utils/agent_remote.go
+++ b/utils/agent_remote.go
@@ -8,6 +8,7 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gp-common-go-libs/operating"
+	"github.com/pkg/errors"
 )
 
 /*
@@ -117,4 +118,29 @@ func CleanUpSegmentHelperProcesses(c *cluster.Cluster, fpInfo FilePathInfo, oper
 	c.CheckClusterError(remoteOutput, "Unable to clean up agent processes", func(contentID int) string {
 		return "Unable to clean up agent process"
 	})
+}
+
+func CheckAgentErrorsOnSegments(c *cluster.Cluster, fpInfo FilePathInfo) error {
+	remoteOutput := c.GenerateAndExecuteCommand("Checking whether segment agents had errors", func(contentID int) string {
+		errorFile := fmt.Sprintf("%s_error", fpInfo.GetSegmentPipeFilePath(contentID))
+		/*
+		 * If an error file exists we want to indicate an error, as that means
+		 * the agent errored out.  If no file exists, the agent was successful.
+		 */
+		return fmt.Sprintf("if [[ -f %s ]]; then echo 'error'; fi; rm -f %s", errorFile, errorFile)
+	}, cluster.ON_SEGMENTS)
+
+	numErrors := 0
+	for contentID := range remoteOutput.Stdouts {
+		if strings.TrimSpace(remoteOutput.Stdouts[contentID]) == "error" {
+			gplog.Verbose("Error occurred with helper agent on segment %d on host %s.", contentID, c.GetHostForContent(contentID))
+			numErrors++
+		}
+	}
+	if numErrors > 0 {
+		helperLogName := fpInfo.GetHelperLogPath()
+		return errors.Errorf("Encountered errors with %d helper agent(s).  See %s for a complete list of segments with errors, and see %s on the corresponding hosts for detailed error messages.",
+			numErrors, gplog.GetLogFilePath(), helperLogName)
+	}
+	return nil
 }


### PR DESCRIPTION
* Create error file when helper panics to signal to gpbackup and
  gprestore an error has occurred
* Check for agent error file in backup
* Return error in CheckRowsRestored instead of panicking to avoid
  goroutine stacktrace

Co-authored-by: Karen Huddleston <khuddleston@pivotal.io>
Co-authored-by: Kevin Yeap <kyeap@pivotal.io>