### PR TITLE
Add support for Replica Identity for a table

### DIFF
--- a/backup/postdata.go
+++ b/backup/postdata.go
@@ -31,6 +31,11 @@ func PrintCreateIndexStatements(metadataFile *utils.FileWithByteCount, toc *util
 				metadataFile.MustPrintf("\nALTER TABLE %s CLUSTER ON %s;", tableFQN, index.Name)
 				toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 			}
+			if index.IsReplicaIdentity {
+				start := metadataFile.ByteCount
+				metadataFile.MustPrintf("\nALTER TABLE %s REPLICA IDENTITY USING INDEX %s;", tableFQN, index.Name)
+				toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
+			}
 		}
 		PrintObjectMetadata(metadataFile, toc, indexMetadata[index.GetUniqueID()], index, "")
 	}

--- a/backup/postdata_test.go
+++ b/backup/postdata_test.go
@@ -45,6 +45,16 @@ var _ = Describe("backup/postdata tests", func() {
 			testutils.AssertBufferContents(toc.PostdataEntries, buffer, "CREATE INDEX testindex ON public.testtable USING btree(i);",
 				"COMMENT ON INDEX public.testindex IS 'This is an index comment.';")
 		})
+		It("can print an index that is a replica identity", func() {
+			index.IsReplicaIdentity = true
+			indexes := []backup.IndexDefinition{index}
+			backup.PrintCreateIndexStatements(backupfile, toc, indexes, emptyMetadataMap)
+			testutils.ExpectEntry(toc.PostdataEntries, 0, "public", "public.testtable", "testindex", "INDEX")
+			testutils.AssertBufferContents(toc.PostdataEntries, buffer,
+				"CREATE INDEX testindex ON public.testtable USING btree(i);",
+				"ALTER TABLE public.testtable REPLICA IDENTITY USING INDEX testindex;",
+			)
+		})
 	})
 	Context("PrintCreateRuleStatements", func() {
 		rule := backup.RuleDefinition{Oid: 1, Name: "testrule", OwningSchema: "public", OwningTable: "testtable", Def: "CREATE RULE update_notify AS ON UPDATE TO testtable DO NOTIFY testtable;"}

--- a/backup/queries_postdata.go
+++ b/backup/queries_postdata.go
@@ -53,6 +53,7 @@ type IndexDefinition struct {
 	Def                string
 	IsClustered        bool
 	SupportsConstraint bool
+	IsReplicaIdentity  bool
 }
 
 func (i IndexDefinition) GetMetadataEntry() (string, utils.MetadataEntry) {
@@ -131,6 +132,7 @@ SELECT DISTINCT
 	coalesce(quote_ident(s.spcname), '') AS tablespace,
 	pg_get_indexdef(i.indexrelid) AS def,
 	i.indisclustered AS isclustered,
+	i.indisreplident AS isreplicaidentity,
 	CASE
 		WHEN conindid > 0 THEN 't'
 		ELSE 'f'

--- a/integration/predata_table_defs_queries_test.go
+++ b/integration/predata_table_defs_queries_test.go
@@ -765,4 +765,35 @@ SET SUBPARTITION TEMPLATE
 			Expect(inheritanceMap).To(Not(HaveKey(partition.Oid)))
 		})
 	})
+	Describe("GetTableReplicaIdentity", func() {
+		It("Returns a map of oid to replica identity with default", func() {
+			testutils.SkipIfBefore6(connectionPool)
+			testhelper.AssertQueryRuns(connectionPool, `CREATE TABLE public.test_table()`)
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.test_table")
+
+			oid := testutils.OidFromObjectName(connectionPool, "public", "test_table", backup.TYPE_RELATION)
+			result := backup.GetTableReplicaIdentity(connectionPool)
+			Expect(result[oid]).To(Equal("d"))
+		})
+		It("Returns a map of oid to replica identity with full", func() {
+			testutils.SkipIfBefore6(connectionPool)
+			testhelper.AssertQueryRuns(connectionPool, `CREATE TABLE public.test_table()`)
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.test_table")
+
+			testhelper.AssertQueryRuns(connectionPool, `ALTER TABLE public.test_table REPLICA IDENTITY FULL;`)
+			oid := testutils.OidFromObjectName(connectionPool, "public", "test_table", backup.TYPE_RELATION)
+			result := backup.GetTableReplicaIdentity(connectionPool)
+			Expect(result[oid]).To(Equal("f"))
+		})
+		It("Returns a map of oid to replica identity with nothing", func() {
+			testutils.SkipIfBefore6(connectionPool)
+			testhelper.AssertQueryRuns(connectionPool, `CREATE TABLE public.test_table()`)
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.test_table")
+
+			testhelper.AssertQueryRuns(connectionPool, `ALTER TABLE public.test_table REPLICA IDENTITY NOTHING;`)
+			oid := testutils.OidFromObjectName(connectionPool, "public", "test_table", backup.TYPE_RELATION)
+			result := backup.GetTableReplicaIdentity(connectionPool)
+			Expect(result[oid]).To(Equal("n"))
+		})
+	})
 })


### PR DESCRIPTION
Introduced in the 9.4 postgres merge. The option is unsupported on
foreign tables, but it seems that replica identity on foreign tables
defaults to "n" and cannot be altered.

Co-Authored-by: Kevin Yeap <kyeap@pivotal.io>
Co-authored-by: Trevor Yacovone <tyacovone@pivotal.io>
Co-Authored-by: Shreya Jhajharia