### PR TITLE
Change WriteOidListToSegments() to use `scp`

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -11,7 +11,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:1ad04ae56ea7834dde93c04ef840866d4a93756bb5cc946931eff919bf94dd8b"
+  digest = "1:d9509205ededc8c81a68c1332f97a7009ed45d7649b6a0d838628ea91ba3e9e8"
   name = "github.com/greenplum-db/gp-common-go-libs"
   packages = [
     "cluster",
@@ -23,7 +23,7 @@
     "testhelper",
   ]
   pruneopts = "NUT"
-  revision = "dc5314443bdb1cf8187e69bec712349a69d6918e"
+  revision = "4580a3f68ffe89bcd3ed5ff87ba27d3df6d47bd3"
 
 [[projects]]
   digest = "1:41933d387bfa3eaa6a82647914ed7044f7b8355764c24fb920892bc8c03ef0c3"
@@ -201,15 +201,15 @@
     "html/charset",
   ]
   pruneopts = "NUT"
-  revision = "3a22650c66bd7f4fb6d1e8072ffd7b75c8a27898"
+  revision = "92fc7df08ae7536330f5a21328292abfa70520a8"
 
 [[projects]]
   branch = "master"
-  digest = "1:b1085269f659d40b582e254edea4b3ab5948e2e9b85669f0da05ef3469aac2ca"
+  digest = "1:0fe83e0566880bb72802c5cb87f5b5049d495f3f34132cae075d6b98a040a6fe"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "NUT"
-  revision = "e77772198cdc3dbfcf7f2de96630204df9fd3a0b"
+  revision = "a34e9553db1e492c9a76e60db2296ae7e5fbb772"
 
 [[projects]]
   digest = "1:7c61a813b250ba8bb02bebb0382e6c3d00e04da2b577dc58985b86312fb89ffd"
@@ -239,7 +239,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:849e1ab274cc58121de7558d8cad12bf9dfe65d8315f3a081126c8442c66455e"
+  digest = "1:7ddcb389cead44e26b0a4570d464cddd3c463c787725e1b781f4fe6d4fbea0dd"
   name = "golang.org/x/tools"
   packages = [
     "cmd/goimports",
@@ -257,7 +257,7 @@
     "internal/semver",
   ]
   pruneopts = "NUT"
-  revision = "8dcb7bc8c7fe0a895995c76c721cef79419ac98a"
+  revision = "589c23e65e65055d47b9ad4a99723bc389136265"
 
 [[projects]]
   digest = "1:df28176ae6eed6b64b667963455f4b60c17ecb2594e6ffa72f149b911ea15fa4"
@@ -268,12 +268,12 @@
   version = "v1.3.2"
 
 [[projects]]
-  digest = "1:30f55ee34f367e29620faaae69dcdf6b78a86348f3a1472cf63f2dbba0f9d4f7"
+  digest = "1:21562b59c496f4cbd7a40beaa257ac6761002dd3e36259f532216082abace8b1"
   name = "gopkg.in/cheggaaa/pb.v1"
   packages = ["."]
   pruneopts = "NUT"
-  revision = "1cc5bbe20449079337944d56292c7383510c534c"
-  version = "v1.0.27"
+  revision = "f907f6f5dd81f77c2bbc1cde92e4c5a04720cb11"
+  version = "v1.0.28"
 
 [[projects]]
   digest = "1:1b91ae0dc69a41d4c2ed23ea5cffb721ea63f5037ca4b81e6d6771fbb8f45129"

