### PR TITLE
Create separate TOC entries for object creation and metadata

### DIFF
--- a/backup/postdata_test.go
+++ b/backup/postdata_test.go
@@ -28,23 +28,22 @@ var _ = Describe("backup/postdata tests", func() {
 			indexes := []backup.IndexDefinition{index}
 			backup.PrintCreateIndexStatements(backupfile, toc, indexes, emptyMetadataMap)
 			testutils.ExpectEntry(toc.PostdataEntries, 0, "public", "public.testtable", "testindex", "INDEX")
-			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE INDEX testindex ON public.testtable USING btree(i);
-ALTER TABLE public.testtable CLUSTER ON testindex;`)
+			testutils.AssertBufferContents(toc.PostdataEntries, buffer, "CREATE INDEX testindex ON public.testtable USING btree(i);",
+				"ALTER TABLE public.testtable CLUSTER ON testindex;")
 		})
 		It("can print an index with a tablespace", func() {
 			index.Tablespace = "test_tablespace"
 			indexes := []backup.IndexDefinition{index}
 			backup.PrintCreateIndexStatements(backupfile, toc, indexes, emptyMetadataMap)
-			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE INDEX testindex ON public.testtable USING btree(i);
-ALTER INDEX public.testindex SET TABLESPACE test_tablespace;`)
+			testutils.AssertBufferContents(toc.PostdataEntries, buffer, "CREATE INDEX testindex ON public.testtable USING btree(i);",
+				"ALTER INDEX public.testindex SET TABLESPACE test_tablespace;")
 		})
 		It("can print an index with a comment", func() {
 			indexes := []backup.IndexDefinition{index}
 			indexMetadataMap := testutils.DefaultMetadataMap("INDEX", false, false, true, false)
 			backup.PrintCreateIndexStatements(backupfile, toc, indexes, indexMetadataMap)
-			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE INDEX testindex ON public.testtable USING btree(i);
-
-COMMENT ON INDEX public.testindex IS 'This is an index comment.';`)
+			testutils.AssertBufferContents(toc.PostdataEntries, buffer, "CREATE INDEX testindex ON public.testtable USING btree(i);",
+				"COMMENT ON INDEX public.testindex IS 'This is an index comment.';")
 		})
 	})
 	Context("PrintCreateRuleStatements", func() {
@@ -54,15 +53,14 @@ COMMENT ON INDEX public.testindex IS 'This is an index comment.';`)
 			emptyMetadataMap := backup.MetadataMap{}
 			backup.PrintCreateRuleStatements(backupfile, toc, rules, emptyMetadataMap)
 			testutils.ExpectEntry(toc.PostdataEntries, 0, "public", "public.testtable", "testrule", "RULE")
-			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE RULE update_notify AS ON UPDATE TO testtable DO NOTIFY testtable;`)
+			testutils.AssertBufferContents(toc.PostdataEntries, buffer, "CREATE RULE update_notify AS ON UPDATE TO testtable DO NOTIFY testtable;")
 		})
 		It("can print a rule with a comment", func() {
 			rules := []backup.RuleDefinition{rule}
 			ruleMetadataMap := testutils.DefaultMetadataMap("RULE", false, false, true, false)
 			backup.PrintCreateRuleStatements(backupfile, toc, rules, ruleMetadataMap)
-			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE RULE update_notify AS ON UPDATE TO testtable DO NOTIFY testtable;
-
-COMMENT ON RULE testrule ON public.testtable IS 'This is a rule comment.';`)
+			testutils.AssertBufferContents(toc.PostdataEntries, buffer, "CREATE RULE update_notify AS ON UPDATE TO testtable DO NOTIFY testtable;",
+				"COMMENT ON RULE testrule ON public.testtable IS 'This is a rule comment.';")
 		})
 	})
 	Context("PrintCreateTriggerStatements", func() {
@@ -72,15 +70,14 @@ COMMENT ON RULE testrule ON public.testtable IS 'This is a rule comment.';`)
 			emptyMetadataMap := backup.MetadataMap{}
 			backup.PrintCreateTriggerStatements(backupfile, toc, triggers, emptyMetadataMap)
 			testutils.ExpectEntry(toc.PostdataEntries, 0, "public", "public.testtable", "testtrigger", "TRIGGER")
-			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON testtable FOR EACH STATEMENT EXECUTE PROCEDURE flatfile_update_trigger();`)
+			testutils.AssertBufferContents(toc.PostdataEntries, buffer, "CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON testtable FOR EACH STATEMENT EXECUTE PROCEDURE flatfile_update_trigger();")
 		})
 		It("can print a trigger with a comment", func() {
 			triggers := []backup.TriggerDefinition{trigger}
 			triggerMetadataMap := testutils.DefaultMetadataMap("TRIGGER", false, false, true, false)
 			backup.PrintCreateTriggerStatements(backupfile, toc, triggers, triggerMetadataMap)
-			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON testtable FOR EACH STATEMENT EXECUTE PROCEDURE flatfile_update_trigger();
-
-COMMENT ON TRIGGER testtrigger ON public.testtable IS 'This is a trigger comment.';`)
+			testutils.AssertBufferContents(toc.PostdataEntries, buffer, "CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON testtable FOR EACH STATEMENT EXECUTE PROCEDURE flatfile_update_trigger();",
+				"COMMENT ON TRIGGER testtrigger ON public.testtable IS 'This is a trigger comment.';")
 		})
 	})
 	Context("PrintCreateEventTriggerStatements", func() {
@@ -102,9 +99,7 @@ EXECUTE PROCEDURE abort_any_command();`)
 			testutils.ExpectEntry(toc.PostdataEntries, 0, "", "", "testeventtrigger", "EVENT TRIGGER")
 			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE EVENT TRIGGER testeventtrigger
 ON ddl_command_start
-EXECUTE PROCEDURE abort_any_command();
-
-COMMENT ON EVENT TRIGGER testeventtrigger IS 'This is an event trigger comment.';`)
+EXECUTE PROCEDURE abort_any_command();`, `COMMENT ON EVENT TRIGGER testeventtrigger IS 'This is an event trigger comment.';`)
 		})
 		It("can print a basic event trigger with an owner", func() {
 			eventTrigger := backup.EventTrigger{Oid: 1, Name: "testeventtrigger", Event: "ddl_command_start", FunctionName: "abort_any_command", Enabled: "O"}
@@ -114,9 +109,7 @@ COMMENT ON EVENT TRIGGER testeventtrigger IS 'This is an event trigger comment.'
 			testutils.ExpectEntry(toc.PostdataEntries, 0, "", "", "testeventtrigger", "EVENT TRIGGER")
 			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE EVENT TRIGGER testeventtrigger
 ON ddl_command_start
-EXECUTE PROCEDURE abort_any_command();
-
-ALTER EVENT TRIGGER testeventtrigger OWNER TO testrole;`)
+EXECUTE PROCEDURE abort_any_command();`, `ALTER EVENT TRIGGER testeventtrigger OWNER TO testrole;`)
 		})
 		It("can print a basic event trigger with a security label", func() {
 			eventTrigger := backup.EventTrigger{Oid: 1, Name: "testeventtrigger", Event: "ddl_command_start", FunctionName: "abort_any_command", Enabled: "O"}
@@ -126,9 +119,7 @@ ALTER EVENT TRIGGER testeventtrigger OWNER TO testrole;`)
 			testutils.ExpectEntry(toc.PostdataEntries, 0, "", "", "testeventtrigger", "EVENT TRIGGER")
 			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE EVENT TRIGGER testeventtrigger
 ON ddl_command_start
-EXECUTE PROCEDURE abort_any_command();
-
-SECURITY LABEL FOR dummy ON EVENT TRIGGER testeventtrigger IS 'unclassified';`)
+EXECUTE PROCEDURE abort_any_command();`, `SECURITY LABEL FOR dummy ON EVENT TRIGGER testeventtrigger IS 'unclassified';`)
 		})
 		It("can print an event trigger with filter variables", func() {
 			eventTrigger := backup.EventTrigger{Oid: 1, Name: "testeventtrigger", Event: "ddl_command_start", FunctionName: "abort_any_command", Enabled: "O", EventTags: `'DROP FUNCTION','DROP TABLE'`}
@@ -149,8 +140,7 @@ EXECUTE PROCEDURE abort_any_command();`)
 			testutils.ExpectEntry(toc.PostdataEntries, 0, "", "", "testeventtrigger", "EVENT TRIGGER")
 			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE EVENT TRIGGER testeventtrigger
 ON ddl_command_start
-EXECUTE PROCEDURE abort_any_command();
-ALTER EVENT TRIGGER testeventtrigger DISABLE;`)
+EXECUTE PROCEDURE abort_any_command();`, `ALTER EVENT TRIGGER testeventtrigger DISABLE;`)
 		})
 		It("can print an event trigger with filter variables with enable option ENABLE", func() {
 			eventTrigger := backup.EventTrigger{Oid: 1, Name: "testeventtrigger", Event: "ddl_command_start", FunctionName: "abort_any_command", Enabled: ""}
@@ -160,8 +150,7 @@ ALTER EVENT TRIGGER testeventtrigger DISABLE;`)
 			testutils.ExpectEntry(toc.PostdataEntries, 0, "", "", "testeventtrigger", "EVENT TRIGGER")
 			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE EVENT TRIGGER testeventtrigger
 ON ddl_command_start
-EXECUTE PROCEDURE abort_any_command();
-ALTER EVENT TRIGGER testeventtrigger ENABLE;`)
+EXECUTE PROCEDURE abort_any_command();`, `ALTER EVENT TRIGGER testeventtrigger ENABLE;`)
 		})
 		It("can print an event trigger with filter variables with enable option ENABLE REPLICA", func() {
 			eventTrigger := backup.EventTrigger{Oid: 1, Name: "testeventtrigger", Event: "ddl_command_start", FunctionName: "abort_any_command", Enabled: "R"}
@@ -171,8 +160,7 @@ ALTER EVENT TRIGGER testeventtrigger ENABLE;`)
 			testutils.ExpectEntry(toc.PostdataEntries, 0, "", "", "testeventtrigger", "EVENT TRIGGER")
 			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE EVENT TRIGGER testeventtrigger
 ON ddl_command_start
-EXECUTE PROCEDURE abort_any_command();
-ALTER EVENT TRIGGER testeventtrigger ENABLE REPLICA;`)
+EXECUTE PROCEDURE abort_any_command();`, `ALTER EVENT TRIGGER testeventtrigger ENABLE REPLICA;`)
 		})
 		It("can print an event trigger with filter variables with enable option ENABLE ALWAYS", func() {
 			eventTrigger := backup.EventTrigger{Oid: 1, Name: "testeventtrigger", Event: "ddl_command_start", FunctionName: "abort_any_command", Enabled: "A"}
@@ -182,8 +170,7 @@ ALTER EVENT TRIGGER testeventtrigger ENABLE REPLICA;`)
 			testutils.ExpectEntry(toc.PostdataEntries, 0, "", "", "testeventtrigger", "EVENT TRIGGER")
 			testutils.AssertBufferContents(toc.PostdataEntries, buffer, `CREATE EVENT TRIGGER testeventtrigger
 ON ddl_command_start
-EXECUTE PROCEDURE abort_any_command();
-ALTER EVENT TRIGGER testeventtrigger ENABLE ALWAYS;`)
+EXECUTE PROCEDURE abort_any_command();`, `ALTER EVENT TRIGGER testeventtrigger ENABLE ALWAYS;`)
 		})
 	})
 })

