### PR TITLE
Refactor NewHistory

### DIFF
--- a/backup/incremental.go
+++ b/backup/incremental.go
@@ -37,7 +37,8 @@ func GetTargetBackupTimestamp() string {
 }
 
 func GetLatestMatchingBackupTimestamp() string {
-	history := backup_history.NewHistory(globalFPInfo.GetBackupHistoryFilePath())
+	history, err := backup_history.NewHistory(globalFPInfo.GetBackupHistoryFilePath())
+	gplog.FatalOnError(err)
 	latestMatchingBackupHistoryEntry := GetLatestMatchingBackupConfig(history, &backupReport.BackupConfig)
 	if latestMatchingBackupHistoryEntry == nil {
 		gplog.FatalOnError(errors.Errorf("There was no matching previous backup found with the flags provided. " +

--- a/backup/incremental.go
+++ b/backup/incremental.go
@@ -38,14 +38,15 @@ func GetTargetBackupTimestamp() string {
 }
 
 func GetLatestMatchingBackupTimestamp() string {
-	history := &backup_history.History{BackupConfigs: make([]backup_history.BackupConfig, 0)}
+	var history *backup_history.History
+	var latestMatchingBackupHistoryEntry *backup_history.BackupConfig
 	var err error
-
 	if iohelper.FileExistsAndIsReadable(globalFPInfo.GetBackupHistoryFilePath()) {
 		history, err = backup_history.NewHistory(globalFPInfo.GetBackupHistoryFilePath())
 		gplog.FatalOnError(err)
+		latestMatchingBackupHistoryEntry = GetLatestMatchingBackupConfig(history, &backupReport.BackupConfig)
 	}
-	latestMatchingBackupHistoryEntry := GetLatestMatchingBackupConfig(history, &backupReport.BackupConfig)
+
 	if latestMatchingBackupHistoryEntry == nil {
 		gplog.FatalOnError(errors.Errorf("There was no matching previous backup found with the flags provided. " +
 			"Please take a full backup."))

--- a/backup/incremental.go
+++ b/backup/incremental.go
@@ -2,6 +2,7 @@ package backup
 
 import (
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/greenplum-db/gp-common-go-libs/iohelper"
 	"github.com/greenplum-db/gpbackup/backup_history"
 	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/pkg/errors"
@@ -37,8 +38,13 @@ func GetTargetBackupTimestamp() string {
 }
 
 func GetLatestMatchingBackupTimestamp() string {
-	history, err := backup_history.NewHistory(globalFPInfo.GetBackupHistoryFilePath())
-	gplog.FatalOnError(err)
+	history := &backup_history.History{BackupConfigs: make([]backup_history.BackupConfig, 0)}
+	var err error
+
+	if iohelper.FileExistsAndIsReadable(globalFPInfo.GetBackupHistoryFilePath()) {
+		history, err = backup_history.NewHistory(globalFPInfo.GetBackupHistoryFilePath())
+		gplog.FatalOnError(err)
+	}
 	latestMatchingBackupHistoryEntry := GetLatestMatchingBackupConfig(history, &backupReport.BackupConfig)
 	if latestMatchingBackupHistoryEntry == nil {
 		gplog.FatalOnError(errors.Errorf("There was no matching previous backup found with the flags provided. " +

--- a/backup/incremental_test.go
+++ b/backup/incremental_test.go
@@ -1,7 +1,12 @@
 package backup_test
 
 import (
+	"errors"
+	"os"
+
+	"github.com/greenplum-db/gp-common-go-libs/operating"
 	"github.com/greenplum-db/gp-common-go-libs/structmatcher"
+	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup/backup"
 	"github.com/greenplum-db/gpbackup/backup_filepath"
 	"github.com/greenplum-db/gpbackup/backup_history"
@@ -9,6 +14,7 @@ import (
 	"github.com/greenplum-db/gpbackup/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
 )
 
 var _ = Describe("backup/incremental tests", func() {
@@ -191,5 +197,50 @@ var _ = Describe("backup/incremental tests", func() {
 			})
 		})
 
+	})
+	Describe("GetLatestMatchingBackupTimestamp", func() {
+		AfterEach(func() {
+			operating.InitializeSystemFunctions()
+		})
+		It("fatals when trying to take an incremental backup without a full backup", func() {
+			backup.SetFPInfo(backup_filepath.FilePathInfo{UserSpecifiedBackupDir: "/tmp", UserSpecifiedSegPrefix: "/kevin"})
+			backup.SetReport(&utils.Report{})
+			_, _, log := testhelper.SetupTestLogger()
+
+			Expect(func() { backup.GetLatestMatchingBackupTimestamp() }).Should(Panic())
+			Expect(log.Contents()).To(ContainSubstring("There was no matching previous backup found with the flags provided. Please take a full backup."))
+
+		})
+		It("fatals when gpbackup_history.yaml can't be read", func() {
+			_, _, log := testhelper.SetupTestLogger()
+			operating.System.Stat = func(string) (os.FileInfo, error) { return nil, nil }
+			operating.System.OpenFileRead = func(string, int, os.FileMode) (operating.ReadCloserAt, error) { return nil, nil }
+			operating.System.ReadFile = func(string) ([]byte, error) { return nil, errors.New("read error") }
+
+			Expect(func() { backup.GetLatestMatchingBackupTimestamp() }).Should(Panic())
+			Expect(log).Should(gbytes.Say("read error"))
+
+		})
+		It("fatals when gpbackup_history.yaml is an invalid format", func() {
+			_, _, log := testhelper.SetupTestLogger()
+			operating.System.Stat = func(string) (os.FileInfo, error) { return nil, nil }
+			operating.System.OpenFileRead = func(string, int, os.FileMode) (operating.ReadCloserAt, error) { return nil, nil }
+			operating.System.ReadFile = func(string) ([]byte, error) { return []byte("not yaml"), nil }
+
+			Expect(func() { backup.GetLatestMatchingBackupTimestamp() }).Should(Panic())
+			Expect(log).Should(gbytes.Say(`yaml: unmarshal errors:`))
+			Expect(log).Should(gbytes.Say("not yaml"))
+		})
+		It("fatals when NewHistory returns an empty History", func() {
+			backup.SetFPInfo(backup_filepath.FilePathInfo{UserSpecifiedBackupDir: "/tmp", UserSpecifiedSegPrefix: "/kevin"})
+			backup.SetReport(&utils.Report{})
+			_, _, log := testhelper.SetupTestLogger()
+			operating.System.Stat = func(string) (os.FileInfo, error) { return nil, nil }
+			operating.System.OpenFileRead = func(string, int, os.FileMode) (operating.ReadCloserAt, error) { return nil, nil }
+			operating.System.ReadFile = func(string) ([]byte, error) { return []byte(""), nil }
+
+			Expect(func() { backup.GetLatestMatchingBackupTimestamp() }).Should(Panic())
+			Expect(log).Should(gbytes.Say("There was no matching previous backup found with the flags provided. Please take a full backup."))
+		})
 	})
 })

--- a/backup_history/history.go
+++ b/backup_history/history.go
@@ -68,17 +68,15 @@ type History struct {
 
 func NewHistory(filename string) (*History, error) {
 	history := &History{BackupConfigs: make([]BackupConfig, 0)}
-	if historyFileExists := iohelper.FileExistsAndIsReadable(filename); historyFileExists {
-
-		contents, err := operating.System.ReadFile(filename)
-		if err != nil {
-			return nil, err
-		}
-		err = yaml.Unmarshal(contents, history)
-		if err != nil {
-			return nil, err
-		}
+	contents, err := operating.System.ReadFile(filename)
+	if err != nil {
+		return nil, err
 	}
+	err = yaml.Unmarshal(contents, history)
+	if err != nil {
+		return nil, err
+	}
+
 	return history, nil
 }
 
@@ -95,8 +93,13 @@ func WriteBackupHistory(historyFilePath string, currentBackupConfig *BackupConfi
 		_ = lock.Unlock()
 	}()
 
-	history, err := NewHistory(historyFilePath)
-	gplog.FatalOnError(err)
+	history := &History{BackupConfigs: make([]BackupConfig, 0)}
+	var err error
+
+	if iohelper.FileExistsAndIsReadable(historyFilePath) {
+		history, err = NewHistory(historyFilePath)
+		gplog.FatalOnError(err)
+	}
 	if len(history.BackupConfigs) == 0 {
 		gplog.Verbose("No existing backup history file could be found. Creating new backup history file.")
 	}

--- a/backup_history/history.go
+++ b/backup_history/history.go
@@ -93,15 +93,17 @@ func WriteBackupHistory(historyFilePath string, currentBackupConfig *BackupConfi
 		_ = lock.Unlock()
 	}()
 
-	history := &History{BackupConfigs: make([]BackupConfig, 0)}
-	var err error
+	var history *History
 
 	if iohelper.FileExistsAndIsReadable(historyFilePath) {
+		var err error
 		history, err = NewHistory(historyFilePath)
 		gplog.FatalOnError(err)
+	} else {
+		history = &History{BackupConfigs: make([]BackupConfig, 0)}
 	}
 	if len(history.BackupConfigs) == 0 {
-		gplog.Verbose("No existing backup history file could be found. Creating new backup history file.")
+		gplog.Verbose("No existing backups found. Creating new backup history file.")
 	}
 	history.AddBackupConfig(currentBackupConfig)
 	history.writeToFileAndMakeReadOnly(historyFilePath)

--- a/backup_history/history_test.go
+++ b/backup_history/history_test.go
@@ -1,11 +1,16 @@
 package backup_history_test
 
 import (
+	"errors"
 	"os"
 
 	"github.com/greenplum-db/gp-common-go-libs/iohelper"
+	"github.com/greenplum-db/gp-common-go-libs/operating"
 	"github.com/greenplum-db/gp-common-go-libs/structmatcher"
+	"github.com/greenplum-db/gpbackup/backup"
+	"github.com/greenplum-db/gpbackup/backup_filepath"
 	"github.com/greenplum-db/gpbackup/backup_history"
+	"github.com/greenplum-db/gpbackup/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v2"
@@ -59,6 +64,40 @@ var _ bool = Describe("backup/history tests", func() {
 
 			structmatcher.ExpectStructsToMatch(&historyWithEntries, resultHistory)
 		})
+		Context("fatals when", func() {
+			BeforeEach(func() {
+				operating.System.Stat = func(string) (os.FileInfo, error) { return nil, nil }
+				operating.System.OpenFileRead = func(string, int, os.FileMode) (operating.ReadCloserAt, error) { return nil, nil }
+			})
+			AfterEach(func() {
+				operating.System = operating.InitializeSystemFunctions()
+			})
+			It("gpbackup_history.yaml can't be read", func() {
+				operating.System.ReadFile = func(string) ([]byte, error) { return nil, errors.New("read error") }
+
+				_, err := backup_history.NewHistory("/tempfile")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("read error"))
+			})
+			It("gpbackup_history.yaml is an invalid format", func() {
+				operating.System.ReadFile = func(string) ([]byte, error) { return []byte("not yaml"), nil }
+
+				_, err := backup_history.NewHistory("/tempfile")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("not yaml"))
+			})
+			It("NewHistory returns an empty History", func() {
+				backup.SetFPInfo(backup_filepath.FilePathInfo{UserSpecifiedBackupDir: "/tmp", UserSpecifiedSegPrefix: "/test-prefix"})
+				backup.SetReport(&utils.Report{})
+				operating.System.ReadFile = func(string) ([]byte, error) { return []byte(""), nil }
+
+				history, err := backup_history.NewHistory("/tempfile")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(history).To(Equal(&backup_history.History{BackupConfigs: make([]backup_history.BackupConfig, 0)}))
+
+			})
+		})
+
 	})
 	Describe("AddBackupConfig", func() {
 		It("adds the most recent history entry and keeps the list sorted", func() {


### PR DESCRIPTION
The backup history file is now being used by gpbackup_manager as well as gpbackup. This PR makes it easier to use the backup history file consistently from both utilities. See commit messages for details.