### PR TITLE
remove Collate information when backing up External tables

### DIFF
--- a/backup/predata_acl.go
+++ b/backup/predata_acl.go
@@ -50,6 +50,36 @@ type ACL struct {
 	ConnectWithGrant    bool
 }
 
+func (acl ACL) Clone() ACL {
+	return ACL{
+		Grantee:             acl.Grantee,
+		Select:              acl.Select,
+		SelectWithGrant:     acl.SelectWithGrant,
+		Insert:              acl.Insert,
+		InsertWithGrant:     acl.InsertWithGrant,
+		Update:              acl.Update,
+		UpdateWithGrant:     acl.UpdateWithGrant,
+		Delete:              acl.Delete,
+		DeleteWithGrant:     acl.DeleteWithGrant,
+		Truncate:            acl.Truncate,
+		TruncateWithGrant:   acl.TruncateWithGrant,
+		References:          acl.References,
+		ReferencesWithGrant: acl.ReferencesWithGrant,
+		Trigger:             acl.Trigger,
+		TriggerWithGrant:    acl.TriggerWithGrant,
+		Usage:               acl.Usage,
+		UsageWithGrant:      acl.UsageWithGrant,
+		Execute:             acl.Execute,
+		ExecuteWithGrant:    acl.ExecuteWithGrant,
+		Create:              acl.Create,
+		CreateWithGrant:     acl.CreateWithGrant,
+		Temporary:           acl.Temporary,
+		TemporaryWithGrant:  acl.TemporaryWithGrant,
+		Connect:             acl.Connect,
+		ConnectWithGrant:    acl.ConnectWithGrant,
+	}
+}
+
 type MetadataMap map[UniqueID]ObjectMetadata
 
 func PrintStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, obj utils.TOCObject, statements []string) {

--- a/backup/queries_table_defs.go
+++ b/backup/queries_table_defs.go
@@ -186,6 +186,36 @@ type ColumnDefinition struct {
 	SecurityLabel         string
 }
 
+func (cd ColumnDefinition) Clone() ColumnDefinition {
+	result := ColumnDefinition{
+		Oid:                   cd.Oid,
+		Num:                   cd.Num,
+		Name:                  cd.Name,
+		NotNull:               cd.NotNull,
+		HasDefault:            cd.HasDefault,
+		Type:                  cd.Type,
+		Encoding:              cd.Encoding,
+		StatTarget:            cd.StatTarget,
+		StorageType:           cd.StorageType,
+		DefaultVal:            cd.DefaultVal,
+		Comment:               cd.Comment,
+		Options:               cd.Options,
+		FdwOptions:            cd.FdwOptions,
+		Collation:             cd.Collation,
+		SecurityLabelProvider: cd.SecurityLabelProvider,
+		SecurityLabel:         cd.SecurityLabel,
+	}
+
+	if cd.ACL != nil {
+		result.ACL = make([]ACL, 0)
+		for _, acl := range cd.ACL {
+			result.ACL = append(result.ACL, acl.Clone())
+		}
+	}
+
+	return result
+}
+
 var storageTypeCodes = map[string]string{
 	"e": "EXTERNAL",
 	"m": "MAIN",


### PR DESCRIPTION
External tables cannot restore any COLLATE information about attributes. Therefore, if that information is present when backing up, ignore it within the metadata for external tables.