--- a/integration/agent_remote_test.go
+++ b/integration/agent_remote_test.go
@@ -1,0 +1,54 @@
+package integration
+
+import (
+	"fmt"
+
+	"github.com/greenplum-db/gp-common-go-libs/cluster"
+	"github.com/greenplum-db/gpbackup/backup_filepath"
+	"github.com/greenplum-db/gpbackup/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("agent remote", func() {
+	var (
+		oidList     []string
+		filePath    backup_filepath.FilePathInfo
+		testCluster *cluster.Cluster
+	)
+	BeforeEach(func() {
+		oidList = []string{"1", "2", "3"}
+		segConfig := cluster.MustGetSegmentConfiguration(connectionPool)
+		testCluster = cluster.NewCluster(segConfig)
+		filePath = backup_filepath.NewFilePathInfo(testCluster, "my_dir", "20190102030405", backup_filepath.GetSegPrefix(connectionPool))
+	})
+	Describe("WriteOidListToSegments()", func() {
+		It("writes oids to a temp file and copies it to all segments", func() {
+			utils.WriteOidListToSegments(oidList, testCluster, filePath)
+
+			remoteOutput := testCluster.GenerateAndExecuteCommand("ensure oid file was written to segments", func(contentID int) string {
+				remoteOidFile := filePath.GetSegmentHelperFilePath(contentID, "oid")
+				return fmt.Sprintf("cat %s", remoteOidFile)
+			}, cluster.ON_SEGMENTS)
+			defer func() {
+				remoteOutputRemoval := testCluster.GenerateAndExecuteCommand("ensure oid file removed", func(contentID int) string {
+					remoteOidFile := filePath.GetSegmentHelperFilePath(contentID, "oid")
+					return fmt.Sprintf("rm %s", remoteOidFile)
+				}, cluster.ON_SEGMENTS)
+				testCluster.CheckClusterError(remoteOutputRemoval, "Could not remove oid file", func(contentID int) string {
+					return "Could not remove oid file"
+				})
+			}()
+
+			// Ensure: command did not fail to execute
+			testCluster.CheckClusterError(remoteOutput, "Could not cat oid file", func(contentID int) string {
+				return "Could not cat oid file"
+			})
+
+			// Ensure: proper contents were written to STDOUT
+			for _, stdout := range remoteOutput.Stdouts {
+				Expect(stdout).To(Equal("1\n2\n3\n"))
+			}
+		})
+	})
+})

--- a/utils/agent_remote_test.go
+++ b/utils/agent_remote_test.go
@@ -1,0 +1,58 @@
+package utils_test
+
+import (
+	"github.com/greenplum-db/gp-common-go-libs/cluster"
+	"github.com/greenplum-db/gp-common-go-libs/testhelper"
+	"github.com/greenplum-db/gpbackup/backup_filepath"
+	"github.com/greenplum-db/gpbackup/utils"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+)
+
+var _ = Describe("agent remote", func() {
+	var (
+		testCluster  *cluster.Cluster
+		testExecutor *testhelper.TestExecutor
+	)
+	BeforeEach(func() {
+		masterSeg := cluster.SegConfig{ContentID: -1, Hostname: "localhost", DataDir: "/data/gpseg-1"}
+		localSegOne := cluster.SegConfig{ContentID: 0, Hostname: "localhost", DataDir: "/data/gpseg0"}
+		remoteSegOne := cluster.SegConfig{ContentID: 1, Hostname: "remotehost1", DataDir: "/data/gpseg1"}
+
+		testExecutor = &testhelper.TestExecutor{
+			ClusterOutput: &cluster.RemoteOutput{},
+		}
+		testCluster = cluster.NewCluster([]cluster.SegConfig{masterSeg, localSegOne, remoteSegOne})
+		testCluster.Executor = testExecutor
+
+	})
+	It("calls the correct command to copy the OID list", func() {
+
+		oidList := []string{"1", "2", "3"}
+		filePath := backup_filepath.NewFilePathInfo(testCluster, "my_dir", "20190102030405", "my_user_seg_prefix")
+
+		utils.WriteOidListToSegments(oidList, testCluster, filePath)
+
+		Expect(testExecutor.ClusterCommands).To(HaveLen(1))
+		Expect(testExecutor.ClusterCommands[0][0][4]).To(ContainSubstring("echo \"1\n2\n3\" > /data/gpseg0/gpbackup_0_20190102030405_oid_"))
+	})
+	It("it panics and prints error message to log when execution fails", func() {
+		failingExecutor := &testhelper.TestExecutor{
+			ClusterOutput: &cluster.RemoteOutput{
+				NumErrors: 1,
+				Errors:    map[int]error{0: errors.New("test error")},
+			},
+		}
+		emptyCluster := cluster.Cluster{
+			Segments: map[int]cluster.SegConfig{},
+			Executor: failingExecutor,
+		}
+
+		oidList := []string{"1", "2", "3"}
+		filePath := backup_filepath.NewFilePathInfo(&emptyCluster, "my_dir", "20190102030405", "my_user_seg_prefix")
+
+		Expect(func() { utils.WriteOidListToSegments(oidList, &emptyCluster, filePath) }).To(Panic())
+		Expect(string(logfile.Contents())).To(ContainSubstring(`-Unable to write oid list to segments on 1 segment`))
+	})
+})

