### PR TITLE
Fix backup filter validation inconsistencies

### DIFF
--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -19,7 +19,9 @@ func relationAndSchemaFilterClause() string {
 	filterClause := SchemaFilterClause("n")
 	if len(MustGetFlagStringSlice(utils.EXCLUDE_RELATION)) > 0 {
 		excludeOids := GetOidsFromRelationList(connectionPool, MustGetFlagStringSlice(utils.EXCLUDE_RELATION))
-		filterClause += fmt.Sprintf("\nAND c.oid NOT IN (%s)", strings.Join(excludeOids, ", "))
+		if len(excludeOids) > 0 {
+			filterClause += fmt.Sprintf("\nAND c.oid NOT IN (%s)", strings.Join(excludeOids, ", "))
+		}
 	}
 	if len(MustGetFlagStringSlice(utils.INCLUDE_RELATION)) > 0 {
 		includeOids := GetOidsFromRelationList(connectionPool, MustGetFlagStringSlice(utils.INCLUDE_RELATION))

--- a/backup/validate.go
+++ b/backup/validate.go
@@ -15,9 +15,7 @@ import (
  */
 
 func validateFilterLists() {
-	ValidateFilterSchemas(connectionPool, MustGetFlagStringSlice(utils.EXCLUDE_SCHEMA))
 	ValidateFilterSchemas(connectionPool, MustGetFlagStringSlice(utils.INCLUDE_SCHEMA))
-	ValidateFilterTables(connectionPool, MustGetFlagStringSlice(utils.EXCLUDE_RELATION))
 	ValidateFilterTables(connectionPool, MustGetFlagStringSlice(utils.INCLUDE_RELATION))
 }
 
@@ -28,6 +26,7 @@ func ValidateFilterSchemas(connectionPool *dbconn.DBConn, schemaList []string) {
 		resultSchemas := dbconn.MustSelectStringSlice(connectionPool, query)
 		if len(resultSchemas) < len(schemaList) {
 			schemaSet := utils.NewIncludeSet(resultSchemas)
+			schemaSet.AlwaysMatchesFilter = false
 			for _, schema := range schemaList {
 				if !schemaSet.MatchesFilter(schema) {
 					gplog.Fatal(nil, "Schema %s does not exist", schema)

--- a/backup/validate.go
+++ b/backup/validate.go
@@ -21,7 +21,7 @@ func validateFilterLists() {
 	ValidateFilterTables(connectionPool, MustGetFlagStringSlice(utils.EXCLUDE_RELATION), true)
 }
 
-func ValidateFilterSchemas(connectionPool *dbconn.DBConn, schemaList []string, noFatal bool) {
+func ValidateFilterSchemas(connectionPool *dbconn.DBConn, schemaList []string, excludeSet bool) {
 	if len(schemaList) == 0 {
 		return
 	}
@@ -33,7 +33,7 @@ func ValidateFilterSchemas(connectionPool *dbconn.DBConn, schemaList []string, n
 		schemaSet.AlwaysMatchesFilter = false
 		for _, schema := range schemaList {
 			if !schemaSet.MatchesFilter(schema) {
-				if noFatal {
+				if excludeSet {
 					gplog.Warn(`Excluded schema %s does not exist`, schema)
 				} else {
 					gplog.Fatal(nil, "Schema %s does not exist", schema)
@@ -43,7 +43,7 @@ func ValidateFilterSchemas(connectionPool *dbconn.DBConn, schemaList []string, n
 	}
 }
 
-func ValidateFilterTables(connectionPool *dbconn.DBConn, tableList []string, noFatal bool) {
+func ValidateFilterTables(connectionPool *dbconn.DBConn, tableList []string, excludeSet bool) {
 	if len(tableList) == 0 {
 		return
 	}
@@ -71,7 +71,7 @@ WHERE quote_ident(n.nspname) || '.' || quote_ident(c.relname) IN (%s)`, quotedTa
 	for _, table := range tableList {
 		tableOid := tableMap[table]
 		if tableOid == 0 {
-			if noFatal {
+			if excludeSet {
 				gplog.Warn("Excluded table %s does not exist", table)
 			} else {
 				gplog.Fatal(nil, "Table %s does not exist", table)

--- a/integration/predata_relations_queries_test.go
+++ b/integration/predata_relations_queries_test.go
@@ -287,6 +287,18 @@ PARTITION BY LIST (gender)
 			Expect(tables).To(HaveLen(1))
 			structmatcher.ExpectStructsToMatchExcluding(&tableFoo, &tables[0], "SchemaOid", "Oid")
 		})
+		It("returns user table information for tables even with an non existant excludeTable", func() {
+			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.foo(i int)")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.foo")
+
+			backupCmdFlags.Set(utils.EXCLUDE_RELATION, "testschema.nonexistant")
+			tables := backup.GetAllUserTables(connectionPool)
+
+			tableFoo := backup.Relation{Schema: "public", Name: "foo"}
+
+			Expect(tables).To(HaveLen(1))
+			structmatcher.ExpectStructsToMatchExcluding(&tableFoo, &tables[0], "SchemaOid", "Oid")
+		})
 	})
 	Describe("GetPartitionTableMap", func() {
 		It("correctly maps oids to parent or leaf table types", func() {

--- a/restore/validate_test.go
+++ b/restore/validate_test.go
@@ -18,7 +18,7 @@ var _ = Describe("restore/validate tests", func() {
 	AfterEach(func() {
 		filterList = []string{}
 	})
-	Describe("ValidateFilterSchemasInBackupSet", func() {
+	Describe("ValidateSchemasInBackupSet", func() {
 		sequence := utils.StatementWithType{ObjectType: "SEQUENCE", Statement: "CREATE SEQUENCE schema.somesequence"}
 		sequenceLen := uint64(len(sequence.Statement))
 		table1 := utils.StatementWithType{ObjectType: "TABLE", Statement: "CREATE TABLE schema1.table1"}
@@ -40,30 +40,30 @@ var _ = Describe("restore/validate tests", func() {
 		It("passes when schema exists in normal backup", func() {
 			restore.SetBackupConfig(&utils.BackupConfig{})
 			filterList = []string{"schema1"}
-			restore.ValidateFilterSchemasInBackupSet(filterList, false)
+			restore.ValidateIncludeSchemasInBackupSet(filterList)
 		})
 		It("panics when schema does not exist in normal backup", func() {
 			restore.SetBackupConfig(&utils.BackupConfig{})
 			filterList = []string{"schema3"}
 			defer testhelper.ShouldPanicWithMessage("Could not find the following schema(s) in the backup set: schema3")
-			restore.ValidateFilterSchemasInBackupSet(filterList, false)
+			restore.ValidateIncludeSchemasInBackupSet(filterList)
 		})
 		It("passes when schema exists in data-only backup", func() {
 			restore.SetBackupConfig(&utils.BackupConfig{DataOnly: true})
 			filterList = []string{"schema1"}
-			restore.ValidateFilterSchemasInBackupSet(filterList, false)
+			restore.ValidateIncludeSchemasInBackupSet(filterList)
 		})
 		It("panics when schema does not exist in data-only backup", func() {
 			restore.SetBackupConfig(&utils.BackupConfig{DataOnly: true})
 			filterList = []string{"schema3"}
 			defer testhelper.ShouldPanicWithMessage("Could not find the following schema(s) in the backup set: schema3")
-			restore.ValidateFilterSchemasInBackupSet(filterList, false)
+			restore.ValidateIncludeSchemasInBackupSet(filterList)
 		})
 		It("generates warning when exclude-schema does not exist in backup and noFatal is true", func() {
 			_, _, logfile = testhelper.SetupTestLogger()
 			restore.SetBackupConfig(&utils.BackupConfig{})
 			filterList = []string{"schema3"}
-			restore.ValidateFilterSchemasInBackupSet(filterList, true)
+			restore.ValidateExcludeSchemasInBackupSet(filterList)
 			testhelper.ExpectRegexp(logfile, "[WARNING]:-Could not find the following excluded schema(s) in the backup set: schema3")
 		})
 	})
@@ -186,7 +186,7 @@ var _ = Describe("restore/validate tests", func() {
 			})
 		})
 	})
-	Describe("ValidateFilterRelationsInBackupSet", func() {
+	Describe("ValidateRelationsInBackupSet", func() {
 		var toc *utils.TOC
 		var backupfile *utils.FileWithByteCount
 		BeforeEach(func() {
@@ -206,57 +206,57 @@ var _ = Describe("restore/validate tests", func() {
 		It("passes when table exists in normal backup", func() {
 			restore.SetBackupConfig(&utils.BackupConfig{})
 			filterList = []string{"schema1.table1"}
-			restore.ValidateFilterRelationsInBackupSet(filterList, false)
+			restore.ValidateIncludeRelationsInBackupSet(filterList)
 		})
 		It("panics when table does not exist in normal backup", func() {
 			restore.SetBackupConfig(&utils.BackupConfig{})
 			filterList = []string{"schema1.table3"}
 			defer testhelper.ShouldPanicWithMessage("Could not find the following relation(s) in the backup set: schema1.table3")
-			restore.ValidateFilterRelationsInBackupSet(filterList, false)
+			restore.ValidateIncludeRelationsInBackupSet(filterList)
 		})
 		It("passes when sequence exists in normal backup", func() {
 			restore.SetBackupConfig(&utils.BackupConfig{})
 			filterList = []string{"schema1.somesequence"}
-			restore.ValidateFilterRelationsInBackupSet(filterList, false)
+			restore.ValidateIncludeRelationsInBackupSet(filterList)
 		})
 		It("generates a warning if the exclude-schema is not in the backup set and noFatal is true", func() {
 			_, _, logfile = testhelper.SetupTestLogger()
 			restore.SetBackupConfig(&utils.BackupConfig{})
 			filterList = []string{"schema1.table3"}
-			restore.ValidateFilterRelationsInBackupSet(filterList, true)
+			restore.ValidateExcludeRelationsInBackupSet(filterList)
 			testhelper.ExpectRegexp(logfile, "[WARNING]:-Could not find the following excluded relation(s) in the backup set: schema1.table3")
 		})
 		It("passes when view exists in normal backup", func() {
 			restore.SetBackupConfig(&utils.BackupConfig{})
 			filterList = []string{"schema1.someview"}
-			restore.ValidateFilterRelationsInBackupSet(filterList, false)
+			restore.ValidateIncludeRelationsInBackupSet(filterList)
 		})
 		It("passes when table exists in data-only backup", func() {
 			restore.SetBackupConfig(&utils.BackupConfig{DataOnly: true})
 			filterList = []string{"schema1.table1"}
-			restore.ValidateFilterRelationsInBackupSet(filterList, false)
+			restore.ValidateIncludeRelationsInBackupSet(filterList)
 		})
 		It("panics when relation does not exist in backup but function with same name does", func() {
 			restore.SetBackupConfig(&utils.BackupConfig{})
 			filterList = []string{"schema1.somefunction"}
 			defer testhelper.ShouldPanicWithMessage("Could not find the following relation(s) in the backup set: schema1.somefunction")
-			restore.ValidateFilterRelationsInBackupSet(filterList, false)
+			restore.ValidateIncludeRelationsInBackupSet(filterList)
 		})
 		It("table does not exist in data-only backup", func() {
 			restore.SetBackupConfig(&utils.BackupConfig{DataOnly: true})
 			filterList = []string{"schema1.table3"}
 			defer testhelper.ShouldPanicWithMessage("Could not find the following relation(s) in the backup set: schema1.table3")
-			restore.ValidateFilterRelationsInBackupSet(filterList, false)
+			restore.ValidateIncludeRelationsInBackupSet(filterList)
 		})
 		It("passes when table exists in most recent restore plan entry", func() {
 			restore.SetBackupConfig(&utils.BackupConfig{RestorePlan: []utils.RestorePlanEntry{{TableFQNs: []string{"schema1.table1_part_1"}}}})
 			filterList = []string{"schema1.table1_part_1"}
-			restore.ValidateFilterRelationsInBackupSet(filterList, false)
+			restore.ValidateIncludeRelationsInBackupSet(filterList)
 		})
 		It("passes when table exists in previous restore plan entry", func() {
 			restore.SetBackupConfig(&utils.BackupConfig{RestorePlan: []utils.RestorePlanEntry{{TableFQNs: []string{"schema1.random_table"}}, {TableFQNs: []string{"schema1.table1_part_1"}}}})
 			filterList = []string{"schema1.table1_part_1"}
-			restore.ValidateFilterRelationsInBackupSet(filterList, false)
+			restore.ValidateIncludeRelationsInBackupSet(filterList)
 		})
 	})
 	Describe("ValidateDatabaseExistence", func() {


### PR DESCRIPTION
When backing up with a nonexistent table and schema using the
--exclude-table/--exclude-schema flag gpbackup would fatal. We now allow
this by removing the validation of the --exclude-table and
--exclude-schema flag as users may want to exclude tables/schemas that
may or may not exist at the time of backup.

When backing up with filtered schemas or tables that do not exist in the
database using --include-schema or --include-table, gpbackup will fail
to validate. This behavior is not intended. Now we properly validate
filter options

Additionally, log warnings when a table/schema does not exist with an --exclude flag.

Co-Authored-by: Kevin Yeap <kyeap@pivotal.io>
Co-Authored-by: Chris Hajas <chajas@pivotal.io>