--- a/backup/predata_externals.go
+++ b/backup/predata_externals.go
@@ -65,7 +65,7 @@ func PrintExternalTableCreateStatement(metadataFile *utils.FileWithByteCount, to
 	}
 	metadataFile.MustPrintf(";")
 	if toc != nil {
-		toc.AddPredataEntry(table.Schema, table.Name, "TABLE", "", start, metadataFile)
+		toc.AddMetadataEntry(table, start, metadataFile.ByteCount)
 	}
 }
 
@@ -333,8 +333,8 @@ func PrintCreateExternalProtocolStatement(metadataFile *utils.FileWithByteCount,
 		metadataFile.MustPrintf("TRUSTED ")
 	}
 	metadataFile.MustPrintf("PROTOCOL %s (%s);\n", protocol.Name, strings.Join(protocolFunctions, ", "))
-	PrintObjectMetadata(metadataFile, protoMetadata, protocol.Name, "PROTOCOL")
-	toc.AddPredataEntry("", protocol.Name, "PROTOCOL", "", start, metadataFile)
+	toc.AddMetadataEntry(protocol, start, metadataFile.ByteCount)
+	PrintObjectMetadata(metadataFile, toc, protoMetadata, protocol, "")
 }
 
 func PrintExchangeExternalPartitionStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, extPartitions []PartitionInfo, partInfoMap map[uint32]PartitionInfo, tables []Table) {
@@ -368,6 +368,6 @@ func PrintExchangeExternalPartitionStatements(metadataFile *utils.FileWithByteCo
 		}
 		metadataFile.MustPrintf("WITH TABLE %s WITHOUT VALIDATION;", extPartRelationName)
 		metadataFile.MustPrintf("\n\nDROP TABLE %s;", extPartRelationName)
-		toc.AddPredataEntry(externalPartition.ParentSchema, externalPartition.ParentRelationName, "EXCHANGE PARTITION", "", start, metadataFile)
+		toc.AddMetadataEntry(externalPartition, start, metadataFile.ByteCount)
 	}
 }

--- a/backup/predata_externals_test.go
+++ b/backup/predata_externals_test.go
@@ -461,15 +461,13 @@ ENCODING 'UTF-8'`)
 			protoMetadata := backup.ObjectMetadata{Privileges: []backup.ACL{{Grantee: "testrole", Select: true, Insert: true}}, Owner: "testrole"}
 
 			backup.PrintCreateExternalProtocolStatement(backupfile, toc, protocolUntrustedReadWrite, funcInfoMap, protoMetadata)
-			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE PROTOCOL s3 (readfunc = public.read_fn_s3, writefunc = public.write_fn_s3);
-
-
-ALTER PROTOCOL s3 OWNER TO testrole;
-
-
-REVOKE ALL ON PROTOCOL s3 FROM PUBLIC;
+			expectedStatements := []string{
+				"CREATE PROTOCOL s3 (readfunc = public.read_fn_s3, writefunc = public.write_fn_s3);",
+				"ALTER PROTOCOL s3 OWNER TO testrole;",
+				`REVOKE ALL ON PROTOCOL s3 FROM PUBLIC;
 REVOKE ALL ON PROTOCOL s3 FROM testrole;
-GRANT ALL ON PROTOCOL s3 TO testrole;`)
+GRANT ALL ON PROTOCOL s3 TO testrole;`}
+			testutils.AssertBufferContents(toc.PredataEntries, buffer, expectedStatements...)
 		})
 	})
 	Describe("PrintExchangeExternalPartitionStatements", func() {

--- a/backup/predata_relations_other_test.go
+++ b/backup/predata_relations_other_test.go
@@ -144,24 +144,19 @@ SELECT pg_catalog.setval('public.seq_''name', 7, true);`)
 			sequenceMetadataMap[seqDefault.GetUniqueID()] = sequenceMetadata
 			sequences := []backup.Sequence{seqDefault}
 			backup.PrintCreateSequenceStatements(backupfile, toc, sequences, sequenceMetadataMap)
-			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE SEQUENCE public.seq_name
+			expectedEntries := []string{`CREATE SEQUENCE public.seq_name
 	INCREMENT BY 1
 	NO MAXVALUE
 	NO MINVALUE
 	CACHE 5;
 
-SELECT pg_catalog.setval('public.seq_name', 7, true);
-
-
-COMMENT ON SEQUENCE public.seq_name IS 'This is a sequence comment.';
-
-
-ALTER TABLE public.seq_name OWNER TO testrole;
-
-
-REVOKE ALL ON SEQUENCE public.seq_name FROM PUBLIC;
+SELECT pg_catalog.setval('public.seq_name', 7, true);`,
+				"COMMENT ON SEQUENCE public.seq_name IS 'This is a sequence comment.';",
+				"ALTER TABLE public.seq_name OWNER TO testrole;",
+				`REVOKE ALL ON SEQUENCE public.seq_name FROM PUBLIC;
 REVOKE ALL ON SEQUENCE public.seq_name FROM testrole;
-GRANT SELECT,USAGE ON SEQUENCE public.seq_name TO testrole;`)
+GRANT SELECT,USAGE ON SEQUENCE public.seq_name TO testrole;`}
+			testutils.AssertBufferContents(toc.PredataEntries, buffer, expectedEntries...)
 			testhelper.SetDBVersion(connectionPool, "5.1.0")
 		})
 		It("can print a sequence with privileges, an owner, security label, and a comment for version >= 6", func() {
@@ -172,28 +167,21 @@ GRANT SELECT,USAGE ON SEQUENCE public.seq_name TO testrole;`)
 			sequenceMetadataMap[seqDefault.GetUniqueID()] = sequenceMetadata
 			sequences := []backup.Sequence{seqDefault}
 			backup.PrintCreateSequenceStatements(backupfile, toc, sequences, sequenceMetadataMap)
-			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE SEQUENCE public.seq_name
+			expectedEntries := []string{`CREATE SEQUENCE public.seq_name
 	START WITH 0
 	INCREMENT BY 1
 	NO MAXVALUE
 	NO MINVALUE
 	CACHE 5;
 
-SELECT pg_catalog.setval('public.seq_name', 7, true);
-
-
-COMMENT ON SEQUENCE public.seq_name IS 'This is a sequence comment.';
-
-
-ALTER SEQUENCE public.seq_name OWNER TO testrole;
-
-
-REVOKE ALL ON SEQUENCE public.seq_name FROM PUBLIC;
+SELECT pg_catalog.setval('public.seq_name', 7, true);`,
+				"COMMENT ON SEQUENCE public.seq_name IS 'This is a sequence comment.';",
+				"ALTER SEQUENCE public.seq_name OWNER TO testrole;",
+				`REVOKE ALL ON SEQUENCE public.seq_name FROM PUBLIC;
 REVOKE ALL ON SEQUENCE public.seq_name FROM testrole;
-GRANT SELECT,USAGE ON SEQUENCE public.seq_name TO testrole;
-
-
-SECURITY LABEL FOR dummy ON SEQUENCE public.seq_name IS 'unclassified';`)
+GRANT SELECT,USAGE ON SEQUENCE public.seq_name TO testrole;`,
+				"SECURITY LABEL FOR dummy ON SEQUENCE public.seq_name IS 'unclassified';"}
+			testutils.AssertBufferContents(toc.PredataEntries, buffer, expectedEntries...)
 			testhelper.SetDBVersion(connectionPool, "5.1.0")
 		})
 		It("can print a sequence with privileges WITH GRANT OPTION", func() {
@@ -207,10 +195,8 @@ SECURITY LABEL FOR dummy ON SEQUENCE public.seq_name IS 'unclassified';`)
 	NO MINVALUE
 	CACHE 5;
 
-SELECT pg_catalog.setval('public.seq_name', 7, true);
-
-
-REVOKE ALL ON SEQUENCE public.seq_name FROM PUBLIC;
+SELECT pg_catalog.setval('public.seq_name', 7, true);`,
+				`REVOKE ALL ON SEQUENCE public.seq_name FROM PUBLIC;
 GRANT SELECT,USAGE ON SEQUENCE public.seq_name TO testrole WITH GRANT OPTION;`)
 		})
 	})
@@ -235,19 +221,13 @@ GRANT SELECT,USAGE ON SEQUENCE public.seq_name TO testrole WITH GRANT OPTION;`)
 
 			viewMetadata := testutils.DefaultMetadata("VIEW", true, true, true, false)
 			backup.PrintCreateViewStatement(backupfile, toc, view, viewMetadata)
-			testutils.AssertBufferContents(toc.PredataEntries, buffer,
-				`CREATE VIEW shamwow.shazam AS SELECT count(*) FROM pg_tables;
-
-
-COMMENT ON VIEW shamwow.shazam IS 'This is a view comment.';
-
-
-ALTER TABLE shamwow.shazam OWNER TO testrole;
-
-
-REVOKE ALL ON shamwow.shazam FROM PUBLIC;
+			expectedEntries := []string{"CREATE VIEW shamwow.shazam AS SELECT count(*) FROM pg_tables;",
+				"COMMENT ON VIEW shamwow.shazam IS 'This is a view comment.';",
+				"ALTER TABLE shamwow.shazam OWNER TO testrole;",
+				`REVOKE ALL ON shamwow.shazam FROM PUBLIC;
 REVOKE ALL ON shamwow.shazam FROM testrole;
-GRANT ALL ON shamwow.shazam TO testrole;`)
+GRANT ALL ON shamwow.shazam TO testrole;`}
+			testutils.AssertBufferContents(toc.PredataEntries, buffer, expectedEntries...)
 		})
 		It("can print a view with privileges, an owner, security label, and a comment for version >= 6", func() {
 			testhelper.SetDBVersion(connectionPool, "6.0.0")
@@ -255,22 +235,14 @@ GRANT ALL ON shamwow.shazam TO testrole;`)
 
 			viewMetadata := testutils.DefaultMetadata("VIEW", true, true, true, true)
 			backup.PrintCreateViewStatement(backupfile, toc, view, viewMetadata)
