### PR TITLE
Add gppkg installer

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -813,6 +813,9 @@ jobs:
     # While the resource is not used, it ensures only releasing if
     # tests are passing
     - get: gpbackup
+    - get: gpdb_src
+    - get: ccp_src
+    - get: bin_gpdb_5x_stable
       passed:
        - units
        - integrations-GPDB5
@@ -823,6 +826,23 @@ jobs:
        - s3_plugin_tests
        - ddboost_plugin_and_boostfs_tests
     - get: gpdb_release
+  - put: terraform
+    params:
+      <<: *ccp_default_params
+      terraform_source: ccp_src/google-nvme-block-device/
+      vars:
+        instance_type: n1-standard-8
+  - task: gen_cluster
+    params:
+      <<: *ccp_gen_cluster_default_params
+    file: ccp_src/ci/tasks/gen_cluster.yml
+    input_mapping:
+      gpdb_binary: bin_gpdb_5x_stable
+      gpdb_src: gpdb_src
+  - task: gpinitsystem
+    file: ccp_src/ci/tasks/gpinitsystem.yml
+  - task: setup-centos-env
+    file: gpbackup/ci/tasks/setup-centos-env.yml
   - task: compile_package_gpbackup
     config:
       platform: linux
@@ -902,6 +922,12 @@ jobs:
 
           tar -czvf "gpbackup-${version}.tar.gz" bin_gpbackup.tar.gz install_gpdb_component smoke_test_gpdb_component version
           popd
+    on_failure:
+      *slack_alert
+  - task: build_gppkg
+    file: gpbackup/ci/tasks/build-gppkg.yml
+    on_success:
+      <<: *ccp_destroy_nvme
     on_failure:
       *slack_alert
   - task: update-manifest

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -813,9 +813,6 @@ jobs:
     # While the resource is not used, it ensures only releasing if
     # tests are passing
     - get: gpbackup
-    - get: gpdb_src
-    - get: ccp_src
-    - get: bin_gpdb_5x_stable
       passed:
        - units
        - integrations-GPDB5
@@ -825,6 +822,9 @@ jobs:
        - integrations-backward-compatibility
        - s3_plugin_tests
        - ddboost_plugin_and_boostfs_tests
+    - get: gpdb_src
+    - get: ccp_src
+    - get: bin_gpdb_5x_stable
     - get: gpdb_release
   - put: terraform
     params:

--- a/ci/scripts/gpbackup_gppkg.sh
+++ b/ci/scripts/gpbackup_gppkg.sh
@@ -25,7 +25,7 @@ mkdir -p ${GPPKG_SOURCE_DIR}/deps
 # Interpolate version values to create gppkg yaml file
 rm -f temp.yml
 ( echo "cat <<EOF >${GPPKG_SOURCE_DIR}/gppkg_spec.yml";   cat ${GPBACKUP_DIR}/gppkg/gppkg_spec.yml.in;   echo "EOF"; ) >temp.yml
