### PR TITLE
Close history file after writing

### DIFF
--- a/backup_history/history.go
+++ b/backup_history/history.go
@@ -147,6 +147,12 @@ func (history *History) WriteToFileAndMakeReadOnly(filename string) error {
 		return err
 	}
 	historyFile := iohelper.MustOpenFileForWriting(filename)
+	defer func() {
+		err = historyFile.Close()
+		if err != nil {
+			gplog.Warn("cannot close history file: %v", err)
+		}
+	}()
 	_, err = historyFile.Write(historyFileContents)
 	if err != nil {
 		return err


### PR DESCRIPTION
We have seen two instances of corruption of the backup_history file that occured when `gpbackup` was run in a tight loop during testing. It could be a race condition that happens because the history file was not closed after writing to it (a posix system always [closes files](http://pubs.opengroup.org/onlinepubs/9699919799/functions/_Exit.html#tag_16_01_03_01) left behind by the process, at some time after process exits). However, as a race, a repro has been difficult to make repeatable.