-			testutils.AssertBufferContents(toc.PredataEntries, buffer,
-				`CREATE VIEW shamwow.shazam AS SELECT count(*) FROM pg_tables;
-
-
-COMMENT ON VIEW shamwow.shazam IS 'This is a view comment.';
-
-
-ALTER VIEW shamwow.shazam OWNER TO testrole;
-
-
-REVOKE ALL ON shamwow.shazam FROM PUBLIC;
+			expectedEntries := []string{"CREATE VIEW shamwow.shazam AS SELECT count(*) FROM pg_tables;",
+				"COMMENT ON VIEW shamwow.shazam IS 'This is a view comment.';",
+				"ALTER VIEW shamwow.shazam OWNER TO testrole;",
+				`REVOKE ALL ON shamwow.shazam FROM PUBLIC;
 REVOKE ALL ON shamwow.shazam FROM testrole;
-GRANT ALL ON shamwow.shazam TO testrole;
-
-
-SECURITY LABEL FOR dummy ON VIEW shamwow.shazam IS 'unclassified';`)
+GRANT ALL ON shamwow.shazam TO testrole;`,
+				"SECURITY LABEL FOR dummy ON VIEW shamwow.shazam IS 'unclassified';"}
+			testutils.AssertBufferContents(toc.PredataEntries, buffer, expectedEntries...)
 		})
 		It("can print a view with options", func() {
 			view.Options = " WITH (security_barrier=true)"

--- a/backup/predata_shared.go
+++ b/backup/predata_shared.go
@@ -42,19 +42,20 @@ func PrintConstraintStatements(metadataFile *utils.FileWithByteCount, toc *utils
 			objStr = "TABLE"
 		}
 		metadataFile.MustPrintf(alterStr, objStr, constraint.OwningObject, constraint.Name, constraint.ConDef)
-		PrintObjectMetadata(metadataFile, conMetadata[constraint.GetUniqueID()], constraint.Name, "CONSTRAINT", constraint.OwningObject)
-		toc.AddPredataEntry(constraint.Schema, constraint.Name, "CONSTRAINT", constraint.OwningObject, start, metadataFile)
+
+		toc.AddMetadataEntry(constraint, start, metadataFile.ByteCount)
+		PrintObjectMetadata(metadataFile, toc, conMetadata[constraint.GetUniqueID()], constraint, constraint.OwningObject)
 	}
 }
 
-func PrintCreateSchemaStatements(backupfile *utils.FileWithByteCount, toc *utils.TOC, schemas []Schema, schemaMetadata MetadataMap) {
+func PrintCreateSchemaStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, schemas []Schema, schemaMetadata MetadataMap) {
 	for _, schema := range schemas {
-		start := backupfile.ByteCount
-		backupfile.MustPrintln()
+		start := metadataFile.ByteCount
+		metadataFile.MustPrintln()
 		if schema.Name != "public" {
-			backupfile.MustPrintf("\nCREATE SCHEMA %s;", schema.Name)
+			metadataFile.MustPrintf("\nCREATE SCHEMA %s;", schema.Name)
 		}
-		PrintObjectMetadata(backupfile, schemaMetadata[schema.GetUniqueID()], schema.Name, "SCHEMA")
-		toc.AddPredataEntry(schema.Name, schema.Name, "SCHEMA", "", start, backupfile)
+		toc.AddMetadataEntry(schema, start, metadataFile.ByteCount)
+		PrintObjectMetadata(metadataFile, toc, schemaMetadata[schema.GetUniqueID()], schema, "")
 	}
 }

--- a/backup/predata_shared_test.go
+++ b/backup/predata_shared_test.go
@@ -45,10 +45,7 @@ var _ = Describe("backup/predata_shared tests", func() {
 				constraintMetadataMap := testutils.DefaultMetadataMap("CONSTRAINT", false, false, true, false)
 				backup.PrintConstraintStatements(backupfile, toc, constraints, constraintMetadataMap)
 				testutils.ExpectEntry(toc.PredataEntries, 0, "", "public.tablename", "tablename_i_key", "CONSTRAINT")
-				testutils.AssertBufferContents(toc.PredataEntries, buffer, `ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_i_key UNIQUE (i);
-
-
-COMMENT ON CONSTRAINT tablename_i_key ON public.tablename IS 'This is a constraint comment.';`)
+				testutils.AssertBufferContents(toc.PredataEntries, buffer, "ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_i_key UNIQUE (i);", "COMMENT ON CONSTRAINT tablename_i_key ON public.tablename IS 'This is a constraint comment.';")
 			})
 			It("prints an ADD CONSTRAINT statement for one UNIQUE constraint", func() {
 				constraints := []backup.Constraint{uniqueOne}
@@ -156,20 +153,14 @@ COMMENT ON CONSTRAINT tablename_i_key ON public.tablename IS 'This is a constrai
 			schemaMetadataMap := testutils.DefaultMetadataMap("SCHEMA", true, true, true, true)
 
 			backup.PrintCreateSchemaStatements(backupfile, toc, schemas, schemaMetadataMap)
-			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE SCHEMA schemaname;
-
-COMMENT ON SCHEMA schemaname IS 'This is a schema comment.';
-
-
-ALTER SCHEMA schemaname OWNER TO testrole;
-
-
-REVOKE ALL ON SCHEMA schemaname FROM PUBLIC;
+			expectedStatements := []string{"CREATE SCHEMA schemaname;",
+				"COMMENT ON SCHEMA schemaname IS 'This is a schema comment.';",
+				"ALTER SCHEMA schemaname OWNER TO testrole;",
+				`REVOKE ALL ON SCHEMA schemaname FROM PUBLIC;
 REVOKE ALL ON SCHEMA schemaname FROM testrole;
-GRANT ALL ON SCHEMA schemaname TO testrole;
-
-
-SECURITY LABEL FOR dummy ON SCHEMA schemaname IS 'unclassified';`)
+GRANT ALL ON SCHEMA schemaname TO testrole;`,
+				"SECURITY LABEL FOR dummy ON SCHEMA schemaname IS 'unclassified';"}
+			testutils.AssertBufferContents(toc.PredataEntries, buffer, expectedStatements...)
 		})
 	})
 })

--- a/backup/predata_textsearch.go
+++ b/backup/predata_textsearch.go
@@ -18,8 +18,7 @@ import (
 
 func PrintCreateTextSearchParserStatement(metadataFile *utils.FileWithByteCount, toc *utils.TOC, parser TextSearchParser, parserMetadata ObjectMetadata) {
 	start := metadataFile.ByteCount
-	parserFQN := utils.MakeFQN(parser.Schema, parser.Name)
-	metadataFile.MustPrintf("\n\nCREATE TEXT SEARCH PARSER %s (", parserFQN)
+	metadataFile.MustPrintf("\n\nCREATE TEXT SEARCH PARSER %s (", parser.FQN())
 	metadataFile.MustPrintf("\n\tSTART = %s,", parser.StartFunc)
 	metadataFile.MustPrintf("\n\tGETTOKEN = %s,", parser.TokenFunc)
 	metadataFile.MustPrintf("\n\tEND = %s,", parser.EndFunc)
@@ -28,52 +27,51 @@ func PrintCreateTextSearchParserStatement(metadataFile *utils.FileWithByteCount,
 		metadataFile.MustPrintf(",\n\tHEADLINE = %s", parser.HeadlineFunc)
 	}
 	metadataFile.MustPrintf("\n);")
-	PrintObjectMetadata(metadataFile, parserMetadata, parserFQN, "TEXT SEARCH PARSER")
-	toc.AddPredataEntry(parser.Schema, parser.Name, "TEXT SEARCH PARSER", "", start, metadataFile)
+	toc.AddMetadataEntry(parser, start, metadataFile.ByteCount)
+	PrintObjectMetadata(metadataFile, toc, parserMetadata, parser, "")
 }
 
 func PrintCreateTextSearchTemplateStatement(metadataFile *utils.FileWithByteCount, toc *utils.TOC, template TextSearchTemplate, templateMetadata ObjectMetadata) {
 	start := metadataFile.ByteCount
-	templateFQN := utils.MakeFQN(template.Schema, template.Name)
-	metadataFile.MustPrintf("\n\nCREATE TEXT SEARCH TEMPLATE %s (", templateFQN)
+	metadataFile.MustPrintf("\n\nCREATE TEXT SEARCH TEMPLATE %s (", template.FQN())
 	if template.InitFunc != "" {
 		metadataFile.MustPrintf("\n\tINIT = %s,", template.InitFunc)
 	}
 	metadataFile.MustPrintf("\n\tLEXIZE = %s", template.LexizeFunc)
 	metadataFile.MustPrintf("\n);")
-	PrintObjectMetadata(metadataFile, templateMetadata, templateFQN, "TEXT SEARCH TEMPLATE")
-	toc.AddPredataEntry(template.Schema, template.Name, "TEXT SEARCH TEMPLATE", "", start, metadataFile)
+	toc.AddMetadataEntry(template, start, metadataFile.ByteCount)
+	PrintObjectMetadata(metadataFile, toc, templateMetadata, template, "")
 }
 
 func PrintCreateTextSearchDictionaryStatement(metadataFile *utils.FileWithByteCount, toc *utils.TOC, dictionary TextSearchDictionary, dictionaryMetadata ObjectMetadata) {
-	dictionaryFQN := utils.MakeFQN(dictionary.Schema, dictionary.Name)
 	start := metadataFile.ByteCount
-	metadataFile.MustPrintf("\n\nCREATE TEXT SEARCH DICTIONARY %s (", dictionaryFQN)
+	metadataFile.MustPrintf("\n\nCREATE TEXT SEARCH DICTIONARY %s (", dictionary.FQN())
 	metadataFile.MustPrintf("\n\tTEMPLATE = %s", dictionary.Template)
 	if dictionary.InitOption != "" {
 		metadataFile.MustPrintf(",\n\t%s", dictionary.InitOption)
 	}
 	metadataFile.MustPrintf("\n);")
-	PrintObjectMetadata(metadataFile, dictionaryMetadata, dictionaryFQN, "TEXT SEARCH DICTIONARY")
-	toc.AddPredataEntry(dictionary.Schema, dictionary.Name, "TEXT SEARCH DICTIONARY", "", start, metadataFile)
+	toc.AddMetadataEntry(dictionary, start, metadataFile.ByteCount)
+	PrintObjectMetadata(metadataFile, toc, dictionaryMetadata, dictionary, "")
 }
 
 func PrintCreateTextSearchConfigurationStatement(metadataFile *utils.FileWithByteCount, toc *utils.TOC, configuration TextSearchConfiguration, configurationMetadata ObjectMetadata) {
-	configurationFQN := utils.MakeFQN(configuration.Schema, configuration.Name)
 	start := metadataFile.ByteCount
-	metadataFile.MustPrintf("\n\nCREATE TEXT SEARCH CONFIGURATION %s (", configurationFQN)
+	metadataFile.MustPrintf("\n\nCREATE TEXT SEARCH CONFIGURATION %s (", configuration.FQN())
 	metadataFile.MustPrintf("\n\tPARSER = %s", configuration.Parser)
 	metadataFile.MustPrintf("\n);")
+	toc.AddMetadataEntry(configuration, start, metadataFile.ByteCount)
 	tokens := []string{}
 	for token := range configuration.TokenToDicts {
 		tokens = append(tokens, token)
 	}
 	sort.Strings(tokens)
 	for _, token := range tokens {
+		start := metadataFile.ByteCount
 		dicts := configuration.TokenToDicts[token]
-		metadataFile.MustPrintf("\n\nALTER TEXT SEARCH CONFIGURATION %s", configurationFQN)
+		metadataFile.MustPrintf("\n\nALTER TEXT SEARCH CONFIGURATION %s", configuration.FQN())
 		metadataFile.MustPrintf("\n\tADD MAPPING FOR \"%s\" WITH %s;", token, strings.Join(dicts, ", "))
+		toc.AddMetadataEntry(configuration, start, metadataFile.ByteCount)
 	}
-	PrintObjectMetadata(metadataFile, configurationMetadata, configurationFQN, "TEXT SEARCH CONFIGURATION")
-	toc.AddPredataEntry(configuration.Schema, configuration.Name, "TEXT SEARCH CONFIGURATION", "", start, metadataFile)
+	PrintObjectMetadata(metadataFile, toc, configurationMetadata, configuration, "")
 }

--- a/backup/predata_textsearch_test.go
+++ b/backup/predata_textsearch_test.go
@@ -33,9 +33,7 @@ var _ = Describe("backup/predata_textsearch tests", func() {
 	END = end_func,
 	LEXTYPES = lextypes_func,
 	HEADLINE = headline_func
-);
-
-COMMENT ON TEXT SEARCH PARSER public.testparser IS 'This is a text search parser comment.';`)
+);`, `COMMENT ON TEXT SEARCH PARSER public.testparser IS 'This is a text search parser comment.';`)
 		})
 	})
 	Describe("PrintCreateTextSearchTemplateStatement", func() {
@@ -47,9 +45,7 @@ COMMENT ON TEXT SEARCH PARSER public.testparser IS 'This is a text search parser
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TEXT SEARCH TEMPLATE public.testtemplate (
 	INIT = dsimple_init,
 	LEXIZE = dsimple_lexize
-);
-
-COMMENT ON TEXT SEARCH TEMPLATE public.testtemplate IS 'This is a text search template comment.';`)
+);`, `COMMENT ON TEXT SEARCH TEMPLATE public.testtemplate IS 'This is a text search template comment.';`)
 		})
 	})
 	Describe("PrintCreateTextSearchDictionaryStatement", func() {
@@ -61,12 +57,7 @@ COMMENT ON TEXT SEARCH TEMPLATE public.testtemplate IS 'This is a text search te
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TEXT SEARCH DICTIONARY public.testdictionary (
 	TEMPLATE = testschema.snowball,
 	language = 'russian', stopwords = 'russian'
-);
-
-COMMENT ON TEXT SEARCH DICTIONARY public.testdictionary IS 'This is a text search dictionary comment.';
-
-
-ALTER TEXT SEARCH DICTIONARY public.testdictionary OWNER TO testrole;`)
+);`, `COMMENT ON TEXT SEARCH DICTIONARY public.testdictionary IS 'This is a text search dictionary comment.';`, `ALTER TEXT SEARCH DICTIONARY public.testdictionary OWNER TO testrole;`)
 		})
 	})
 	Describe("PrintCreateTextSearchConfigurationStatement", func() {
@@ -83,20 +74,15 @@ ALTER TEXT SEARCH DICTIONARY public.testdictionary OWNER TO testrole;`)
 			metadata := testutils.DefaultMetadata("TEXT SEARCH CONFIGURATION", false, true, true, false)
 			backup.PrintCreateTextSearchConfigurationStatement(backupfile, toc, configurations, metadata)
 			testutils.ExpectEntry(toc.PredataEntries, 0, "public", "", "testconfiguration", "TEXT SEARCH CONFIGURATION")