-. temp.yml
+. ./temp.yml
 rm -f temp.yml
 
 cp ${RPMROOT}/RPMS/x86_64/*.rpm ${GPPKG_SOURCE_DIR}

--- a/ci/scripts/gpbackup_gppkg.sh
+++ b/ci/scripts/gpbackup_gppkg.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -ex
 
 # USAGE: ./gpbackup_gppkg.sh [gpbackup version] [gpdb major version] [os]

--- a/ci/scripts/gpbackup_gppkg.sh
+++ b/ci/scripts/gpbackup_gppkg.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -ex
+
+# USAGE: ./gpbackup_gppkg.sh [gpbackup version] [gpdb major version] [os]
+# Example: ./gpbackup_gppkg.sh 1.8.0 6 rhel6
+if [ "$#" -ne 3 ]; then
+    echo "./gpbackup_gppkg.sh [gpbackup version] [gpdb major version] [os]"
+fi
+
+GPBACKUP_VERSION=$1
+GPDB_MAJOR_VERSION=$2
+OS=$3
+
+GPBACKUP_DIR=$(dirname $0)/../..
+RPMROOT=/tmp/gpbackup_rpm
+
+GPPKG_DEST_DIR=gpbackup_gppkg
+GPBACKUP_GPPKG=gpbackup-${GPBACKUP_VERSION}-gp${GPDB_MAJOR_VERSION}-${OS}-x86_64.gppkg
+
+# Create gppkg directory structure
+GPPKG_SOURCE_DIR=/tmp/gpbackup_gppkg
+rm -rf ${GPPKG_SOURCE_DIR}
+mkdir -p ${GPPKG_SOURCE_DIR}/deps
+
+# Interpolate version values to create gppkg yaml file
+rm -f temp.yml
+( echo "cat <<EOF >${GPPKG_SOURCE_DIR}/gppkg_spec.yml";   cat ${GPBACKUP_DIR}/gppkg/gppkg_spec.yml.in;   echo "EOF"; ) >temp.yml
+. temp.yml
+rm -f temp.yml
+
+cp ${RPMROOT}/RPMS/x86_64/*.rpm ${GPPKG_SOURCE_DIR}
+gppkg --build ${GPPKG_SOURCE_DIR}
+echo "Successfully built gppkg"
+
+if [ ${GPDB_MAJOR_VERSION} == '5' ] && [ ${OS} == "rhel6" ]; then
+    echo "Testing installation of gpbackup using gppkg"
+    GPBIN=${GPHOME}/bin
+    rm -f ${GPBIN}/gpbackup
+    rm -f ${GPBIN}/gprestore
+    rm -f ${GPBIN}/gpbackup_helper
+
+    gppkg -i ${GPBACKUP_GPPKG}
+    if [ ! -f ${GPBIN}/gpbackup ] || [ ! -f ${GPBIN}/gprestore ] || [ ! -f ${GPBIN}/gpbackup_helper ]; then
+        echo "Failed to install gpbackup using gppkg!"
+        exit 1
+    fi
+
+    gppkg -r gpbackup
+    if [ -f ${GPBIN}/gpbackup ] || [ -f ${GPBIN}/gprestore ] || [ -f ${GPBIN}/gpbackup_helper ]; then
+        echo "Failed to remove gpbackup using gppkg!"
+        exit 1
+    fi
+    echo "gpbackup_gppkg installation test passed"
+fi
+
+echo "Moving ${GPBACKUP_GPPKG} to ${GPPKG_DEST_DIR}"
+mkdir -p ${GPPKG_DEST_DIR}
+mv ${GPBACKUP_GPPKG} ${GPPKG_DEST_DIR}/.

--- a/ci/scripts/gpbackup_rpm.sh
+++ b/ci/scripts/gpbackup_rpm.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -ex
+
+# USAGE: ./gpbackup_rpm.sh [gpbackup version] [source targz file]
+# Example: ./gpbackup_rpm.sh 1.8.0 mybinaries.tar.gz
+if [ "$#" -ne 2 ]; then
+    echo "./gpbackup_rpm.sh [gpbackup version] [source targz file]"
+fi
+
+GPBACKUP_VERSION=$1
+SOURCE_TARGZ=$2
+
+GPBACKUP_DIR=$(dirname $0)/../..
+
+# Create rpm directory structure
+RPMROOT=/tmp/gpbackup_rpm
+rm -rf ${RPMROOT}
+mkdir -p ${RPMROOT}/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
+
+
+# Interpolate version values to create spec file for rpm
+rm -f temp.spec
+( echo "cat <<EOF >${RPMROOT}/SPECS/gpbackup.spec";   cat ${GPBACKUP_DIR}/gppkg/gpbackup.spec.in;   echo "EOF"; ) >temp.spec
+. temp.spec
+rm -f temp.spec
+
+# Move source targz to SOURCES
+cp ${SOURCE_TARGZ} ${RPMROOT}/SOURCES/.
+
+rpmbuild -bb ${RPMROOT}/SPECS/gpbackup.spec --define "%_topdir ${RPMROOT}" --define "debug_package %{nil}"
+
+echo "Successfully built RPM"

--- a/ci/scripts/gpbackup_rpm.sh
+++ b/ci/scripts/gpbackup_rpm.sh
@@ -19,7 +19,8 @@ mkdir -p ${RPMROOT}/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 
 # Move source targz to SOURCES
 cp ${SOURCE_TARGZ} ${RPMROOT}/SOURCES/.
+cp ${GPBACKUP_DIR}/gppkg/gpbackup.spec.in ${RPMROOT}/SPECS/gpbackup.spec
 
-rpmbuild -bb ${RPMROOT}/SPECS/gpbackup.spec.in --define "%_topdir ${RPMROOT}" --define "debug_package %{nil}" --define "gpbackup_version $GPBACKUP_VERSION"
+rpmbuild -bb ${RPMROOT}/SPECS/gpbackup.spec --define "%_topdir ${RPMROOT}" --define "debug_package %{nil}" --define "gpbackup_version $GPBACKUP_VERSION"
 
 echo "Successfully built RPM"

--- a/ci/scripts/gpbackup_rpm.sh
+++ b/ci/scripts/gpbackup_rpm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 set -ex
 
 # USAGE: ./gpbackup_rpm.sh [gpbackup version] [source targz file]
@@ -17,16 +17,9 @@ RPMROOT=/tmp/gpbackup_rpm
 rm -rf ${RPMROOT}
 mkdir -p ${RPMROOT}/{BUILD,RPMS,SOURCES,SPECS,SRPMS}
 
-
-# Interpolate version values to create spec file for rpm
-rm -f temp.spec
-( echo "cat <<EOF >${RPMROOT}/SPECS/gpbackup.spec";   cat ${GPBACKUP_DIR}/gppkg/gpbackup.spec.in;   echo "EOF"; ) >temp.spec
-. temp.spec
-rm -f temp.spec
-
 # Move source targz to SOURCES
 cp ${SOURCE_TARGZ} ${RPMROOT}/SOURCES/.
 
-rpmbuild -bb ${RPMROOT}/SPECS/gpbackup.spec --define "%_topdir ${RPMROOT}" --define "debug_package %{nil}"
+rpmbuild -bb ${RPMROOT}/SPECS/gpbackup.spec.in --define "%_topdir ${RPMROOT}" --define "debug_package %{nil}" --define "gpbackup_version $GPBACKUP_VERSION"
 
 echo "Successfully built RPM"

--- a/ci/tasks/build-gppkg.yml
+++ b/ci/tasks/build-gppkg.yml
@@ -9,6 +9,7 @@ image_resource:
 inputs:
 - name: component_gpbackup
 - name: gpbackup_tagged_src
+  path: gpbackup
 - name: ccp_src
 - name: cluster_env_files
 
@@ -27,18 +28,18 @@ run:
     set -ex
     source env.sh
 
-    ./gpbackup_tagged_src/ci/scripts/gpbackup_rpm.sh $GPBACKUP_VERSION component_gpbackup/bin_gpbackup.tar.gz
-    ./gpbackup_tagged_src/ci/scripts/gpbackup_gppkg.sh $GPBACKUP_VERSION 4 rhel5
-    ./gpbackup_tagged_src/ci/scripts/gpbackup_gppkg.sh $GPBACKUP_VERSION 4 sles11
-    ./gpbackup_tagged_src/ci/scripts/gpbackup_gppkg.sh $GPBACKUP_VERSION 5 rhel6
-    ./gpbackup_tagged_src/ci/scripts/gpbackup_gppkg.sh $GPBACKUP_VERSION 5 rhel7
-    ./gpbackup_tagged_src/ci/scripts/gpbackup_gppkg.sh $GPBACKUP_VERSION 5 sles11
-    ./gpbackup_tagged_src/ci/scripts/gpbackup_gppkg.sh $GPBACKUP_VERSION 5 sles12
+    ./gpbackup/ci/scripts/gpbackup_rpm.sh $GPBACKUP_VERSION component_gpbackup/bin_gpbackup.tar.gz
+    ./gpbackup/ci/scripts/gpbackup_gppkg.sh $GPBACKUP_VERSION 4 rhel5
+    ./gpbackup/ci/scripts/gpbackup_gppkg.sh $GPBACKUP_VERSION 4 sles11
+    ./gpbackup/ci/scripts/gpbackup_gppkg.sh $GPBACKUP_VERSION 5 rhel6
+    ./gpbackup/ci/scripts/gpbackup_gppkg.sh $GPBACKUP_VERSION 5 rhel7
+    ./gpbackup/ci/scripts/gpbackup_gppkg.sh $GPBACKUP_VERSION 5 sles11
+    ./gpbackup/ci/scripts/gpbackup_gppkg.sh $GPBACKUP_VERSION 5 sles12
 
     SCRIPT
 
     scp -r component_gpbackup mdw:/home/gpadmin/.
-    scp -r gpbackup_tagged_src mdw:/home/gpadmin/.
+    scp -r gpbackup mdw:/home/gpadmin/.
     chmod +x /tmp/build_gppkg.bash
     scp /tmp/build_gppkg.bash mdw:/home/gpadmin/build_gppkg.bash
     ssh -t mdw "bash /home/gpadmin/build_gppkg.bash"

--- a/ci/tasks/build-gppkg.yml
+++ b/ci/tasks/build-gppkg.yml
@@ -1,0 +1,45 @@
+PLATFORM: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: pivotaldata/centos-gpdb-dev
+    tag: '6-gcc6.2-llvm3.7'
+
+inputs:
+- name: component_gpbackup
+- name: gpbackup_tagged_src
+- name: ccp_src
+- name: cluster_env_files
+
+run:
+  path: bash
+  args:
+  - -c
+  - |
+    set -ex
+
+    ccp_src/scripts/setup_ssh_to_cluster.sh
+    ssh -t centos@mdw "sudo yum -y install rpm-build"
+    GPBACKUP_VERSION=$(cat component_gpbackup/version)
+
+    cat <<SCRIPT > /tmp/build_gppkg.bash
+    set -ex
+    source env.sh
+
+    ./gpbackup_tagged_src/ci/scripts/gpbackup_rpm.sh $GPBACKUP_VERSION component_gpbackup/bin_gpbackup.tar.gz
+    ./gpbackup_tagged_src/ci/scripts/gpbackup_gppkg.sh $GPBACKUP_VERSION 4 rhel5
+    ./gpbackup_tagged_src/ci/scripts/gpbackup_gppkg.sh $GPBACKUP_VERSION 4 sles11
+    ./gpbackup_tagged_src/ci/scripts/gpbackup_gppkg.sh $GPBACKUP_VERSION 5 rhel6
+    ./gpbackup_tagged_src/ci/scripts/gpbackup_gppkg.sh $GPBACKUP_VERSION 5 rhel7
+    ./gpbackup_tagged_src/ci/scripts/gpbackup_gppkg.sh $GPBACKUP_VERSION 5 sles11
+    ./gpbackup_tagged_src/ci/scripts/gpbackup_gppkg.sh $GPBACKUP_VERSION 5 sles12
+
+    SCRIPT
+
+    scp -r component_gpbackup mdw:/home/gpadmin/.
+    scp -r gpbackup_tagged_src mdw:/home/gpadmin/.
+    chmod +x /tmp/build_gppkg.bash
+    scp /tmp/build_gppkg.bash mdw:/home/gpadmin/build_gppkg.bash
+    ssh -t mdw "bash /home/gpadmin/build_gppkg.bash"
+    scp -r mdw:/home/gpadmin/gpbackup_gppkg .

--- a/gppkg/gpbackup.spec.in
+++ b/gppkg/gpbackup.spec.in
@@ -1,26 +1,26 @@
 Name:       gpbackup
-Version:    ${GPBACKUP_VERSION}
-Release:    noop
-Summary:    template rpm for gpbackup
+Version:    %{gpbackup_version}
+Release:    1
+Summary:    Backup and restore utilities for Greenplum
 License:    ASL 2.0
 Source0:    bin_gpbackup.tar.gz
 BuildArch:  x86_64
-Prefix:     /
+Prefix:     /usr/local
 
 # Disable automatic dependency processing both for requirements and provides
 AutoReqProv: no
 
 %description
-template rpm generation for gpbackup
+Backup and restore utilities for Greenplum
 
 %prep
 %setup -c -q -T -D -a 0
 
 %install
-mkdir -p \$RPM_BUILD_ROOT/bin
-cp bin/gpbackup bin/gprestore bin/gpbackup_helper \$RPM_BUILD_ROOT/bin
+mkdir -p \$RPM_BUILD_ROOT%{prefix}/bin
+cp bin/gpbackup bin/gprestore bin/gpbackup_helper \$RPM_BUILD_ROOT%{prefix}/bin
 
 %files
-/bin/gpbackup
-/bin/gprestore
-/bin/gpbackup_helper
+%{prefix}/bin/gpbackup
+%{prefix}/bin/gprestore
+%{prefix}/bin/gpbackup_helper

--- a/gppkg/gpbackup.spec.in
+++ b/gppkg/gpbackup.spec.in
@@ -1,0 +1,26 @@
+Name:       gpbackup
+Version:    ${GPBACKUP_VERSION}
+Release:    noop
+Summary:    template rpm for gpbackup
+License:    ASL 2.0
+Source0:    bin_gpbackup.tar.gz
+BuildArch:  x86_64
+Prefix:     /
+
+# Disable automatic dependency processing both for requirements and provides
+AutoReqProv: no
+
+%description
+template rpm generation for gpbackup
+
+%prep
+%setup -c -q -T -D -a 0
+
+%install
+mkdir -p \$RPM_BUILD_ROOT/bin
+cp bin/gpbackup bin/gprestore bin/gpbackup_helper \$RPM_BUILD_ROOT/bin
+
+%files
+/bin/gpbackup
+/bin/gprestore
+/bin/gpbackup_helper

--- a/gppkg/gpbackup.spec.in
+++ b/gppkg/gpbackup.spec.in
@@ -2,7 +2,7 @@ Name:       gpbackup
 Version:    %{gpbackup_version}
 Release:    1
 Summary:    Backup and restore utilities for Greenplum
-License:    ASL 2.0
+License:    Pivotal Software EULA
 Source0:    bin_gpbackup.tar.gz
 BuildArch:  x86_64
 Prefix:     /usr/local
@@ -17,8 +17,8 @@ Backup and restore utilities for Greenplum
 %setup -c -q -T -D -a 0
 
 %install
-mkdir -p \$RPM_BUILD_ROOT%{prefix}/bin
-cp bin/gpbackup bin/gprestore bin/gpbackup_helper \$RPM_BUILD_ROOT%{prefix}/bin
+mkdir -p $RPM_BUILD_ROOT%{prefix}/bin
+cp bin/gpbackup bin/gprestore bin/gpbackup_helper $RPM_BUILD_ROOT%{prefix}/bin
 
 %files
 %{prefix}/bin/gpbackup

--- a/gppkg/gppkg_spec.yml.in
+++ b/gppkg/gppkg_spec.yml.in
@@ -1,0 +1,8 @@
+Pkgname: gpbackup
+Architecture: x86_64
+OS: ${OS}
+Version: ${GPBACKUP_VERSION}-gp${GPDB_MAJOR_VERSION}
+GPDBVersion: ${GPDB_MAJOR_VERSION}
+Description: gpbackup package
+PostInstall:
+- Master:  "echo 'gpbackup ${GPBACKUP_VERSION} successfully installed';"


### PR DESCRIPTION
Introduces gppkg installer that will allow installing gpbackup,
gprestore, and gpbackup_helper on existing GPDB clusters.

Co-authored-by: Kevin Yeap <kyeap@pivotal.io>
Co-authored-by: Chris Hajas <chajas@pivotal.io>