### PR TITLE
Support ALTER TABLESPACE ... SET options

### DIFF
--- a/backup/metadata_globals.go
+++ b/backup/metadata_globals.go
@@ -310,6 +310,13 @@ func PrintCreateTablespaceStatements(metadataFile *utils.FileWithByteCount, toc 
 		}
 		metadataFile.MustPrintf("\n\nCREATE TABLESPACE %s %s;", tablespace.Tablespace, locationStr)
 		toc.AddGlobalEntry("", tablespace.Tablespace, "TABLESPACE", start, metadataFile)
+
+		if tablespace.Options != "" {
+			start = metadataFile.ByteCount
+			metadataFile.MustPrintf("\n\nALTER TABLESPACE %s SET (%s);\n", tablespace.Tablespace, tablespace.Options)
+			toc.AddGlobalEntry("", tablespace.Tablespace, "TABLESPACE", start, metadataFile)
+		}
+
 		start = metadataFile.ByteCount
 		PrintObjectMetadata(metadataFile, tablespaceMetadata[tablespace.GetUniqueID()], tablespace.Tablespace, "TABLESPACE")
 		if metadataFile.ByteCount > start {

--- a/backup/metadata_globals_test.go
+++ b/backup/metadata_globals_test.go
@@ -378,5 +378,19 @@ GRANT ALL ON TABLESPACE test_tablespace TO testrole;`)
 			testutils.AssertBufferContents(toc.GlobalEntries, buffer, `CREATE TABLESPACE test_tablespace LOCATION '/data/dir'
 	WITH (content1='/data/dir1', content2='/data/dir2', content3='/data/dir3');`)
 		})
+		It("prints a tablespace with options", func() {
+			expectedTablespace := backup.Tablespace{
+				Oid: 1, Tablespace: "test_tablespace", FileLocation: "'/data/dir'",
+				SegmentLocations: []string{},
+				Options:          "param1=val1, param2=val2",
+			}
+			emptyMetadataMap := backup.MetadataMap{}
+			backup.PrintCreateTablespaceStatements(backupfile, toc, []backup.Tablespace{expectedTablespace}, emptyMetadataMap)
+			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "", "test_tablespace", "TABLESPACE")
+			testutils.ExpectEntry(toc.GlobalEntries, 1, "", "", "test_tablespace", "TABLESPACE")
+			expectedStatements := []string{`CREATE TABLESPACE test_tablespace LOCATION '/data/dir';`,
+				`ALTER TABLESPACE test_tablespace SET (param1=val1, param2=val2);`}
+			testutils.AssertBufferContents(toc.GlobalEntries, buffer, expectedStatements...)
+		})
 	})
 })

--- a/backup/queries_globals.go
+++ b/backup/queries_globals.go
@@ -385,6 +385,7 @@ type Tablespace struct {
 	Tablespace       string
 	FileLocation     string // FILESPACE in 4.3 and 5, LOCATION in 6 and later
 	SegmentLocations []string
+	Options          string
 }
 
 func (t Tablespace) GetUniqueID() UniqueID {
@@ -406,7 +407,8 @@ AND spcname != 'pg_global';`
 SELECT
 	oid,
 	quote_ident(spcname) AS tablespace,
-	'''' || pg_catalog.pg_tablespace_location(oid) || '''' AS filelocation
+	'''' || pg_catalog.pg_tablespace_location(oid) || '''' AS filelocation,
+    coalesce(array_to_string(spcoptions, ', '), '') AS options
 FROM pg_tablespace
 WHERE spcname != 'pg_default'
 AND spcname != 'pg_global';`

--- a/integration/metadata_globals_queries_test.go
+++ b/integration/metadata_globals_queries_test.go
@@ -451,13 +451,14 @@ CREATEEXTTABLE (protocol='gphdfs', type='writable')`)
 			}
 			Fail("Tablespace 'test_tablespace' was not created")
 		})
-		It("returns a tablespace with segment locations", func() {
+		It("returns a tablespace with segment locations and options", func() {
 			testutils.SkipIfBefore6(connectionPool)
 
-			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLESPACE test_tablespace LOCATION '/tmp/test_dir' WITH (content0='/tmp/test_dir1')")
+			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLESPACE test_tablespace LOCATION '/tmp/test_dir' WITH (content0='/tmp/test_dir1', seq_page_cost=123)")
 			expectedTablespace := backup.Tablespace{
 				Oid: 0, Tablespace: "test_tablespace", FileLocation: "'/tmp/test_dir'",
 				SegmentLocations: []string{"content0='/tmp/test_dir1'"},
+				Options:          "seq_page_cost=123",
 			}
 
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLESPACE test_tablespace")


### PR DESCRIPTION
The database now supports tablespaces with options. seq_page_cost and
random_page_cost are the only two valid options at this time, but more
may be added later.