--- a/utils/agent_remote_test.go
+++ b/utils/agent_remote_test.go
@@ -1,10 +1,15 @@
 package utils_test
 
 import (
+	"io"
+	"os"
+
+	"github.com/greenplum-db/gpbackup/utils"
+
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
+	"github.com/greenplum-db/gp-common-go-libs/operating"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup/backup_filepath"
-	"github.com/greenplum-db/gpbackup/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
@@ -12,47 +17,122 @@ import (
 
 var _ = Describe("agent remote", func() {
 	var (
-		testCluster  *cluster.Cluster
-		testExecutor *testhelper.TestExecutor
+		oidList []string
 	)
 	BeforeEach(func() {
-		masterSeg := cluster.SegConfig{ContentID: -1, Hostname: "localhost", DataDir: "/data/gpseg-1"}
-		localSegOne := cluster.SegConfig{ContentID: 0, Hostname: "localhost", DataDir: "/data/gpseg0"}
-		remoteSegOne := cluster.SegConfig{ContentID: 1, Hostname: "remotehost1", DataDir: "/data/gpseg1"}
-
-		testExecutor = &testhelper.TestExecutor{
-			ClusterOutput: &cluster.RemoteOutput{},
+		oidList = []string{"1", "2", "3"}
+		operating.System.OpenFileWrite = func(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
+			return buffer, nil
 		}
-		testCluster = cluster.NewCluster([]cluster.SegConfig{masterSeg, localSegOne, remoteSegOne})
-		testCluster.Executor = testExecutor
-
+		operating.System.Remove = func(name string) error {
+			return nil
+		}
 	})
-	It("calls the correct command to copy the OID list", func() {
+	Describe("WriteOidListToSegments()", func() {
+		var (
+			filePath     backup_filepath.FilePathInfo
+			testCluster  *cluster.Cluster
+			testExecutor *testhelper.TestExecutor
+		)
+		BeforeEach(func() {
+			masterSeg := cluster.SegConfig{ContentID: -1, Hostname: "localhost", DataDir: "/data/gpseg-1"}
+			localSegOne := cluster.SegConfig{ContentID: 0, Hostname: "localhost", DataDir: "/data/gpseg0"}
+			remoteSegOne := cluster.SegConfig{ContentID: 1, Hostname: "remotehost1", DataDir: "/data/gpseg1"}
 
-		oidList := []string{"1", "2", "3"}
-		filePath := backup_filepath.NewFilePathInfo(testCluster, "my_dir", "20190102030405", "my_user_seg_prefix")
+			testExecutor = &testhelper.TestExecutor{
+				ErrorOnExecNum: -1,
+			}
+			testCluster = cluster.NewCluster([]cluster.SegConfig{masterSeg, localSegOne, remoteSegOne})
+			testCluster.Executor = testExecutor
+			filePath = backup_filepath.NewFilePathInfo(testCluster, "my_dir", "20190102030405", "my_user_seg_prefix")
+		})
+		It("writes oid list, delimited by newline characters, to temp file", func() {
+			utils.WriteOidListToSegments(oidList, testCluster, filePath)
 
-		utils.WriteOidListToSegments(oidList, testCluster, filePath)
+			Expect(string(buffer.Contents())).To(Equal("1\n2\n3\n"))
+		})
+		It("generates the correct command to copy the OID list", func() {
+			utils.WriteOidListToSegments(oidList, testCluster, filePath)
 
-		Expect(testExecutor.ClusterCommands).To(HaveLen(1))
-		Expect(testExecutor.ClusterCommands[0][0][4]).To(ContainSubstring("echo \"1\n2\n3\" > /data/gpseg0/gpbackup_0_20190102030405_oid_"))
+			// one command per segment
+			Expect(testExecutor.LocalCommands).To(HaveLen(2))
+			Expect(testExecutor.LocalCommands[0]).To(MatchRegexp(`^scp /tmp/gpbackup-oids\d+ localhost:/data/gpseg0/gpbackup_0_20190102030405_oid_\d+$`))
+			Expect(testExecutor.LocalCommands[1]).To(MatchRegexp(`^scp /tmp/gpbackup-oids\d+ remotehost1:/data/gpseg1/gpbackup_1_20190102030405_oid_\d+$`))
+		})
+		It("panics and prints when command execution fails", func() {
+			failingExecutor := &testhelper.TestExecutor{
+				LocalError: errors.New("command execution error"),
+			}
+			testCluster.Executor = failingExecutor
+
+			Expect(func() { utils.WriteOidListToSegments(oidList, testCluster, filePath) }).To(Panic())
+			Expect(string(logfile.Contents())).To(MatchRegexp(`.*command execution error.*`))
+		})
+		It("logs a warning when temp file cannot be removed", func() {
+			operating.System.Remove = func(name string) error {
+				return errors.New("failed to remove oid temp file")
+			}
+
+			utils.WriteOidListToSegments(oidList, testCluster, filePath)
+			Expect(string(logfile.Contents())).To(MatchRegexp(`.*\[WARNING\]:-.*failed to remove oid temp file.*`))
+		})
 	})
-	It("it panics and prints error message to log when execution fails", func() {
-		failingExecutor := &testhelper.TestExecutor{
-			ClusterOutput: &cluster.RemoteOutput{
-				NumErrors: 1,
-				Errors:    map[int]error{0: errors.New("test error")},
-			},
-		}
-		emptyCluster := cluster.Cluster{
-			Segments: map[int]cluster.SegConfig{},
-			Executor: failingExecutor,
-		}
+	Describe("WriteOidsToFile()", func() {
+		It("writes oid list, delimited by newline characters", func() {
+			utils.WriteOidsToFile("myFilename", oidList)
 
-		oidList := []string{"1", "2", "3"}
-		filePath := backup_filepath.NewFilePathInfo(&emptyCluster, "my_dir", "20190102030405", "my_user_seg_prefix")
+			Expect(string(buffer.Contents())).To(Equal("1\n2\n3\n"))
+		})
+		It("panics and prints when it cannot open local oid file", func() {
+			operating.System.OpenFileWrite = func(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
+				return nil, errors.New("cannot open local oid file")
+			}
 
-		Expect(func() { utils.WriteOidListToSegments(oidList, &emptyCluster, filePath) }).To(Panic())
-		Expect(string(logfile.Contents())).To(ContainSubstring(`-Unable to write oid list to segments on 1 segment`))
+			Expect(func() { utils.WriteOidsToFile("filename", oidList) }).To(Panic())
+			Expect(string(logfile.Contents())).To(ContainSubstring(`cannot open local oid file`))
+		})
+		It("panics and prints when it cannot close local oid file", func() {
+			operating.System.OpenFileWrite = func(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
+				return testWriter{CloseErr: errors.New("cannot close local oid file")}, nil
+			}
+
+			Expect(func() { utils.WriteOidsToFile("filename", oidList) }).To(Panic())
+			Expect(string(logfile.Contents())).To(ContainSubstring(`cannot close local oid file`))
+		})
+		It("panics and prints when WriteOids returns an error", func() {
+			operating.System.OpenFileWrite = func(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
+				return testWriter{WriteErr: errors.New("WriteOids returned err")}, nil
+			}
+
+			Expect(func() { utils.WriteOidsToFile("filename", oidList) }).To(Panic())
+			Expect(string(logfile.Contents())).To(ContainSubstring("WriteOids returned err"))
+		})
+	})
+	Describe("WriteOids()", func() {
+		It("writes oid list, delimited by newline characters", func() {
+			err := utils.WriteOids(buffer, oidList)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(string(buffer.Contents())).To(Equal("1\n2\n3\n"))
+		})
+		It("returns an error if it fails to write an oid", func() {
+			tw := testWriter{}
+			tw.WriteErr = errors.New("fail oid write")
+
+			err := utils.WriteOids(tw, oidList)
+			Expect(err).To(Equal(tw.WriteErr))
+		})
 	})
 })
+
+type testWriter struct {
+	WriteErr error
+	CloseErr error
+}
+
+func (f testWriter) Write(p []byte) (n int, err error) {
+	return 0, f.WriteErr
+}
+func (f testWriter) Close() error {
+	return f.CloseErr
+}


### PR DESCRIPTION
Previously, OIDs were transmitted to segments without `scp`, via "echo". However, a large enough database will have a million OIDs, which can blow out the capacity of a single command line.
