### PR TITLE
Fix missing Function ACLs

### DIFF
--- a/backup/queries_acl.go
+++ b/backup/queries_acl.go
@@ -65,7 +65,7 @@ var (
 )
 
 func InitializeMetadataParams(connectionPool *dbconn.DBConn) {
-	TYPE_AGGREGATE = MetadataQueryParams{NameField: "proname", SchemaField: "pronamespace", OwnerField: "proowner", CatalogTable: "pg_proc"}
+	TYPE_AGGREGATE = MetadataQueryParams{NameField: "proname", SchemaField: "pronamespace", ACLField: "proacl", OwnerField: "proowner", CatalogTable: "pg_proc"}
 	TYPE_CAST = MetadataQueryParams{NameField: "typname", OidField: "oid", OidTable: "pg_type", CatalogTable: "pg_cast"}
 	TYPE_COLLATION = MetadataQueryParams{NameField: "collname", OidField: "oid", SchemaField: "collnamespace", OwnerField: "collowner", CatalogTable: "pg_collation"}
 	TYPE_CONSTRAINT = MetadataQueryParams{NameField: "conname", SchemaField: "connamespace", OidField: "oid", CatalogTable: "pg_constraint"}
@@ -75,7 +75,7 @@ func InitializeMetadataParams(connectionPool *dbconn.DBConn) {
 	TYPE_EXTENSION = MetadataQueryParams{NameField: "extname", OidField: "oid", CatalogTable: "pg_extension"}
 	TYPE_FOREIGNDATAWRAPPER = MetadataQueryParams{NameField: "fdwname", ACLField: "fdwacl", OwnerField: "fdwowner", CatalogTable: "pg_foreign_data_wrapper"}
 	TYPE_FOREIGNSERVER = MetadataQueryParams{NameField: "srvname", ACLField: "srvacl", OwnerField: "srvowner", CatalogTable: "pg_foreign_server"}
-	TYPE_FUNCTION = MetadataQueryParams{NameField: "proname", SchemaField: "pronamespace", ACLField: "proacl", OwnerField: "proowner", CatalogTable: "pg_proc"}
+	TYPE_FUNCTION = TYPE_AGGREGATE // Aggregates are functions. So the metadata call to get them are the same.
 	TYPE_INDEX = MetadataQueryParams{NameField: "relname", OidField: "indexrelid", OidTable: "pg_class", CommentTable: "pg_class", CatalogTable: "pg_index"}
 	TYPE_PROCLANGUAGE = MetadataQueryParams{NameField: "lanname", ACLField: "lanacl", CatalogTable: "pg_language"}
 	if connectionPool.Version.Before("5") {

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -304,6 +304,11 @@ func RetrieveAggregates(sortables *[]Sortable, metadataMap MetadataMap) {
 	gplog.Verbose("Retrieving AGGREGATE information")
 	aggregates := GetAggregates(connectionPool)
 	objectCounts["Aggregates"] = len(aggregates)
+	/* This call to get Metadata for Aggregates, although redundant, is preserved for
+	 * consistency with other, similar methods.  The metadata for aggregate
+	 * are located on the same catalog table as functions (pg_proc). This means that when we
+	 * get function metadata we also get aggregate metadata at the same time.
+	 */
 	aggMetadata := GetMetadataForObjectType(connectionPool, TYPE_AGGREGATE)
 
 	*sortables = append(*sortables, convertToSortableSlice(aggregates)...)

--- a/integration/predata_acl_queries_test.go
+++ b/integration/predata_acl_queries_test.go
@@ -252,10 +252,16 @@ LANGUAGE SQL`)
 				testhelper.AssertQueryRuns(connectionPool, "COMMENT ON AGGREGATE public.agg_prefunc(numeric, numeric) IS 'This is an aggregate comment.'")
 				testutils.CreateSecurityLabelIfGPDB6(connectionPool, "AGGREGATE", "public.agg_prefunc(numeric, numeric)")
 
+				testhelper.AssertQueryRuns(connectionPool, `
+				GRANT ALL ON FUNCTION public.agg_prefunc(numeric, numeric)
+				  to testrole`)
+				testhelper.AssertQueryRuns(connectionPool, `
+				REVOKE ALL ON FUNCTION public.agg_prefunc(numeric, numeric) FROM public`)
+
 				resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_AGGREGATE)
 
 				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "", "agg_prefunc", backup.TYPE_AGGREGATE)
-				expectedMetadata := testutils.DefaultMetadata("AGGREGATE", false, true, true, includeSecurityLabels)
+				expectedMetadata := testutils.DefaultMetadata("AGGREGATE", true, true, true, includeSecurityLabels)
 				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})

--- a/testutils/functions.go
+++ b/testutils/functions.go
@@ -184,7 +184,7 @@ func DefaultACLForType(grantee string, objType string) backup.ACL {
 		References: objType == "TABLE" || objType == "VIEW" || objType == "FOREIGN TABLE",
 		Trigger:    objType == "TABLE" || objType == "VIEW" || objType == "FOREIGN TABLE",
 		Usage:      objType == "LANGUAGE" || objType == "SCHEMA" || objType == "SEQUENCE" || objType == "FOREIGN DATA WRAPPER" || objType == "FOREIGN SERVER",
-		Execute:    objType == "FUNCTION",
+		Execute:    objType == "FUNCTION" || objType == "AGGREGATE",
 		Create:     objType == "DATABASE" || objType == "SCHEMA" || objType == "TABLESPACE",
 		Temporary:  objType == "DATABASE",
 		Connect:    objType == "DATABASE",


### PR DESCRIPTION
Aggregates are extensions of functions so they also get entries in catalogTable.pg_proc where the ACLs are stored. This means getting ACLs for functions and aggregates should be exactly the same. When getting metadata for functions we also get aggregate ACLs and stored them to metadataMap. The issue here is that the same ACLs were retrieved twice and for the second retrieval the TYPE_AGGREGATES was not configured to retrieve ACLs. So when we got aggregate (and function) metadata it would clobber the entries initially put in by function metadata retrieval.