### PR TITLE
Log name of database when creating it during restore

### DIFF
--- a/restore/restore.go
+++ b/restore/restore.go
@@ -158,14 +158,16 @@ func DoRestore() {
 
 func createDatabase(metadataFilename string) {
 	objectTypes := []string{"SESSION GUCS", "DATABASE GUC", "DATABASE", "DATABASE METADATA"}
+	dbName := backupConfig.DatabaseName
 	gplog.Info("Creating database")
 	statements := GetRestoreMetadataStatements("global", metadataFilename, objectTypes, []string{}, false, false)
 	if MustGetFlagString(utils.REDIRECT_DB) != "" {
 		quotedDBName := utils.QuoteIdent(connectionPool, MustGetFlagString(utils.REDIRECT_DB))
+		dbName = quotedDBName
 		statements = utils.SubstituteRedirectDatabaseInStatements(statements, backupConfig.DatabaseName, quotedDBName)
 	}
 	ExecuteRestoreMetadataStatements(statements, "", nil, utils.PB_NONE, false)
-	gplog.Info("Database creation complete")
+	gplog.Info("Database creation complete for: %s", dbName)
 }
 
 func restoreGlobal(metadataFilename string) {


### PR DESCRIPTION
When restore creates a database because of the `--create-db` flag, log the name of that created database

Sample output below. See string "Database creation complete for: test" where the database is named, wait for it, "test".
```

$ gprestore --create-db --timestamp 20190205202246 --backup-dir /tmp/test_backup
20190205:20:23:50 gprestore:pivotal:workstation-1:028040-[INFO]:-Restore Key = 20190205202246
20190205:20:23:51 gprestore:pivotal:workstation-1:028040-[INFO]:-Creating database
20190205:20:23:51 gprestore:pivotal:workstation-1:028040-[INFO]:-Database creation complete for: test
20190205:20:23:51 gprestore:pivotal:workstation-1:028040-[INFO]:-Restoring pre-data metadata
Pre-data objects restored:  6 / 6 [=====================================================] 100.00% 0s
20190205:20:23:52 gprestore:pivotal:workstation-1:028040-[INFO]:-Pre-data metadata restore complete
20190205:20:23:52 gprestore:pivotal:workstation-1:028040-[INFO]:-Restoring post-data metadata
20190205:20:23:52 gprestore:pivotal:workstation-1:028040-[INFO]:-Post-data metadata restore complete
20190205:20:23:52 gprestore:pivotal:workstation-1:028040-[INFO]:-Found neither /usr/local/gpdb/bin/gp_email_contacts.yaml nor /home/pivotal/gp_email_contacts.yaml
20190205:20:23:52 gprestore:pivotal:workstation-1:028040-[INFO]:-Email containing gprestore report /tmp/test_backup/demoDataDir-1/backups/20190205/20190205202246/gprestore_20190205202246_20190205202350_report will not be sent
20190205:20:23:52 gprestore:pivotal:workstation-1:028040-[INFO]:-Restore completed successfully
```