### PR TITLE
Backup per db role settings

### DIFF
--- a/backup/metadata_globals.go
+++ b/backup/metadata_globals.go
@@ -179,7 +179,7 @@ func PrintCreateResourceGroupStatements(metadataFile *utils.FileWithByteCount, t
 	}
 }
 
-func PrintCreateRoleStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, roles []Role, roleGUCs map[string][]string, roleMetadata MetadataMap) {
+func PrintCreateRoleStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, roles []Role, roleGUCs map[string][]RoleGUC, roleMetadata MetadataMap) {
 	for _, role := range roles {
 		start := metadataFile.ByteCount
 		attrs := []string{}
@@ -257,9 +257,12 @@ CREATE ROLE %s;
 ALTER ROLE %s WITH %s;`, role.Name, role.Name, strings.Join(attrs, " "))
 
 		for _, roleGUC := range roleGUCs[role.Name] {
-			metadataFile.MustPrintf(`
+			dbString := ""
+			if roleGUC.DbName != "" {
+				dbString = fmt.Sprintf("IN DATABASE %s ", roleGUC.DbName)
+			}
+			metadataFile.MustPrintf("\n\nALTER ROLE %s %s%s;", role.Name, dbString, roleGUC.Config)
 
-ALTER ROLE %s %s;`, role.Name, roleGUC)
 		}
 
 		if len(role.TimeConstraints) != 0 {

--- a/backup/metadata_globals_test.go
+++ b/backup/metadata_globals_test.go
@@ -249,7 +249,7 @@ ALTER RESOURCE GROUP default_group SET CPU_RATE_LIMIT 10;`)
 				},
 			},
 		}
-		emptyConfigMap := map[string][]string{}
+		emptyConfigMap := map[string][]backup.RoleGUC{}
 		It("prints basic role", func() {
 			roleMetadataMap := testutils.DefaultMetadataMap("ROLE", false, false, true)
 			backup.PrintCreateRoleStatements(backupfile, toc, []backup.Role{testrole1}, emptyConfigMap, roleMetadataMap)
@@ -262,8 +262,11 @@ COMMENT ON ROLE testrole1 IS 'This is a role comment.';`)
 		})
 		It("prints basic role with user GUCs set", func() {
 			roleMetadataMap := testutils.DefaultMetadataMap("ROLE", false, false, true)
-			roleConfigMap := map[string][]string{
-				"testrole1": {"SET search_path TO public", "SET client_min_messages TO 'error'", "SET gp_default_storage_options TO 'appendonly=true, compresslevel=6, orientation=row, compresstype=none'"},
+			roleConfigMap := map[string][]backup.RoleGUC{
+				"testrole1": {
+					{RoleName: "testrole1", Config: "SET search_path TO public"},
+					{RoleName: "testrole1", DbName: "testdb", Config: "SET client_min_messages TO 'error'"},
+					{RoleName: "testrole1", Config: "SET gp_default_storage_options TO 'appendonly=true, compresslevel=6, orientation=row, compresstype=none'"}},
 			}
 			backup.PrintCreateRoleStatements(backupfile, toc, []backup.Role{testrole1}, roleConfigMap, roleMetadataMap)
 
@@ -273,7 +276,7 @@ ALTER ROLE testrole1 WITH NOSUPERUSER NOINHERIT NOCREATEROLE NOCREATEDB NOLOGIN 
 
 ALTER ROLE testrole1 SET search_path TO public;
 
-ALTER ROLE testrole1 SET client_min_messages TO 'error';
+ALTER ROLE testrole1 IN DATABASE testdb SET client_min_messages TO 'error';
 
 ALTER ROLE testrole1 SET gp_default_storage_options TO 'appendonly=true, compresslevel=6, orientation=row, compresstype=none';
 


### PR DESCRIPTION
Postgres now supports setting GUCs on Roles that apply to a particular
database. These are stored in the pg_db_role_setting table.