### PR TITLE
Handle comments on indexes generated from constraints

### DIFF
--- a/backup/postdata.go
+++ b/backup/postdata.go
@@ -13,22 +13,24 @@ import (
 func PrintCreateIndexStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, indexes []IndexDefinition, indexMetadata MetadataMap) {
 	for _, index := range indexes {
 		start := metadataFile.ByteCount
-		section, entry := index.GetMetadataEntry()
+		if !index.SupportsConstraint {
+			section, entry := index.GetMetadataEntry()
 
-		metadataFile.MustPrintf("\n\n%s;", index.Def)
-		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
+			metadataFile.MustPrintf("\n\n%s;", index.Def)
+			toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 
-		indexFQN := utils.MakeFQN(index.OwningSchema, index.Name)
-		if index.Tablespace != "" {
-			start := metadataFile.ByteCount
-			metadataFile.MustPrintf("\nALTER INDEX %s SET TABLESPACE %s;", indexFQN, index.Tablespace)
-			toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
-		}
-		tableFQN := utils.MakeFQN(index.OwningSchema, index.OwningTable)
-		if index.IsClustered {
-			start := metadataFile.ByteCount
-			metadataFile.MustPrintf("\nALTER TABLE %s CLUSTER ON %s;", tableFQN, index.Name)
-			toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
+			indexFQN := utils.MakeFQN(index.OwningSchema, index.Name)
+			if index.Tablespace != "" {
+				start := metadataFile.ByteCount
+				metadataFile.MustPrintf("\nALTER INDEX %s SET TABLESPACE %s;", indexFQN, index.Tablespace)
+				toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
+			}
+			tableFQN := utils.MakeFQN(index.OwningSchema, index.OwningTable)
+			if index.IsClustered {
+				start := metadataFile.ByteCount
+				metadataFile.MustPrintf("\nALTER TABLE %s CLUSTER ON %s;", tableFQN, index.Name)
+				toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
+			}
 		}
 		PrintObjectMetadata(metadataFile, toc, indexMetadata[index.GetUniqueID()], index, "")
 	}

--- a/backup/queries_postdata.go
+++ b/backup/queries_postdata.go
@@ -23,7 +23,7 @@ import (
  * to get indexes, but multiple unique indexes can be created on the
  * same column so we only want to filter out the implicit ones.
  */
-func ConstructImplicitIndexNames(connectionPool *dbconn.DBConn) *utils.FilterSet {
+func ConstructImplicitIndexNames(connectionPool *dbconn.DBConn) string {
 	query := `
 SELECT DISTINCT
 	n.nspname || '.' || t.relname || '_' || a.attname || '_key' AS string
@@ -41,18 +41,18 @@ AND i.indisunique = 't'
 AND i.indisprimary = 'f';
 `
 	indexNames := dbconn.MustSelectStringSlice(connectionPool, query)
-	indexNameSet := utils.NewExcludeSet(indexNames)
-	return indexNameSet
+	return utils.SliceToQuotedString(indexNames)
 }
 
 type IndexDefinition struct {
-	Oid          uint32
-	Name         string
-	OwningSchema string
-	OwningTable  string
-	Tablespace   string
-	Def          string
-	IsClustered  bool
+	Oid                uint32
+	Name               string
+	OwningSchema       string
+	OwningTable        string
+	Tablespace         string
+	Def                string
+	IsClustered        bool
+	SupportsConstraint bool
 }
 
 func (i IndexDefinition) GetMetadataEntry() (string, utils.MetadataEntry) {
@@ -76,10 +76,19 @@ func (i IndexDefinition) FQN() string {
 	return utils.MakeFQN(i.OwningSchema, i.Name)
 }
 
+/*
+ * GetIndexes queries for all user and implicitly created indexes, since
+ * implicitly created indexes could still have metadata to be backed up.
+ * e.g. comments on implicitly created indexes
+ */
 func GetIndexes(connectionPool *dbconn.DBConn) []IndexDefinition {
 	resultIndexes := make([]IndexDefinition, 0)
 	if connectionPool.Version.Before("6") {
 		indexNameSet := ConstructImplicitIndexNames(connectionPool)
+		implicitIndexStr := ""
+		if indexNameSet != "" {
+			implicitIndexStr = fmt.Sprintf("OR n.nspname || '.' || ic.relname IN (%s)", indexNameSet)
+		}
 		query := fmt.Sprintf(`
 SELECT DISTINCT
 	i.indexrelid AS oid,
@@ -88,7 +97,11 @@ SELECT DISTINCT
 	quote_ident(c.relname) AS owningtable,
 	coalesce(quote_ident(s.spcname), '') AS tablespace,
 	pg_get_indexdef(i.indexrelid) AS def,
-	i.indisclustered AS isclustered
+	i.indisclustered AS isclustered,
+	CASE
+		WHEN i.indisprimary = 't' %s THEN 't'
+		ELSE 'f'
+	END AS supportsconstraint
 FROM pg_index i
 JOIN pg_class ic
 	ON (ic.oid = i.indexrelid)
@@ -102,21 +115,12 @@ LEFT JOIN pg_tablespace s
 	ON (ic.reltablespace = s.oid)
 WHERE %s
 AND i.indisvalid
-AND i.indisprimary = 'f'
 AND n.nspname || '.' || c.relname NOT IN (SELECT partitionschemaname || '.' || partitiontablename FROM pg_partitions)
 AND %s
-ORDER BY name;`, relationAndSchemaFilterClause(), ExtensionFilterClause("c"))
+ORDER BY name;`, implicitIndexStr, relationAndSchemaFilterClause(), ExtensionFilterClause("c"))
 
-		results := make([]IndexDefinition, 0)
-		err := connectionPool.Select(&results, query)
+		err := connectionPool.Select(&resultIndexes, query)
 		gplog.FatalOnError(err)
-		for _, index := range results {
-			// We don't want to quote the index name to use it as a map key, just prepend the schema
-			indexFQN := fmt.Sprintf("%s.%s", index.OwningSchema, index.Name)
-			if indexNameSet.MatchesFilter(indexFQN) {
-				resultIndexes = append(resultIndexes, index)
-			}
-		}
 	} else {
 		query := fmt.Sprintf(`
 SELECT DISTINCT
@@ -126,7 +130,11 @@ SELECT DISTINCT
 	quote_ident(c.relname) AS owningtable,
 	coalesce(quote_ident(s.spcname), '') AS tablespace,
 	pg_get_indexdef(i.indexrelid) AS def,
-	i.indisclustered AS isclustered
+	i.indisclustered AS isclustered,
+	CASE
+		WHEN conindid > 0 THEN 't'
+		ELSE 'f'
+	END as supportsconstraint
 FROM pg_index i
 JOIN pg_class ic
 	ON (ic.oid = i.indexrelid)
@@ -145,7 +153,6 @@ AND i.indisvalid
 AND i.indisready
 AND i.indisprimary = 'f'
 AND n.nspname || '.' || c.relname NOT IN (SELECT partitionschemaname || '.' || partitiontablename FROM pg_partitions)
-AND con.conindid IS NULL
 AND %s
 ORDER BY name;`, relationAndSchemaFilterClause(), ExtensionFilterClause("c")) // The index itself does not have a dependency on the extension, but the index's table does
 		err := connectionPool.Select(&resultIndexes, query)

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -54,7 +54,7 @@ func gpbackup(gpbackupPath string, backupHelperPath string, args ...string) stri
 		mustRunCommand(command)
 		os.Chdir("end_to_end")
 	}
-	args = append([]string{"--dbname", "testdb"}, args...)
+	args = append([]string{"--verbose", "--dbname", "testdb"}, args...)
 	command := exec.Command(gpbackupPath, args...)
 	output := mustRunCommand(command)
 	r := regexp.MustCompile(`Backup Timestamp = (\d{14})`)
@@ -68,7 +68,7 @@ func gprestore(gprestorePath string, restoreHelperPath string, timestamp string,
 		mustRunCommand(command)
 		os.Chdir("end_to_end")
 	}
-	args = append([]string{"--timestamp", timestamp}, args...)
+	args = append([]string{"--verbose", "--timestamp", timestamp}, args...)
 	command := exec.Command(gprestorePath, args...)
 	output := mustRunCommand(command)
 	return output
@@ -854,7 +854,7 @@ var _ = Describe("backup end to end integration tests", func() {
 			backupdir := filepath.Join(custom_backup_dir, "leaf_partition_data") // Must be unique
 			timestamp := gpbackup(gpbackupPath, backupHelperPath, "--leaf-partition-data", "--backup-dir", backupdir)
 			output := gprestore(gprestorePath, restoreHelperPath, timestamp, "--redirect-db", "restoredb", "--backup-dir", backupdir)
-			Expect(string(output)).To(ContainSubstring("Tables restored:  30 / 30"))
+			Expect(string(output)).To(ContainSubstring("table 30 of 30"))
 
 			assertDataRestored(restoreConn, publicSchemaTupleCounts)
 			assertDataRestored(restoreConn, schema2TupleCounts)


### PR DESCRIPTION
Currently, gpbackup ignores indexes generated to support constraints.
These just get generated again when the table is restored. But in the
case where the user adds a comment on a generated index, the comment
did not get restored.