### PR TITLE
Add support for security labels

### DIFF
--- a/backup/predata_acl_test.go
+++ b/backup/predata_acl_test.go
@@ -262,7 +262,7 @@ ALTER DEFAULT PRIVILEGES FOR ROLE testrole GRANT USAGE ON TABLES TO somerole WIT
 	Describe("ConstructMetadataMap", func() {
 		object1A := backup.MetadataQueryStruct{UniqueID: backup.UniqueID{Oid: 1}, Privileges: sql.NullString{String: "gpadmin=r/gpadmin", Valid: true}, Kind: "", Owner: "testrole", Comment: ""}
 		object1B := backup.MetadataQueryStruct{UniqueID: backup.UniqueID{Oid: 1}, Privileges: sql.NullString{String: "testrole=r/testrole", Valid: true}, Kind: "", Owner: "testrole", Comment: ""}
-		object2 := backup.MetadataQueryStruct{UniqueID: backup.UniqueID{Oid: 2}, Privileges: sql.NullString{String: "testrole=r/testrole", Valid: true}, Kind: "", Owner: "testrole", Comment: "this is a comment"}
+		object2 := backup.MetadataQueryStruct{UniqueID: backup.UniqueID{Oid: 2}, Privileges: sql.NullString{String: "testrole=r/testrole", Valid: true}, Kind: "", Owner: "testrole", Comment: "this is a comment", SecurityLabelProvider: "some_provider", SecurityLabel: "some_label"}
 		objectDefaultKind := backup.MetadataQueryStruct{UniqueID: backup.UniqueID{Oid: 3}, Privileges: sql.NullString{String: "", Valid: false}, Kind: "Default", Owner: "testrole", Comment: ""}
 		objectEmptyKind := backup.MetadataQueryStruct{UniqueID: backup.UniqueID{Oid: 4}, Privileges: sql.NullString{String: "", Valid: false}, Kind: "Empty", Owner: "testrole", Comment: ""}
 		var metadataList []backup.MetadataQueryStruct
@@ -281,7 +281,7 @@ ALTER DEFAULT PRIVILEGES FOR ROLE testrole GRANT USAGE ON TABLES TO somerole WIT
 		It("One object", func() {
 			metadataList = []backup.MetadataQueryStruct{object2}
 			metadataMap := backup.ConstructMetadataMap(metadataList)
-			expectedObjectMetadata := backup.ObjectMetadata{Privileges: []backup.ACL{{Grantee: "testrole", Select: true}}, Owner: "testrole", Comment: "this is a comment"}
+			expectedObjectMetadata := backup.ObjectMetadata{Privileges: []backup.ACL{{Grantee: "testrole", Select: true}}, Owner: "testrole", Comment: "this is a comment", SecurityLabelProvider: "some_provider", SecurityLabel: "some_label"}
 			Expect(metadataMap).To(HaveLen(1))
 			Expect(metadataMap[backup.UniqueID{Oid: 2}]).To(Equal(expectedObjectMetadata))
 
@@ -297,7 +297,7 @@ ALTER DEFAULT PRIVILEGES FOR ROLE testrole GRANT USAGE ON TABLES TO somerole WIT
 			metadataList = []backup.MetadataQueryStruct{object1A, object1B, object2}
 			metadataMap := backup.ConstructMetadataMap(metadataList)
 			expectedObjectMetadataOne := backup.ObjectMetadata{Privileges: []backup.ACL{{Grantee: "gpadmin", Select: true}, {Grantee: "testrole", Select: true}}, Owner: "testrole"}
-			expectedObjectMetadataTwo := backup.ObjectMetadata{Privileges: []backup.ACL{{Grantee: "testrole", Select: true}}, Owner: "testrole", Comment: "this is a comment"}
+			expectedObjectMetadataTwo := backup.ObjectMetadata{Privileges: []backup.ACL{{Grantee: "testrole", Select: true}}, Owner: "testrole", Comment: "this is a comment", SecurityLabelProvider: "some_provider", SecurityLabel: "some_label"}
 			Expect(metadataMap).To(HaveLen(2))
 			Expect(metadataMap[backup.UniqueID{Oid: 1}]).To(Equal(expectedObjectMetadataOne))
 			Expect(metadataMap[backup.UniqueID{Oid: 2}]).To(Equal(expectedObjectMetadataTwo))

--- a/backup/predata_operators_test.go
+++ b/backup/predata_operators_test.go
@@ -17,7 +17,7 @@ var _ = Describe("backup/predata_operators tests", func() {
 			operator         backup.Operator
 		)
 		BeforeEach(func() {
-			operatorMetadata = testutils.DefaultMetadata("OPERATOR", false, true, true)
+			operatorMetadata = testutils.DefaultMetadata("OPERATOR", false, true, true, false)
 			operator = backup.Operator{Oid: 0, Schema: "public", Name: "##", Procedure: "public.path_inter", LeftArgType: "public.path", RightArgType: `public."PATH"`, CommutatorOp: "0", NegatorOp: "0", RestrictFunction: "-", JoinFunction: "-", CanHash: false, CanMerge: false}
 		})
 		It("prints a basic operator", func() {
@@ -95,7 +95,7 @@ ALTER OPERATOR public.## (NONE, public."PATH") OWNER TO testrole;`)
 		It("prints an operator family with an owner and comment", func() {
 			operatorFamily := backup.OperatorFamily{Oid: 1, Schema: "public", Name: "testfam", IndexMethod: "hash"}
 
-			metadataMap := testutils.DefaultMetadataMap("OPERATOR FAMILY", false, true, true)
+			metadataMap := testutils.DefaultMetadataMap("OPERATOR FAMILY", false, true, true, false)
 
 			backup.PrintCreateOperatorFamilyStatements(backupfile, toc, []backup.OperatorFamily{operatorFamily}, metadataMap)
 
@@ -202,7 +202,7 @@ ALTER OPERATOR FAMILY public.testfam USING hash OWNER TO testrole;`)
 		It("prints an operator class with a function and owner and comment", func() {
 			operatorClass.Functions = []backup.OperatorClassFunction{function1}
 
-			objMetadata := testutils.DefaultMetadata("OPERATOR CLASS", false, true, true)
+			objMetadata := testutils.DefaultMetadata("OPERATOR CLASS", false, true, true, false)
 			backup.PrintCreateOperatorClassStatement(backupfile, toc, operatorClass, objMetadata)
 
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE OPERATOR CLASS public.testclass

--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -373,6 +373,10 @@ func PrintPostCreateTableStatements(metadataFile *utils.FileWithByteCount, table
 			columnPrivileges := columnMetadata.GetPrivilegesStatements(table.FQN(), "COLUMN", att.Name)
 			metadataFile.MustPrintln(columnPrivileges)
 		}
+		if att.SecurityLabel != "" {
+			escapedLabel := utils.EscapeSingleQuotes(att.SecurityLabel)
+			metadataFile.MustPrintf("\n\nSECURITY LABEL FOR %s ON COLUMN %s.%s IS '%s';", att.SecurityLabelProvider, table.FQN(), att.Name, escapedLabel)
+		}
 	}
 }
 

--- a/backup/predata_relations_test.go
+++ b/backup/predata_relations_test.go
@@ -625,6 +625,18 @@ REVOKE ALL (j) ON TABLE public.tablename FROM PUBLIC;
 REVOKE ALL (j) ON TABLE public.tablename FROM testrole;
 GRANT ALL (j) ON TABLE public.tablename TO testrole2;`)
 		})
+		It("prints a security group statement on a table column", func() {
+			privilegesColumnOne := backup.ColumnDefinition{Oid: 0, Num: 1, Name: "i", Type: "integer", StatTarget: -1, SecurityLabelProvider: "dummy", SecurityLabel: "unclassified"}
+			privilegesColumnTwo := backup.ColumnDefinition{Oid: 1, Num: 2, Name: "j", Type: "character varying(20)", StatTarget: -1, SecurityLabelProvider: "dummy", SecurityLabel: "unclassified"}
+			col := []backup.ColumnDefinition{privilegesColumnOne, privilegesColumnTwo}
+			tableDef.ColumnDefs = col
+			backup.PrintPostCreateTableStatements(backupfile, testTable, tableDef, backup.ObjectMetadata{})
+			testhelper.ExpectRegexp(buffer, `
+
+SECURITY LABEL FOR dummy ON COLUMN public.tablename.i IS 'unclassified';
+
+SECURITY LABEL FOR dummy ON COLUMN public.tablename.j IS 'unclassified';`)
+		})
 	})
 	Describe("PrintCreateSequenceStatements", func() {
 		baseSequence := backup.Relation{SchemaOid: 0, Oid: 1, Schema: "public", Name: "seq_name"}

--- a/backup/predata_shared_test.go
+++ b/backup/predata_shared_test.go
@@ -42,7 +42,7 @@ var _ = Describe("backup/predata_shared tests", func() {
 		Context("Constraints involving different columns", func() {
 			It("prints an ADD CONSTRAINT statement for one UNIQUE constraint with a comment", func() {
 				constraints := []backup.Constraint{uniqueOne}
-				constraintMetadataMap := testutils.DefaultMetadataMap("CONSTRAINT", false, false, true)
+				constraintMetadataMap := testutils.DefaultMetadataMap("CONSTRAINT", false, false, true, false)
 				backup.PrintConstraintStatements(backupfile, toc, constraints, constraintMetadataMap)
 				testutils.ExpectEntry(toc.PredataEntries, 0, "", "public.tablename", "tablename_i_key", "CONSTRAINT")
 				testutils.AssertBufferContents(toc.PredataEntries, buffer, `ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_i_key UNIQUE (i);
@@ -151,9 +151,9 @@ COMMENT ON CONSTRAINT tablename_i_key ON public.tablename IS 'This is a constrai
 			testutils.ExpectEntry(toc.PredataEntries, 0, "schemaname", "", "schemaname", "SCHEMA")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, "CREATE SCHEMA schemaname;")
 		})
-		It("can print a schema with privileges, an owner, and a comment", func() {
+		It("can print a schema with privileges, an owner, security label, and a comment", func() {
 			schemas := []backup.Schema{{Oid: 1, Name: "schemaname"}}
-			schemaMetadataMap := testutils.DefaultMetadataMap("SCHEMA", true, true, true)
+			schemaMetadataMap := testutils.DefaultMetadataMap("SCHEMA", true, true, true, true)
 
 			backup.PrintCreateSchemaStatements(backupfile, toc, schemas, schemaMetadataMap)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE SCHEMA schemaname;
@@ -166,7 +166,10 @@ ALTER SCHEMA schemaname OWNER TO testrole;
 
 REVOKE ALL ON SCHEMA schemaname FROM PUBLIC;
 REVOKE ALL ON SCHEMA schemaname FROM testrole;
-GRANT ALL ON SCHEMA schemaname TO testrole;`)
+GRANT ALL ON SCHEMA schemaname TO testrole;
+
+
+SECURITY LABEL FOR dummy ON SCHEMA schemaname IS 'unclassified';`)
 		})
 	})
 })

--- a/backup/predata_textsearch_test.go
+++ b/backup/predata_textsearch_test.go
@@ -25,7 +25,7 @@ var _ = Describe("backup/predata_textsearch tests", func() {
 		})
 		It("prints a text search parser with a headline and comment", func() {
 			parser := backup.TextSearchParser{Oid: 1, Schema: "public", Name: "testparser", StartFunc: "start_func", TokenFunc: "token_func", EndFunc: "end_func", LexTypesFunc: "lextypes_func", HeadlineFunc: "headline_func"}
-			metadata := testutils.DefaultMetadata("TEXT SEARCH PARSER", false, false, true)
+			metadata := testutils.DefaultMetadata("TEXT SEARCH PARSER", false, false, true, false)
 			backup.PrintCreateTextSearchParserStatement(backupfile, toc, parser, metadata)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TEXT SEARCH PARSER public.testparser (
 	START = start_func,
@@ -41,7 +41,7 @@ COMMENT ON TEXT SEARCH PARSER public.testparser IS 'This is a text search parser
 	Describe("PrintCreateTextSearchTemplateStatement", func() {
 		It("prints a basic text search template with comment", func() {
 			template := backup.TextSearchTemplate{Oid: 1, Schema: "public", Name: "testtemplate", InitFunc: "dsimple_init", LexizeFunc: "dsimple_lexize"}
-			metadata := testutils.DefaultMetadata("TEXT SEARCH TEMPLATE", false, false, true)
+			metadata := testutils.DefaultMetadata("TEXT SEARCH TEMPLATE", false, false, true, false)
 			backup.PrintCreateTextSearchTemplateStatement(backupfile, toc, template, metadata)
 			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "testtemplate", "TEXT SEARCH TEMPLATE")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TEXT SEARCH TEMPLATE public.testtemplate (
@@ -55,7 +55,7 @@ COMMENT ON TEXT SEARCH TEMPLATE public.testtemplate IS 'This is a text search te
 	Describe("PrintCreateTextSearchDictionaryStatement", func() {
 		It("prints a basic text search dictionary with comment", func() {
 			dictionary := backup.TextSearchDictionary{Oid: 1, Schema: "public", Name: "testdictionary", Template: "testschema.snowball", InitOption: "language = 'russian', stopwords = 'russian'"}
-			metadata := testutils.DefaultMetadata("TEXT SEARCH DICTIONARY", false, true, true)
+			metadata := testutils.DefaultMetadata("TEXT SEARCH DICTIONARY", false, true, true, false)
 			backup.PrintCreateTextSearchDictionaryStatement(backupfile, toc, dictionary, metadata)
 			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "testdictionary", "TEXT SEARCH DICTIONARY")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TEXT SEARCH DICTIONARY public.testdictionary (
@@ -80,7 +80,7 @@ ALTER TEXT SEARCH DICTIONARY public.testdictionary OWNER TO testrole;`)
 		It("prints a text search configuration with multiple mappings and comment", func() {
 			tokenToDicts := map[string][]string{"int": {"simple", "english_stem"}, "asciiword": {"english_stem"}}
 			configurations := backup.TextSearchConfiguration{Oid: 1, Schema: "public", Name: "testconfiguration", Parser: `pg_catalog."default"`, TokenToDicts: tokenToDicts}
-			metadata := testutils.DefaultMetadata("TEXT SEARCH CONFIGURATION", false, true, true)
+			metadata := testutils.DefaultMetadata("TEXT SEARCH CONFIGURATION", false, true, true, false)
 			backup.PrintCreateTextSearchConfigurationStatement(backupfile, toc, configurations, metadata)
 			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "testconfiguration", "TEXT SEARCH CONFIGURATION")
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TEXT SEARCH CONFIGURATION public.testconfiguration (

--- a/backup/predata_types_test.go
+++ b/backup/predata_types_test.go
@@ -29,8 +29,8 @@ var _ = Describe("backup/predata_types tests", func() {
 	'foo'
 );`)
 		})
-		It("prints an enum type with comment and owner", func() {
-			typeMetadataMap = testutils.DefaultMetadataMap("TYPE", false, true, true)
+		It("prints an enum type with comment, security label, and owner", func() {
+			typeMetadataMap = testutils.DefaultMetadataMap("TYPE", false, true, true, true)
 			backup.PrintCreateEnumTypeStatements(backupfile, toc, []backup.Type{enumTwo}, typeMetadataMap)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TYPE public.enum_type AS ENUM (
 	'bar',
@@ -42,7 +42,10 @@ var _ = Describe("backup/predata_types tests", func() {
 COMMENT ON TYPE public.enum_type IS 'This is a type comment.';
 
 
-ALTER TYPE public.enum_type OWNER TO testrole;`)
+ALTER TYPE public.enum_type OWNER TO testrole;
+
+
+SECURITY LABEL FOR dummy ON TYPE public.enum_type IS 'unclassified';`)
 		})
 	})
 	Describe("PrintCreateCompositeTypeStatement", func() {
@@ -79,9 +82,9 @@ ALTER TYPE public.enum_type OWNER TO testrole;`)
 	bar text
 );`)
 		})
-		It("prints a composite type with comment and owner", func() {
+		It("prints a composite type with comment, security label, and owner", func() {
 			compType.Attributes = twoAtts
-			typeMetadata = testutils.DefaultMetadata("TYPE", false, true, true)
+			typeMetadata = testutils.DefaultMetadata("TYPE", false, true, true, true)
 			backup.PrintCreateCompositeTypeStatement(backupfile, toc, compType, typeMetadata)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TYPE public.composite_type AS (
 	foo integer,
@@ -91,7 +94,10 @@ ALTER TYPE public.enum_type OWNER TO testrole;`)
 COMMENT ON TYPE public.composite_type IS 'This is a type comment.';
 
 
-ALTER TYPE public.composite_type OWNER TO testrole;`)
+ALTER TYPE public.composite_type OWNER TO testrole;
+
+
+SECURITY LABEL FOR dummy ON TYPE public.composite_type IS 'unclassified';`)
 		})
 		It("prints a composite type with attribute comment", func() {
 			attWithComment := []backup.Attribute{{Name: "foo", Type: "integer", Comment: "'attribute comment'"}}
@@ -175,8 +181,8 @@ ALTER TYPE public.base_type
 	STORAGE = extended
 );`)
 		})
-		It("prints a base type with comment and owner", func() {
-			typeMetadata = testutils.DefaultMetadata("TYPE", false, true, true)
+		It("prints a base type with comment, security label, and owner", func() {
+			typeMetadata = testutils.DefaultMetadata("TYPE", false, true, true, true)
 			backup.PrintCreateBaseTypeStatement(backupfile, toc, baseSimple, typeMetadata)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TYPE public.base_type (
 	INPUT = input_fn,
@@ -187,7 +193,10 @@ ALTER TYPE public.base_type
 COMMENT ON TYPE public.base_type IS 'This is a type comment.';
 
 
-ALTER TYPE public.base_type OWNER TO testrole;`)
+ALTER TYPE public.base_type OWNER TO testrole;
+
+
+SECURITY LABEL FOR dummy ON TYPE public.base_type IS 'unclassified';`)
 		})
 	})
 	Describe("PrintCreateShellTypeStatements", func() {
@@ -224,8 +233,8 @@ ALTER TYPE public.base_type OWNER TO testrole;`)
 			backup.PrintCreateDomainStatement(backupfile, toc, domainOne, emptyMetadata, emptyConstraint)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE DOMAIN public.domain1 AS numeric DEFAULT 4 COLLATE public.mycollation NOT NULL;`)
 		})
-		It("prints a domain without constraint with comment and owner", func() {
-			typeMetadata = testutils.DefaultMetadata("DOMAIN", false, true, true)
+		It("prints a domain without constraint with comment, security label, and owner", func() {
+			typeMetadata = testutils.DefaultMetadata("DOMAIN", false, true, true, true)
 			backup.PrintCreateDomainStatement(backupfile, toc, domainTwo, typeMetadata, emptyConstraint)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE DOMAIN public.domain2 AS varchar;
 
@@ -233,7 +242,10 @@ ALTER TYPE public.base_type OWNER TO testrole;`)
 COMMENT ON DOMAIN public.domain2 IS 'This is a domain comment.';
 
 
-ALTER DOMAIN public.domain2 OWNER TO testrole;`)
+ALTER DOMAIN public.domain2 OWNER TO testrole;
+
+
+SECURITY LABEL FOR dummy ON DOMAIN public.domain2 IS 'unclassified';`)
 		})
 	})
 	Describe("PrintCreateRangeTypeStatement", func() {
@@ -266,8 +278,8 @@ ALTER DOMAIN public.domain2 OWNER TO testrole;`)
 	SUBTYPE_DIFF = diff_schema.test_diff
 );`)
 		})
