### PR TITLE
Fix on-error-continue case for restoreSchemas

### DIFF
--- a/backup/backup_suite_test.go
+++ b/backup/backup_suite_test.go
@@ -39,10 +39,6 @@ func TestBackup(t *testing.T) {
 
 var cmdFlags *pflag.FlagSet
 
-var _ = BeforeSuite(func() {
-	connectionPool, mock, stdout, stderr, logfile = testutils.SetupTestEnvironment()
-})
-
 var _ = BeforeEach(func() {
 	cmdFlags = pflag.NewFlagSet("gpbackup", pflag.ExitOnError)
 
@@ -52,6 +48,8 @@ var _ = BeforeEach(func() {
 
 	utils.SetPipeThroughProgram(utils.PipeThroughProgram{})
 
+	connectionPool, mock, stdout, stderr, logfile = testutils.SetupTestEnvironment()
+	backup.SetConnection(connectionPool)
+	backup.InitializeMetadataParams(connectionPool)
 	buffer = gbytes.NewBuffer()
-	connectionPool, mock = testutils.CreateAndConnectMockDB(1)
 })

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -194,7 +194,7 @@ func restorePredata(metadataFilename string) {
 	progressBar := utils.NewProgressBar(len(schemaStatements)+len(statements), "Pre-data objects restored: ", utils.PB_VERBOSE)
 	progressBar.Start()
 
-	restoreSchemas(schemaStatements, progressBar)
+	RestoreSchemas(schemaStatements, progressBar)
 	ExecuteRestoreMetadataStatements(statements, "Pre-data objects", progressBar, utils.PB_VERBOSE, false)
 
 	progressBar.Finish()

--- a/restore/restore_suite_test.go
+++ b/restore/restore_suite_test.go
@@ -50,13 +50,10 @@ func TestRestore(t *testing.T) {
 
 var cmdFlags *pflag.FlagSet
 
-var _ = BeforeSuite(func() {
-	connectionPool, mock, stdout, stderr, logfile = testutils.SetupTestEnvironment()
-	buffer = gbytes.NewBuffer()
-})
-
 var _ = BeforeEach(func() {
-	connectionPool, mock = testutils.CreateAndConnectMockDB(1)
+	connectionPool, mock, stdout, stderr, logfile = testutils.SetupTestEnvironment()
+	restore.SetConnection(connectionPool)
+	buffer = gbytes.NewBuffer()
 
 	cmdFlags = pflag.NewFlagSet("gprestore", pflag.ExitOnError)
 	restore.SetCmdFlags(cmdFlags)

--- a/restore/wrappers_test.go
+++ b/restore/wrappers_test.go
@@ -3,8 +3,11 @@ package restore_test
 import (
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup/restore"
+	"github.com/greenplum-db/gpbackup/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+	"gopkg.in/DATA-DOG/go-sqlmock.v1"
 )
 
 var _ = Describe("wrapper tests", func() {
@@ -33,6 +36,57 @@ var _ = Describe("wrapper tests", func() {
 			testhelper.SetDBVersion(connectionPool, "5.10.999")
 			result := restore.SetMaxCsvLineLengthQuery(connectionPool)
 			Expect(result).To(Equal("SET gp_max_csv_line_length = 4194304;\n"))
+		})
+	})
+	Describe("RestoreSchemas", func() {
+		var (
+			ignoredProgressBar utils.ProgressBar
+			schemaArray        = []utils.StatementWithType{{Name: "foo", Statement: "create schema foo"}}
+		)
+		BeforeEach(func() {
+			ignoredProgressBar = utils.NewProgressBar(1, "", utils.PB_NONE)
+			ignoredProgressBar.Start()
+		})
+		AfterEach(func() {
+			ignoredProgressBar.Finish()
+		})
+		It("logs nothing if there are no errors", func() {
+			expectedResult := sqlmock.NewResult(0, 1)
+			mock.ExpectExec("create schema foo").WillReturnResult(expectedResult)
+
+			restore.RestoreSchemas(schemaArray, ignoredProgressBar)
+
+			testhelper.NotExpectRegexp(logfile, "Schema foo already exists")
+			testhelper.NotExpectRegexp(logfile, "Error encountered while creating schema foo")
+		})
+		It("logs warning if schema already exists", func() {
+			expectedErr := errors.New(`schema "foo" already exists`)
+			mock.ExpectExec("create schema foo").WillReturnError(expectedErr)
+
+			restore.RestoreSchemas(schemaArray, ignoredProgressBar)
+
+			testhelper.ExpectRegexp(logfile, "[WARNING]:-Schema foo already exists")
+		})
+		It("logs error if --on-error-continue is set", func() {
+			cmdFlags.Set(utils.ON_ERROR_CONTINUE, "true")
+			defer cmdFlags.Set(utils.ON_ERROR_CONTINUE, "false")
+			expectedErr := errors.New("some other schema error")
+			mock.ExpectExec("create schema foo").WillReturnError(expectedErr)
+
+			restore.RestoreSchemas(schemaArray, ignoredProgressBar)
+
+			expectedDebugMsg := "[DEBUG]:-Error encountered while creating schema foo: some other schema error"
+			testhelper.ExpectRegexp(logfile, expectedDebugMsg)
+			expectedErrMsg := "[ERROR]:-Encountered 1 errors during schema restore; see log file gbytes.Buffer for a list of errors."
+			testhelper.ExpectRegexp(logfile, expectedErrMsg)
+		})
+		It("panics if create schema statement fails", func() {
+			expectedErr := errors.New("some other schema error")
+			mock.ExpectExec("create schema foo").WillReturnError(expectedErr)
+			expectedPanicMsg := "[CRITICAL]:-some other schema error: Error encountered while creating schema foo"
+			defer testhelper.ShouldPanicWithMessage(expectedPanicMsg)
+
+			restore.RestoreSchemas(schemaArray, ignoredProgressBar)
 		})
 	})
 })

--- a/testutils/functions.go
+++ b/testutils/functions.go
@@ -32,14 +32,6 @@ func SetupTestEnvironment() (*dbconn.DBConn, sqlmock.Sqlmock, *gbytes.Buffer, *g
 	return connectionPool, mock, testStdout, testStderr, testLogfile
 }
 
-func CreateAndConnectMockDB(numConns int) (*dbconn.DBConn, sqlmock.Sqlmock) {
-	connectionPool, mock := testhelper.CreateAndConnectMockDB(numConns)
-	backup.SetConnection(connectionPool)
-	restore.SetConnection(connectionPool)
-	backup.InitializeMetadataParams(connectionPool)
-	return connectionPool, mock
-}
-
 func SetupTestCluster() {
 	testCluster := SetDefaultSegmentConfiguration()
 	backup.SetCluster(testCluster)

--- a/utils/utils_suite_test.go
+++ b/utils/utils_suite_test.go
@@ -46,8 +46,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = BeforeEach(func() {
-	stdout, stderr, logfile = testhelper.SetupTestLogger()
-	connectionPool, mock = testutils.CreateAndConnectMockDB(1)
+	connectionPool, mock, stdout, stderr, logfile = testhelper.SetupTestEnvironment()
 	operating.System = operating.InitializeSystemFunctions()
 	buffer = gbytes.NewBuffer()
 })


### PR DESCRIPTION
We were not failing on errors if the schema already existed, but we were
failing if we encountered some other error. Now we will log and continue
if --on-error-continue is set.

