### PR TITLE
use `rm -rf` to delete optional temp setup file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ install_helper :
 		else \
 			echo 'Database is not running, please start the database and run this make target again'; \
 		fi; \
-		rm /tmp/seg_hosts
+		rm -rf /tmp/seg_hosts
 
 clean :
 		# Build artifacts


### PR DESCRIPTION
* this allows file to be optional, without breaking build in case where file doesn't exist


here is what I experienced when running `make` (no args) against a 6x database:

```
[1551727927] backup tests - 474/474 specs •••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••••• SUCCESS! 139.472664ms PASS
[1551727927] BackupHistory Suite - 11/11 specs ••••••••••• SUCCESS! 11.135888ms PASS

Ginkgo ran 7 suites in 25.255358719s
Test Suite Passed
Successfully copied gpbackup_helper to /usr/local/gpdb on all segments
go build -tags 'gpbackup'  -o /Users/pivotal/go/bin/gpbackup -ldflags "-X github.com/greenplum-db/gpbackup/backup.version=1.10.0+dev.15.g62ab52e"
go build -tags 'gprestore'  -o /Users/pivotal/go/bin/gprestore -ldflags "-X github.com/greenplum-db/gpbackup/restore.version=1.10.0+dev.15.g62ab52e"
go build -tags 'gpbackup_helper'  -o /Users/pivotal/go/bin/gpbackup_helper -ldflags "-X github.com/greenplum-db/gpbackup/helper.version=1.10.0+dev.15.g62ab52e"
Successfully copied gpbackup_helper to /usr/local/gpdb on all segments
rm: /tmp/seg_hosts: No such file or directory
make[2]: *** [install_helper] Error 1
make[1]: *** [build] Error 2
Failure [4.855 seconds]
[BeforeSuite] BeforeSuite
/Users/pivotal/go/src/github.com/greenplum-db/gpbackup/integration/integration_suite_test.go:41

  exit status 2

  /Users/pivotal/go/src/github.com/greenplum-db/gpbackup/integration/helper_test.go:66
------------------------------

Ran 476 of 0 Specs in 5.602 seconds
FAIL! -- 0 Passed | 476 Failed | 0 Pending | 0 Skipped
--- FAIL: TestQueries (5.62s)
FAIL

Ginkgo ran 1 suite in 28.462283301s
Test Suite Failed
make: *** [integration] Error 1
```