### PR TITLE
Pass in entry struct instead of TOCObject to AddMetadataEntry

### DIFF
--- a/backup/predata_acl.go
+++ b/backup/predata_acl.go
@@ -56,12 +56,13 @@ func PrintStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, obj 
 	for _, statement := range statements {
 		start := metadataFile.ByteCount
 		metadataFile.MustPrintf("\n\n%s\n", statement)
-		toc.AddMetadataEntry(obj, start, metadataFile.ByteCount)
+		section, entry := obj.GetMetadataEntry()
+		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 	}
 }
 
 func PrintObjectMetadata(file *utils.FileWithByteCount, toc *utils.TOC, metadata ObjectMetadata, obj utils.TOCObjectWithMetadata, owningTable string) {
-	_, entry := obj.GetMetadataEntry(0, 0)
+	_, entry := obj.GetMetadataEntry()
 	if entry.ObjectType == "DATABASE METADATA" {
 		entry.ObjectType = "DATABASE"
 	}
@@ -478,7 +479,8 @@ func PrintDefaultPrivilegesStatements(metadataFile *utils.FileWithByteCount, toc
 		}
 		start := metadataFile.ByteCount
 		metadataFile.MustPrintln("\n\n" + strings.Join(statements, "\n"))
-		toc.AddMetadataEntry(priv, start, metadataFile.ByteCount)
+		section, entry := priv.GetMetadataEntry()
+		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 	}
 }
 

--- a/backup/predata_externals.go
+++ b/backup/predata_externals.go
@@ -65,7 +65,8 @@ func PrintExternalTableCreateStatement(metadataFile *utils.FileWithByteCount, to
 	}
 	metadataFile.MustPrintf(";")
 	if toc != nil {
-		toc.AddMetadataEntry(table, start, metadataFile.ByteCount)
+		section, entry := table.GetMetadataEntry()
+		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 	}
 }
 
@@ -305,7 +306,6 @@ func PrintExternalTableStatements(metadataFile *utils.FileWithByteCount, tableNa
 
 func PrintCreateExternalProtocolStatement(metadataFile *utils.FileWithByteCount, toc *utils.TOC, protocol ExternalProtocol, funcInfoMap map[uint32]FunctionInfo, protoMetadata ObjectMetadata) {
 	start := metadataFile.ByteCount
-
 	funcOidList := []uint32{protocol.ReadFunction, protocol.WriteFunction, protocol.Validator}
 	hasUserDefinedFunc := false
 	for _, funcOid := range funcOidList {
@@ -333,7 +333,9 @@ func PrintCreateExternalProtocolStatement(metadataFile *utils.FileWithByteCount,
 		metadataFile.MustPrintf("TRUSTED ")
 	}
 	metadataFile.MustPrintf("PROTOCOL %s (%s);\n", protocol.Name, strings.Join(protocolFunctions, ", "))
-	toc.AddMetadataEntry(protocol, start, metadataFile.ByteCount)
+
+	section, entry := protocol.GetMetadataEntry()
+	toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 	PrintObjectMetadata(metadataFile, toc, protoMetadata, protocol, "")
 }
 
@@ -368,6 +370,8 @@ func PrintExchangeExternalPartitionStatements(metadataFile *utils.FileWithByteCo
 		}
 		metadataFile.MustPrintf("WITH TABLE %s WITHOUT VALIDATION;", extPartRelationName)
 		metadataFile.MustPrintf("\n\nDROP TABLE %s;", extPartRelationName)
-		toc.AddMetadataEntry(externalPartition, start, metadataFile.ByteCount)
+
+		section, entry := externalPartition.GetMetadataEntry()
+		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 	}
 }

--- a/backup/predata_functions.go
+++ b/backup/predata_functions.go
@@ -21,8 +21,9 @@ func PrintCreateFunctionStatement(metadataFile *utils.FileWithByteCount, toc *ut
 	metadataFile.MustPrintf("LANGUAGE %s", funcDef.Language)
 	PrintFunctionModifiers(metadataFile, funcDef)
 	metadataFile.MustPrintln(";")
-	toc.AddMetadataEntry(funcDef, start, metadataFile.ByteCount)
 
+	section, entry := funcDef.GetMetadataEntry()
+	toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 	PrintObjectMetadata(metadataFile, toc, funcMetadata, funcDef, "")
 }
 
@@ -161,7 +162,8 @@ func PrintCreateAggregateStatement(metadataFile *utils.FileWithByteCount, toc *u
 	}
 	metadataFile.MustPrintln("\n);")
 
-	toc.AddMetadataEntry(aggDef, start, metadataFile.ByteCount)
+	section, entry := aggDef.GetMetadataEntry()
+	toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 	PrintObjectMetadata(metadataFile, toc, aggMetadata, aggDef, "")
 }
 
@@ -186,7 +188,8 @@ func PrintCreateCastStatement(metadataFile *utils.FileWithByteCount, toc *utils.
 	}
 	metadataFile.MustPrintf(";")
 
-	toc.AddMetadataEntry(castDef, start, metadataFile.ByteCount)
+	section, entry := castDef.GetMetadataEntry()
+	toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 	PrintObjectMetadata(metadataFile, toc, castMetadata, castDef, "")
 }
 
@@ -194,7 +197,9 @@ func PrintCreateExtensionStatements(metadataFile *utils.FileWithByteCount, toc *
 	for _, extensionDef := range extensionDefs {
 		start := metadataFile.ByteCount
 		metadataFile.MustPrintf("\n\nSET search_path=%s,pg_catalog;\nCREATE EXTENSION IF NOT EXISTS %s WITH SCHEMA %s;\nSET search_path=pg_catalog;", extensionDef.Schema, extensionDef.Name, extensionDef.Schema)
-		toc.AddMetadataEntry(extensionDef, start, metadataFile.ByteCount)
+
+		section, entry := extensionDef.GetMetadataEntry()
+		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 		PrintObjectMetadata(metadataFile, toc, extensionMetadata[extensionDef.GetUniqueID()], extensionDef, "")
 	}
 }
@@ -261,11 +266,13 @@ func PrintCreateLanguageStatements(metadataFile *utils.FileWithByteCount, toc *u
 			alterStr += fmt.Sprintf("\nALTER FUNCTION %s(%s) OWNER TO %s;", validatorInfo.QualifiedName, validatorInfo.Arguments, procLang.Owner)
 		}
 		metadataFile.MustPrintf("%s;", paramsStr)
-		toc.AddMetadataEntry(procLang, start, metadataFile.ByteCount)
+
+		section, entry := procLang.GetMetadataEntry()
+		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 
 		start = metadataFile.ByteCount
 		metadataFile.MustPrintf(alterStr)
-		toc.AddMetadataEntry(procLang, start, metadataFile.ByteCount)
+		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 
 		PrintObjectMetadata(metadataFile, toc, procLangMetadata[procLang.GetUniqueID()], procLang, "")
 	}