-		It("prints a range type with an owner and a comment", func() {
-			typeMetadata = testutils.DefaultMetadata("TYPE", false, true, true)
+		It("prints a range type with an owner, security label, and a comment", func() {
+			typeMetadata = testutils.DefaultMetadata("TYPE", false, true, true, true)
 			backup.PrintCreateRangeTypeStatement(backupfile, toc, basicRangeType, typeMetadata)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TYPE public.rangetype AS RANGE (
 	SUBTYPE = test_subtype_schema.test_subtype
@@ -277,7 +289,10 @@ ALTER DOMAIN public.domain2 OWNER TO testrole;`)
 COMMENT ON TYPE public.rangetype IS 'This is a type comment.';
 
 
-ALTER TYPE public.rangetype OWNER TO testrole;`)
+ALTER TYPE public.rangetype OWNER TO testrole;
+
+
+SECURITY LABEL FOR dummy ON TYPE public.rangetype IS 'unclassified';`)
 		})
 	})
 	Describe("PrintCreateCollationStatement", func() {
@@ -289,7 +304,7 @@ ALTER TYPE public.rangetype OWNER TO testrole;`)
 		})
 		It("prints a create collation statement with owner and comment", func() {
 			collation := backup.Collation{Oid: 1, Name: "collation1", Collate: "collate1", Ctype: "ctype1", Schema: "schema1"}
-			collationMetadataMap := testutils.DefaultMetadataMap("COLLATION", false, true, true)
+			collationMetadataMap := testutils.DefaultMetadataMap("COLLATION", false, true, true, false)
 			backup.PrintCreateCollationStatements(backupfile, toc, []backup.Collation{collation}, collationMetadataMap)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE COLLATION schema1.collation1 (LC_COLLATE = 'collate1', LC_CTYPE = 'ctype1');
 

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -385,7 +385,7 @@ func BackupRoles(metadataFile *utils.FileWithByteCount) {
 	roles := GetRoles(connectionPool)
 	objectCounts["Roles"] = len(roles)
 	roleGUCs := GetRoleGUCs(connectionPool)
-	roleMetadata := GetCommentsForObjectType(connectionPool, TYPE_ROLE)
+	roleMetadata := GetMetadataForObjectType(connectionPool, TYPE_ROLE)
 	PrintCreateRoleStatements(metadataFile, globalTOC, roles, roleGUCs, roleMetadata)
 }
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -157,6 +157,16 @@ resources:
     secret_access_key: {{gpdb4-bucket-secret-access-key}}
     versioned_file: DDBoostFS-1.1.0.1-565598.rhel.x86_64.rpm
 
+- name: dummy_seclabel
+  type: s3
+  source:
+    access_key_id: {{gpdb4-bucket-access-key-id}}
+    bucket: {{dpm_bucket}}
+    region_name: {{aws-region}}
+    secret_access_key: {{gpdb4-bucket-secret-access-key}}
+    versioned_file: dummy_seclabel.so
+
+
 - name: slack-alert
   type: slack-notification
   source:
@@ -570,6 +580,7 @@ jobs:
     - get: bin_gpdb_master
     - get: ccp_src
     - get: gpdb_src
+    - get: dummy_seclabel
   - put: terraform
     params:
       <<: *ccp_default_params
@@ -585,7 +596,7 @@ jobs:
   - task: gpinitsystem
     file: ccp_src/ci/tasks/gpinitsystem.yml
   - task: setup-centos-env
-    file: gpbackup/ci/tasks/setup-centos-env.yml
+    file: gpbackup/ci/tasks/setup-centos-env-gpdb6.yml
   - task: integration-tests
     file: gpbackup/ci/tasks/integration-tests.yml
     on_success:

--- a/ci/tasks/setup-centos-env-gpdb6.yml
+++ b/ci/tasks/setup-centos-env-gpdb6.yml
@@ -1,0 +1,58 @@
+
+PLATFORM: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: pivotaldata/centos-gpdb-dev
+    tag: '6-gcc6.2-llvm3.7'
+
+inputs:
+- name: gpbackup
+  path: go/src/github.com/greenplum-db/gpbackup
+- name: ccp_src
+- name: cluster_env_files
+- name: dummy_seclabel
+
+run:
+  path: bash
+  args:
+  - -c
+  - |
+    set -ex
+
+    ccp_src/scripts/setup_ssh_to_cluster.sh
+
+    cat <<SCRIPT > /tmp/setup_centos_env.bash
+    set -ex
+        cat << ENV_SCRIPT > env.sh
+        export GOPATH=/home/gpadmin/go
+        source /usr/local/greenplum-db-devel/greenplum_path.sh
+        export PGPORT=5432
+        export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1
+        export PATH=\\\$GOPATH/bin:/usr/local/go/bin:\\\$PATH
+    ENV_SCRIPT
+
+    export GOPATH=/home/gpadmin/go
+    chown gpadmin:gpadmin -R \$GOPATH
+    chmod +x env.sh
+    source env.sh
+    gpconfig --skipvalidation -c fsync -v off
+    gpconfig -c shared_preload_libraries -v dummy_seclabel
+    gpstop -ar
+
+    pushd \$GOPATH/src/github.com/greenplum-db/gpbackup
+        make depend
+        make build
+    popd
+    SCRIPT
+
+    scp dummy_seclabel/dummy_seclabel.so mdw:/usr/local/greenplum-db-devel/lib/postgresql/dummy_seclabel.so
+    scp dummy_seclabel/dummy_seclabel.so sdw1:/usr/local/greenplum-db-devel/lib/postgresql/dummy_seclabel.so
+
+    ssh -t centos@mdw "sudo yum -y install wget git && wget https://storage.googleapis.com/golang/go1.10.3.linux-amd64.tar.gz && tar -xzf go1.10.3.linux-amd64.tar.gz && sudo mv go /usr/local"
+    chmod +x /tmp/setup_centos_env.bash
+    scp /tmp/setup_centos_env.bash mdw:/home/gpadmin/setup_centos_env.bash
+    ssh -t mdw "mkdir -p /home/gpadmin/go/src/github.com/greenplum-db"
+    scp -r go/src/github.com/greenplum-db/gpbackup mdw:/home/gpadmin/go/src/github.com/greenplum-db/gpbackup
+    ssh -t mdw "bash /home/gpadmin/setup_centos_env.bash"

--- a/integration/metadata_globals_create_test.go
+++ b/integration/metadata_globals_create_test.go
@@ -14,7 +14,11 @@ import (
 )
 
 var _ = Describe("backup integration create statement tests", func() {
+	var includeSecurityLabels bool
 	BeforeEach(func() {
+		if connectionPool.Version.AtLeast("6") {
+			includeSecurityLabels = true
+		}
 		toc, backupfile = testutils.InitializeTestTOC(buffer, "predata")
 	})
 	Describe("PrintCreateDatabaseStatement", func() {
@@ -85,7 +89,7 @@ var _ = Describe("backup integration create statement tests", func() {
 	Describe("PrintCreateResourceQueueStatements", func() {
 		It("creates a basic resource queue with a comment", func() {
 			basicQueue := backup.ResourceQueue{Oid: 1, Name: `"basicQueue"`, ActiveStatements: -1, MaxCost: "32.80", CostOvercommit: false, MinCost: "0.00", Priority: "medium", MemoryLimit: "-1"}
-			resQueueMetadataMap := testutils.DefaultMetadataMap("RESOURCE QUEUE", false, false, true)
+			resQueueMetadataMap := testutils.DefaultMetadataMap("RESOURCE QUEUE", false, false, true, false)
 			resQueueMetadata := resQueueMetadataMap[basicQueue.GetUniqueID()]
 
 			backup.PrintCreateResourceQueueStatements(backupfile, toc, []backup.ResourceQueue{basicQueue}, resQueueMetadataMap)
@@ -295,7 +299,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			if connectionPool.Version.Before("5") {
 				role1.ResGroup = ""
 			}
-			metadataMap := testutils.DefaultMetadataMap("ROLE", false, false, true)
+			metadataMap := testutils.DefaultMetadataMap("ROLE", false, false, true, includeSecurityLabels)
 
 			backup.PrintCreateRoleStatements(backupfile, toc, []backup.Role{role1}, emptyConfigMap, metadataMap)
 
@@ -427,9 +431,9 @@ var _ = Describe("backup integration create statement tests", func() {
 			}
 			Fail("Tablespace 'test_tablespace' was not created")
 		})
-		It("creates a tablespace with permissions, an owner, and a comment", func() {
+		It("creates a tablespace with permissions, an owner, security label, and a comment", func() {
 			numTablespaces := len(backup.GetTablespaces(connectionPool))
-			tablespaceMetadataMap := testutils.DefaultMetadataMap("TABLESPACE", true, true, true)
+			tablespaceMetadataMap := testutils.DefaultMetadataMap("TABLESPACE", true, true, true, includeSecurityLabels)
 			tablespaceMetadata := tablespaceMetadataMap[expectedTablespace.GetUniqueID()]
 			backup.PrintCreateTablespaceStatements(backupfile, toc, []backup.Tablespace{expectedTablespace}, tablespaceMetadataMap)
 

--- a/integration/predata_operators_create_test.go
+++ b/integration/predata_operators_create_test.go
@@ -40,7 +40,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			testhelper.AssertQueryRuns(connectionPool, "CREATE FUNCTION testschema.\"testFunc\" (path,path) RETURNS path AS 'SELECT $1' LANGUAGE SQL IMMUTABLE")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP FUNCTION testschema.\"testFunc\" (path,path)")
 
-			operatorMetadata := testutils.DefaultMetadata("OPERATOR", false, false, true)
+			operatorMetadata := testutils.DefaultMetadata("OPERATOR", false, false, true, false)
 			operator := backup.Operator{Oid: 1, Schema: "testschema", Name: "##", Procedure: "testschema.\"testFunc\"", LeftArgType: "path", RightArgType: "path", CommutatorOp: "0", NegatorOp: "0", RestrictFunction: "-", JoinFunction: "-", CanHash: false, CanMerge: false}
 
 			backup.PrintCreateOperatorStatement(backupfile, toc, operator, operatorMetadata)
@@ -75,7 +75,7 @@ var _ = Describe("backup integration create statement tests", func() {
 		It("creates operator family with owner and comment", func() {
 			operatorFamily := backup.OperatorFamily{Oid: 1, Schema: "public", Name: "testfam", IndexMethod: "hash"}
 			operatorFamilies := []backup.OperatorFamily{operatorFamily}
-			operatorFamilyMetadataMap := testutils.DefaultMetadataMap("OPERATOR FAMILY", false, true, true)
+			operatorFamilyMetadataMap := testutils.DefaultMetadataMap("OPERATOR FAMILY", false, true, true, false)
 			operatorFamilyMetadata := operatorFamilyMetadataMap[operatorFamily.GetUniqueID()]
 
 			backup.PrintCreateOperatorFamilyStatements(backupfile, toc, operatorFamilies, operatorFamilyMetadataMap)
@@ -159,7 +159,7 @@ var _ = Describe("backup integration create statement tests", func() {
 		})
 		It("creates basic operator class with a comment and owner", func() {
 			operatorClass := backup.OperatorClass{Oid: 1, Schema: "public", Name: "testclass", FamilySchema: "public", FamilyName: "testclass", IndexMethod: "hash", Type: "integer", Default: false, StorageType: "-", Operators: nil, Functions: nil}
-			operatorClassMetadata := testutils.DefaultMetadata("OPERATOR CLASS", false, true, true)
+			operatorClassMetadata := testutils.DefaultMetadata("OPERATOR CLASS", false, true, true, false)
 			if connectionPool.Version.Before("5") { // Operator families do not exist prior to GPDB5
 				operatorClass.FamilySchema = ""
 				operatorClass.FamilyName = ""

--- a/integration/predata_relations_queries_test.go
+++ b/integration/predata_relations_queries_test.go
@@ -402,11 +402,12 @@ PARTITION BY RANGE (year)
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.atttable(i character(8) COLLATE public.some_coll)")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.atttable")
 			testhelper.AssertQueryRuns(connectionPool, "ALTER TABLE ONLY public.atttable ALTER COLUMN i SET (n_distinct=1);")
+			testhelper.AssertQueryRuns(connectionPool, "SECURITY LABEL FOR dummy ON COLUMN public.atttable.i IS 'unclassified';")
 			oid := testutils.OidFromObjectName(connectionPool, "public", "atttable", backup.TYPE_RELATION)
 			privileges := backup.GetPrivilegesForColumns(connectionPool)
 			tableAtts := backup.GetColumnDefinitions(connectionPool, privileges)[oid]
 
-			columnA := backup.ColumnDefinition{Oid: 0, Num: 1, Name: "i", NotNull: false, HasDefault: false, Type: "character(8)", Encoding: "", StatTarget: -1, StorageType: "", DefaultVal: "", Comment: "", ACL: emptyColumnACL, Options: "n_distinct=1", Collation: "public.some_coll"}
+			columnA := backup.ColumnDefinition{Oid: 0, Num: 1, Name: "i", NotNull: false, HasDefault: false, Type: "character(8)", Encoding: "", StatTarget: -1, StorageType: "", DefaultVal: "", Comment: "", ACL: emptyColumnACL, Options: "n_distinct=1", Collation: "public.some_coll", SecurityLabelProvider: "dummy", SecurityLabel: "unclassified"}
 
 			Expect(tableAtts).To(HaveLen(1))
 

--- a/integration/predata_shared_create_test.go
+++ b/integration/predata_shared_create_test.go
@@ -11,13 +11,17 @@ import (
 )
 
 var _ = Describe("backup integration create statement tests", func() {
+	var includeSecurityLabels bool
 	BeforeEach(func() {
+		if connectionPool.Version.AtLeast("6") {
+			includeSecurityLabels = true
+		}
 		toc, backupfile = testutils.InitializeTestTOC(buffer, "predata")
 	})
 	Describe("PrintCreateSchemaStatements", func() {
 		It("creates a non public schema", func() {
 			schemas := []backup.Schema{{Oid: 0, Name: "test_schema"}}
-			schemaMetadata := testutils.DefaultMetadataMap("SCHEMA", true, true, true)
+			schemaMetadata := testutils.DefaultMetadataMap("SCHEMA", true, true, true, includeSecurityLabels)
 
 			backup.PrintCreateSchemaStatements(backupfile, toc, schemas, schemaMetadata)
 
@@ -34,7 +38,7 @@ var _ = Describe("backup integration create statement tests", func() {
 
 		It("modifies the public schema", func() {
 			schemas := []backup.Schema{{Oid: 2200, Name: "public"}}
-			schemaMetadata := testutils.DefaultMetadataMap("SCHEMA", true, true, true)
+			schemaMetadata := testutils.DefaultMetadataMap("SCHEMA", true, true, true, includeSecurityLabels)
 
 			backup.PrintCreateSchemaStatements(backupfile, toc, schemas, schemaMetadata)
 

--- a/integration/predata_textsearch_create_test.go
+++ b/integration/predata_textsearch_create_test.go
@@ -29,7 +29,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&parser, &resultParsers[0], "Oid")
 		})
 		It("creates a basic text search parser with a comment", func() {
-			parserMetadata := testutils.DefaultMetadata("TEXT SEARCH PARSER", false, false, true)
+			parserMetadata := testutils.DefaultMetadata("TEXT SEARCH PARSER", false, false, true, false)
 
 			backup.PrintCreateTextSearchParserStatement(backupfile, toc, parser, parserMetadata)
 
@@ -59,7 +59,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&template, &resultTemplates[0], "Oid")
 		})
 		It("creates a basic text search template with a comment", func() {
-			templateMetadata := testutils.DefaultMetadata("TEXT SEARCH TEMPLATE", false, false, true)
+			templateMetadata := testutils.DefaultMetadata("TEXT SEARCH TEMPLATE", false, false, true, false)
 
 			backup.PrintCreateTextSearchTemplateStatement(backupfile, toc, template, templateMetadata)
 
@@ -91,7 +91,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&dictionary, &resultDictionaries[0], "Oid")
 		})
 		It("creates a basic text search dictionary with a comment and owner", func() {
-			dictionaryMetadata := testutils.DefaultMetadata("TEXT SEARCH DICTIONARY", false, true, true)
+			dictionaryMetadata := testutils.DefaultMetadata("TEXT SEARCH DICTIONARY", false, true, true, false)
 
 			backup.PrintCreateTextSearchDictionaryStatement(backupfile, toc, dictionary, dictionaryMetadata)
 
@@ -122,7 +122,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&configuration, &resultConfigurations[0], "Oid")
 		})
 		It("creates a basic text search configuration with a comment and owner", func() {
-			configurationMetadata := testutils.DefaultMetadata("TEXT SEARCH CONFIGURATION", false, true, true)
+			configurationMetadata := testutils.DefaultMetadata("TEXT SEARCH CONFIGURATION", false, true, true, false)
 
 			backup.PrintCreateTextSearchConfigurationStatement(backupfile, toc, configuration, configurationMetadata)
 

--- a/testutils/functions.go
+++ b/testutils/functions.go
@@ -63,7 +63,7 @@ func SetDefaultSegmentConfiguration() *cluster.Cluster {
 	return cluster
 }
 
-func DefaultMetadata(objType string, hasPrivileges bool, hasOwner bool, hasComment bool) backup.ObjectMetadata {
+func DefaultMetadata(objType string, hasPrivileges bool, hasOwner bool, hasComment bool, hasSecurityLabel bool) backup.ObjectMetadata {
 	privileges := []backup.ACL{}
 	if hasPrivileges {
 		privileges = []backup.ACL{DefaultACLForType("testrole", objType)}
@@ -81,14 +81,20 @@ func DefaultMetadata(objType string, hasPrivileges bool, hasOwner bool, hasComme
 		}
 		comment = fmt.Sprintf("This is a%s %s comment.", n, strings.ToLower(objType))
 	}
-	return backup.ObjectMetadata{Privileges: privileges, Owner: owner, Comment: comment}
+	securityLabelProvider := ""
+	securityLabel := ""
+	if hasSecurityLabel {
+		securityLabelProvider = "dummy"
+		securityLabel = "unclassified"
+	}
+	return backup.ObjectMetadata{Privileges: privileges, Owner: owner, Comment: comment, SecurityLabelProvider: securityLabelProvider, SecurityLabel: securityLabel}
 
 }
 
 // objType should be an all-caps string like TABLE, INDEX, etc.
-func DefaultMetadataMap(objType string, hasPrivileges bool, hasOwner bool, hasComment bool) backup.MetadataMap {
+func DefaultMetadataMap(objType string, hasPrivileges bool, hasOwner bool, hasComment bool, hasSecurityLabel bool) backup.MetadataMap {
 	return backup.MetadataMap{
-		backup.UniqueID{ClassID: ClassIDFromObjectName(objType), Oid: 1}: DefaultMetadata(objType, hasPrivileges, hasOwner, hasComment),
+		backup.UniqueID{ClassID: ClassIDFromObjectName(objType), Oid: 1}: DefaultMetadata(objType, hasPrivileges, hasOwner, hasComment, hasSecurityLabel),
 	}
 }
 
@@ -385,6 +391,12 @@ func UniqueIDFromObjectName(connectionPool *dbconn.DBConn, schemaName string, ob
 
 func GetUserByID(connectionPool *dbconn.DBConn, oid uint32) string {
 	return dbconn.MustSelectString(connectionPool, fmt.Sprintf("SELECT rolname AS string FROM pg_roles WHERE oid = %d", oid))
+}
+
+func CreateSecurityLabelIfGPDB6(connectionPool *dbconn.DBConn, objectType string, objectName string) {
+	if connectionPool.Version.AtLeast("6") {
+		testhelper.AssertQueryRuns(connectionPool, fmt.Sprintf("SECURITY LABEL FOR dummy ON %s %s IS 'unclassified';", objectType, objectName))
+	}
 }
 
 func SkipIfNot4(connectionPool *dbconn.DBConn) {


### PR DESCRIPTION
Security labels were introduced in GPDB6 during the 9.1 merge.

* This also refactors some tests to use the DefaultMetadata and
DefaultMetadataMap functions instead of manually constructing the
metadata
* In some of the create tests, we aren't actually asserting that the
metadata is logically correct, but rather only syntactically correct. Since
the bulk of this code is the same, it's likely ok for now.

I still need to figure out how to get this to run in CI, but it's reviewable in this state.

Authored-by: Chris Hajas <chajas@pivotal.io>