-			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TEXT SEARCH CONFIGURATION public.testconfiguration (
+			expectedStatements := []string{`CREATE TEXT SEARCH CONFIGURATION public.testconfiguration (
 	PARSER = pg_catalog."default"
-);
-
-ALTER TEXT SEARCH CONFIGURATION public.testconfiguration
-	ADD MAPPING FOR "asciiword" WITH english_stem;
-
-ALTER TEXT SEARCH CONFIGURATION public.testconfiguration
-	ADD MAPPING FOR "int" WITH simple, english_stem;
-
-COMMENT ON TEXT SEARCH CONFIGURATION public.testconfiguration IS 'This is a text search configuration comment.';
-
-
-ALTER TEXT SEARCH CONFIGURATION public.testconfiguration OWNER TO testrole;`)
+);`, `ALTER TEXT SEARCH CONFIGURATION public.testconfiguration
+	ADD MAPPING FOR "asciiword" WITH english_stem;`,
+				`ALTER TEXT SEARCH CONFIGURATION public.testconfiguration
+	ADD MAPPING FOR "int" WITH simple, english_stem;`,
+				`COMMENT ON TEXT SEARCH CONFIGURATION public.testconfiguration IS 'This is a text search configuration comment.';`,
+				`ALTER TEXT SEARCH CONFIGURATION public.testconfiguration OWNER TO testrole;`}
+			testutils.AssertBufferContents(toc.PredataEntries, buffer, expectedStatements...)
 		})
 	})
 })

--- a/backup/predata_types_test.go
+++ b/backup/predata_types_test.go
@@ -32,20 +32,15 @@ var _ = Describe("backup/predata_types tests", func() {
 		It("prints an enum type with comment, security label, and owner", func() {
 			typeMetadataMap = testutils.DefaultMetadataMap("TYPE", false, true, true, true)
 			backup.PrintCreateEnumTypeStatements(backupfile, toc, []backup.Type{enumTwo}, typeMetadataMap)
-			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TYPE public.enum_type AS ENUM (
+			expectedStatements := []string{`CREATE TYPE public.enum_type AS ENUM (
 	'bar',
 	'baz',
 	'foo'
-);
-
-
-COMMENT ON TYPE public.enum_type IS 'This is a type comment.';
-
-
-ALTER TYPE public.enum_type OWNER TO testrole;
-
-
-SECURITY LABEL FOR dummy ON TYPE public.enum_type IS 'unclassified';`)
+);`,
+				"COMMENT ON TYPE public.enum_type IS 'This is a type comment.';",
+				"ALTER TYPE public.enum_type OWNER TO testrole;",
+				"SECURITY LABEL FOR dummy ON TYPE public.enum_type IS 'unclassified';"}
+			testutils.AssertBufferContents(toc.PredataEntries, buffer, expectedStatements...)
 		})
 	})
 	Describe("PrintCreateCompositeTypeStatement", func() {
@@ -86,18 +81,14 @@ SECURITY LABEL FOR dummy ON TYPE public.enum_type IS 'unclassified';`)
 			compType.Attributes = twoAtts
 			typeMetadata = testutils.DefaultMetadata("TYPE", false, true, true, true)
 			backup.PrintCreateCompositeTypeStatement(backupfile, toc, compType, typeMetadata)
-			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TYPE public.composite_type AS (
+			expectedEntries := []string{`CREATE TYPE public.composite_type AS (
 	foo integer,
 	bar text
-);
-
-COMMENT ON TYPE public.composite_type IS 'This is a type comment.';
-
-
-ALTER TYPE public.composite_type OWNER TO testrole;
-
-
-SECURITY LABEL FOR dummy ON TYPE public.composite_type IS 'unclassified';`)
+);`,
+				"COMMENT ON TYPE public.composite_type IS 'This is a type comment.';",
+				"ALTER TYPE public.composite_type OWNER TO testrole;",
+				"SECURITY LABEL FOR dummy ON TYPE public.composite_type IS 'unclassified';"}
+			testutils.AssertBufferContents(toc.PredataEntries, buffer, expectedEntries...)
 		})
 		It("prints a composite type with attribute comment", func() {
 			attWithComment := []backup.Attribute{{Name: "foo", Type: "integer", Comment: "'attribute comment'"}}
@@ -105,9 +96,7 @@ SECURITY LABEL FOR dummy ON TYPE public.composite_type IS 'unclassified';`)
 			backup.PrintCreateCompositeTypeStatement(backupfile, toc, compType, typeMetadata)
 			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TYPE public.composite_type AS (
 	foo integer
-);
-
-COMMENT ON COLUMN public.composite_type.foo IS 'attribute comment';`)
+);`, "COMMENT ON COLUMN public.composite_type.foo IS 'attribute comment';")
 		})
 	})
 	Describe("PrintCreateBaseTypeStatement", func() {
@@ -184,19 +173,14 @@ ALTER TYPE public.base_type
 		It("prints a base type with comment, security label, and owner", func() {
 			typeMetadata = testutils.DefaultMetadata("TYPE", false, true, true, true)
 			backup.PrintCreateBaseTypeStatement(backupfile, toc, baseSimple, typeMetadata)
-			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TYPE public.base_type (
+			expectedEntries := []string{`CREATE TYPE public.base_type (
 	INPUT = input_fn,
 	OUTPUT = output_fn
-);
-
-
-COMMENT ON TYPE public.base_type IS 'This is a type comment.';
-
-
-ALTER TYPE public.base_type OWNER TO testrole;
-
-
-SECURITY LABEL FOR dummy ON TYPE public.base_type IS 'unclassified';`)
+);`,
+				"COMMENT ON TYPE public.base_type IS 'This is a type comment.';",
+				"ALTER TYPE public.base_type OWNER TO testrole;",
+				"SECURITY LABEL FOR dummy ON TYPE public.base_type IS 'unclassified';"}
+			testutils.AssertBufferContents(toc.PredataEntries, buffer, expectedEntries...)
 		})
 	})
 	Describe("PrintCreateShellTypeStatements", func() {
@@ -236,16 +220,11 @@ SECURITY LABEL FOR dummy ON TYPE public.base_type IS 'unclassified';`)
 		It("prints a domain without constraint with comment, security label, and owner", func() {
 			typeMetadata = testutils.DefaultMetadata("DOMAIN", false, true, true, true)
 			backup.PrintCreateDomainStatement(backupfile, toc, domainTwo, typeMetadata, emptyConstraint)
-			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE DOMAIN public.domain2 AS varchar;
-
-
-COMMENT ON DOMAIN public.domain2 IS 'This is a domain comment.';
-
-
-ALTER DOMAIN public.domain2 OWNER TO testrole;
-
-
-SECURITY LABEL FOR dummy ON DOMAIN public.domain2 IS 'unclassified';`)
+			expectedEntries := []string{"CREATE DOMAIN public.domain2 AS varchar;",
+				"COMMENT ON DOMAIN public.domain2 IS 'This is a domain comment.';",
+				"ALTER DOMAIN public.domain2 OWNER TO testrole;",
+				"SECURITY LABEL FOR dummy ON DOMAIN public.domain2 IS 'unclassified';"}
+			testutils.AssertBufferContents(toc.PredataEntries, buffer, expectedEntries...)
 		})
 	})
 	Describe("PrintCreateRangeTypeStatement", func() {
@@ -281,18 +260,13 @@ SECURITY LABEL FOR dummy ON DOMAIN public.domain2 IS 'unclassified';`)
 		It("prints a range type with an owner, security label, and a comment", func() {
 			typeMetadata = testutils.DefaultMetadata("TYPE", false, true, true, true)
 			backup.PrintCreateRangeTypeStatement(backupfile, toc, basicRangeType, typeMetadata)
-			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE TYPE public.rangetype AS RANGE (
+			expectedStatements := []string{`CREATE TYPE public.rangetype AS RANGE (
 	SUBTYPE = test_subtype_schema.test_subtype
-);
-
-
-COMMENT ON TYPE public.rangetype IS 'This is a type comment.';
-
-
-ALTER TYPE public.rangetype OWNER TO testrole;
-
-
-SECURITY LABEL FOR dummy ON TYPE public.rangetype IS 'unclassified';`)
+);`,
+				"COMMENT ON TYPE public.rangetype IS 'This is a type comment.';",
+				"ALTER TYPE public.rangetype OWNER TO testrole;",
+				"SECURITY LABEL FOR dummy ON TYPE public.rangetype IS 'unclassified';"}
+			testutils.AssertBufferContents(toc.PredataEntries, buffer, expectedStatements...)
 		})
 	})
 	Describe("PrintCreateCollationStatement", func() {
@@ -306,12 +280,11 @@ SECURITY LABEL FOR dummy ON TYPE public.rangetype IS 'unclassified';`)
 			collation := backup.Collation{Oid: 1, Name: "collation1", Collate: "collate1", Ctype: "ctype1", Schema: "schema1"}
 			collationMetadataMap := testutils.DefaultMetadataMap("COLLATION", false, true, true, false)
 			backup.PrintCreateCollationStatements(backupfile, toc, []backup.Collation{collation}, collationMetadataMap)
-			testutils.AssertBufferContents(toc.PredataEntries, buffer, `CREATE COLLATION schema1.collation1 (LC_COLLATE = 'collate1', LC_CTYPE = 'ctype1');
-
-COMMENT ON COLLATION schema1.collation1 IS 'This is a collation comment.';
-
-
-ALTER COLLATION schema1.collation1 OWNER TO testrole;`)
+			expectedStatements := []string{
+				"CREATE COLLATION schema1.collation1 (LC_COLLATE = 'collate1', LC_CTYPE = 'ctype1');",
+				"COMMENT ON COLLATION schema1.collation1 IS 'This is a collation comment.';",
+				"ALTER COLLATION schema1.collation1 OWNER TO testrole;"}
+			testutils.AssertBufferContents(toc.PredataEntries, buffer, expectedStatements...)
 		})
 	})
 })

--- a/backup/queries_acl.go
+++ b/backup/queries_acl.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/greenplum-db/gpbackup/utils"
 )
 
 /*
@@ -239,6 +240,18 @@ type DefaultPrivileges struct {
 	Schema     string
 	Privileges []ACL
 	ObjectType string
+}
+
+func (dp DefaultPrivileges) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	return "postdata",
+		utils.MetadataEntry{
+			Schema:          dp.Schema,
+			Name:            "",
+			ObjectType:      "DEFAULT PRIVILEGES",
+			ReferenceObject: "",
+			StartByte:       start,
+			EndByte:         end,
+		}
 }
 
 func GetDefaultPrivileges(connectionPool *dbconn.DBConn) []DefaultPrivileges {

--- a/backup/queries_externals.go
+++ b/backup/queries_externals.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/greenplum-db/gpbackup/utils"
 )
 
 func GetExternalTableDefinitions(connectionPool *dbconn.DBConn) map[uint32]ExternalTableDefinition {
@@ -109,6 +110,18 @@ type ExternalProtocol struct {
 	Validator     uint32 `db:"ptcvalidatorfn"`
 }
 
+func (p ExternalProtocol) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	return "predata",
+		utils.MetadataEntry{
+			Schema:          "",
+			Name:            p.Name,
+			ObjectType:      "PROTOCOL",
+			ReferenceObject: "",
+			StartByte:       start,
+			EndByte:         end,
+		}
+}
+
 func (p ExternalProtocol) GetUniqueID() UniqueID {
 	return UniqueID{ClassID: PG_EXTPROTOCOL_OID, Oid: p.Oid}
 }
@@ -145,6 +158,18 @@ type PartitionInfo struct {
 	PartitionName          string
 	PartitionRank          int
 	IsExternal             bool
+}
+
+func (pi PartitionInfo) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	return "predata",
+		utils.MetadataEntry{
+			Schema:          pi.ParentSchema,
+			Name:            pi.ParentRelationName,
+			ObjectType:      "EXCHANGE PARTITION",
+			ReferenceObject: "",
+			StartByte:       start,
+			EndByte:         end,
+		}
 }
 
 func GetExternalPartitionInfo(connectionPool *dbconn.DBConn) ([]PartitionInfo, map[uint32]PartitionInfo) {

--- a/backup/queries_globals.go
+++ b/backup/queries_globals.go
@@ -17,6 +17,18 @@ type SessionGUCs struct {
 	ClientEncoding string `db:"client_encoding"`
 }
 
+func (sg SessionGUCs) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	return "global",
+		utils.MetadataEntry{
+			Schema:          "",
+			Name:            "",
+			ObjectType:      "SESSION GUCS",
+			ReferenceObject: "",
+			StartByte:       start,
+			EndByte:         end,
+		}
+}
+
 func GetSessionGUCs(connectionPool *dbconn.DBConn) SessionGUCs {
 	result := SessionGUCs{}
 	query := "SHOW client_encoding;"
@@ -34,8 +46,24 @@ type Database struct {
 	Encoding   string
 }
 
+func (db Database) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	return "global",
+		utils.MetadataEntry{
+			Schema:          "",
+			Name:            db.Name,
+			ObjectType:      "DATABASE METADATA",
+			ReferenceObject: "",
+			StartByte:       start,
+			EndByte:         end,
+		}
+}
+
 func (db Database) GetUniqueID() UniqueID {
 	return UniqueID{ClassID: PG_DATABASE_OID, Oid: db.Oid}
+}
+
+func (db Database) FQN() string {
+	return db.Name
 }
 
 func GetDefaultDatabaseEncodingInfo(connectionPool *dbconn.DBConn) Database {
@@ -112,8 +140,24 @@ type ResourceQueue struct {
 	MemoryLimit      string
 }
 
+func (rq ResourceQueue) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	return "global",
+		utils.MetadataEntry{
+			Schema:          "",
+			Name:            rq.Name,
+			ObjectType:      "RESOURCE QUEUE",
+			ReferenceObject: "",
+			StartByte:       start,
+			EndByte:         end,
+		}
+}
+
 func (rq ResourceQueue) GetUniqueID() UniqueID {
 	return UniqueID{ClassID: PG_RESQUEUE_OID, Oid: rq.Oid}
+}
+
+func (rq ResourceQueue) FQN() string {
+	return rq.Name
 }
 
 func GetResourceQueues(connectionPool *dbconn.DBConn) []ResourceQueue {
@@ -158,8 +202,24 @@ type ResourceGroup struct {
 	Cpuset            string
 }
 
+func (rg ResourceGroup) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	return "global",
+		utils.MetadataEntry{
+			Schema:          "",
+			Name:            rg.Name,
+			ObjectType:      "RESOURCE GROUP",
+			ReferenceObject: "",
+			StartByte:       start,
+			EndByte:         end,
+		}
+}
+
 func (rg ResourceGroup) GetUniqueID() UniqueID {
 	return UniqueID{ClassID: PG_RESGROUP_OID, Oid: rg.Oid}
+}
+
+func (rg ResourceGroup) FQN() string {
+	return rg.Name
 }
 
 func GetResourceGroups(connectionPool *dbconn.DBConn) []ResourceGroup {
@@ -225,8 +285,24 @@ type Role struct {
 	TimeConstraints []TimeConstraint
 }
 
+func (r Role) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	return "global",
+		utils.MetadataEntry{
+			Schema:          "",
+			Name:            r.Name,
+			ObjectType:      "ROLE",
+			ReferenceObject: "",
+			StartByte:       start,
+			EndByte:         end,
+		}
+}
+
 func (r Role) GetUniqueID() UniqueID {
 	return UniqueID{ClassID: PG_AUTHID_OID, Oid: r.Oid}
+}
+
+func (r Role) FQN() string {
+	return r.Name
 }
 
 /*
@@ -283,6 +359,18 @@ type RoleGUC struct {
 	RoleName string
 	DbName   string
 	Config   string
+}
+
+func (rg RoleGUC) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	return "global",
+		utils.MetadataEntry{
+			Schema:          "",
+			Name:            rg.RoleName,
+			ObjectType:      "ROLE GUCS",
+			ReferenceObject: "",
+			StartByte:       start,
+			EndByte:         end,
+		}
 }
 
 func GetRoleGUCs(connectionPool *dbconn.DBConn) map[string][]RoleGUC {
@@ -364,6 +452,18 @@ type RoleMember struct {
 	IsAdmin bool
 }
 
+func (rm RoleMember) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	return "global",
+		utils.MetadataEntry{
+			Schema:          "",
+			Name:            rm.Member,
+			ObjectType:      "ROLE GRANT",
+			ReferenceObject: "",
+			StartByte:       start,
+			EndByte:         end,
+		}
+}
+
 func GetRoleMembers(connectionPool *dbconn.DBConn) []RoleMember {
 	query := `
 SELECT
@@ -388,8 +488,24 @@ type Tablespace struct {
 	Options          string
 }
 
+func (t Tablespace) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	return "global",
+		utils.MetadataEntry{
+			Schema:          "",
+			Name:            t.Tablespace,
+			ObjectType:      "TABLESPACE",
+			ReferenceObject: "",
+			StartByte:       start,
+			EndByte:         end,
+		}
+}
+
 func (t Tablespace) GetUniqueID() UniqueID {
 	return UniqueID{ClassID: PG_TABLESPACE_OID, Oid: t.Oid}
+}
+
+func (t Tablespace) FQN() string {
+	return t.Tablespace
 }
 
 func GetTablespaces(connectionPool *dbconn.DBConn) []Tablespace {

--- a/backup/queries_operators.go
+++ b/backup/queries_operators.go
@@ -28,12 +28,32 @@ type Operator struct {
 	CanMerge         bool
 }
 
+func (o Operator) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	return "predata",
+		utils.MetadataEntry{
+			Schema:          o.Schema,
+			Name:            o.Name,
+			ObjectType:      "OPERATOR",
+			ReferenceObject: "",
+			StartByte:       start,
+			EndByte:         end,
+		}
+}
+
 func (o Operator) GetUniqueID() UniqueID {
 	return UniqueID{ClassID: PG_OPERATOR_OID, Oid: o.Oid}
 }
 
 func (o Operator) FQN() string {
-	return utils.MakeFQN(o.Schema, o.Name)
+	leftArg := "NONE"
+	rightArg := "NONE"
+	if o.LeftArgType != "-" {
+		leftArg = o.LeftArgType
+	}
+	if o.RightArgType != "-" {
+		rightArg = o.RightArgType
+	}
+	return fmt.Sprintf("%s.%s (%s, %s)", o.Schema, o.Name, leftArg, rightArg)
 }
 
 func GetOperators(connectionPool *dbconn.DBConn) []Operator {
@@ -96,8 +116,24 @@ type OperatorFamily struct {
 	IndexMethod string
 }
 
+func (opf OperatorFamily) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	return "predata",
+		utils.MetadataEntry{
+			Schema:          opf.Schema,
+			Name:            opf.Name,
+			ObjectType:      "OPERATOR FAMILY",
+			ReferenceObject: "",
+			StartByte:       start,
+			EndByte:         end,
+		}
+}
+
 func (opf OperatorFamily) GetUniqueID() UniqueID {
 	return UniqueID{ClassID: PG_OPFAMILY_OID, Oid: opf.Oid}
+}
+
+func (opf OperatorFamily) FQN() string {
+	return fmt.Sprintf("%s USING %s", utils.MakeFQN(opf.Schema, opf.Name), opf.IndexMethod)
 }
 
 func GetOperatorFamilies(connectionPool *dbconn.DBConn) []OperatorFamily {
@@ -129,6 +165,18 @@ type OperatorClass struct {
 	StorageType  string
 	Operators    []OperatorClassOperator
 	Functions    []OperatorClassFunction
+}
+
+func (opc OperatorClass) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	return "predata",
+		utils.MetadataEntry{
+			Schema:          opc.Schema,
+			Name:            opc.Name,
+			ObjectType:      "OPERATOR CLASS",
+			ReferenceObject: "",
+			StartByte:       start,
+			EndByte:         end,
+		}
 }
 
 func (opc OperatorClass) GetUniqueID() UniqueID {

--- a/backup/queries_postdata.go
+++ b/backup/queries_postdata.go
@@ -55,8 +55,25 @@ type IndexDefinition struct {
 	IsClustered  bool
 }
 
+func (i IndexDefinition) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	tableFQN := utils.MakeFQN(i.OwningSchema, i.OwningTable)
+	return "postdata",
+		utils.MetadataEntry{
+			Schema:          i.OwningSchema,
+			Name:            i.Name,
+			ObjectType:      "INDEX",
+			ReferenceObject: tableFQN,
+			StartByte:       start,
+			EndByte:         end,
+		}
+}
+
 func (i IndexDefinition) GetUniqueID() UniqueID {
 	return UniqueID{ClassID: PG_INDEX_OID, Oid: i.Oid}
+}
+
+func (i IndexDefinition) FQN() string {
+	return utils.MakeFQN(i.OwningSchema, i.Name)
 }
 
 func GetIndexes(connectionPool *dbconn.DBConn) []IndexDefinition {
@@ -162,6 +179,10 @@ func (r RuleDefinition) GetUniqueID() UniqueID {
 	return UniqueID{ClassID: PG_REWRITE_OID, Oid: r.Oid}
 }
 
+func (r RuleDefinition) FQN() string {
+	return r.Name
+}
+
 /*
  * Rules named "_RETURN", "pg_settings_n", and "pg_settings_u" are
  * built-in rules and we don't want to back them up. We use two `%` to
@@ -211,6 +232,10 @@ func (t TriggerDefinition) GetUniqueID() UniqueID {
 	return UniqueID{ClassID: PG_TRIGGER_OID, Oid: t.Oid}
 }
 
+func (t TriggerDefinition) FQN() string {
+	return t.Name
+}
+
 func GetTriggers(connectionPool *dbconn.DBConn) []TriggerDefinition {
 	constraintClause := "NOT tgisinternal"
 	if connectionPool.Version.Before("6") {
@@ -249,8 +274,24 @@ type EventTrigger struct {
 	EventTags    string
 }
 
+func (et EventTrigger) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	return "postdata",
+		utils.MetadataEntry{
+			Schema:          "",
+			Name:            et.Name,
+			ObjectType:      "EVENT TRIGGER",
+			ReferenceObject: "",
+			StartByte:       start,
+			EndByte:         end,
+		}
+}
+
 func (et EventTrigger) GetUniqueID() UniqueID {
 	return UniqueID{ClassID: PG_EVENT_TRIGGER, Oid: et.Oid}
+}
+
+func (et EventTrigger) FQN() string {
+	return et.Name
 }
 
 func GetEventTriggers(connectionPool *dbconn.DBConn) []EventTrigger {

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -203,6 +203,18 @@ type Sequence struct {
 	SequenceDefinition
 }
 
+func (s Sequence) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	return "predata",
+		utils.MetadataEntry{
+			Schema:          s.Schema,
+			Name:            s.Name,
+			ObjectType:      "SEQUENCE",
+			ReferenceObject: s.OwningTable,
+			StartByte:       start,
+			EndByte:         end,
+		}
+}
+
 type SequenceDefinition struct {
 	LastVal     int64
 	StartVal    int64
@@ -315,6 +327,18 @@ type View struct {
 	Name       string
 	Options    string
 	Definition string
+}
+
+func (v View) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	return "predata",
+		utils.MetadataEntry{
+			Schema:          v.Schema,
+			Name:            v.Name,
+			ObjectType:      "VIEW",
+			ReferenceObject: "",
+			StartByte:       start,
+			EndByte:         end,
+		}
 }
 
 func (v View) GetUniqueID() UniqueID {

--- a/backup/queries_shared.go
+++ b/backup/queries_shared.go
@@ -31,8 +31,24 @@ type Schema struct {
 	Name string
 }
 
+func (s Schema) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	return "predata",
+		utils.MetadataEntry{
+			Schema:          s.Name,
+			Name:            s.Name,
+			ObjectType:      "SCHEMA",
+			ReferenceObject: "",
+			StartByte:       start,
+			EndByte:         end,
+		}
+}
+
 func (s Schema) GetUniqueID() UniqueID {
 	return UniqueID{ClassID: PG_NAMESPACE_OID, Oid: s.Oid}
+}
+
+func (s Schema) FQN() string {
+	return s.Name
 }
 
 func GetAllUserSchemas(connectionPool *dbconn.DBConn) []Schema {
@@ -68,8 +84,28 @@ type Constraint struct {
 	IsPartitionParent  bool
 }
 
+func (c Constraint) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	return "predata",
+		utils.MetadataEntry{
+			Schema:          c.Schema,
+			Name:            c.Name,
+			ObjectType:      "CONSTRAINT",
+			ReferenceObject: c.OwningObject,
+			StartByte:       start,
+			EndByte:         end,
+		}
+}
+
 func (c Constraint) GetUniqueID() UniqueID {
 	return UniqueID{ClassID: PG_CONSTRAINT_OID, Oid: c.Oid}
+}
+
+func (c Constraint) FQN() string {
+	/*
+	 * It is invalid to specify the schema name with the constraint
+	 * even though they are technically part of the parent table's schema
+	 */
+	return c.Name
 }
 
 func GetConstraints(connectionPool *dbconn.DBConn, includeTables ...Relation) []Constraint {

--- a/backup/queries_table_defs.go
+++ b/backup/queries_table_defs.go
@@ -25,6 +25,22 @@ func (t Table) SkipDataBackup() bool {
 	return def.IsExternal || (def.ForeignDef != ForeignTableDefinition{})
 }
 
+func (t Table) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	objectType := "TABLE"
+	if (t.ForeignDef != ForeignTableDefinition{}) {
+		objectType = "FOREIGN TABLE"
+	}
+	return "predata",
+		utils.MetadataEntry{
+			Schema:          t.Schema,
+			Name:            t.Name,
+			ObjectType:      objectType,
+			ReferenceObject: "",
+			StartByte:       start,
+			EndByte:         end,
+		}
+}
+
 type TableDefinition struct {
 	DistPolicy         string
 	PartDef            string

--- a/backup/queries_textsearch.go
+++ b/backup/queries_textsearch.go
@@ -27,6 +27,18 @@ type TextSearchParser struct {
 	HeadlineFunc string
 }
 
+func (tsp TextSearchParser) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	return "predata",
+		utils.MetadataEntry{
+			Schema:          tsp.Schema,
+			Name:            tsp.Name,
+			ObjectType:      "TEXT SEARCH PARSER",
+			ReferenceObject: "",
+			StartByte:       start,
+			EndByte:         end,
+		}
+}
+
 func (tsp TextSearchParser) GetUniqueID() UniqueID {
 	return UniqueID{ClassID: PG_TS_PARSER_OID, Oid: tsp.Oid}
 }
@@ -66,6 +78,18 @@ type TextSearchTemplate struct {
 	LexizeFunc string
 }
 
+func (tst TextSearchTemplate) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	return "predata",
+		utils.MetadataEntry{
+			Schema:          tst.Schema,
+			Name:            tst.Name,
+			ObjectType:      "TEXT SEARCH TEMPLATE",
+			ReferenceObject: "",
+			StartByte:       start,
+			EndByte:         end,
+		}
+}
+
 func (tst TextSearchTemplate) GetUniqueID() UniqueID {
 	return UniqueID{ClassID: PG_TS_TEMPLATE_OID, Oid: tst.Oid}
 }