@@ -282,7 +289,8 @@ func PrintCreateConversionStatements(metadataFile *utils.FileWithByteCount, toc 
 		metadataFile.MustPrintf("\n\nCREATE%s CONVERSION %s FOR '%s' TO '%s' FROM %s;",
 			defaultStr, convFQN, conversion.ForEncoding, conversion.ToEncoding, conversion.ConversionFunction)
 
-		toc.AddMetadataEntry(conversion, start, metadataFile.ByteCount)
+		section, entry := conversion.GetMetadataEntry()
+		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 		PrintObjectMetadata(metadataFile, toc, conversionMetadata[conversion.GetUniqueID()], conversion, "")
 	}
 }
@@ -302,7 +310,9 @@ func PrintCreateForeignDataWrapperStatement(metadataFile *utils.FileWithByteCoun
 		metadataFile.MustPrintf("\n\tOPTIONS (%s)", fdw.Options)
 	}
 	metadataFile.MustPrintf(";")
-	toc.AddMetadataEntry(fdw, start, metadataFile.ByteCount)
+
+	section, entry := fdw.GetMetadataEntry()
+	toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 	PrintObjectMetadata(metadataFile, toc, fdwMetadata, fdw, "")
 }
 
@@ -322,7 +332,8 @@ func PrintCreateServerStatement(metadataFile *utils.FileWithByteCount, toc *util
 	metadataFile.MustPrintf(";")
 
 	//NOTE: We must specify SERVER when creating and dropping, but FOREIGN SERVER when granting and revoking
-	toc.AddMetadataEntry(server, start, metadataFile.ByteCount)
+	section, entry := server.GetMetadataEntry()
+	toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 	PrintObjectMetadata(metadataFile, toc, serverMetadata, server, "")
 }
 
@@ -333,5 +344,7 @@ func PrintCreateUserMappingStatement(metadataFile *utils.FileWithByteCount, toc 
 		metadataFile.MustPrintf("\n\tOPTIONS (%s)", mapping.Options)
 	}
 	metadataFile.MustPrintf(";")
-	toc.AddMetadataEntry(mapping, start, metadataFile.ByteCount)
+
+	section, entry := mapping.GetMetadataEntry()
+	toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 }

