### PR TITLE
Fix restore validation to consider all filtering

### DIFF
--- a/restore/restore.go
+++ b/restore/restore.go
@@ -123,7 +123,8 @@ func DoSetup() {
 	 * but since they will not stop the restore, it is not necessary to log them twice.
 	 */
 	if !MustGetFlagBool(utils.CREATE_DB) && !MustGetFlagBool(utils.ON_ERROR_CONTINUE) {
-		ValidateRelationsInRestoreDatabase(connectionPool, MustGetFlagStringSlice(utils.INCLUDE_RELATION))
+		relationsToRestore := GenerateRestoreRelationList()
+		ValidateRelationsInRestoreDatabase(connectionPool, relationsToRestore)
 	}
 }
 

--- a/restore/restore_suite_test.go
+++ b/restore/restore_suite_test.go
@@ -64,4 +64,8 @@ var _ = BeforeEach(func() {
 	cmdFlags.Bool(utils.ON_ERROR_CONTINUE, false, "")
 	cmdFlags.Bool(utils.DATA_ONLY, false, "")
 	cmdFlags.String(utils.PLUGIN_CONFIG, "", "")
+	cmdFlags.StringSlice(utils.INCLUDE_RELATION, []string{}, "")
+	cmdFlags.StringSlice(utils.EXCLUDE_RELATION, []string{}, "")
+	cmdFlags.StringSlice(utils.INCLUDE_SCHEMA, []string{}, "")
+	cmdFlags.StringSlice(utils.EXCLUDE_SCHEMA, []string{}, "")
 })

--- a/restore/validate_test.go
+++ b/restore/validate_test.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("restore/validate tests", func() {
@@ -59,117 +60,130 @@ var _ = Describe("restore/validate tests", func() {
 			restore.ValidateFilterSchemasInBackupSet(filterList)
 		})
 	})
