### PR TITLE
Do not dump DB encoding info if it is the same as defaults

### DIFF
--- a/backup/metadata_globals.go
+++ b/backup/metadata_globals.go
@@ -23,20 +23,20 @@ SET client_encoding = '%s';
 	toc.AddGlobalEntry("", "", "SESSION GUCS", start, metadataFile)
 }
 
-func PrintCreateDatabaseStatement(metadataFile *utils.FileWithByteCount, toc *utils.TOC, db Database, dbMetadata MetadataMap) {
+func PrintCreateDatabaseStatement(metadataFile *utils.FileWithByteCount, toc *utils.TOC, defaultDB Database, db Database, dbMetadata MetadataMap) {
 	dbname := db.Name
 	start := metadataFile.ByteCount
 	metadataFile.MustPrintf("\n\nCREATE DATABASE %s TEMPLATE template0", dbname)
 	if db.Tablespace != "pg_default" {
 		metadataFile.MustPrintf(" TABLESPACE %s", db.Tablespace)
 	}
-	if db.Encoding != "" {
+	if db.Encoding != "" && (db.Encoding != defaultDB.Encoding) {
 		metadataFile.MustPrintf(" ENCODING '%s'", db.Encoding)
 	}
-	if db.Collate != "" {
+	if db.Collate != "" && (db.Collate != defaultDB.Collate) {
 		metadataFile.MustPrintf(" LC_COLLATE '%s'", db.Collate)
 	}
-	if db.CType != "" {
+	if db.CType != "" && (db.CType != defaultDB.CType) {
 		metadataFile.MustPrintf(" LC_CTYPE '%s'", db.CType)
 	}
 	metadataFile.MustPrintf(";")

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -350,9 +350,10 @@ func BackupTablespaces(metadataFile *utils.FileWithByteCount) {
 
 func BackupCreateDatabase(metadataFile *utils.FileWithByteCount) {
 	gplog.Verbose("Writing CREATE DATABASE statement to metadata file")
+	defaultDB := GetDefaultDatabaseEncodingInfo(connectionPool)
 	db := GetDatabaseInfo(connectionPool)
 	dbMetadata := GetMetadataForObjectType(connectionPool, TYPE_DATABASE)
-	PrintCreateDatabaseStatement(metadataFile, globalTOC, db, dbMetadata)
+	PrintCreateDatabaseStatement(metadataFile, globalTOC, defaultDB, db, dbMetadata)
 }
 
 func BackupDatabaseGUCs(metadataFile *utils.FileWithByteCount) {


### PR DESCRIPTION
This encoding info includes
* LC_COLLATE
* LC_CTYPE
* ENCODING
Since this information is often platform specific, not dumping it unless
necessary will make it easier to port database statements across
platforms.

Also adds integration tests for PrintCreateDatabaseStatement