--- a/backup/predata_operators.go
+++ b/backup/predata_operators.go
@@ -51,7 +51,9 @@ CREATE OPERATOR %s.%s (
 	PROCEDURE = %s,
 	%s
 );`, operator.Schema, operator.Name, operator.Procedure, strings.Join(optionalFields, ",\n\t"))
-	toc.AddMetadataEntry(operator, start, metadataFile.ByteCount)
+
+	section, entry := operator.GetMetadataEntry()
+	toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 	PrintObjectMetadata(metadataFile, toc, operatorMetadata, operator, "")
 }
 
@@ -63,7 +65,9 @@ func PrintCreateOperatorFamilyStatements(metadataFile *utils.FileWithByteCount, 
 	for _, operatorFamily := range operatorFamilies {
 		start := metadataFile.ByteCount
 		metadataFile.MustPrintf("\n\nCREATE OPERATOR FAMILY %s;", operatorFamily.FQN())
-		toc.AddMetadataEntry(operatorFamily, start, metadataFile.ByteCount)
+
+		section, entry := operatorFamily.GetMetadataEntry()
+		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 		PrintObjectMetadata(metadataFile, toc, operatorFamilyMetadata[operatorFamily.GetUniqueID()], operatorFamily, "")
 	}
 }
@@ -111,6 +115,8 @@ func PrintCreateOperatorClassStatement(metadataFile *utils.FileWithByteCount, to
 		opClassClauses = append(opClassClauses, fmt.Sprintf("STORAGE %s", storageType))
 	}
 	metadataFile.MustPrintf(" AS\n\t%s;", strings.Join(opClassClauses, ",\n\t"))
-	toc.AddMetadataEntry(operatorClass, start, metadataFile.ByteCount)
+
+	section, entry := operatorClass.GetMetadataEntry()
+	toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 	PrintObjectMetadata(metadataFile, toc, operatorClassMetadata, operatorClass, "")
 }

--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -153,7 +153,8 @@ func PrintCreateTableStatement(metadataFile *utils.FileWithByteCount, toc *utils
 	} else {
 		PrintRegularTableCreateStatement(metadataFile, nil, table)
 	}
-	toc.AddMetadataEntry(table, start, metadataFile.ByteCount)
+	section, entry := table.GetMetadataEntry()
+	toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 	PrintPostCreateTableStatements(metadataFile, toc, table, tableMetadata)
 }
 
@@ -202,7 +203,8 @@ func PrintRegularTableCreateStatement(metadataFile *utils.FileWithByteCount, toc
 	}
 	printAlterColumnStatements(metadataFile, table, table.ColumnDefs)
 	if toc != nil {
-		toc.AddMetadataEntry(table, start, metadataFile.ByteCount)
+		section, entry := table.GetMetadataEntry()
+		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 	}
 }
 
@@ -309,7 +311,8 @@ func PrintCreateSequenceStatements(metadataFile *utils.FileWithByteCount, toc *u
 
 		metadataFile.MustPrintf("\n\nSELECT pg_catalog.setval('%s', %d, %v);\n", utils.EscapeSingleQuotes(sequence.FQN()), sequence.LastVal, sequence.IsCalled)
 
-		toc.AddMetadataEntry(sequence, start, metadataFile.ByteCount)
+		section, entry := sequence.GetMetadataEntry()
+		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 		PrintObjectMetadata(metadataFile, toc, sequenceMetadata[sequence.Relation.GetUniqueID()], sequence, "")
 	}
 }
@@ -323,7 +326,8 @@ func PrintAlterSequenceStatements(metadataFile *utils.FileWithByteCount, toc *ut
 			start := metadataFile.ByteCount
 			metadataFile.MustPrintf("\n\nALTER SEQUENCE %s OWNED BY %s;\n", seqFQN, owningColumn)
 			//TODO: see if the SEQUENCE OWNER type is being utilized in restore or if it could be SEQUENCE. I think we should be using it for filtering, but aren't
-			toc.AddMetadataEntryLongArgs(sequence.Relation.Schema, sequence.Relation.Name, "SEQUENCE OWNER", sequence.OwningTable, start, metadataFile, "predata")
+			entry := utils.MetadataEntry{sequence.Relation.Schema, sequence.Relation.Name, "SEQUENCE OWNER", sequence.OwningTable, 0, 0}
+			toc.AddMetadataEntry("predata", entry, start, metadataFile.ByteCount)
 		}
 	}
 }
@@ -331,6 +335,8 @@ func PrintAlterSequenceStatements(metadataFile *utils.FileWithByteCount, toc *ut
 func PrintCreateViewStatement(metadataFile *utils.FileWithByteCount, toc *utils.TOC, view View, viewMetadata ObjectMetadata) {
 	start := metadataFile.ByteCount
 	metadataFile.MustPrintf("\n\nCREATE VIEW %s%s AS %s\n", view.FQN(), view.Options, view.Definition)
-	toc.AddMetadataEntry(view, start, metadataFile.ByteCount)
+
+	section, entry := view.GetMetadataEntry()
+	toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 	PrintObjectMetadata(metadataFile, toc, viewMetadata, view, "")
 }

--- a/backup/predata_shared.go
+++ b/backup/predata_shared.go
@@ -43,7 +43,8 @@ func PrintConstraintStatements(metadataFile *utils.FileWithByteCount, toc *utils
 		}
 		metadataFile.MustPrintf(alterStr, objStr, constraint.OwningObject, constraint.Name, constraint.ConDef)
 
-		toc.AddMetadataEntry(constraint, start, metadataFile.ByteCount)
+		section, entry := constraint.GetMetadataEntry()
+		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 		PrintObjectMetadata(metadataFile, toc, conMetadata[constraint.GetUniqueID()], constraint, constraint.OwningObject)
 	}
 }
@@ -55,7 +56,8 @@ func PrintCreateSchemaStatements(metadataFile *utils.FileWithByteCount, toc *uti
 		if schema.Name != "public" {
 			metadataFile.MustPrintf("\nCREATE SCHEMA %s;", schema.Name)
 		}
-		toc.AddMetadataEntry(schema, start, metadataFile.ByteCount)
+		section, entry := schema.GetMetadataEntry()
+		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 		PrintObjectMetadata(metadataFile, toc, schemaMetadata[schema.GetUniqueID()], schema, "")
 	}
 }

--- a/backup/predata_textsearch.go
+++ b/backup/predata_textsearch.go
@@ -27,7 +27,9 @@ func PrintCreateTextSearchParserStatement(metadataFile *utils.FileWithByteCount,
 		metadataFile.MustPrintf(",\n\tHEADLINE = %s", parser.HeadlineFunc)
 	}
 	metadataFile.MustPrintf("\n);")
-	toc.AddMetadataEntry(parser, start, metadataFile.ByteCount)
+
+	section, entry := parser.GetMetadataEntry()
+	toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 	PrintObjectMetadata(metadataFile, toc, parserMetadata, parser, "")
 }
 
@@ -39,7 +41,9 @@ func PrintCreateTextSearchTemplateStatement(metadataFile *utils.FileWithByteCoun
 	}
 	metadataFile.MustPrintf("\n\tLEXIZE = %s", template.LexizeFunc)
 	metadataFile.MustPrintf("\n);")
-	toc.AddMetadataEntry(template, start, metadataFile.ByteCount)
+
+	section, entry := template.GetMetadataEntry()
+	toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 	PrintObjectMetadata(metadataFile, toc, templateMetadata, template, "")
 }
 
@@ -51,7 +55,9 @@ func PrintCreateTextSearchDictionaryStatement(metadataFile *utils.FileWithByteCo
 		metadataFile.MustPrintf(",\n\t%s", dictionary.InitOption)
 	}
 	metadataFile.MustPrintf("\n);")
-	toc.AddMetadataEntry(dictionary, start, metadataFile.ByteCount)
+
+	section, entry := dictionary.GetMetadataEntry()
+	toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 	PrintObjectMetadata(metadataFile, toc, dictionaryMetadata, dictionary, "")
 }
 
@@ -60,7 +66,10 @@ func PrintCreateTextSearchConfigurationStatement(metadataFile *utils.FileWithByt
 	metadataFile.MustPrintf("\n\nCREATE TEXT SEARCH CONFIGURATION %s (", configuration.FQN())
 	metadataFile.MustPrintf("\n\tPARSER = %s", configuration.Parser)
 	metadataFile.MustPrintf("\n);")
-	toc.AddMetadataEntry(configuration, start, metadataFile.ByteCount)
+
+	section, entry := configuration.GetMetadataEntry()
+	toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
+
 	tokens := []string{}
 	for token := range configuration.TokenToDicts {
 		tokens = append(tokens, token)
@@ -71,7 +80,7 @@ func PrintCreateTextSearchConfigurationStatement(metadataFile *utils.FileWithByt
 		dicts := configuration.TokenToDicts[token]
 		metadataFile.MustPrintf("\n\nALTER TEXT SEARCH CONFIGURATION %s", configuration.FQN())
 		metadataFile.MustPrintf("\n\tADD MAPPING FOR \"%s\" WITH %s;", token, strings.Join(dicts, ", "))
-		toc.AddMetadataEntry(configuration, start, metadataFile.ByteCount)
+		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 	}
 	PrintObjectMetadata(metadataFile, toc, configurationMetadata, configuration, "")
 }

--- a/backup/predata_types.go
+++ b/backup/predata_types.go
@@ -21,14 +21,15 @@ import (
  * shell type statements for base types.
  */
 func PrintCreateShellTypeStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, types []Type) {
-	start := metadataFile.ByteCount
 	metadataFile.MustPrintf("\n\n")
 	for _, typ := range types {
 		if typ.Type == "b" || typ.Type == "p" || typ.Type == "r" {
+			start := metadataFile.ByteCount
 			typeFQN := utils.MakeFQN(typ.Schema, typ.Name)
 			metadataFile.MustPrintf("CREATE TYPE %s;\n", typeFQN)
-			toc.AddMetadataEntry(typ, start, metadataFile.ByteCount)
-			start = metadataFile.ByteCount
+
+			section, entry := typ.GetMetadataEntry()
+			toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 		}
 	}
 }
@@ -49,7 +50,9 @@ func PrintCreateDomainStatement(metadataFile *utils.FileWithByteCount, toc *util
 		metadataFile.MustPrintf("\n\tCONSTRAINT %s %s", constraint.Name, constraint.ConDef)
 	}
 	metadataFile.MustPrintln(";")
-	toc.AddMetadataEntry(domain, start, metadataFile.ByteCount)
+
+	section, entry := domain.GetMetadataEntry()
+	toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 	PrintObjectMetadata(metadataFile, toc, typeMetadata, domain, "")
 }
 
@@ -123,7 +126,8 @@ func PrintCreateBaseTypeStatement(metadataFile *utils.FileWithByteCount, toc *ut
 	if base.StorageOptions != "" {
 		metadataFile.MustPrintf("\nALTER TYPE %s\n\tSET DEFAULT ENCODING (%s);", base.FQN(), base.StorageOptions)
 	}
-	toc.AddMetadataEntry(base, start, metadataFile.ByteCount)
+	section, entry := base.GetMetadataEntry()
+	toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 	PrintObjectMetadata(metadataFile, toc, typeMetadata, base, "")
 }
 
@@ -141,7 +145,9 @@ func PrintCreateCompositeTypeStatement(metadataFile *utils.FileWithByteCount, to
 	metadataFile.MustPrintf("\n\nCREATE TYPE %s AS (\n", composite.FQN())
 	metadataFile.MustPrintln(strings.Join(attributeList, ",\n"))
 	metadataFile.MustPrintf(");")
-	toc.AddMetadataEntry(composite, start, metadataFile.ByteCount)
+
+	section, entry := composite.GetMetadataEntry()
+	toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 	PrintPostCreateCompositeTypeStatement(metadataFile, toc, composite, typeMetadata)
 }
 
@@ -157,10 +163,12 @@ func PrintPostCreateCompositeTypeStatement(metadataFile *utils.FileWithByteCount
 }
 
 func PrintCreateEnumTypeStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, enums []Type, typeMetadata MetadataMap) {
-	start := metadataFile.ByteCount
 	for _, enum := range enums {
+		start := metadataFile.ByteCount
 		metadataFile.MustPrintf("\n\nCREATE TYPE %s AS ENUM (\n\t%s\n);\n", enum.FQN(), enum.EnumLabels)
-		toc.AddMetadataEntry(enum, start, metadataFile.ByteCount)
+
+		section, entry := enum.GetMetadataEntry()
+		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 		PrintObjectMetadata(metadataFile, toc, typeMetadata[enum.GetUniqueID()], enum, "")
 	}
 }
@@ -183,7 +191,8 @@ func PrintCreateRangeTypeStatement(metadataFile *utils.FileWithByteCount, toc *u
 	}
 	metadataFile.MustPrintf("\n);\n")
 
-	toc.AddMetadataEntry(rangeType, start, metadataFile.ByteCount)
+	section, entry := rangeType.GetMetadataEntry()
+	toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 	PrintObjectMetadata(metadataFile, toc, typeMetadata, rangeType, "")
 }
 
@@ -191,7 +200,9 @@ func PrintCreateCollationStatements(metadataFile *utils.FileWithByteCount, toc *
 	for _, collation := range collations {
 		start := metadataFile.ByteCount
 		metadataFile.MustPrintf("\nCREATE COLLATION %s (LC_COLLATE = '%s', LC_CTYPE = '%s');", collation.FQN(), collation.Collate, collation.Ctype)
-		toc.AddMetadataEntry(collation, start, metadataFile.ByteCount)
+
+		section, entry := collation.GetMetadataEntry()
+		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 		PrintObjectMetadata(metadataFile, toc, collationMetadata[collation.GetUniqueID()], collation, "")
 	}
 }

--- a/backup/queries_acl.go
+++ b/backup/queries_acl.go
@@ -242,15 +242,15 @@ type DefaultPrivileges struct {
 	ObjectType string
 }
 
-func (dp DefaultPrivileges) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (dp DefaultPrivileges) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "postdata",
 		utils.MetadataEntry{
 			Schema:          dp.Schema,
 			Name:            "",
 			ObjectType:      "DEFAULT PRIVILEGES",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 

--- a/backup/queries_externals.go
+++ b/backup/queries_externals.go
@@ -110,15 +110,15 @@ type ExternalProtocol struct {
 	Validator     uint32 `db:"ptcvalidatorfn"`
 }
 
-func (p ExternalProtocol) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (p ExternalProtocol) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "predata",
 		utils.MetadataEntry{
 			Schema:          "",
 			Name:            p.Name,
 			ObjectType:      "PROTOCOL",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -160,15 +160,15 @@ type PartitionInfo struct {
 	IsExternal             bool
 }
 
-func (pi PartitionInfo) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (pi PartitionInfo) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "predata",
 		utils.MetadataEntry{
 			Schema:          pi.ParentSchema,
 			Name:            pi.ParentRelationName,
 			ObjectType:      "EXCHANGE PARTITION",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 

--- a/backup/queries_functions.go
+++ b/backup/queries_functions.go
@@ -37,7 +37,7 @@ type Function struct {
 	ExecLocation      string `db:"proexeclocation"`
 }
 
-func (f Function) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (f Function) GetMetadataEntry() (string, utils.MetadataEntry) {
 	nameWithArgs := fmt.Sprintf("%s(%s)", f.Name, f.IdentArgs)
 	return "predata",
 		utils.MetadataEntry{
@@ -45,8 +45,8 @@ func (f Function) GetMetadataEntry(start uint64, end uint64) (string, utils.Meta
 			Name:            nameWithArgs,
 			ObjectType:      "FUNCTION",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -306,7 +306,7 @@ type Aggregate struct {
 	MInitValIsNull             bool
 }
 
-func (a Aggregate) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (a Aggregate) GetMetadataEntry() (string, utils.MetadataEntry) {
 	identArgumentsStr := "*"
 	if a.IdentArgs != "" {
 		identArgumentsStr = a.IdentArgs
@@ -318,8 +318,8 @@ func (a Aggregate) GetMetadataEntry(start uint64, end uint64) (string, utils.Met
 			Name:            aggWithArgs,
 			ObjectType:      "AGGREGATE",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -516,7 +516,7 @@ type Cast struct {
 	CastMethod     string
 }
 
-func (c Cast) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (c Cast) GetMetadataEntry() (string, utils.MetadataEntry) {
 	castStr := fmt.Sprintf("(%s AS %s)", c.SourceTypeFQN, c.TargetTypeFQN)
 	filterSchema := "pg_catalog"
 	if c.CastMethod == "f" {
@@ -528,8 +528,8 @@ func (c Cast) GetMetadataEntry(start uint64, end uint64) (string, utils.Metadata
 			Name:            castStr,
 			ObjectType:      "CAST",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -600,15 +600,15 @@ type Extension struct {
 	Schema string
 }
 
-func (e Extension) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (e Extension) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "predata",
 		utils.MetadataEntry{
 			Schema:          "",
 			Name:            e.Name,
 			ObjectType:      "EXTENSION",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -647,15 +647,15 @@ type ProceduralLanguage struct {
 	Validator uint32 `db:"lanvalidator"`
 }
 
-func (pl ProceduralLanguage) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (pl ProceduralLanguage) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "predata",
 		utils.MetadataEntry{
 			Schema:          "",
 			Name:            pl.Name,
 			ObjectType:      "LANGUAGE",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -718,15 +718,15 @@ type Conversion struct {
 	IsDefault          bool `db:"condefault"`
 }
 
-func (c Conversion) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (c Conversion) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "predata",
 		utils.MetadataEntry{
 			Schema:          c.Schema,
 			Name:            c.Name,
 			ObjectType:      "CONVERSION",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -770,15 +770,15 @@ type ForeignDataWrapper struct {
 	Options   string
 }
 
-func (fdw ForeignDataWrapper) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (fdw ForeignDataWrapper) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "predata",
 		utils.MetadataEntry{
 			Schema:          "",
 			Name:            fdw.Name,
 			ObjectType:      "FOREIGN DATA WRAPPER",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -820,15 +820,15 @@ type ForeignServer struct {
 	Options            string
 }
 
-func (fs ForeignServer) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (fs ForeignServer) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "predata",
 		utils.MetadataEntry{
 			Schema:          "",
 			Name:            fs.Name,
 			ObjectType:      "FOREIGN SERVER",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -870,15 +870,15 @@ type UserMapping struct {
 	Options string
 }
 
-func (um UserMapping) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (um UserMapping) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "predata",
 		utils.MetadataEntry{
 			Schema:          "",
 			Name:            um.FQN(),
 			ObjectType:      "USER MAPPING",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 

--- a/backup/queries_globals.go
+++ b/backup/queries_globals.go
@@ -17,15 +17,15 @@ type SessionGUCs struct {
 	ClientEncoding string `db:"client_encoding"`
 }
 
-func (sg SessionGUCs) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (sg SessionGUCs) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "global",
 		utils.MetadataEntry{
 			Schema:          "",
 			Name:            "",
 			ObjectType:      "SESSION GUCS",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -46,15 +46,15 @@ type Database struct {
 	Encoding   string
 }
 
-func (db Database) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (db Database) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "global",
 		utils.MetadataEntry{
 			Schema:          "",
 			Name:            db.Name,
 			ObjectType:      "DATABASE METADATA",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -140,15 +140,15 @@ type ResourceQueue struct {
 	MemoryLimit      string
 }
 
-func (rq ResourceQueue) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (rq ResourceQueue) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "global",
 		utils.MetadataEntry{
 			Schema:          "",
 			Name:            rq.Name,
 			ObjectType:      "RESOURCE QUEUE",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -202,15 +202,15 @@ type ResourceGroup struct {
 	Cpuset            string
 }
 
-func (rg ResourceGroup) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (rg ResourceGroup) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "global",
 		utils.MetadataEntry{
 			Schema:          "",
 			Name:            rg.Name,
 			ObjectType:      "RESOURCE GROUP",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -285,15 +285,15 @@ type Role struct {
 	TimeConstraints []TimeConstraint
 }
 
-func (r Role) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (r Role) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "global",
 		utils.MetadataEntry{
 			Schema:          "",
 			Name:            r.Name,
 			ObjectType:      "ROLE",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -361,15 +361,15 @@ type RoleGUC struct {
 	Config   string
 }
 
-func (rg RoleGUC) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (rg RoleGUC) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "global",
 		utils.MetadataEntry{
 			Schema:          "",
 			Name:            rg.RoleName,
 			ObjectType:      "ROLE GUCS",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -452,15 +452,15 @@ type RoleMember struct {
 	IsAdmin bool
 }
 
-func (rm RoleMember) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (rm RoleMember) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "global",
 		utils.MetadataEntry{
 			Schema:          "",
 			Name:            rm.Member,
 			ObjectType:      "ROLE GRANT",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -488,15 +488,15 @@ type Tablespace struct {
 	Options          string
 }
 
-func (t Tablespace) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (t Tablespace) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "global",
 		utils.MetadataEntry{
 			Schema:          "",
 			Name:            t.Tablespace,
 			ObjectType:      "TABLESPACE",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 

--- a/backup/queries_operators.go
+++ b/backup/queries_operators.go
@@ -28,15 +28,15 @@ type Operator struct {
 	CanMerge         bool
 }
 
-func (o Operator) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (o Operator) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "predata",
 		utils.MetadataEntry{
 			Schema:          o.Schema,
 			Name:            o.Name,
 			ObjectType:      "OPERATOR",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -116,15 +116,15 @@ type OperatorFamily struct {
 	IndexMethod string
 }
 
-func (opf OperatorFamily) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (opf OperatorFamily) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "predata",
 		utils.MetadataEntry{
 			Schema:          opf.Schema,
 			Name:            opf.Name,
 			ObjectType:      "OPERATOR FAMILY",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -167,15 +167,15 @@ type OperatorClass struct {
 	Functions    []OperatorClassFunction
 }
 
-func (opc OperatorClass) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (opc OperatorClass) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "predata",
 		utils.MetadataEntry{
 			Schema:          opc.Schema,
 			Name:            opc.Name,
 			ObjectType:      "OPERATOR CLASS",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 

--- a/backup/queries_postdata.go
+++ b/backup/queries_postdata.go
@@ -55,7 +55,7 @@ type IndexDefinition struct {
 	IsClustered  bool
 }
 
-func (i IndexDefinition) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (i IndexDefinition) GetMetadataEntry() (string, utils.MetadataEntry) {
 	tableFQN := utils.MakeFQN(i.OwningSchema, i.OwningTable)
 	return "postdata",
 		utils.MetadataEntry{
@@ -63,8 +63,8 @@ func (i IndexDefinition) GetMetadataEntry(start uint64, end uint64) (string, uti
 			Name:            i.Name,
 			ObjectType:      "INDEX",
 			ReferenceObject: tableFQN,
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -162,7 +162,7 @@ type RuleDefinition struct {
 	Def          string
 }
 
-func (r RuleDefinition) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (r RuleDefinition) GetMetadataEntry() (string, utils.MetadataEntry) {
 	tableFQN := utils.MakeFQN(r.OwningSchema, r.OwningTable)
 	return "postdata",
 		utils.MetadataEntry{
@@ -170,8 +170,8 @@ func (r RuleDefinition) GetMetadataEntry(start uint64, end uint64) (string, util
 			Name:            r.Name,
 			ObjectType:      "RULE",
 			ReferenceObject: tableFQN,
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -215,7 +215,7 @@ ORDER BY rulename;`, relationAndSchemaFilterClause(), ExtensionFilterClause("c")
 
 type TriggerDefinition RuleDefinition
 
