### PR TITLE
Support restoring database with read only GUC set

### DIFF
--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -57,6 +57,7 @@ SET default_with_oids = off;
 	if connectionPool.Version.AtLeast("6") {
 		setupQuery += "SET allow_system_table_mods = true;\n"
 		setupQuery += "SET lock_timeout = 0;\n"
+		setupQuery += "SET default_transaction_read_only = off;\n"
 	}
 	setupQuery += SetMaxCsvLineLengthQuery(connectionPool)
 


### PR DESCRIPTION
If a database has a ALTER DATABASE SET default_transaction_read_only
setting, restore would fail since the database would not allow writing.
Instead, set this GUC off during the restore session. This GUC was
introduced in GPDB6.

Authored-by: Chris Hajas <chajas@pivotal.io>