### PR TITLE
Fix whitespace changes in expected output in tests introduced from 9.4 merge

### DIFF
--- a/integration/postdata_create_test.go
+++ b/integration/postdata_create_test.go
@@ -99,7 +99,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			if connectionPool.Version.Before("6") {
 				ruleDef = "CREATE RULE update_notify AS ON UPDATE TO public.testtable DO NOTIFY testtable;"
 			} else {
-				ruleDef = "CREATE RULE update_notify AS\n    ON UPDATE TO public.testtable DO \n NOTIFY testtable;"
+				ruleDef = "CREATE RULE update_notify AS\n    ON UPDATE TO public.testtable DO\n NOTIFY testtable;"
 			}
 		})
 		It("creates a basic rule", func() {

--- a/integration/postdata_queries_test.go
+++ b/integration/postdata_queries_test.go
@@ -188,8 +188,8 @@ PARTITION BY RANGE (date)
 				ruleDef1 = "CREATE RULE double_insert AS ON INSERT TO public.rule_table1 DO INSERT INTO public.rule_table1 (i) VALUES (1);"
 				ruleDef2 = "CREATE RULE update_notify AS ON UPDATE TO public.rule_table1 DO NOTIFY rule_table1;"
 			} else {
-				ruleDef1 = "CREATE RULE double_insert AS\n    ON INSERT TO public.rule_table1 DO  INSERT INTO public.rule_table1 (i) \n  VALUES (1);"
-				ruleDef2 = "CREATE RULE update_notify AS\n    ON UPDATE TO public.rule_table1 DO \n NOTIFY rule_table1;"
+				ruleDef1 = "CREATE RULE double_insert AS\n    ON INSERT TO public.rule_table1 DO  INSERT INTO public.rule_table1 (i)\n  VALUES (1);"
+				ruleDef2 = "CREATE RULE update_notify AS\n    ON UPDATE TO public.rule_table1 DO\n NOTIFY rule_table1;"
 			}
 			rule1 = backup.QuerySimpleDefinition{ClassID: backup.PG_REWRITE_OID, Oid: 0, Name: "double_insert", OwningSchema: "public", OwningTable: "rule_table1", Def: ruleDef1}
 		})

--- a/integration/predata_relations_queries_test.go
+++ b/integration/predata_relations_queries_test.go
@@ -641,8 +641,13 @@ PARTITION BY LIST (gender)
 
 			result := backup.GetPartitionTemplates(connectionPool)[oid]
 
-			// The spacing is very specific here and is output from the postgres function
-			expectedResult := `ALTER TABLE public.part_table 
+			/*
+			 * The spacing is very specific here and is output from the postgres function
+			 * The only difference between the below statements is spacing
+			 */
+			expectedResult := ""
+			if connectionPool.Version.Before("6") {
+				expectedResult = `ALTER TABLE public.part_table 
 SET SUBPARTITION TEMPLATE  
           (
           SUBPARTITION usa VALUES('usa') WITH (tablename='part_table'), 
@@ -651,6 +656,17 @@ SET SUBPARTITION TEMPLATE
           DEFAULT SUBPARTITION other_regions  WITH (tablename='part_table')
           )
 `
+			} else {
+				expectedResult = `ALTER TABLE public.part_table 
+SET SUBPARTITION TEMPLATE 
+          (
+          SUBPARTITION usa VALUES('usa') WITH (tablename='part_table'), 
+          SUBPARTITION asia VALUES('asia') WITH (tablename='part_table'), 
+          SUBPARTITION europe VALUES('europe') WITH (tablename='part_table'), 
+          DEFAULT SUBPARTITION other_regions  WITH (tablename='part_table')
+          )
+`
+			}
 
 			Expect(result).To(Equal(expectedResult))
 		})
@@ -689,8 +705,13 @@ SET SUBPARTITION TEMPLATE
 			Expect(results).To(HaveLen(1))
 			result := results[oid]
 
-			// The spacing is very specific here and is output from the postgres function
-			expectedResult := `ALTER TABLE public.part_table 
+			/*
+			 * The spacing is very specific here and is output from the postgres function
+			 * The only difference between the below statements is spacing
+			 */
+			expectedResult := ""
+			if connectionPool.Version.Before("6") {
+				expectedResult = `ALTER TABLE public.part_table 
 SET SUBPARTITION TEMPLATE  
           (
           SUBPARTITION usa VALUES('usa') WITH (tablename='part_table'), 
@@ -699,8 +720,19 @@ SET SUBPARTITION TEMPLATE
           DEFAULT SUBPARTITION other_regions  WITH (tablename='part_table')
           )
 `
-
+			} else {
+				expectedResult = `ALTER TABLE public.part_table 
+SET SUBPARTITION TEMPLATE 
+          (
+          SUBPARTITION usa VALUES('usa') WITH (tablename='part_table'), 
+          SUBPARTITION asia VALUES('asia') WITH (tablename='part_table'), 
+          SUBPARTITION europe VALUES('europe') WITH (tablename='part_table'), 
+          DEFAULT SUBPARTITION other_regions  WITH (tablename='part_table')
+          )
+`
+			}
 			Expect(result).To(Equal(expectedResult))
+
 		})
 		It("returns a value for a subpartition template in a specific schema", func() {
 			testhelper.AssertQueryRuns(connectionPool, `CREATE TABLE public.part_table (trans_id int, date date, amount decimal(9,2), region text)
@@ -738,8 +770,13 @@ SET SUBPARTITION TEMPLATE
 			Expect(results).To(HaveLen(1))
 			result := results[oid]
 
-			// The spacing is very specific here and is output from the postgres function
-			expectedResult := `ALTER TABLE testschema.part_table 
+			/*
+			 * The spacing is very specific here and is output from the postgres function
+			 * The only difference between the below statements is spacing
+			 */
+			expectedResult := ""
+			if connectionPool.Version.Before("6") {
+				expectedResult = `ALTER TABLE testschema.part_table 
 SET SUBPARTITION TEMPLATE  
           (
           SUBPARTITION usa VALUES('usa') WITH (tablename='part_table'), 
@@ -748,6 +785,17 @@ SET SUBPARTITION TEMPLATE
           DEFAULT SUBPARTITION other_regions  WITH (tablename='part_table')
           )
 `
+			} else {
+				expectedResult = `ALTER TABLE testschema.part_table 
+SET SUBPARTITION TEMPLATE 
+          (
+          SUBPARTITION usa VALUES('usa') WITH (tablename='part_table'), 
+          SUBPARTITION asia VALUES('asia') WITH (tablename='part_table'), 
+          SUBPARTITION europe VALUES('europe') WITH (tablename='part_table'), 
+          DEFAULT SUBPARTITION other_regions  WITH (tablename='part_table')
+          )
+`
+			}
 
 			Expect(result).To(Equal(expectedResult))
 		})


### PR DESCRIPTION
The 9.4 merge introduced changes in the whitespace output from the
get_partitiondef and get_ruledef functions. Updated tests to account for
these changes.

Authored-by: Chris Hajas <chajas@pivotal.io>