+	Describe("GenerateRestoreRelationList", func() {
+		BeforeEach(func() {
+			toc, _ = testutils.InitializeTestTOC(buffer, "metadata")
+			toc.AddMasterDataEntry("s1", "table1", 1, "(j)", 0, "")
+			toc.AddMasterDataEntry("s1", "table2", 2, "(j)", 0, "")
+			toc.AddMasterDataEntry("s2", "table1", 3, "(j)", 0, "")
+			toc.AddMasterDataEntry("s2", "table2", 4, "(j)", 0, "")
+			restore.SetTOC(toc)
+			cmdFlags.Set(utils.INCLUDE_RELATION, "")
+			cmdFlags.Set(utils.EXCLUDE_RELATION, "")
+			cmdFlags.Set(utils.INCLUDE_SCHEMA, "")
+			cmdFlags.Set(utils.EXCLUDE_SCHEMA, "")
+		})
+		It("returns all tables if no filtering is used", func() {
+			expectedRelations := []string{"s1.table1", "s1.table2", "s2.table1", "s2.table2"}
+
+			resultRelations := restore.GenerateRestoreRelationList()
+
+			Expect(resultRelations).To(ConsistOf(expectedRelations))
+		})
+		It("filters on include relations", func() {
+			cmdFlags.Set(utils.INCLUDE_RELATION, "s1.table1,s2.table2")
+			expectedRelations := []string{"s1.table1", "s2.table2"}
+
+			resultRelations := restore.GenerateRestoreRelationList()
+
+			Expect(resultRelations).To(ConsistOf(expectedRelations))
+		})
+		It("filters on exclude relations", func() {
+			cmdFlags.Set(utils.EXCLUDE_RELATION, "s1.table2,s2.table1")
+			expectedRelations := []string{"s1.table1", "s2.table2"}
+
+			resultRelations := restore.GenerateRestoreRelationList()
+
+			Expect(resultRelations).To(ConsistOf(expectedRelations))
+		})
+		It("filters on include schema", func() {
+			cmdFlags.Set(utils.INCLUDE_SCHEMA, "s1")
+			expectedRelations := []string{"s1.table1", "s1.table2"}
+
+			resultRelations := restore.GenerateRestoreRelationList()
+
+			Expect(resultRelations).To(ConsistOf(expectedRelations))
+		})
+		It("filters on exclude schema", func() {
+			cmdFlags.Set(utils.EXCLUDE_SCHEMA, "s2")
+			expectedRelations := []string{"s1.table1", "s1.table2"}
+
+			resultRelations := restore.GenerateRestoreRelationList()
+
+			Expect(resultRelations).To(ConsistOf(expectedRelations))
+		})
+		It("filters on exclude schema", func() {
+			cmdFlags.Set(utils.EXCLUDE_SCHEMA, "s2")
+			expectedRelations := []string{"s1.table1", "s1.table2"}
+
+			resultRelations := restore.GenerateRestoreRelationList()
+
+			Expect(resultRelations).To(ConsistOf(expectedRelations))
+		})
+		It("filters on include schema with exclude relation", func() {
+			cmdFlags.Set(utils.INCLUDE_SCHEMA, "s1")
+			cmdFlags.Set(utils.EXCLUDE_RELATION, "s1.table1")
+			expectedRelations := []string{"s1.table2"}
+
+			resultRelations := restore.GenerateRestoreRelationList()
+
+			Expect(resultRelations).To(ConsistOf(expectedRelations))
+		})
+	})
 	Describe("ValidateRelationsInRestoreDatabase", func() {
 		BeforeEach(func() {
 			restore.SetBackupConfig(&utils.BackupConfig{DataOnly: false})
 			cmdFlags.Set(utils.DATA_ONLY, "false")
-			toc, _ = testutils.InitializeTestTOC(buffer, "metadata")
-			toc.AddMasterDataEntry("public", "table1", 1, "(j)", 0, "")
-			toc.AddMasterDataEntry("public", "table2", 2, "(j)", 0, "")
-			restore.SetTOC(toc)
-
 		})
 		Context("data-only restore", func() {
 			BeforeEach(func() {
 				cmdFlags.Set(utils.DATA_ONLY, "true")
 			})
-			Context("with filtering", func() {
-				It("panics if all tables missing from database", func() {
-					no_table_rows := sqlmock.NewRows([]string{"string"})
-					mock.ExpectQuery("SELECT (.*)").WillReturnRows(no_table_rows)
-					filterList = []string{"public.table2"}
-					defer testhelper.ShouldPanicWithMessage("Relation public.table2 must exist for data-only restore")
-					restore.ValidateRelationsInRestoreDatabase(connectionPool, filterList)
-				})
-				It("panics if some tables missing from database", func() {
-					single_table_row := sqlmock.NewRows([]string{"string"}).
-						AddRow("public.table1")
-					mock.ExpectQuery("SELECT (.*)").WillReturnRows(single_table_row)
-					filterList = []string{"public.table1", "public.table2"}
-					defer testhelper.ShouldPanicWithMessage("Relation public.table2 must exist for data-only restore")
-					restore.ValidateRelationsInRestoreDatabase(connectionPool, filterList)
-				})
-				It("passes if all tables are present in database", func() {
-					two_table_rows := sqlmock.NewRows([]string{"string"}).
-						AddRow("public.table1").AddRow("public.table2")
-					mock.ExpectQuery("SELECT (.*)").WillReturnRows(two_table_rows)
-					filterList = []string{"public.table1", "public.table2"}
-					restore.ValidateRelationsInRestoreDatabase(connectionPool, filterList)
-				})
+			It("panics if all tables missing from database", func() {
+				no_table_rows := sqlmock.NewRows([]string{"string"})
+				mock.ExpectQuery("SELECT (.*)").WillReturnRows(no_table_rows)
+				filterList = []string{"public.table2"}
+				defer testhelper.ShouldPanicWithMessage("Relation public.table2 must exist for data-only restore")
+				restore.ValidateRelationsInRestoreDatabase(connectionPool, filterList)
 			})
-			Context("without filtering", func() {
-				It("panics if all tables missing from database", func() {
-					no_table_rows := sqlmock.NewRows([]string{"string"})
-					mock.ExpectQuery("SELECT (.*)").WillReturnRows(no_table_rows)
-					defer testhelper.ShouldPanicWithMessage("Relation public.table2 must exist for data-only restore")
-					restore.ValidateRelationsInRestoreDatabase(connectionPool, filterList)
-				})
-				It("panics if some tables missing from database", func() {
-					single_table_row := sqlmock.NewRows([]string{"string"}).
-						AddRow("public.table1")
-					mock.ExpectQuery("SELECT (.*)").WillReturnRows(single_table_row)
-					defer testhelper.ShouldPanicWithMessage("Relation public.table2 must exist for data-only restore")
-					restore.ValidateRelationsInRestoreDatabase(connectionPool, filterList)
-				})
-				It("passes if all tables are present in database", func() {
-					two_table_rows := sqlmock.NewRows([]string{"string"}).
-						AddRow("public.table1").AddRow("public.view1")
-					mock.ExpectQuery("SELECT (.*)").WillReturnRows(two_table_rows)
-					restore.ValidateRelationsInRestoreDatabase(connectionPool, filterList)
-				})
+			It("panics if some tables missing from database", func() {
+				single_table_row := sqlmock.NewRows([]string{"string"}).
+					AddRow("public.table1")
+				mock.ExpectQuery("SELECT (.*)").WillReturnRows(single_table_row)
+				filterList = []string{"public.table1", "public.table2"}
+				defer testhelper.ShouldPanicWithMessage("Relation public.table2 must exist for data-only restore")
+				restore.ValidateRelationsInRestoreDatabase(connectionPool, filterList)
+			})
+			It("passes if all tables are present in database", func() {
+				two_table_rows := sqlmock.NewRows([]string{"string"}).
+					AddRow("public.table1").AddRow("public.table2")
+				mock.ExpectQuery("SELECT (.*)").WillReturnRows(two_table_rows)
+				filterList = []string{"public.table1", "public.table2"}
+				restore.ValidateRelationsInRestoreDatabase(connectionPool, filterList)
 			})
 		})
 		Context("restore includes metadata", func() {
-			Context("with filtering", func() {
-				It("passes if table is not present in database", func() {
-					no_table_rows := sqlmock.NewRows([]string{"string"})
-					mock.ExpectQuery("SELECT (.*)").WillReturnRows(no_table_rows)
-					filterList = []string{"public.table2"}
-					restore.ValidateRelationsInRestoreDatabase(connectionPool, filterList)
-				})
-				It("panics if single table is present in database", func() {
-					single_table_row := sqlmock.NewRows([]string{"string"}).
-						AddRow("public.table1")
-					mock.ExpectQuery("SELECT (.*)").WillReturnRows(single_table_row)
-					filterList = []string{"public.table1"}
-					defer testhelper.ShouldPanicWithMessage("Relation public.table1 already exists")
-					restore.ValidateRelationsInRestoreDatabase(connectionPool, filterList)
-				})
-				It("panics if multiple tables are present in database", func() {
-					two_table_rows := sqlmock.NewRows([]string{"string"}).
-						AddRow("public.table1").AddRow("public.view1")
-					mock.ExpectQuery("SELECT (.*)").WillReturnRows(two_table_rows)
-					filterList = []string{"public.table1", "public.view1"}
-					defer testhelper.ShouldPanicWithMessage("Relation public.table1 already exists")
-					restore.ValidateRelationsInRestoreDatabase(connectionPool, filterList)
-				})
+			It("passes if table is not present in database", func() {
+				no_table_rows := sqlmock.NewRows([]string{"string"})
+				mock.ExpectQuery("SELECT (.*)").WillReturnRows(no_table_rows)
+				filterList = []string{"public.table2"}
+				restore.ValidateRelationsInRestoreDatabase(connectionPool, filterList)
 			})
-			Context("without filtering", func() {
-				It("passes if table is not present in database", func() {
-					no_table_rows := sqlmock.NewRows([]string{"string"})
-					mock.ExpectQuery("SELECT (.*)").WillReturnRows(no_table_rows)
-					restore.ValidateRelationsInRestoreDatabase(connectionPool, filterList)
-				})
-				It("passes if there are no data entries in the backup", func() {
-					toc, _ = testutils.InitializeTestTOC(buffer, "metadata")
-					restore.SetTOC(toc)
-
-					restore.ValidateRelationsInRestoreDatabase(connectionPool, filterList)
-				})
-				It("panics if single table is present in database", func() {
-					single_table_row := sqlmock.NewRows([]string{"string"}).
-						AddRow("public.table1")
-					mock.ExpectQuery("SELECT (.*)").WillReturnRows(single_table_row)
-					defer testhelper.ShouldPanicWithMessage("Relation public.table1 already exists")
-					restore.ValidateRelationsInRestoreDatabase(connectionPool, filterList)
-				})
-				It("panics if multiple tables are present in database", func() {
-					two_table_rows := sqlmock.NewRows([]string{"string"}).
-						AddRow("public.table1").AddRow("public.table2")
-					mock.ExpectQuery("SELECT (.*)").WillReturnRows(two_table_rows)
-					defer testhelper.ShouldPanicWithMessage("Relation public.table1 already exists")
-					restore.ValidateRelationsInRestoreDatabase(connectionPool, filterList)
-				})
+			It("panics if single table is present in database", func() {
+				single_table_row := sqlmock.NewRows([]string{"string"}).
+					AddRow("public.table1")
+				mock.ExpectQuery("SELECT (.*)").WillReturnRows(single_table_row)
+				filterList = []string{"public.table1", "public.table2"}
+				defer testhelper.ShouldPanicWithMessage("Relation public.table1 already exists")
+				restore.ValidateRelationsInRestoreDatabase(connectionPool, filterList)
+			})
+			It("panics if multiple tables are present in database", func() {
+				two_table_rows := sqlmock.NewRows([]string{"string"}).
+					AddRow("public.table1").AddRow("public.view1")
+				mock.ExpectQuery("SELECT (.*)").WillReturnRows(two_table_rows)
+				filterList = []string{"public.table1", "public.view1"}
+				defer testhelper.ShouldPanicWithMessage("Relation public.table1 already exists")
+				restore.ValidateRelationsInRestoreDatabase(connectionPool, filterList)
 			})
 		})
 	})


### PR DESCRIPTION
We were only considering the --include-table option before and would
assume all tables in the backup set were being restored otherwise. This
could result in validation failing because a table exists in the
database even when it wouldn't really be restored because of other
filtering options.

We now construct a correct list of tables that we intend to restore by
considering all filtering options before checking if they are in the
database or not.

Co-authored-by: Karen Huddleston <khuddleston@pivotal.io>
Co-authored-by: Nadeem Ghani <nghani@pivotal.io>