### PR TITLE
Refactor set implementation

### DIFF
--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -64,10 +64,8 @@ func SplitTablesByPartitionType(tables []Relation, tableDefs map[uint32]TableDef
 				if partType != "p" && partType != "i" {
 					dataTables = append(dataTables, table)
 				}
-			} else if len(includeList) > 0 {
-				if includeSet.MatchesFilter(table.FQN()) {
-					dataTables = append(dataTables, table)
-				}
+			} else if includeSet.MatchesFilter(table.FQN()) {
+				dataTables = append(dataTables, table)
 			}
 		}
 	} else {

--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -50,7 +50,7 @@ func SplitTablesByPartitionType(tables []Relation, tableDefs map[uint32]TableDef
 	metadataTables := make([]Relation, 0)
 	dataTables := make([]Relation, 0)
 	if MustGetFlagBool(utils.LEAF_PARTITION_DATA) || len(includeList) > 0 {
-		includeSet := utils.NewIncludeSet(includeList)
+		includeSet := utils.NewSet(includeList)
 		for _, table := range tables {
 			if tableDefs[table.Oid].IsExternal && tableDefs[table.Oid].PartitionLevelInfo.Level == "l" {
 				table.Name = AppendExtPartSuffix(table.Name)

--- a/backup/validate.go
+++ b/backup/validate.go
@@ -29,8 +29,7 @@ func ValidateFilterSchemas(connectionPool *dbconn.DBConn, schemaList []string, e
 	query := fmt.Sprintf("SELECT nspname AS string FROM pg_namespace WHERE nspname IN (%s)", quotedSchemasStr)
 	resultSchemas := dbconn.MustSelectStringSlice(connectionPool, query)
 	if len(resultSchemas) < len(schemaList) {
-		schemaSet := utils.NewIncludeSet(resultSchemas)
-		schemaSet.AlwaysMatchesFilter = false
+		schemaSet := utils.NewSet(resultSchemas)
 		for _, schema := range schemaList {
 			if !schemaSet.MatchesFilter(schema) {
 				if excludeSet {

--- a/restore/validate.go
+++ b/restore/validate.go
@@ -125,9 +125,7 @@ WHERE quote_ident(n.nspname) || '.' || quote_ident(c.relname) IN (%s)`, quotedTa
 	errMsg := ""
 	if backupConfig.DataOnly || MustGetFlagBool(utils.DATA_ONLY) {
 		if len(relationsInDB) < len(relationList) {
-			dbRelationsSet := utils.NewIncludeSet(relationsInDB)
-			//The default behavior is to match when the set is empty, but we don't want this
-			dbRelationsSet.AlwaysMatchesFilter = false
+			dbRelationsSet := utils.NewSet(relationsInDB)
 			for _, restoreRelation := range relationList {
 				matches := dbRelationsSet.MatchesFilter(restoreRelation)
 				if !matches {

--- a/utils/set.go
+++ b/utils/set.go
@@ -22,20 +22,24 @@ type FilterSet struct {
 	AlwaysMatchesFilter bool
 }
 
-func NewIncludeSet(list []string) *FilterSet {
+func NewSet(list []string) *FilterSet {
 	newSet := FilterSet{}
-	newSet.AlwaysMatchesFilter = len(list) == 0
 	newSet.Set = make(map[string]bool, len(list))
-	if !newSet.AlwaysMatchesFilter {
-		for _, item := range list {
-			newSet.Set[item] = true
-		}
+	for _, item := range list {
+		newSet.Set[item] = true
 	}
 	return &newSet
 }
 
+func NewIncludeSet(list []string) *FilterSet {
+	newSet := NewSet(list)
+	(*newSet).AlwaysMatchesFilter = len(list) == 0
+	return newSet
+}
+
 func NewExcludeSet(list []string) *FilterSet {
-	newSet := NewIncludeSet(list)
+	newSet := NewSet(list)
+	(*newSet).AlwaysMatchesFilter = len(list) == 0
 	(*newSet).IsExclude = true
 	return newSet
 }
@@ -53,18 +57,6 @@ func (s *FilterSet) MatchesFilter(item string) bool {
 
 func (s *FilterSet) Length() int {
 	return len(s.Set)
-}
-
-func (s *FilterSet) Add(item string) {
-	s.Set[item] = true
-	s.AlwaysMatchesFilter = false
-}
-
-func (s *FilterSet) Delete(item string) {
-	delete(s.Set, item)
-	if s.Length() == 0 {
-		s.AlwaysMatchesFilter = true
-	}
 }
 
 func (s *FilterSet) Equals(s1 *FilterSet) bool {

--- a/utils/set_test.go
+++ b/utils/set_test.go
@@ -8,92 +8,95 @@ import (
 )
 
 var _ = Describe("utils/set tests", func() {
-	var inc, exc, incEmpty, excEmpty *utils.FilterSet
-	BeforeEach(func() {
-		inc = utils.NewIncludeSet([]string{"foo", "bar"})
-		exc = utils.NewExcludeSet([]string{"foo", "bar"})
-		incEmpty = utils.NewIncludeSet([]string{})
-		excEmpty = utils.NewExcludeSet([]string{})
+	Describe("NewSet", func() {
+		It("can create a set from an empty list", func() {
+			emptySet := utils.NewSet([]string{})
+
+			expectedMap := map[string]bool{}
+			Expect(emptySet.Set).To(Equal(expectedMap))
+			Expect(emptySet.IsExclude).To(BeFalse())
+			Expect(emptySet.AlwaysMatchesFilter).To(BeFalse())
+		})
+		It("can create a set from a list of strings", func() {
+			setWithEntries := utils.NewSet([]string{"foo", "bar"})
+
+			expectedMap := map[string]bool{"foo": true, "bar": true}
+			Expect(setWithEntries.Set).To(Equal(expectedMap))
+			Expect(setWithEntries.IsExclude).To(BeFalse())
+			Expect(setWithEntries.AlwaysMatchesFilter).To(BeFalse())
+		})
 	})
 	Describe("NewIncludeSet", func() {
 		It("can create a set from an empty list", func() {
+			emptyInclude := utils.NewIncludeSet([]string{})
+
 			expectedMap := map[string]bool{}
-			Expect(incEmpty.Set).To(Equal(expectedMap))
-			Expect(incEmpty.IsExclude).To(BeFalse())
-			Expect(incEmpty.AlwaysMatchesFilter).To(BeTrue())
+			Expect(emptyInclude.Set).To(Equal(expectedMap))
+			Expect(emptyInclude.IsExclude).To(BeFalse())
+			Expect(emptyInclude.AlwaysMatchesFilter).To(BeTrue())
 		})
 		It("can create a set from a list of strings", func() {
+			includeWithEntries := utils.NewIncludeSet([]string{"foo", "bar"})
+
 			expectedMap := map[string]bool{"foo": true, "bar": true}
-			Expect(inc.Set).To(Equal(expectedMap))
-			Expect(inc.IsExclude).To(BeFalse())
-			Expect(inc.AlwaysMatchesFilter).To(BeFalse())
+			Expect(includeWithEntries.Set).To(Equal(expectedMap))
+			Expect(includeWithEntries.IsExclude).To(BeFalse())
+			Expect(includeWithEntries.AlwaysMatchesFilter).To(BeFalse())
 		})
 	})
 	Describe("NewExcludeSet", func() {
 		It("can create a set from an empty list", func() {
+			emptyExclude := utils.NewExcludeSet([]string{})
+
 			expectedMap := map[string]bool{}
-			Expect(excEmpty.Set).To(Equal(expectedMap))
-			Expect(excEmpty.IsExclude).To(BeTrue())
-			Expect(excEmpty.AlwaysMatchesFilter).To(BeTrue())
+			Expect(emptyExclude.Set).To(Equal(expectedMap))
+			Expect(emptyExclude.IsExclude).To(BeTrue())
+			Expect(emptyExclude.AlwaysMatchesFilter).To(BeTrue())
 		})
 		It("can create a set from a list of strings", func() {
+			excludeWithEntries := utils.NewExcludeSet([]string{"foo", "bar"})
+
 			expectedMap := map[string]bool{"foo": true, "bar": true}
-			Expect(exc.Set).To(Equal(expectedMap))
-			Expect(exc.IsExclude).To(BeTrue())
-			Expect(exc.AlwaysMatchesFilter).To(BeFalse())
+			Expect(excludeWithEntries.Set).To(Equal(expectedMap))
+			Expect(excludeWithEntries.IsExclude).To(BeTrue())
+			Expect(excludeWithEntries.AlwaysMatchesFilter).To(BeFalse())
 		})
 	})
 	Describe("MatchesFilter", func() {
-		It("returns true if an item is in a non-empty include set", func() {
-			Expect(inc.MatchesFilter("foo")).To(BeTrue())
+		Context("Include Set", func() {
+			It("returns true if an item is in a non-empty include set", func() {
+				includeWithEntries := utils.NewIncludeSet([]string{"foo", "bar"})
+				Expect(includeWithEntries.MatchesFilter("foo")).To(BeTrue())
+			})
+			It("returns false if an item is not in a non-empty include set", func() {
+				includeWithEntries := utils.NewIncludeSet([]string{"foo", "bar"})
+				Expect(includeWithEntries.MatchesFilter("nonexistent")).To(BeFalse())
+			})
+			It("returns true if an include set is empty", func() {
+				emptyInclude := utils.NewIncludeSet([]string{})
+				Expect(emptyInclude.MatchesFilter("foo")).To(BeTrue())
+			})
 		})
-		It("returns false if an item is not in a non-empty include set", func() {
-			Expect(inc.MatchesFilter("nonexistent")).To(BeFalse())
-		})
-		It("returns true if an include set is empty", func() {
-			Expect(incEmpty.MatchesFilter("foo")).To(BeTrue())
-		})
-		It("returns true if an item is not in a non-empty exclude set", func() {
-			Expect(exc.MatchesFilter("nonexistent")).To(BeTrue())
-		})
-		It("returns false if an item is in a non-empty exclude set", func() {
-			Expect(exc.MatchesFilter("foo")).To(BeFalse())
-		})
-		It("returns true if an exclude set is empty", func() {
-			Expect(excEmpty.MatchesFilter("foo")).To(BeTrue())
+		Context("Exclude Set", func() {
+			It("returns true if an item is not in a non-empty exclude set", func() {
+				excludeWithEntries := utils.NewExcludeSet([]string{"foo", "bar"})
+				Expect(excludeWithEntries.MatchesFilter("nonexistent")).To(BeTrue())
+			})
+			It("returns false if an item is in a non-empty exclude set", func() {
+				excludeWithEntries := utils.NewExcludeSet([]string{"foo", "bar"})
+				Expect(excludeWithEntries.MatchesFilter("foo")).To(BeFalse())
+			})
+			It("returns true if an exclude set is empty", func() {
+				emptyExclude := utils.NewExcludeSet([]string{})
+				Expect(emptyExclude.MatchesFilter("foo")).To(BeTrue())
+			})
 		})
 	})
 	Describe("Length", func() {
 		It("returns the length of the underlying map", func() {
-			Expect(inc.Length()).To(Equal(2))
-		})
-	})
-	Describe("Add", func() {
-		It("adds an item to a non-empty set", func() {
-			Expect(inc.Length()).To(Equal(2))
-			Expect(inc.AlwaysMatchesFilter).To(BeFalse())
-			inc.Add("baz")
-			Expect(inc.Length()).To(Equal(3))
-			Expect(inc.AlwaysMatchesFilter).To(BeFalse())
-		})
-		It("adds an item to an empty set and sets AlwaysMatchesFilter to false", func() {
-			Expect(incEmpty.Length()).To(Equal(0))
-			Expect(incEmpty.AlwaysMatchesFilter).To(BeTrue())
-			incEmpty.Add("baz")
-			Expect(incEmpty.Length()).To(Equal(1))
-			Expect(incEmpty.AlwaysMatchesFilter).To(BeFalse())
-		})
-	})
-	Describe("Delete", func() {
-		It("removes an item from a non-empty set and sets AlwaysMatchesFilter to true if the new length is 0", func() {
-			Expect(inc.Length()).To(Equal(2))
-			Expect(inc.AlwaysMatchesFilter).To(BeFalse())
-			inc.Delete("bar")
-			Expect(inc.Length()).To(Equal(1))
-			Expect(inc.AlwaysMatchesFilter).To(BeFalse())
-			inc.Delete("foo")
-			Expect(inc.Length()).To(Equal(0))
-			Expect(inc.AlwaysMatchesFilter).To(BeTrue())
+			setWithEntries := utils.NewSet([]string{"foo", "bar"})
+
+			Expect(setWithEntries.Length()).To(Equal(2))
 		})
 	})
 	Describe("Equals", func() {

--- a/utils/toc.go
+++ b/utils/toc.go
@@ -180,8 +180,7 @@ func shouldIncludeStatement(entry MetadataEntry, objectSet *FilterSet, schemaSet
 }
 
 func getLeafPartitions(tableFQNs []string, tocDataEntries []MasterDataEntry) (leafPartitions []string) {
-	tableSet := NewIncludeSet(tableFQNs)
-	tableSet.AlwaysMatchesFilter = false
+	tableSet := NewSet(tableFQNs)
 
 	for _, entry := range tocDataEntries {
 		if entry.PartitionRoot == "" {
@@ -216,8 +215,7 @@ func (toc *TOC) GetDataEntriesMatching(includeSchemas []string, excludeSchemas [
 		tableSet = NewExcludeSet(excludeTableFQNs)
 	}
 
-	restorePlanTableSet := NewIncludeSet(restorePlanTableFQNs)
-	restorePlanTableSet.AlwaysMatchesFilter = false
+	restorePlanTableSet := NewSet(restorePlanTableFQNs)
 
 	matchingEntries := make([]MasterDataEntry, 0)
 	for _, entry := range toc.DataEntries {


### PR DESCRIPTION
Previously, we were using sets for two purposes:
  1) As an include or exclude set to match table/schemas that were to be
  included or excluded from the backup or restore
  2) As a regular set

The first case uses a modified implementation, where an empty set would
always return that a object exists. This was done so that the default
behavior would backup/restore all objects. However, in cases where a
generic set without the property was wanted, it could lead to confusing
behavior.

This introduces a NewSet constructor and replaces instances that should
have been using a regular set with this call.

Additionally, this removes the Add and Delete set functionality since
they weren't being used.

Authored-by: Chris Hajas <chajas@pivotal.io>