### PR TITLE
Close connection to "postgres" database during restore

### DIFF
--- a/restore/restore.go
+++ b/restore/restore.go
@@ -81,7 +81,7 @@ func DoSetup() {
 	restoreStartTime = utils.CurrentTimestamp()
 	gplog.Info("Restore Key = %s", MustGetFlagString(utils.TIMESTAMP))
 
-	InitializeConnection("postgres")
+	InitializeConnectionPool("postgres")
 	segConfig := cluster.MustGetSegmentConfiguration(connectionPool)
 	globalCluster = cluster.NewCluster(segConfig)
 	segPrefix := utils.ParseSegPrefix(MustGetFlagString(utils.BACKUP_DIR), MustGetFlagString(utils.TIMESTAMP))
@@ -107,7 +107,10 @@ func DoSetup() {
 	if MustGetFlagBool(utils.CREATE_DB) {
 		createDatabase(metadataFilename)
 	}
-	InitializeConnection(unquotedRestoreDatabase)
+	if connectionPool != nil {
+		connectionPool.Close()
+	}
+	InitializeConnectionPool(unquotedRestoreDatabase)
 
 	if MustGetFlagBool(utils.WITH_GLOBALS) {
 		restoreGlobal(metadataFilename)

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -31,7 +31,7 @@ func SetLoggerVerbosity() {
 	}
 }
 
-func InitializeConnection(unquotedDBName string) {
+func InitializeConnectionPool(unquotedDBName string) {
 	connectionPool = dbconn.NewDBConnFromEnvironment(unquotedDBName)
 	connectionPool.MustConnect(MustGetFlagInt(utils.JOBS))
 	utils.ValidateGPDBVersionCompatibility(connectionPool)


### PR DESCRIPTION
During restore, we first connect to the "postgres" database to create
the destination restore database. However, we never closed this
connection, which meant that an extra connection was left around for the
duration of the restore. This also meant that when using N jobs, N extra
connections would be established and left around.

Now, we close these connections before connecting to the destination
database.

Authored-by: Chris Hajas <chajas@pivotal.io>