### PR TITLE
Support check constraints on parent and child tables

### DIFF
--- a/backup/predata_shared.go
+++ b/backup/predata_shared.go
@@ -37,8 +37,9 @@ func PrintConstraintStatements(metadataFile *utils.FileWithByteCount, toc *utils
 		if constraint.IsDomainConstraint {
 			continue
 		}
+		// ConIsLocal should always return true from GetConstraints because we filter out constraints that are inherited using the INHERITS clause, or inherited from a parent partition table. This field only accurately reflects constraints in GPDB6+ because check constraints on parent tables must propogate to children. For GPDB versions 5 or lower, this field will default to false.
 		objStr := "TABLE ONLY"
-		if constraint.IsPartitionParent {
+		if constraint.IsPartitionParent || (constraint.ConType == "c" && constraint.ConIsLocal) {
 			objStr = "TABLE"
 		}
 		metadataFile.MustPrintf(alterStr, objStr, constraint.OwningObject, constraint.Name, constraint.ConDef)

--- a/backup/predata_shared_test.go
+++ b/backup/predata_shared_test.go
@@ -137,6 +137,12 @@ var _ = Describe("backup/predata_shared tests", func() {
 				backup.PrintConstraintStatements(backupfile, toc, constraints, emptyMetadataMap)
 				testutils.AssertBufferContents(toc.PostdataEntries, buffer, `ALTER TABLE public.tablename ADD CONSTRAINT tablename_i_key UNIQUE (i);`)
 			})
+			It("prints an ADD CONSTRAINT [name] CHECK statement without keyword ONLY for a table with descendants (another table inherits it)", func() {
+				checkConstraint := backup.Constraint{Oid: 0, Name: "check1", ConType: "c", ConDef: "CHECK (VALUE <> 42::numeric)", OwningObject: "public.tablename", IsDomainConstraint: false, IsPartitionParent: false, ConIsLocal: true}
+				constraints := []backup.Constraint{checkConstraint}
+				backup.PrintConstraintStatements(backupfile, toc, constraints, emptyMetadataMap)
+				testutils.AssertBufferContents(toc.PostdataEntries, buffer, `ALTER TABLE public.tablename ADD CONSTRAINT check1 CHECK (VALUE <> 42::numeric);`)
+			})
 		})
 	})
 	Describe("PrintCreateSchemaStatements", func() {

--- a/integration/predata_shared_create_test.go
+++ b/integration/predata_shared_create_test.go
@@ -69,6 +69,14 @@ var _ = Describe("backup integration create statement tests", func() {
 			partitionCheckConstraint = backup.Constraint{Oid: 0, Schema: "public", Name: "check1", ConType: "c", ConDef: "CHECK (id <> 0)", OwningObject: "public.part", IsDomainConstraint: false, IsPartitionParent: true}
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.testtable(a int, b text) DISTRIBUTED BY (b)")
 			conMetadataMap = backup.MetadataMap{}
+
+			if connectionPool.Version.AtLeast("6") {
+				uniqueConstraint.ConIsLocal = true
+				pkConstraint.ConIsLocal = true
+				fkConstraint.ConIsLocal = true
+				checkConstraint.ConIsLocal = true
+				partitionCheckConstraint.ConIsLocal = true
+			}
 		})
 		AfterEach(func() {
 			testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.testtable CASCADE")


### PR DESCRIPTION
Previously, it was possible to add check constraints to tables which
have inherited tables underneath it without the constraint propagating
to its children.  This is changed in GPDB6 since check constraints on
parent tables MUST also be applied to it's children.

It's unsure if we can just change all constraint statements to not use the ONLY keyword constraint so I took a safe approach. 