@@ -100,6 +124,18 @@ type TextSearchDictionary struct {
 	Name       string
 	Template   string
 	InitOption string
+}
+
+func (tsd TextSearchDictionary) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	return "predata",
+		utils.MetadataEntry{
+			Schema:          tsd.Schema,
+			Name:            tsd.Name,
+			ObjectType:      "TEXT SEARCH DICTIONARY",
+			ReferenceObject: "",
+			StartByte:       start,
+			EndByte:         end,
+		}
 }
 
 func (tsd TextSearchDictionary) GetUniqueID() UniqueID {
@@ -138,6 +174,18 @@ type TextSearchConfiguration struct {
 	Name         string
 	Parser       string
 	TokenToDicts map[string][]string
+}
+
+func (tsc TextSearchConfiguration) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	return "predata",
+		utils.MetadataEntry{
+			Schema:          tsc.Schema,
+			Name:            tsc.Name,
+			ObjectType:      "TEXT SEARCH CONFIGURATION",
+			ReferenceObject: "",
+			StartByte:       start,
+			EndByte:         end,
+		}
 }
 
 func (tsc TextSearchConfiguration) GetUniqueID() UniqueID {

--- a/backup/queries_types.go
+++ b/backup/queries_types.go
@@ -121,6 +121,22 @@ type Type struct {
 	SubTypeDiff     string
 }
 
+func (t Type) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	objectType := "TYPE"
+	if t.Type == "d" {
+		objectType = "DOMAIN"
+	}
+	return "predata",
+		utils.MetadataEntry{
+			Schema:          t.Schema,
+			Name:            t.Name,
+			ObjectType:      objectType,
+			ReferenceObject: "",
+			StartByte:       start,
+			EndByte:         end,
+		}
+}
+
 func (t Type) GetUniqueID() UniqueID {
 	return UniqueID{ClassID: PG_TYPE_OID, Oid: t.Oid}
 }