-func (t TriggerDefinition) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (t TriggerDefinition) GetMetadataEntry() (string, utils.MetadataEntry) {
 	tableFQN := utils.MakeFQN(t.OwningSchema, t.OwningTable)
 	return "postdata",
 		utils.MetadataEntry{
@@ -223,8 +223,8 @@ func (t TriggerDefinition) GetMetadataEntry(start uint64, end uint64) (string, u
 			Name:            t.Name,
 			ObjectType:      "TRIGGER",
 			ReferenceObject: tableFQN,
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -274,15 +274,15 @@ type EventTrigger struct {
 	EventTags    string
 }
 
-func (et EventTrigger) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (et EventTrigger) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "postdata",
 		utils.MetadataEntry{
 			Schema:          "",
 			Name:            et.Name,
 			ObjectType:      "EVENT TRIGGER",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -203,15 +203,15 @@ type Sequence struct {
 	SequenceDefinition
 }
 
-func (s Sequence) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (s Sequence) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "predata",
 		utils.MetadataEntry{
 			Schema:          s.Schema,
 			Name:            s.Name,
 			ObjectType:      "SEQUENCE",
 			ReferenceObject: s.OwningTable,
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -329,15 +329,15 @@ type View struct {
 	Definition string
 }
 
-func (v View) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (v View) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "predata",
 		utils.MetadataEntry{
 			Schema:          v.Schema,
 			Name:            v.Name,
 			ObjectType:      "VIEW",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 

--- a/backup/queries_shared.go
+++ b/backup/queries_shared.go
@@ -31,15 +31,15 @@ type Schema struct {
 	Name string
 }
 
-func (s Schema) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (s Schema) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "predata",
 		utils.MetadataEntry{
 			Schema:          s.Name,
 			Name:            s.Name,
 			ObjectType:      "SCHEMA",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -84,15 +84,15 @@ type Constraint struct {
 	IsPartitionParent  bool
 }
 
-func (c Constraint) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (c Constraint) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "predata",
 		utils.MetadataEntry{
 			Schema:          c.Schema,
 			Name:            c.Name,
 			ObjectType:      "CONSTRAINT",
 			ReferenceObject: c.OwningObject,
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 

--- a/backup/queries_table_defs.go
+++ b/backup/queries_table_defs.go
@@ -25,7 +25,7 @@ func (t Table) SkipDataBackup() bool {
 	return def.IsExternal || (def.ForeignDef != ForeignTableDefinition{})
 }
 
-func (t Table) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (t Table) GetMetadataEntry() (string, utils.MetadataEntry) {
 	objectType := "TABLE"
 	if (t.ForeignDef != ForeignTableDefinition{}) {
 		objectType = "FOREIGN TABLE"
@@ -36,8 +36,8 @@ func (t Table) GetMetadataEntry(start uint64, end uint64) (string, utils.Metadat
 			Name:            t.Name,
 			ObjectType:      objectType,
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 

--- a/backup/queries_textsearch.go
+++ b/backup/queries_textsearch.go
@@ -27,15 +27,15 @@ type TextSearchParser struct {
 	HeadlineFunc string
 }
 
-func (tsp TextSearchParser) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (tsp TextSearchParser) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "predata",
 		utils.MetadataEntry{
 			Schema:          tsp.Schema,
 			Name:            tsp.Name,
 			ObjectType:      "TEXT SEARCH PARSER",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -78,15 +78,15 @@ type TextSearchTemplate struct {
 	LexizeFunc string
 }
 
-func (tst TextSearchTemplate) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (tst TextSearchTemplate) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "predata",
 		utils.MetadataEntry{
 			Schema:          tst.Schema,
 			Name:            tst.Name,
 			ObjectType:      "TEXT SEARCH TEMPLATE",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -126,15 +126,15 @@ type TextSearchDictionary struct {
 	InitOption string
 }
 
-func (tsd TextSearchDictionary) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (tsd TextSearchDictionary) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "predata",
 		utils.MetadataEntry{
 			Schema:          tsd.Schema,
 			Name:            tsd.Name,
 			ObjectType:      "TEXT SEARCH DICTIONARY",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -176,15 +176,15 @@ type TextSearchConfiguration struct {
 	TokenToDicts map[string][]string
 }
 
-func (tsc TextSearchConfiguration) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (tsc TextSearchConfiguration) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "predata",
 		utils.MetadataEntry{
 			Schema:          tsc.Schema,
 			Name:            tsc.Name,
 			ObjectType:      "TEXT SEARCH CONFIGURATION",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 

--- a/backup/queries_types.go
+++ b/backup/queries_types.go
@@ -121,7 +121,7 @@ type Type struct {
 	SubTypeDiff     string
 }
 
-func (t Type) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (t Type) GetMetadataEntry() (string, utils.MetadataEntry) {
 	objectType := "TYPE"
 	if t.Type == "d" {
 		objectType = "DOMAIN"
@@ -132,8 +132,8 @@ func (t Type) GetMetadataEntry(start uint64, end uint64) (string, utils.Metadata
 			Name:            t.Name,
 			ObjectType:      objectType,
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 
@@ -446,15 +446,15 @@ type Collation struct {
 	Ctype   string
 }
 
-func (c Collation) GetMetadataEntry(start uint64, end uint64) (string, utils.MetadataEntry) {
+func (c Collation) GetMetadataEntry() (string, utils.MetadataEntry) {
 	return "predata",
 		utils.MetadataEntry{
 			Schema:          c.Schema,
 			Name:            c.Name,
 			ObjectType:      "COLLATION",
 			ReferenceObject: "",
-			StartByte:       start,
-			EndByte:         end,
+			StartByte:       0,
+			EndByte:         0,
 		}
 }
 

--- a/backup/statistics.go
+++ b/backup/statistics.go
@@ -27,7 +27,8 @@ func PrintStatisticsStatementsForTable(statisticsFile *utils.FileWithByteCount, 
 		attributeQuery := GenerateAttributeStatisticsQuery(table, attStat)
 		statisticsFile.MustPrintf("\n\n%s\n", attributeQuery)
 	}
-	toc.AddMetadataEntryLongArgs(table.Schema, table.Name, "STATISTICS", "", start, statisticsFile, "statistics")
+	entry := utils.MetadataEntry{table.Schema, table.Name, "STATISTICS", "", 0, 0}
+	toc.AddMetadataEntry("statistics", entry, start, statisticsFile.ByteCount)
 }
 
 func GenerateTupleStatisticsQuery(table Table, tupleStat TupleStatistic) string {

--- a/restore/validate_test.go
+++ b/restore/validate_test.go
@@ -29,13 +29,13 @@ var _ = Describe("restore/validate tests", func() {
 		BeforeEach(func() {
 			toc, backupfile = testutils.InitializeTestTOC(buffer, "predata")
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntryLongArgs("schema1", "table1", "", "TABLE", 0, backupfile, "predata")
+			toc.AddMetadataEntry("predata", utils.MetadataEntry{"schema1", "table1", "TABLE", "", 0, 0}, 0, backupfile.ByteCount)
 			toc.AddMasterDataEntry("schema1", "table1", 1, "(i)", 0, "")
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntryLongArgs("schema2", "table2", "TABLE", "", table1Len, backupfile, "predata")
+			toc.AddMetadataEntry("predata", utils.MetadataEntry{"schema2", "table2", "TABLE", "", 0, 0}, table1Len, backupfile.ByteCount)
 			toc.AddMasterDataEntry("schema2", "table2", 2, "(j)", 0, "")
 			backupfile.ByteCount += sequenceLen
-			toc.AddMetadataEntryLongArgs("schema", "somesequence", "SEQUENCE", "", table1Len+table2Len, backupfile, "predata")
+			toc.AddMetadataEntry("predata", utils.MetadataEntry{"schema", "somesequence", "SEQUENCE", "", 0, 0}, table1Len+table2Len, backupfile.ByteCount)
 			restore.SetTOC(toc)
 		})
 		It("passes when schema exists in normal backup", func() {
@@ -192,15 +192,15 @@ var _ = Describe("restore/validate tests", func() {
 		var backupfile *utils.FileWithByteCount
 		BeforeEach(func() {
 			toc, backupfile = testutils.InitializeTestTOC(buffer, "predata")
-			toc.AddMetadataEntryLongArgs("schema1", "table1", "TABLE", "", 0, backupfile, "predata")
+			toc.AddMetadataEntry("predata", utils.MetadataEntry{"schema1", "table1", "TABLE", "", 0, 0}, 0, backupfile.ByteCount)
 			toc.AddMasterDataEntry("schema1", "table1", 1, "(i)", 0, "")
 
-			toc.AddMetadataEntryLongArgs("schema2", "table2", "TABLE", "", 0, backupfile, "predata")
+			toc.AddMetadataEntry("predata", utils.MetadataEntry{"schema2", "table2", "TABLE", "", 0, 0}, 0, backupfile.ByteCount)
 			toc.AddMasterDataEntry("schema2", "table2", 2, "(j)", 0, "")
 
-			toc.AddMetadataEntryLongArgs("schema1", "somesequence", "SEQUENCE", "", 0, backupfile, "predata")
-			toc.AddMetadataEntryLongArgs("schema1", "someview", "VIEW", "", 0, backupfile, "predata")
-			toc.AddMetadataEntryLongArgs("schema1", "somefunction", "FUNCTION", "", 0, backupfile, "predata")
+			toc.AddMetadataEntry("predata", utils.MetadataEntry{"schema1", "somesequence", "SEQUENCE", "", 0, 0}, 0, backupfile.ByteCount)
+			toc.AddMetadataEntry("predata", utils.MetadataEntry{"schema1", "someview", "VIEW", "", 0, 0}, 0, backupfile.ByteCount)
+			toc.AddMetadataEntry("predata", utils.MetadataEntry{"schema1", "somefunction", "FUNCTION", "", 0, 0}, 0, backupfile.ByteCount)
 
 			restore.SetTOC(toc)
 		})

--- a/utils/toc.go
+++ b/utils/toc.go
@@ -262,21 +262,18 @@ func (toc *TOC) InitializeMetadataEntryMap() {
 }
 
 type TOCObject interface {
-	GetMetadataEntry(uint64, uint64) (string, MetadataEntry)
+	GetMetadataEntry() (string, MetadataEntry)
 }
 
 type TOCObjectWithMetadata interface {
-	GetMetadataEntry(uint64, uint64) (string, MetadataEntry)
+	GetMetadataEntry() (string, MetadataEntry)
 	FQN() string
 }
 
-func (toc *TOC) AddMetadataEntry(obj TOCObject, start, end uint64) {
-	section, entry := obj.GetMetadataEntry(start, end)
+func (toc *TOC) AddMetadataEntry(section string, entry MetadataEntry, start, end uint64) {
+	entry.StartByte = start
+	entry.EndByte = end
 	*toc.metadataEntryMap[section] = append(*toc.metadataEntryMap[section], entry)
-}
-
-func (toc *TOC) AddMetadataEntryLongArgs(schema string, name string, objectType string, referenceObject string, start uint64, file *FileWithByteCount, section string) {
-	*toc.metadataEntryMap[section] = append(*toc.metadataEntryMap[section], MetadataEntry{schema, name, objectType, referenceObject, start, file.ByteCount})
 }
 
 func (toc *TOC) AddMasterDataEntry(schema string, name string, oid uint32, attributeString string, rowsCopied int64, PartitionRoot string) {

--- a/utils/toc_test.go
+++ b/utils/toc_test.go
@@ -39,7 +39,7 @@ var _ = Describe("utils/toc tests", func() {
 		var noInObj, noExObj, noInSchema, noExSchema, noInRelation, noExRelation []string
 		It("returns statement for a single object type", func() {
 			backupfile.ByteCount = commentLen + createLen
-			toc.AddMetadataEntryLongArgs("", "somedatabase", "DATABASE", "", commentLen, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"", "somedatabase", "DATABASE", "", 0, 0}, commentLen, backupfile.ByteCount)
 
 			metadataFile := bytes.NewReader([]byte(comment.Statement + create.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, []string{"DATABASE"}, noExObj, noInSchema, noExSchema, noInRelation, noExRelation)
@@ -48,11 +48,11 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns statement for multiple object types", func() {
 			backupfile.ByteCount = commentLen + createLen
-			toc.AddMetadataEntryLongArgs("", "somedatabase", "DATABASE", "", commentLen, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"", "somedatabase", "DATABASE", "", 0, 0}, commentLen, backupfile.ByteCount)
 			backupfile.ByteCount += role1Len
-			toc.AddMetadataEntryLongArgs("", "somerole1", "ROLE", "", commentLen+createLen, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"", "somerole1", "ROLE", "", 0, 0}, commentLen+createLen, backupfile.ByteCount)
 			backupfile.ByteCount += role2Len
-			toc.AddMetadataEntryLongArgs("", "somerole2", "ROLE", "", commentLen+createLen+role1Len, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"", "somerole2", "ROLE", "", 0, 0}, commentLen+createLen+role1Len, backupfile.ByteCount)
 
 			metadataFile := bytes.NewReader([]byte(comment.Statement + create.Statement + role1.Statement + role2.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, []string{"DATABASE", "ROLE"}, noExObj, noInSchema, noExSchema, noInRelation, noExRelation)
@@ -61,11 +61,11 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("does not return a statement type listed in the exclude list", func() {
 			backupfile.ByteCount = commentLen + createLen
-			toc.AddMetadataEntryLongArgs("", "somedatabase", "DATABASE", "", commentLen, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"", "somedatabase", "DATABASE", "", 0, 0}, commentLen, backupfile.ByteCount)
 			backupfile.ByteCount += role1Len
-			toc.AddMetadataEntryLongArgs("", "somerole1", "ROLE", "", commentLen+createLen, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"", "somerole1", "ROLE", "", 0, 0}, commentLen+createLen, backupfile.ByteCount)
 			backupfile.ByteCount += role2Len
-			toc.AddMetadataEntryLongArgs("", "somerole2", "ROLE", "", commentLen+createLen+role1Len, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"", "somerole2", "ROLE", "", 0, 0}, commentLen+createLen+role1Len, backupfile.ByteCount)
 
 			metadataFile := bytes.NewReader([]byte(comment.Statement + create.Statement + role1.Statement + role2.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, noInObj, []string{"DATABASE"}, noInSchema, noExSchema, noInRelation, noExRelation)
@@ -74,7 +74,7 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns empty statement when no object types are found", func() {
 			backupfile.ByteCount = commentLen + createLen
-			toc.AddMetadataEntryLongArgs("", "somedatabase", "DATABASE", "", commentLen, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"", "somedatabase", "DATABASE", "", 0, 0}, commentLen, backupfile.ByteCount)
 
 			metadataFile := bytes.NewReader([]byte(comment.Statement + create.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, []string{"TABLE"}, noExObj, noInSchema, noExSchema, noInRelation, noExRelation)
@@ -83,11 +83,11 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns statement for a single object type with matching schema", func() {
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntryLongArgs("schema", "table1", "TABLE", "", 0, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema", "table1", "TABLE", "", 0, 0}, 0, backupfile.ByteCount)
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntryLongArgs("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema2", "table2", "TABLE", "", 0, 0}, table1Len, backupfile.ByteCount)
 			backupfile.ByteCount += sequenceLen
-			toc.AddMetadataEntryLongArgs("schema", "somesequence", "SEQUENCE", "", table1Len+table2Len, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema", "somesequence", "SEQUENCE", "", 0, 0}, table1Len+table2Len, backupfile.ByteCount)
 
 			metadataFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, []string{"TABLE"}, noExObj, []string{"schema"}, noExSchema, noInRelation, noExRelation)
@@ -96,11 +96,11 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns statement for any object type in the include schema", func() {
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntryLongArgs("schema", "table1", "TABLE", "", 0, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema", "table1", "TABLE", "", 0, 0}, 0, backupfile.ByteCount)
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntryLongArgs("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema2", "table2", "TABLE", "", 0, 0}, table1Len, backupfile.ByteCount)
 			backupfile.ByteCount += sequenceLen
-			toc.AddMetadataEntryLongArgs("schema", "somesequence", "SEQUENCE", "", table1Len+table2Len, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema", "somesequence", "SEQUENCE", "", 0, 0}, table1Len+table2Len, backupfile.ByteCount)
 
 			metadataFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, noInObj, noExObj, []string{"schema"}, noExSchema, noInRelation, noExRelation)
@@ -109,11 +109,11 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns statement for any object type not in the exclude schema", func() {
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntryLongArgs("schema", "table1", "TABLE", "", 0, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema", "table1", "TABLE", "", 0, 0}, 0, backupfile.ByteCount)
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntryLongArgs("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema2", "table2", "TABLE", "", 0, 0}, table1Len, backupfile.ByteCount)
 			backupfile.ByteCount += sequenceLen
-			toc.AddMetadataEntryLongArgs("schema", "somesequence", "SEQUENCE", "", table1Len+table2Len, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema", "somesequence", "SEQUENCE", "", 0, 0}, table1Len+table2Len, backupfile.ByteCount)
 
 			metadataFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, noInObj, noExObj, noInSchema, []string{"schema2"}, noInRelation, noExRelation)
@@ -122,11 +122,11 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns statement for a table matching an included table", func() {
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntryLongArgs("schema", "table1", "TABLE", "", 0, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema", "table1", "TABLE", "", 0, 0}, 0, backupfile.ByteCount)
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntryLongArgs("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema2", "table2", "TABLE", "", 0, 0}, table1Len, backupfile.ByteCount)
 			backupfile.ByteCount += sequenceLen
-			toc.AddMetadataEntryLongArgs("schema", "somesequence", "SEQUENCE", "", table1Len+table2Len, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema", "somesequence", "SEQUENCE", "", 0, 0}, table1Len+table2Len, backupfile.ByteCount)
 
 			metadataFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, noInObj, noExObj, noInSchema, noExSchema, []string{"schema.table1"}, noExRelation)
@@ -135,7 +135,7 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns statement for a view matching an included view", func() {
 			backupfile.ByteCount = view1Len
-			toc.AddMetadataEntryLongArgs("schema", "view1", "VIEW", "", 0, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema", "view1", "VIEW", "", 0, 0}, 0, backupfile.ByteCount)
 
 			metadataFile := bytes.NewReader([]byte(view1.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, noInObj, noExObj, noInSchema, noExSchema, []string{"schema.view1"}, noExRelation)
@@ -144,7 +144,7 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns statement for a sequence matching an included sequence", func() {
 			backupfile.ByteCount = sequence1Len
-			toc.AddMetadataEntryLongArgs("schema", "sequence1", "SEQUENCE", "", 0, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema", "sequence1", "SEQUENCE", "", 0, 0}, 0, backupfile.ByteCount)
 
 			metadataFile := bytes.NewReader([]byte(sequence1.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, noInObj, noExObj, noInSchema, noExSchema, []string{"schema.sequence1"}, noExRelation)
@@ -153,11 +153,11 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns statement for any object type or reference object not matching an excluded table", func() {
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntryLongArgs("schema", "table1", "TABLE", "", 0, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema", "table1", "TABLE", "", 0, 0}, 0, backupfile.ByteCount)
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntryLongArgs("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema2", "table2", "TABLE", "", 0, 0}, table1Len, backupfile.ByteCount)
 			backupfile.ByteCount += sequenceLen
-			toc.AddMetadataEntryLongArgs("schema", "somesequence", "SEQUENCE", "schema.table2", table1Len+table2Len, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema", "somesequence", "SEQUENCE", "schema.table2", 0, 0}, table1Len+table2Len, backupfile.ByteCount)
 
 			metadataFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, noInObj, noExObj, noInSchema, noExSchema, noInRelation, []string{"schema.table1"})
@@ -166,13 +166,13 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns no statements for any object type with reference object matching an excluded table", func() {
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntryLongArgs("schema", "table1", "TABLE", "", 0, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema", "table1", "TABLE", "", 0, 0}, 0, backupfile.ByteCount)
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntryLongArgs("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema2", "table2", "TABLE", "", 0, 0}, table1Len, backupfile.ByteCount)
 			backupfile.ByteCount += sequenceLen
-			toc.AddMetadataEntryLongArgs("schema", "somesequence", "SEQUENCE", "schema.table1", table1Len+table2Len, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema", "somesequence", "SEQUENCE", "schema.table1", 0, 0}, table1Len+table2Len, backupfile.ByteCount)
 			backupfile.ByteCount += indexLen
-			toc.AddMetadataEntryLongArgs("schema", "someindex", "INDEX", "schema.table1", table1Len+table2Len+sequenceLen, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema", "someindex", "INDEX", "schema.table1", 0, 0}, table1Len+table2Len+sequenceLen, backupfile.ByteCount)
 
 			metadataFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + sequence.Statement + index.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, noInObj, noExObj, noInSchema, noExSchema, noInRelation, []string{"schema.table1"})
@@ -181,9 +181,9 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns no statements for an excluded view or sequence", func() {
 			backupfile.ByteCount = view1Len
-			toc.AddMetadataEntryLongArgs("schema", "view1", "VIEW", "", 0, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema", "view1", "VIEW", "", 0, 0}, 0, backupfile.ByteCount)
 			backupfile.ByteCount += sequence1Len
-			toc.AddMetadataEntryLongArgs("schema", "sequence1", "SEQUENCE", "", view1Len, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema", "sequence1", "SEQUENCE", "", 0, 0}, view1Len, backupfile.ByteCount)
 
 			metadataFile := bytes.NewReader([]byte(view1.Statement + sequence1.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, noInObj, noExObj, noInSchema, noExSchema, noInRelation, []string{"schema.view1", "schema.sequence1"})
@@ -192,11 +192,11 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns statement for any object type with matching reference object", func() {
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntryLongArgs("schema", "table1", "INDEX", "", 0, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema", "table1", "INDEX", "", 0, 0}, 0, backupfile.ByteCount)
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntryLongArgs("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema2", "table2", "TABLE", "", 0, 0}, table1Len, backupfile.ByteCount)
 			backupfile.ByteCount += indexLen
-			toc.AddMetadataEntryLongArgs("schema", "someindex", "INDEX", "schema.table", table1Len+table2Len, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema", "someindex", "INDEX", "schema.table", 0, 0}, table1Len+table2Len, backupfile.ByteCount)
 
 			metadataFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + index.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, noInObj, noExObj, noInSchema, noExSchema, []string{"schema.table"}, noExRelation)
@@ -206,11 +206,11 @@ var _ = Describe("utils/toc tests", func() {
 		})
 		It("returns no statements for a non-relation object with matching name from relation list", func() {
 			backupfile.ByteCount = table1Len
-			toc.AddMetadataEntryLongArgs("schema", "table1", "TABLE", "", 0, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema", "table1", "TABLE", "", 0, 0}, 0, backupfile.ByteCount)
 			backupfile.ByteCount += table2Len
-			toc.AddMetadataEntryLongArgs("schema2", "table2", "TABLE", "", table1Len, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema2", "table2", "TABLE", "", 0, 0}, table1Len, backupfile.ByteCount)
 			backupfile.ByteCount += sequenceLen
-			toc.AddMetadataEntryLongArgs("schema", "someindex", "INDEX", "", table1Len+table2Len, backupfile, "global")
+			toc.AddMetadataEntry("global", utils.MetadataEntry{"schema", "someindex", "INDEX", "", 0, 0}, table1Len+table2Len, backupfile.ByteCount)
 
 			metadataFile := bytes.NewReader([]byte(table1.Statement + table2.Statement + index.Statement))
 			statements := toc.GetSQLStatementForObjectTypes("global", metadataFile, noInObj, noExObj, noInSchema, noExSchema, []string{"schema.someindex"}, noExRelation)


### PR DESCRIPTION
This will help us get rid of AddMetadataLongArgs.

The entries passed in will have 0's for start and end byte so that we
can reuse the same entry for multiple metadata adds. AddMetadataEntry
will set the start and end bytes before adding to the TOC.

Authored-by: Karen Huddleston <khuddleston@pivotal.io>