### PR TITLE
Fix Print*Statements to handle '%'

### DIFF
--- a/backup/predata_externals.go
+++ b/backup/predata_externals.go
@@ -289,18 +289,18 @@ func PrintExternalTableStatements(metadataFile *utils.FileWithByteCount, tableNa
 	}
 	if extTableDef.Type == READABLE_WEB || extTableDef.Type == WRITABLE_WEB {
 		if extTableDef.Command != "" {
-			metadataFile.MustPrintf(generateExecuteStatement(extTableDef))
+			metadataFile.MustPrint(generateExecuteStatement(extTableDef))
 		}
 	}
 	metadataFile.MustPrintln()
-	metadataFile.MustPrintf(GenerateFormatStatement(extTableDef))
+	metadataFile.MustPrint(GenerateFormatStatement(extTableDef))
 	metadataFile.MustPrintln()
 	if extTableDef.Options != "" {
 		metadataFile.MustPrintf("OPTIONS (\n\t%s\n)\n", extTableDef.Options)
 	}
 	metadataFile.MustPrintf("ENCODING '%s'", extTableDef.Encoding)
 	if extTableDef.Type == READABLE || extTableDef.Type == READABLE_WEB {
-		metadataFile.MustPrintf(generateLogErrorStatement(extTableDef, tableName))
+		metadataFile.MustPrint(generateLogErrorStatement(extTableDef, tableName))
 	}
 }
 

--- a/backup/predata_externals_test.go
+++ b/backup/predata_externals_test.go
@@ -347,6 +347,14 @@ ENCODING 'UTF-8'`)
 				Expect(resultStatement).To(Equal(`FORMAT 'TEXT' (delimiter E' ' null E'
 ' escape E'	')`))
 			})
+			It("generates a FORMAT statement delimiter of special char", func() {
+				extTableDef.FormatType = "t"
+				extTableDef.FormatOpts = `delimiter '%' null '' escape 'OFF'`
+
+				resultStatement := backup.GenerateFormatStatement(extTableDef)
+
+				Expect(resultStatement).To(Equal(`FORMAT 'TEXT' (delimiter E'%' null E'' escape E'OFF')`))
+			})
 		})
 		Context("CSV format", func() {
 			It("generates a FORMAT statement with no options provided", func() {

--- a/backup/predata_functions.go
+++ b/backup/predata_functions.go
@@ -271,7 +271,7 @@ func PrintCreateLanguageStatements(metadataFile *utils.FileWithByteCount, toc *u
 		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 
 		start = metadataFile.ByteCount
-		metadataFile.MustPrintf(alterStr)
+		metadataFile.MustPrint(alterStr)
 		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 
 		PrintObjectMetadata(metadataFile, toc, procLangMetadata[procLang.GetUniqueID()], procLang, "")

--- a/utils/io.go
+++ b/utils/io.go
@@ -127,3 +127,11 @@ func (file *FileWithByteCount) MustPrintf(s string, v ...interface{}) {
 	}
 	file.ByteCount += uint64(bytesWritten)
 }
+
+func (file *FileWithByteCount) MustPrint(s string) {
+	bytesWritten, err := fmt.Fprint(file.writer, s)
+	if err != nil {
+		gplog.Fatal(err, "Unable to write to file")
+	}
+	file.ByteCount += uint64(bytesWritten)
+}

--- a/utils/io.go
+++ b/utils/io.go
@@ -114,24 +114,18 @@ func (file *FileWithByteCount) Close() {
 
 func (file *FileWithByteCount) MustPrintln(v ...interface{}) {
 	bytesWritten, err := fmt.Fprintln(file.writer, v...)
-	if err != nil {
-		gplog.Fatal(err, "Unable to write to file")
-	}
+	gplog.FatalOnError(err, "Unable to write to file")
 	file.ByteCount += uint64(bytesWritten)
 }
 
 func (file *FileWithByteCount) MustPrintf(s string, v ...interface{}) {
 	bytesWritten, err := fmt.Fprintf(file.writer, s, v...)
-	if err != nil {
-		gplog.Fatal(err, "Unable to write to file")
-	}
+	gplog.FatalOnError(err, "Unable to write to file")
 	file.ByteCount += uint64(bytesWritten)
 }
 
 func (file *FileWithByteCount) MustPrint(s string) {
 	bytesWritten, err := fmt.Fprint(file.writer, s)
-	if err != nil {
-		gplog.Fatal(err, "Unable to write to file")
-	}
+	gplog.FatalOnError(err, "Unable to write to file")
 	file.ByteCount += uint64(bytesWritten)
 }


### PR DESCRIPTION
Previously, PrintExternalTableCreateStatement and
PrintCreateLanguageStatements were constructing the create statement
using Fprintf which would result in a (MISSING) error because Fprintf
thought '%' was a template to replace. Use Fprint to prevent this error.