### PR TITLE
Fix validUntil field for roles with infinity val

### DIFF
--- a/backup/queries_globals.go
+++ b/backup/queries_globals.go
@@ -331,7 +331,11 @@ SELECT
 	%s
 	rolconnlimit,
 	coalesce(rolpassword, '') AS password,
-	coalesce(timezone('UTC', rolvaliduntil) || '-00', '') AS validuntil,
+	CASE
+		WHEN (rolvaliduntil = 'infinity'::timestamp OR rolvaliduntil = '-infinity'::timestamp)
+		THEN timezone('UTC', rolvaliduntil)::text
+		ELSE coalesce(timezone('UTC', rolvaliduntil) || '-00', '')
+	END AS validuntil,
 	(SELECT quote_ident(rsqname) FROM pg_resqueue WHERE pg_resqueue.oid = rolresqueue) AS resqueue,
 	%s
 	rolcreaterexthttp,


### PR DESCRIPTION
Timestamp object types can take on two irregular values: 'infinity' and
'-infinity'. This causes an issue when appending a UTC offset value of
'-00' to the values in the validUntil field. We choose not to append
this offset when the validUntil is infinity.
