### PR TITLE
Do not backup gphdfs for GPDB6

### DIFF
--- a/backup/queries_globals.go
+++ b/backup/queries_globals.go
@@ -316,9 +316,14 @@ func GetRoles(connectionPool *dbconn.DBConn) []Role {
 		resgroupQuery = "(SELECT quote_ident(rsgname) FROM pg_resgroup WHERE pg_resgroup.oid = rolresgroup) AS resgroup,"
 	}
 	replicationQuery := ""
+	readExtHdfs := "rolcreaterexthdfs,"
+	writeExtHdfs := "rolcreatewexthdfs,"
 	if connectionPool.Version.AtLeast("6") {
 		replicationQuery = "rolreplication,"
+		readExtHdfs = ""
+		writeExtHdfs = ""
 	}
+
 	query := fmt.Sprintf(`
 SELECT
 	oid,
@@ -339,12 +344,12 @@ SELECT
 	(SELECT quote_ident(rsqname) FROM pg_resqueue WHERE pg_resqueue.oid = rolresqueue) AS resqueue,
 	%s
 	rolcreaterexthttp,
+	%s
+	%s
 	rolcreaterextgpfd,
-	rolcreatewextgpfd,
-	rolcreaterexthdfs,
-	rolcreatewexthdfs
+	rolcreatewextgpfd
 FROM
-	pg_authid`, replicationQuery, resgroupQuery)
+	pg_authid`, replicationQuery, resgroupQuery, readExtHdfs, writeExtHdfs)
 
 	roles := make([]Role, 0)
 	err := connectionPool.Select(&roles, query)

--- a/integration/metadata_globals_create_test.go
+++ b/integration/metadata_globals_create_test.go
@@ -236,7 +236,7 @@ var _ = Describe("backup integration create statement tests", func() {
 				Password:        "md5a8b2c77dfeba4705f29c094592eb3369",
 				ValidUntil:      "2099-01-01 08:00:00-00",
 				ResQueue:        "pg_default",
-				ResGroup:        "default_group",
+				ResGroup:        "",
 				Createrexthttp:  true,
 				Createrextgpfd:  true,
 				Createwextgpfd:  true,
@@ -258,8 +258,12 @@ var _ = Describe("backup integration create statement tests", func() {
 					},
 				},
 			}
-			if connectionPool.Version.Before("5") {
-				role1.ResGroup = ""
+			if connectionPool.Version.AtLeast("5") {
+				role1.ResGroup = "default_group"
+			}
+			if connectionPool.Version.AtLeast("6") {
+				role1.Createrexthdfs = false
+				role1.Createwexthdfs = false
 			}
 			metadataMap := testutils.DefaultMetadataMap("ROLE", false, false, true, includeSecurityLabels)
 


### PR DESCRIPTION
gphdfs has been depricated in GPDB6. When backing up a role do not
backup the two gphdfs attributes createrexthdfs and createwexthdfs

Authored-by: Kevin Yeap <kyeap@pivotal.io>