### PR TITLE
Update dev workflow for test execution.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # Greenplum Backup
 
-gpbackup and gprestore are Go utilities for performing backups and restores of a Greenplum Database. They are still currently in active development.
+`gpbackup` and `gprestore` are Go utilities for performing Greenplum Database backups.  They are still currently in active development.
 
 ## Pre-Requisites
 
-gpbackup requires Go version 1.8 or higher.
-Follow the directions [here](https://golang.org/doc/) to get the language set up.
+The project requires the Go Programming language version 1.8 or higher. Follow the directions [here](https://golang.org/doc/) for installation, usage and configuration instructions.
 
 ## Downloading
 
@@ -17,36 +16,42 @@ This will place the code in `$GOPATH/github.com/greenplum-db/gpbackup`.
 
 ## Building and installing binaries
 
-cd into the gpbackup directory and run
+Make the `gpbackup` directory your current working directory and run:
 
 ```bash
 make depend
 make build
 ```
 
-This will put the gpbackup and gprestore binaries in `$HOME/go/bin`
+The `build` target will put the `gpbackup` and `gprestore` binaries in `$HOME/go/bin`.
+
+This will also attempt to copy `gpbackup_helper` to the greenplum segments (retrieving hostnames from `gp_segment_configuration`). Pay attention to the output as it will indicate whether this operation was successful.
 
 `make build_linux` and `make build_mac` are for cross compiling between macOS and Linux
 
-`make install_helper` will scp the gpbackup_helper binary (used with -single-data-file flag) to all hosts
-
-## Running the utilities
-
-The basic command for gpbackup is
-```bash
-gpbackup --dbname <your_db_name>
-```
-
-The basic command for gprestore is
-```bash
-gprestore --timestamp <YYYYMMDDHHMMSS>
-```
-
-Run `--help` with either command for a complete list of options.
+`make install_helper` will scp the `gpbackup_helper` binary (used with -single-data-file flag) to all hosts
 
 ## Validation and code quality
 
-To run all tests except end-to-end (unit, integration, and linters), use
+### Test setup
+
+Required for Greenplum Database 6 or higher, several tests require the `dummy_seclabel` Greenplum contrib module. This module exists only to support regression testing of the SECURITY LABEL statement. It is not intended to be used in production. Use the following commands to install the module.
+
+```bash
+pushd ~/workspace/gpdb/contrib/dummy_seclabel
+    make install
+    gpconfig -c shared_preload_libraries -v dummy_seclabel
+    gpstop -ra
+    gpconfig -s shared_preload_libraries | grep dummy_seclabel
+popd
+
+```
+
+### Test execution
+
+**NOTE**: The integration and end_to_end tests require a running Greenplum Database instance.
+
+To run all tests except end-to-end (linters, unit, and integration), use
 ```bash
 make test
 ```
@@ -54,12 +59,12 @@ To run only unit tests, use
 ```bash
 make unit
 ```
-To run only integration tests (which require a running GPDB instance), use
+To run only integration tests (requires a running GPDB instance), use
 ```bash
 make integration
 ```
 
-To run end to end tests, use
+To run end to end tests (requires a running GPDB instance), use
 ```bash
 make end_to_end
 ```
@@ -82,6 +87,20 @@ make format
 This target runs [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports) and [gofmt](https://golang.org/cmd/gofmt/).
 We will only accept code that has been formatted using this target or an equivalent `gofmt` call.
 
+## Running the utilities
+
+The basic command for gpbackup is
+```bash
+gpbackup --dbname <your_db_name>
+```
+
+The basic command for gprestore is
+```bash
+gprestore --timestamp <YYYYMMDDHHMMSS>
+```
+
+Run `--help` with either command for a complete list of options.
+
 ## Cleaning up
 
 To remove the compiled binaries and other generated files, run
@@ -91,7 +110,7 @@ make clean
 
 # More Information
 
-The GitHub wiki for this project has several articles providing a more in-depth explanation of certain aspects of gpbackup and gprestore.
+The Greenplum Backup [wiki](https://github.com/greenplum-db/gpbackup/wiki) for this project has several articles providing a more in-depth explanation of certain aspects of gpbackup and gprestore.
 
 # How to Contribute
 
@@ -116,7 +135,10 @@ Overall we follow GPDB's comprehensive contribution policy. Please refer to it [
 
 # Troubleshooting
 
-On macOS, if you see errors in many integration tests, such as:
+## Dummy Security Label module is not installed or configured
+
+If you see errors in many integration tests (below), review the
+Validation and code quality [Test setup](#Test setup) section above:
 
 ```
 SECURITY LABEL FOR dummy ON TYPE public.testtype IS 'unclassified';
@@ -127,14 +149,17 @@ SECURITY LABEL FOR dummy ON TYPE public.testtype IS 'unclassified';
               Message: "security label provider \"dummy\" is not loaded",
 ```
 
-then you need to load a "dummy" security label, by using the gpdb tool in `gpdb/contrib/dummy_seclabel`. A utility script for this is:
+## Tablespace already exists
 
-```bash
-pushd ~/workspace/gpdb/contrib/dummy_seclabel
-    make install
-    gpconfig -c shared_preload_libraries -v dummy_seclabel
-    gpstop -ra
-    gpconfig -s shared_preload_libraries | grep dummy_seclabel
-popd
+If you see errors indicating the `test_tablespace` tablespace already
+exists (below), execute `psql postgres -c 'DROP TABLESPACE
+test_tablespace'` to cleanup the environment and rerun the tests.
 
+```
+    CREATE TABLESPACE test_tablespace LOCATION '/tmp/test_dir'
+    Expected
+        <pgx.PgError>: {
+            Severity: "ERROR",
+            Code: "42710",
+            Message: "tablespace \"test_tablespace\" already exists",
 ```


### PR DESCRIPTION
I have updated the GPBackup README.me file based on my build and test session. I was able to successfully perform a Greenplum (with orca) and GPBackup builds and test runs.

For reference, the following captures my environment:

```
✔ ~/go/src/github.com/greenplum-db/gpbackup [README-ubuntu-18.04-update|✚ 2]
12:10 $   gcc --version
gcc (Ubuntu 7.3.0-27ubuntu1~18.04) 7.3.0
Copyright (C) 2017 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

✔ ~/go/src/github.com/greenplum-db/gpbackup [README-ubuntu-18.04-update|✚ 1]
13:55 $   go version
go version go1.11.5 linux/amd64
✔ ~/go/src/github.com/greenplum-db/gpbackup [README-ubuntu-18.04-update|✚ 1]
13:55 $   postgres --gp-version
postgres (Greenplum Database) 6.0.0-alpha.0+dev.15791.ge2c8b17863 build dev-oss
✔ ~/go/src/github.com/greenplum-db/gpbackup [README-ubuntu-18.04-update|✚ 1]
13:55 $   psql template1 -c 'select gp_opt_version()'
                gp_opt_version
----------------------------------------------
 GPOPT version: 3.23.3, Xerces version: 3.1.2
(1 row)
```