### PR TITLE
Check error on functions in tests

### DIFF
--- a/backup/data_test.go
+++ b/backup/data_test.go
@@ -72,7 +72,9 @@ var _ bool = Describe("backup/data tests", func() {
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.gz"
 
-			backup.CopyTableOut(connectionPool, testTable, filename, defaultConnNum)
+			_, err := backup.CopyTableOut(connectionPool, testTable, filename, defaultConnNum)
+
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("will back up a table to its own file with compression using a plugin", func() {
 			cmdFlags.Set(utils.PLUGIN_CONFIG, "/tmp/plugin_config")
@@ -84,7 +86,9 @@ var _ bool = Describe("backup/data tests", func() {
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456"
-			backup.CopyTableOut(connectionPool, testTable, filename, defaultConnNum)
+			_, err := backup.CopyTableOut(connectionPool, testTable, filename, defaultConnNum)
+
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("will back up a table to its own file without compression", func() {
 			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "cat", OutputCommand: "cat -", InputCommand: "cat -", Extension: ""})
@@ -93,7 +97,9 @@ var _ bool = Describe("backup/data tests", func() {
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456"
 
-			backup.CopyTableOut(connectionPool, testTable, filename, defaultConnNum)
+			_, err := backup.CopyTableOut(connectionPool, testTable, filename, defaultConnNum)
+
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("will back up a table to its own file without compression using a plugin", func() {
 			cmdFlags.Set(utils.PLUGIN_CONFIG, "/tmp/plugin_config")
@@ -105,16 +111,20 @@ var _ bool = Describe("backup/data tests", func() {
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456"
-			backup.CopyTableOut(connectionPool, testTable, filename, defaultConnNum)
+			_, err := backup.CopyTableOut(connectionPool, testTable, filename, defaultConnNum)
+
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("will back up a table to a single file", func() {
 			cmdFlags.Set(utils.SINGLE_DATA_FILE, "true")
 			testTable := backup.Relation{SchemaOid: 2345, Oid: 3456, Schema: "public", Name: "foo"}
-			execStr := regexp.QuoteMeta(`COPY public.foo TO PROGRAM '(test -p "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456" || (echo "Pipe not found">&2; exit 1)) && cat - > <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456' WITH CSV DELIMITER ',' ON SEGMENT IGNORE EXTERNAL PARTITIONS;`)
+			execStr := regexp.QuoteMeta(`COPY public.foo TO PROGRAM '(test -p "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456" || (echo "Pipe not found <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456">&2; exit 1)) && cat - > <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456' WITH CSV DELIMITER ',' ON SEGMENT IGNORE EXTERNAL PARTITIONS;`)
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456"
 
-			backup.CopyTableOut(connectionPool, testTable, filename, defaultConnNum)
+			_, err := backup.CopyTableOut(connectionPool, testTable, filename, defaultConnNum)
+
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
 	Describe("BackupSingleTableData", func() {
@@ -141,8 +151,9 @@ var _ bool = Describe("backup/data tests", func() {
 			backupFile := fmt.Sprintf("<SEG_DATA_DIR>/gpbackup_<SEGID>_20170101010101_pipe_(.*)_%d", testTable.Oid)
 			copyCmd := fmt.Sprintf(copyFmtStr, backupFile)
 			mock.ExpectExec(copyCmd).WillReturnResult(sqlmock.NewResult(0, 10))
-			backup.BackupSingleTableData(tableDef, testTable, rowsCopiedMap, &counters, 0)
+			err := backup.BackupSingleTableData(tableDef, testTable, rowsCopiedMap, &counters, 0)
 
+			Expect(err).ShouldNot(HaveOccurred())
 			Expect(rowsCopiedMap[0]).To(Equal(int64(10)))
 			Expect(counters.NumRegTables).To(Equal(int64(1)))
 		})
@@ -152,24 +163,27 @@ var _ bool = Describe("backup/data tests", func() {
 			backupFile := fmt.Sprintf("<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_%d", testTable.Oid)
 			copyCmd := fmt.Sprintf(copyFmtStr, backupFile)
 			mock.ExpectExec(copyCmd).WillReturnResult(sqlmock.NewResult(0, 10))
-			backup.BackupSingleTableData(tableDef, testTable, rowsCopiedMap, &counters, 0)
+			err := backup.BackupSingleTableData(tableDef, testTable, rowsCopiedMap, &counters, 0)
 
+			Expect(err).ShouldNot(HaveOccurred())
 			Expect(rowsCopiedMap[0]).To(Equal(int64(10)))
 			Expect(counters.NumRegTables).To(Equal(int64(1)))
 		})
 		It("backs up a single external table", func() {
 			cmdFlags.Set(utils.LEAF_PARTITION_DATA, "false")
 			tableDef.IsExternal = true
-			backup.BackupSingleTableData(tableDef, testTable, rowsCopiedMap, &counters, 0)
+			err := backup.BackupSingleTableData(tableDef, testTable, rowsCopiedMap, &counters, 0)
 
+			Expect(err).ShouldNot(HaveOccurred())
 			Expect(rowsCopiedMap).To(BeEmpty())
 			Expect(counters.NumRegTables).To(Equal(int64(0)))
 		})
 		It("backs up a single foreign table", func() {
 			cmdFlags.Set(utils.LEAF_PARTITION_DATA, "false")
 			tableDef.ForeignDef = backup.ForeignTableDefinition{Oid: 23, Options: "", Server: "fs"}
-			backup.BackupSingleTableData(tableDef, testTable, rowsCopiedMap, &counters, 0)
+			err := backup.BackupSingleTableData(tableDef, testTable, rowsCopiedMap, &counters, 0)
 
+			Expect(err).ShouldNot(HaveOccurred())
 			Expect(rowsCopiedMap).To(BeEmpty())
 			Expect(counters.NumRegTables).To(Equal(int64(0)))
 		})

--- a/restore/data_test.go
+++ b/restore/data_test.go
@@ -24,19 +24,25 @@ var _ = Describe("restore/data tests", func() {
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.gz | gzip -d -c' WITH CSV DELIMITER ',' ON SEGMENT;")
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.gz"
-			restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
+
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("will restore a table from its own file without compression", func() {
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456 | cat -' WITH CSV DELIMITER ',' ON SEGMENT;")
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456"
-			restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
+
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("will restore a table from a single data file", func() {
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456 | cat -' WITH CSV DELIMITER ',' ON SEGMENT;")
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456"
-			restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, true, 0)
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, true, 0)
+
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("will restore a table from its own file with compression using a plugin", func() {
 			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "gzip", OutputCommand: "gzip -c -1", InputCommand: "gzip -d -c", Extension: ".gz"})
@@ -47,7 +53,9 @@ var _ = Describe("restore/data tests", func() {
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz"
-			restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
+
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 		It("will restore a table from its own file without compression using a plugin", func() {
 			cmdFlags.Set(utils.PLUGIN_CONFIG, "/tmp/plugin_config")
@@ -57,7 +65,9 @@ var _ = Describe("restore/data tests", func() {
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz"
-			restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
+
+			Expect(err).ShouldNot(HaveOccurred())
 		})
 	})
 	Describe("CheckRowsRestored", func() {

--- a/utils/flag_test.go
+++ b/utils/flag_test.go
@@ -44,19 +44,19 @@ var _ = Describe("utils/flag tests", func() {
 		})
 		Context("CheckExclusiveFlags", func() {
 			It("does not panic if no flags in the argument list are set", func() {
-				flag.CommandLine.Parse([]string{})
+				Expect(flag.CommandLine.Parse([]string{})).To(Succeed())
 				utils.CheckExclusiveFlags(flagSet, "boolFlag")
 			})
 			It("does not panic if one flags in the argument list is set", func() {
-				flagSet.Parse([]string{"--stringFlag", "foo"})
+				Expect(flagSet.Parse([]string{"--stringFlag", "foo"})).To(Succeed())
 				utils.CheckExclusiveFlags(flagSet, "boolFlag")
 			})
 			It("does not panic if one flags in the argument list is set with flags not in the set", func() {
-				flagSet.Parse([]string{"--stringFlag", "foo", "--intFlag", "42"})
+				Expect(flagSet.Parse([]string{"--stringFlag", "foo", "--intFlag", "42"})).To(Succeed())
 				utils.CheckExclusiveFlags(flagSet, "boolFlag")
 			})
 			It("panics if two or more flags in the argument list are set", func() {
-				flagSet.Parse([]string{"--stringFlag", "foo", "--boolFlag"})
+				Expect(flagSet.Parse([]string{"--stringFlag", "foo", "--boolFlag"})).To(Succeed())
 				defer testhelper.ShouldPanicWithMessage("The following flags may not be specified together: stringFlag, boolFlag")
 				utils.CheckExclusiveFlags(flagSet, "stringFlag", "boolFlag")
 			})


### PR DESCRIPTION
This checks that the functions under test don't return errors. There
were a few tests that we had missed, and in one case the function was
actually returning an error.

Authored-by: Chris Hajas <chajas@pivotal.io>