### PR TITLE
Fix restore filtering for sequences

### DIFF
--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -209,7 +209,7 @@ func (s Sequence) GetMetadataEntry() (string, utils.MetadataEntry) {
 			Schema:          s.Schema,
 			Name:            s.Name,
 			ObjectType:      "SEQUENCE",
-			ReferenceObject: s.OwningTable,
+			ReferenceObject: "",
 			StartByte:       0,
 			EndByte:         0,
 		}

--- a/utils/toc.go
+++ b/utils/toc.go
@@ -174,7 +174,8 @@ func shouldIncludeStatement(entry MetadataEntry, objectSet *FilterSet, schemaSet
 	relationFQN := MakeFQN(entry.Schema, entry.Name)
 	shouldIncludeRelation := (relationSet.IsExclude && entry.ObjectType != "TABLE" && entry.ObjectType != "VIEW" && entry.ObjectType != "SEQUENCE" && entry.ReferenceObject == "") ||
 		((entry.ObjectType == "TABLE" || entry.ObjectType == "VIEW" || entry.ObjectType == "SEQUENCE") && relationSet.MatchesFilter(relationFQN) && entry.ReferenceObject == "") || // Relations should match the filter
-		(entry.ReferenceObject != "" && relationSet.MatchesFilter(entry.ReferenceObject)) // Include relations that filtered tables depend on
+		(entry.ObjectType != "SEQUENCE OWNER" && entry.ReferenceObject != "" && relationSet.MatchesFilter(entry.ReferenceObject)) || // Include relations that filtered tables depend on
+		(entry.ObjectType == "SEQUENCE OWNER" && relationSet.MatchesFilter(relationFQN) && relationSet.MatchesFilter(entry.ReferenceObject)) //Include sequence owners if both table and sequence are being restored
 
 	return shouldIncludeObject && shouldIncludeSchema && shouldIncludeRelation
 }


### PR DESCRIPTION
Clean up TOC tests to make them easier to understand.

Make restore filtering for sequences more similar to how we do it for backup.