@@ -430,8 +446,24 @@ type Collation struct {
 	Ctype   string
 }
 
+func (c Collation) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+	return "predata",
+		utils.MetadataEntry{
+			Schema:          c.Schema,
+			Name:            c.Name,
+			ObjectType:      "COLLATION",
+			ReferenceObject: "",
+			StartByte:       start,
+			EndByte:         end,
+		}
+}
+
 func (c Collation) GetUniqueID() UniqueID {
 	return UniqueID{ClassID: PG_COLLATION_OID, Oid: c.Oid}
+}
+
+func (c Collation) FQN() string {
+	return utils.MakeFQN(c.Schema, c.Name)
 }
 
 func GetCollations(connectionPool *dbconn.DBConn) []Collation {

--- a/backup/statistics.go
+++ b/backup/statistics.go
@@ -27,7 +27,7 @@ func PrintStatisticsStatementsForTable(statisticsFile *utils.FileWithByteCount, 
 		attributeQuery := GenerateAttributeStatisticsQuery(table, attStat)
 		statisticsFile.MustPrintf("\n\n%s\n", attributeQuery)
 	}
-	toc.AddStatisticsEntry(table.Schema, table.Name, "STATISTICS", start, statisticsFile)
+	toc.AddMetadataEntryLongArgs(table.Schema, table.Name, "STATISTICS", "", start, statisticsFile, "statistics")
 }
 
 func GenerateTupleStatisticsQuery(table Table, tupleStat TupleStatistic) string {

--- a/integration/metadata_globals_create_test.go
+++ b/integration/metadata_globals_create_test.go
@@ -449,10 +449,10 @@ var _ = Describe("backup integration create statement tests", func() {
 				 */
 				gbuffer := gbytes.BufferWithBytes([]byte(buffer.String()))
 				entries, _ := testutils.SliceBufferByEntries(toc.GlobalEntries, gbuffer)
-				create, metadata := entries[0], entries[1]
-				testhelper.AssertQueryRuns(connectionPool, create)
+				for _, entry := range entries {
+					testhelper.AssertQueryRuns(connectionPool, entry)
+				}
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLESPACE test_tablespace")
-				testhelper.AssertQueryRuns(connectionPool, metadata)
 			} else {
 				testhelper.AssertQueryRuns(connectionPool, buffer.String())
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLESPACE test_tablespace")

--- a/integration/predata_relations_create_test.go
+++ b/integration/predata_relations_create_test.go
@@ -303,7 +303,7 @@ SET SUBPARTITION TEMPLATE ` + `
 			backup.PrintRegularTableCreateStatement(backupfile, toc, testTable)
 
 			metadata := testutils.DefaultMetadata("TABLE", true, true, true, true)
-			backup.PrintPostCreateTableStatements(backupfile, testTable, metadata)
+			backup.PrintPostCreateTableStatements(backupfile, toc, testTable, metadata)
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP FOREIGN TABLE public.testtable")
@@ -335,7 +335,7 @@ SET SUBPARTITION TEMPLATE ` + `
 		})
 		It("prints only owner for a table with no comment or column comments", func() {
 			tableMetadata.Owner = "testrole"
-			backup.PrintPostCreateTableStatements(backupfile, testTable, tableMetadata)
+			backup.PrintPostCreateTableStatements(backupfile, toc, testTable, tableMetadata)
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 			testTableUniqueID := testutils.UniqueIDFromObjectName(connectionPool, "public", "testtable", backup.TYPE_RELATION)
@@ -349,9 +349,9 @@ SET SUBPARTITION TEMPLATE ` + `
 			structmatcher.ExpectStructsToMatchExcluding(&testTable.TableDefinition, &resultTable.TableDefinition, "ColumnDefs.Oid", "ColumnDefs.ACL", "ExtTableDef")
 		})
 		It("prints table comment, table privileges, table owner, table security label, and column comments for a table", func() {
-			metadata := testutils.DefaultMetadata("TABLE", true, true, true, includeSecurityLabels)
+			tableMetadata = testutils.DefaultMetadata("TABLE", true, true, true, includeSecurityLabels)
 			testTable.ColumnDefs[0].Comment = "This is a column comment."
-			backup.PrintPostCreateTableStatements(backupfile, testTable, metadata)
+			backup.PrintPostCreateTableStatements(backupfile, toc, testTable, tableMetadata)
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 
@@ -362,14 +362,14 @@ SET SUBPARTITION TEMPLATE ` + `
 
 			resultMetadata := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_RELATION)
 			resultTableMetadata := resultMetadata[testTableUniqueID]
-			structmatcher.ExpectStructsToMatch(&metadata, &resultTableMetadata)
+			structmatcher.ExpectStructsToMatch(&tableMetadata, &resultTableMetadata)
 		})
 		It("prints column level privileges", func() {
 			testutils.SkipIfBefore6(connectionPool)
 			privilegesColumnOne := backup.ColumnDefinition{Oid: 0, Num: 1, Name: "i", Type: "integer", StatTarget: -1, ACL: []backup.ACL{{Grantee: "testrole", Select: true}}}
 			tableMetadata.Owner = "testrole"
 			testTable.ColumnDefs = []backup.ColumnDefinition{privilegesColumnOne}
-			backup.PrintPostCreateTableStatements(backupfile, testTable, tableMetadata)
+			backup.PrintPostCreateTableStatements(backupfile, toc, testTable, tableMetadata)
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 
@@ -382,7 +382,7 @@ SET SUBPARTITION TEMPLATE ` + `
 			testutils.SkipIfBefore6(connectionPool)
 			securityLabelColumnOne := backup.ColumnDefinition{Oid: 0, Num: 1, Name: "i", Type: "integer", StatTarget: -1, ACL: []backup.ACL{}, SecurityLabelProvider: "dummy", SecurityLabel: "unclassified"}
 			testTable.ColumnDefs = []backup.ColumnDefinition{securityLabelColumnOne}
-			backup.PrintPostCreateTableStatements(backupfile, testTable, tableMetadata)
+			backup.PrintPostCreateTableStatements(backupfile, toc, testTable, tableMetadata)
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 

--- a/restore/validate_test.go
+++ b/restore/validate_test.go
@@ -29,13 +29,13 @@ var _ = Describe("restore/validate tests", func() {
 		BeforeEach(func() {
 			toc, backupfile = testutils.InitializeTestTOC(buffer, "predata")
 			backupfile.ByteCount = table1Len
-			toc.AddPredataEntry("schema1", "table1", "", "TABLE", 0, backupfile)
+			toc.AddMetadataEntryLongArgs("schema1", "table1", "", "TABLE", 0, backupfile, "predata")
 			toc.AddMasterDataEntry("schema1", "table1", 1, "(i)", 0, "")
 			backupfile.ByteCount += table2Len
-			toc.AddPredataEntry("schema2", "table2", "TABLE", "", table1Len, backupfile)
+			toc.AddMetadataEntryLongArgs("schema2", "table2", "TABLE", "", table1Len, backupfile, "predata")
 			toc.AddMasterDataEntry("schema2", "table2", 2, "(j)", 0, "")
 			backupfile.ByteCount += sequenceLen
-			toc.AddPredataEntry("schema", "somesequence", "SEQUENCE", "", table1Len+table2Len, backupfile)
+			toc.AddMetadataEntryLongArgs("schema", "somesequence", "SEQUENCE", "", table1Len+table2Len, backupfile, "predata")
 			restore.SetTOC(toc)
 		})
 		It("passes when schema exists in normal backup", func() {
@@ -192,15 +192,15 @@ var _ = Describe("restore/validate tests", func() {
 		var backupfile *utils.FileWithByteCount
 		BeforeEach(func() {
 			toc, backupfile = testutils.InitializeTestTOC(buffer, "predata")
-			toc.AddPredataEntry("schema1", "table1", "TABLE", "", 0, backupfile)
+			toc.AddMetadataEntryLongArgs("schema1", "table1", "TABLE", "", 0, backupfile, "predata")
 			toc.AddMasterDataEntry("schema1", "table1", 1, "(i)", 0, "")
 
-			toc.AddPredataEntry("schema2", "table2", "TABLE", "", 0, backupfile)
+			toc.AddMetadataEntryLongArgs("schema2", "table2", "TABLE", "", 0, backupfile, "predata")
 			toc.AddMasterDataEntry("schema2", "table2", 2, "(j)", 0, "")
 
-			toc.AddPredataEntry("schema1", "somesequence", "SEQUENCE", "", 0, backupfile)
-			toc.AddPredataEntry("schema1", "someview", "VIEW", "", 0, backupfile)
-			toc.AddPredataEntry("schema1", "somefunction", "FUNCTION", "", 0, backupfile)
+			toc.AddMetadataEntryLongArgs("schema1", "somesequence", "SEQUENCE", "", 0, backupfile, "predata")
+			toc.AddMetadataEntryLongArgs("schema1", "someview", "VIEW", "", 0, backupfile, "predata")
+			toc.AddMetadataEntryLongArgs("schema1", "somefunction", "FUNCTION", "", 0, backupfile, "predata")
 
 			restore.SetTOC(toc)
 		})

--- a/utils/toc.go
+++ b/utils/toc.go
@@ -261,24 +261,22 @@ func (toc *TOC) InitializeMetadataEntryMap() {
 	toc.metadataEntryMap["statistics"] = &toc.StatisticsEntries
 }
 
-func (toc *TOC) AddMetadataEntry(schema string, name string, objectType string, referenceObject string, start uint64, file *FileWithByteCount, section string) {
+type TOCObject interface {
+	GetMetadataEntry(uint64, uint64) (string, MetadataEntry)
+}
+
+type TOCObjectWithMetadata interface {
+	GetMetadataEntry(uint64, uint64) (string, MetadataEntry)
+	FQN() string
+}
+
+func (toc *TOC) AddMetadataEntry(obj TOCObject, start, end uint64) {
+	section, entry := obj.GetMetadataEntry(start, end)
+	*toc.metadataEntryMap[section] = append(*toc.metadataEntryMap[section], entry)
+}
+
+func (toc *TOC) AddMetadataEntryLongArgs(schema string, name string, objectType string, referenceObject string, start uint64, file *FileWithByteCount, section string) {
 	*toc.metadataEntryMap[section] = append(*toc.metadataEntryMap[section], MetadataEntry{schema, name, objectType, referenceObject, start, file.ByteCount})
-}
-
-func (toc *TOC) AddGlobalEntry(schema string, name string, objectType string, start uint64, file *FileWithByteCount) {
-	toc.AddMetadataEntry(schema, name, objectType, "", start, file, "global")
-}
-
-func (toc *TOC) AddPredataEntry(schema string, name string, objectType string, referenceObject string, start uint64, file *FileWithByteCount) {
-	toc.AddMetadataEntry(schema, name, objectType, referenceObject, start, file, "predata")
-}
-
-func (toc *TOC) AddPostdataEntry(schema string, name string, objectType string, referenceObject string, start uint64, file *FileWithByteCount) {
-	toc.AddMetadataEntry(schema, name, objectType, referenceObject, start, file, "postdata")
-}
-
-func (toc *TOC) AddStatisticsEntry(schema string, name string, objectType string, start uint64, file *FileWithByteCount) {
-	toc.AddMetadataEntry(schema, name, objectType, "", start, file, "statistics")
 }
 
 func (toc *TOC) AddMasterDataEntry(schema string, name string, oid uint32, attributeString string, rowsCopied int64, PartitionRoot string) {

--- a/utils/toc_test.go
+++ b/utils/toc_test.go
@@ -39,7 +39,7 @@ var _ = Describe("utils/toc tests", func() {
 		var noInObj, noExObj, noInSchema, noExSchema, noInRelation, noExRelation []string
 		It("returns statement for a single object type", func() {
 			backupfile.ByteCount = commentLen + createLen
-			toc.AddMetadataEntry("", "somedatabase", "DATABASE", "", commentLen, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("", "somedatabase", "DATABASE", "", commentLen, backupfile, "global")
 
 			metadataFile := bytes.NewReader([]byte(comment.Statement + create.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, []string{"DATABASE"}, noExObj, noInSchema, noExSchema, noInRelation, noExRelation)
@@ -48,11 +48,11 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns statement for multiple object types", func() {
 			backupfile.ByteCount = commentLen + createLen
-			toc.AddMetadataEntry("", "somedatabase", "DATABASE", "", commentLen, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("", "somedatabase", "DATABASE", "", commentLen, backupfile, "global")
 			backupfile.ByteCount += role1Len
-			toc.AddMetadataEntry("", "somerole1", "ROLE", "", commentLen+createLen, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("", "somerole1", "ROLE", "", commentLen+createLen, backupfile, "global")
 			backupfile.ByteCount += role2Len
-			toc.AddMetadataEntry("", "somerole2", "ROLE", "", commentLen+createLen+role1Len, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("", "somerole2", "ROLE", "", commentLen+createLen+role1Len, backupfile, "global")
 
 			metadataFile := bytes.NewReader([]byte(comment.Statement + create.Statement + role1.Statement + role2.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, []string{"DATABASE", "ROLE"}, noExObj, noInSchema, noExSchema, noInRelation, noExRelation)
@@ -61,11 +61,11 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("does not return a statement type listed in the exclude list", func() {
 			backupfile.ByteCount = commentLen + createLen
-			toc.AddMetadataEntry("", "somedatabase", "DATABASE", "", commentLen, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("", "somedatabase", "DATABASE", "", commentLen, backupfile, "global")
 			backupfile.ByteCount += role1Len
-			toc.AddMetadataEntry("", "somerole1", "ROLE", "", commentLen+createLen, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("", "somerole1", "ROLE", "", commentLen+createLen, backupfile, "global")
 			backupfile.ByteCount += role2Len
-			toc.AddMetadataEntry("", "somerole2", "ROLE", "", commentLen+createLen+role1Len, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("", "somerole2", "ROLE", "", commentLen+createLen+role1Len, backupfile, "global")
 
 			metadataFile := bytes.NewReader([]byte(comment.Statement + create.Statement + role1.Statement + role2.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, noInObj, []string{"DATABASE"}, noInSchema, noExSchema, noInRelation, noExRelation)
@@ -74,7 +74,7 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns empty statement when no object types are found", func() {
 			backupfile.ByteCount = commentLen + createLen
-			toc.AddMetadataEntry("", "somedatabase", "DATABASE", "", commentLen, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("", "somedatabase", "DATABASE", "", commentLen, backupfile, "global")
 
 			metadataFile := bytes.NewReader([]byte(comment.Statement + create.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, []string{"TABLE"}, noExObj, noInSchema, noExSchema, noInRelation, noExRelation)
@@ -83,11 +83,11 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns statement for a single object type with matching schema", func() {
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntry("schema", "table1", "TABLE", "", 0, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema", "table1", "TABLE", "", 0, backupfile, "global")
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntry("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
 			backupfile.ByteCount += sequenceLen
-			toc.AddMetadataEntry("schema", "somesequence", "SEQUENCE", "", table1Len+table2Len, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema", "somesequence", "SEQUENCE", "", table1Len+table2Len, backupfile, "global")
 
 			metadataFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, []string{"TABLE"}, noExObj, []string{"schema"}, noExSchema, noInRelation, noExRelation)
@@ -96,11 +96,11 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns statement for any object type in the include schema", func() {
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntry("schema", "table1", "TABLE", "", 0, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema", "table1", "TABLE", "", 0, backupfile, "global")
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntry("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
 			backupfile.ByteCount += sequenceLen
-			toc.AddMetadataEntry("schema", "somesequence", "SEQUENCE", "", table1Len+table2Len, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema", "somesequence", "SEQUENCE", "", table1Len+table2Len, backupfile, "global")
 
 			metadataFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, noInObj, noExObj, []string{"schema"}, noExSchema, noInRelation, noExRelation)
@@ -109,11 +109,11 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns statement for any object type not in the exclude schema", func() {
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntry("schema", "table1", "TABLE", "", 0, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema", "table1", "TABLE", "", 0, backupfile, "global")
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntry("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
 			backupfile.ByteCount += sequenceLen
-			toc.AddMetadataEntry("schema", "somesequence", "SEQUENCE", "", table1Len+table2Len, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema", "somesequence", "SEQUENCE", "", table1Len+table2Len, backupfile, "global")
 
 			metadataFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, noInObj, noExObj, noInSchema, []string{"schema2"}, noInRelation, noExRelation)
@@ -122,11 +122,11 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns statement for a table matching an included table", func() {
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntry("schema", "table1", "TABLE", "", 0, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema", "table1", "TABLE", "", 0, backupfile, "global")
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntry("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
 			backupfile.ByteCount += sequenceLen
-			toc.AddMetadataEntry("schema", "somesequence", "SEQUENCE", "", table1Len+table2Len, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema", "somesequence", "SEQUENCE", "", table1Len+table2Len, backupfile, "global")
 
 			metadataFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, noInObj, noExObj, noInSchema, noExSchema, []string{"schema.table1"}, noExRelation)
@@ -135,7 +135,7 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns statement for a view matching an included view", func() {
 			backupfile.ByteCount = view1Len
-			toc.AddMetadataEntry("schema", "view1", "VIEW", "", 0, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema", "view1", "VIEW", "", 0, backupfile, "global")
 
 			metadataFile := bytes.NewReader([]byte(view1.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, noInObj, noExObj, noInSchema, noExSchema, []string{"schema.view1"}, noExRelation)
@@ -144,7 +144,7 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns statement for a sequence matching an included sequence", func() {
 			backupfile.ByteCount = sequence1Len
-			toc.AddMetadataEntry("schema", "sequence1", "SEQUENCE", "", 0, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema", "sequence1", "SEQUENCE", "", 0, backupfile, "global")
 
 			metadataFile := bytes.NewReader([]byte(sequence1.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, noInObj, noExObj, noInSchema, noExSchema, []string{"schema.sequence1"}, noExRelation)
@@ -153,11 +153,11 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns statement for any object type or reference object not matching an excluded table", func() {
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntry("schema", "table1", "TABLE", "", 0, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema", "table1", "TABLE", "", 0, backupfile, "global")
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntry("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
 			backupfile.ByteCount += sequenceLen
-			toc.AddMetadataEntry("schema", "somesequence", "SEQUENCE", "schema.table2", table1Len+table2Len, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema", "somesequence", "SEQUENCE", "schema.table2", table1Len+table2Len, backupfile, "global")
 
 			metadataFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, noInObj, noExObj, noInSchema, noExSchema, noInRelation, []string{"schema.table1"})
@@ -166,13 +166,13 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns no statements for any object type with reference object matching an excluded table", func() {
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntry("schema", "table1", "TABLE", "", 0, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema", "table1", "TABLE", "", 0, backupfile, "global")
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntry("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
 			backupfile.ByteCount += sequenceLen
-			toc.AddMetadataEntry("schema", "somesequence", "SEQUENCE", "schema.table1", table1Len+table2Len, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema", "somesequence", "SEQUENCE", "schema.table1", table1Len+table2Len, backupfile, "global")
 			backupfile.ByteCount += indexLen
-			toc.AddMetadataEntry("schema", "someindex", "INDEX", "schema.table1", table1Len+table2Len+sequenceLen, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema", "someindex", "INDEX", "schema.table1", table1Len+table2Len+sequenceLen, backupfile, "global")
 
 			metadataFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement + index.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, noInObj, noExObj, noInSchema, noExSchema, noInRelation, []string{"schema.table1"})
@@ -181,9 +181,9 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns no statements for an excluded view or sequence", func() {
 			backupfile.ByteCount = view1Len
-			toc.AddMetadataEntry("schema", "view1", "VIEW", "", 0, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema", "view1", "VIEW", "", 0, backupfile, "global")
 			backupfile.ByteCount += sequence1Len
-			toc.AddMetadataEntry("schema", "sequence1", "SEQUENCE", "", view1Len, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema", "sequence1", "SEQUENCE", "", view1Len, backupfile, "global")
 
 			metadataFile := bytes.NewReader([]byte(view1.Statement + sequence1.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, noInObj, noExObj, noInSchema, noExSchema, noInRelation, []string{"schema.view1", "schema.sequence1"})
@@ -192,11 +192,11 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns statement for any object type with matching reference object", func() {
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntry("schema", "table1", "INDEX", "", 0, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema", "table1", "INDEX", "", 0, backupfile, "global")
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntry("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
 			backupfile.ByteCount += indexLen
-			toc.AddMetadataEntry("schema", "someindex", "INDEX", "schema.table", table1Len+table2Len, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema", "someindex", "INDEX", "schema.table", table1Len+table2Len, backupfile, "global")
 
 			metadataFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + index.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, noInObj, noExObj, noInSchema, noExSchema, []string{"schema.table"}, noExRelation)
@@ -206,11 +206,11 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns no statements for a non-relation object with matching name from relation list", func() {
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntry("schema", "table1", "TABLE", "", 0, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema", "table1", "TABLE", "", 0, backupfile, "global")
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntry("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
 			backupfile.ByteCount += sequenceLen
-			toc.AddMetadataEntry("schema", "someindex", "INDEX", "", table1Len+table2Len, backupfile, "global")
+			toc.AddMetadataEntryLongArgs("schema", "someindex", "INDEX", "", table1Len+table2Len, backupfile, "global")
 
 			metadataFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + index.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, noInObj, noExObj, noInSchema, noExSchema, []string{"schema.someindex"}, noExRelation)


### PR DESCRIPTION
We discovered an issue where the way we are executing SQL queries on
restore does not recognize the block of statements we are trying to run
as separate statements. We can have a case where a user is running with
--on-error-continue and some statements will pass, but others may fail
and it will rollback the entire block. Our solution is to create
separate TOC entries for each statement so they will all be executed on
their own at restore time.

This modifies PrintObjectMetadata and AddMetadataEntry functions to take
in a struct that satisfies the TOCObject interface. We call the
GetMetadataEntry method on these structs to add new entries rather than
passing in arguments so it is easier to add entries from within
the PrintObjectMetadata function.

Authored-by: Karen Huddleston <khuddleston@pivotal.io>