### PR TITLE
Create build-dependencies job for gpbackup pipeline

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -77,6 +77,15 @@ resources:
       access_key_id: {{bucket-access-key-id}}
       secret_access_key: {{bucket-secret-access-key}}
 
+- name: gpbackup-dependencies
+  type: s3
+  source:
+      bucket: gpbackup-dependencies
+      versioned_file: gpbackup-dependencies/dependencies.tar.gz
+      region_name: us-west-2
+      access_key_id: {{bucket-access-key-id}}
+      secret_access_key: {{bucket-secret-access-key}}
+
 - name: bin_gpdb_5x_stable
   type: s3
   source:
@@ -210,6 +219,21 @@ resources:
       bucket_path: clusters-aws/
 
 jobs:
+- name: build_dependencies
+  plan:
+  - aggregate:
+    - get: gpbackup
+      trigger: true
+    - get: gpbackup-dependencies
+    - get: nightly-trigger
+      trigger: true
+  - task: build-dependencies
+    file: gpbackup/ci/tasks/build-dependencies.yml
+    attempts: 5
+  - put: gpbackup-dependencies
+    params:
+        file: output_deps/dependencies.tar.gz
+
 - name: units
   plan:
   - aggregate:
@@ -217,6 +241,9 @@ jobs:
       trigger: true
     - get: nightly-trigger
       trigger: true
+    - get: gpbackup-dependencies
+      passed:
+       - build_dependencies
   - task: unit-tests
     file: gpbackup/ci/tasks/unit-tests.yml
     on_failure:
@@ -229,11 +256,14 @@ jobs:
       trigger: true
     - get: gpbackup
       trigger: true
-    - get: nightly-trigger
-      trigger: true
     - get: ccp_src
     - get: gpdb_src
     - get: bin_gpdb_5x_stable
+    - get: nightly-trigger
+      trigger: true
+    - get: gpbackup-dependencies
+      passed:
+       - build_dependencies
   - put: terraform
     params:
       <<: *ccp_default_params
@@ -280,6 +310,7 @@ jobs:
           set -ex
           source env.sh
 
+
           cd \$GOPATH/src/github.com/greenplum-db
           pushd gpbackup-s3-plugin
           make depend
@@ -320,9 +351,6 @@ jobs:
     - get: gpbackup
       tags: ["ddboost"]
       trigger: true
-    - get: nightly-trigger
-      tags: ["ddboost"]
-      trigger: true
     - get: ccp_src
       tags: ["ddboost"]
     - get: gpdb_src
@@ -331,6 +359,12 @@ jobs:
       tags: ["ddboost"]
     - get: boostfs_installer
       tags: ["ddboost"]
+    - get: nightly-trigger
+      trigger: true
+    - get: gpbackup-dependencies
+      tags: ["ddboost"]
+      passed:
+       - build_dependencies
   - put: ddboost_terraform
     tags: ["ddboost"]
     params:
@@ -511,11 +545,14 @@ jobs:
   - aggregate:
     - get: gpbackup
       trigger: true
-    - get: nightly-trigger
-      trigger: true
     - get: bin_gpdb_5x_stable
     - get: ccp_src
     - get: gpdb_src
+    - get: nightly-trigger
+      trigger: true
+    - get: gpbackup-dependencies
+      passed:
+       - build_dependencies
   - put: terraform
     params:
       <<: *ccp_default_params
@@ -547,11 +584,14 @@ jobs:
   - aggregate:
     - get: gpbackup
       trigger: true
-    - get: nightly-trigger
-      trigger: true
     - get: bin_gpdb_5x_stable_centos7
     - get: ccp_src
     - get: gpdb_src
+    - get: nightly-trigger
+      trigger: true
+    - get: gpbackup-dependencies
+      passed:
+       - build_dependencies
   - put: terraform_aws
     params:
       <<: *ccp_default_params_aws
@@ -591,12 +631,15 @@ jobs:
   - aggregate:
     - get: gpbackup
       trigger: true
-    - get: nightly-trigger
-      trigger: true
     - get: bin_gpdb_master
     - get: ccp_src
     - get: gpdb_src
     - get: dummy_seclabel
+    - get: nightly-trigger
+      trigger: true
+    - get: gpbackup-dependencies
+      passed:
+       - build_dependencies
   - put: terraform
     params:
       <<: *ccp_default_params
@@ -627,11 +670,14 @@ jobs:
   - aggregate:
     - get: gpbackup
       trigger: true
-    - get: nightly-trigger
-      trigger: true
     - get: bin_gpdb_5x_stable
     - get: ccp_src
     - get: gpdb_src
+    - get: nightly-trigger
+      trigger: true
+    - get: gpbackup-dependencies
+      passed:
+       - build_dependencies
   - put: terraform
     params:
       <<: *ccp_default_params
@@ -662,11 +708,14 @@ jobs:
   - aggregate:
     - get: gpbackup
       trigger: true
-    - get: nightly-trigger
-      trigger: true
     - get: bin_gpdb_43_stable
     - get: ccp_src
     - get: gpdb_src
+    - get: nightly-trigger
+      trigger: true
+    - get: gpbackup-dependencies
+      passed:
+       - build_dependencies
   - put: terraform
     params:
       <<: *ccp_default_params
@@ -697,11 +746,14 @@ jobs:
   - aggregate:
     - get: gpbackup
       trigger: true
-    - get: nightly-trigger
-      trigger: true
     - get: bin_gpdb_5x_stable
     - get: ccp_src
     - get: gpdb_src
+    - get: nightly-trigger
+      trigger: true
+    - get: gpbackup-dependencies
+      passed:
+       - build_dependencies
   - put: terraform
     params:
       <<: *ccp_default_params
@@ -737,10 +789,16 @@ jobs:
   plan:
   - aggregate:
     - get: gpbackup
+      trigger: true
     - get: bin_gpdb_master
     - get: ccp_src
     - get: gpdb_src
     - get: scale_schema
+    - get: nightly-trigger
+      trigger: true
+    - get: gpbackup-dependencies
+      passed:
+       - build_dependencies
   - put: terraform
     params:
       <<: *ccp_default_params
@@ -772,10 +830,16 @@ jobs:
   plan:
   - aggregate:
     - get: gpbackup
+      trigger: true
     - get: bin_gpdb_5x_stable
     - get: ccp_src
     - get: gpdb_src
     - get: scale_schema
+    - get: nightly-trigger
+      trigger: true
+    - get: gpbackup-dependencies
+      passed:
+       - build_dependencies
   - put: terraform
     params:
       <<: *ccp_default_params
@@ -806,10 +870,16 @@ jobs:
   plan:
   - aggregate:
     - get: gpbackup
+      trigger: true
     - get: bin_gpdb_43_stable
     - get: ccp_src
     - get: gpdb_src
     - get: scale_schema
+    - get: nightly-trigger
+      trigger: true
+    - get: gpbackup-dependencies
+      passed:
+       - build_dependencies
   - put: terraform
     params:
       <<: *ccp_default_params
@@ -858,6 +928,7 @@ jobs:
     - get: gpdb_src
     - get: ccp_src
     - get: bin_gpdb_5x_stable
+    - get: gpbackup-dependencies
   - put: terraform
     params:
       <<: *ccp_default_params
@@ -974,7 +1045,6 @@ jobs:
         - component_gpbackup/bin/gpbackup
         - component_gpbackup/bin/gprestore
         - component_gpbackup/bin/gpbackup_helper
-
 
 ccp_default_params_anchor: &ccp_default_params
   action: create

--- a/ci/tasks/build-dependencies.yml
+++ b/ci/tasks/build-dependencies.yml
@@ -8,9 +8,12 @@ image_resource:
     tag: '1.10.3'
 
 inputs:
-- name: gpbackup
-  path: go/src/github.com/greenplum-db/gpbackup
-- name: gpbackup-dependencies
+ - name: gpbackup
+   path: go/src/github.com/greenplum-db/gpbackup
+ - name: gpbackup-dependencies
+
+outputs:
+- name: output_deps
 
 run:
   path: bash
@@ -24,6 +27,8 @@ run:
 
     tar -zxf gpbackup-dependencies/dependencies.tar.gz -C $GOPATH/src/github.com/greenplum-db/gpbackup/
 
-    cd $GOPATH/src/github.com/greenplum-db/gpbackup
-    make depend
-    make unit
+    pushd $GOPATH/src/github.com/greenplum-db/gpbackup
+      make depend
+      tar cfz dependencies.tar.gz vendor
+    popd
+    cp $GOPATH/src/github.com/greenplum-db/gpbackup/dependencies.tar.gz output_deps/

--- a/ci/tasks/setup-centos-env-gpdb6.yml
+++ b/ci/tasks/setup-centos-env-gpdb6.yml
@@ -13,6 +13,7 @@ inputs:
 - name: ccp_src
 - name: cluster_env_files
 - name: dummy_seclabel
+- name: gpbackup-dependencies
 
 run:
   path: bash
@@ -41,6 +42,8 @@ run:
     gpconfig -c shared_preload_libraries -v dummy_seclabel
     gpstop -ar
 
+    tar -zxf gpbackup-dependencies/dependencies.tar.gz -C \$GOPATH/src/github.com/greenplum-db/gpbackup/
+
     pushd \$GOPATH/src/github.com/greenplum-db/gpbackup
         make depend
         make build
@@ -52,6 +55,7 @@ run:
 
     ssh -t centos@mdw "sudo yum -y install wget git && wget https://storage.googleapis.com/golang/go1.10.3.linux-amd64.tar.gz && tar -xzf go1.10.3.linux-amd64.tar.gz && sudo mv go /usr/local"
     chmod +x /tmp/setup_centos_env.bash
+    rsync -a gpbackup-dependencies mdw:/home/gpadmin
     scp /tmp/setup_centos_env.bash mdw:/home/gpadmin/setup_centos_env.bash
     ssh -t mdw "mkdir -p /home/gpadmin/go/src/github.com/greenplum-db"
     scp -r go/src/github.com/greenplum-db/gpbackup mdw:/home/gpadmin/go/src/github.com/greenplum-db/gpbackup

--- a/ci/tasks/setup-centos-env.yml
+++ b/ci/tasks/setup-centos-env.yml
@@ -12,6 +12,7 @@ inputs:
   path: go/src/github.com/greenplum-db/gpbackup
 - name: ccp_src
 - name: cluster_env_files
+- name: gpbackup-dependencies
 
 run:
   path: bash
@@ -38,6 +39,8 @@ run:
     source env.sh
     gpconfig --skipvalidation -c fsync -v off
     gpstop -u
+          
+    tar -zxf gpbackup-dependencies/dependencies.tar.gz -C \$GOPATH/src/github.com/greenplum-db/gpbackup/
 
     pushd \$GOPATH/src/github.com/greenplum-db/gpbackup
         make depend
@@ -47,6 +50,7 @@ run:
 
     ssh -t centos@mdw "sudo yum -y install wget git && wget https://storage.googleapis.com/golang/go1.10.3.linux-amd64.tar.gz && tar -xzf go1.10.3.linux-amd64.tar.gz && sudo mv go /usr/local"
     chmod +x /tmp/setup_centos_env.bash
+    rsync -a gpbackup-dependencies mdw:/home/gpadmin
     scp /tmp/setup_centos_env.bash mdw:/home/gpadmin/setup_centos_env.bash
     ssh -t mdw "mkdir -p /home/gpadmin/go/src/github.com/greenplum-db"
     scp -r go/src/github.com/greenplum-db/gpbackup mdw:/home/gpadmin/go/src/github.com/greenplum-db/gpbackup

--- a/ci/tasks/setup-oracle-env.yml
+++ b/ci/tasks/setup-oracle-env.yml
@@ -12,6 +12,7 @@ inputs:
   path: go/src/github.com/greenplum-db/gpbackup
 - name: ccp_src
 - name: cluster_env_files
+- name: gpbackup-dependencies
 
 run:
   path: bash
@@ -38,6 +39,8 @@ run:
     source env.sh
     gpconfig --skipvalidation -c fsync -v off
     gpstop -u
+          
+    tar -zxf gpbackup-dependencies/dependencies.tar.gz -C \$GOPATH/src/github.com/greenplum-db/gpbackup/
 
     pushd \$GOPATH/src/github.com/greenplum-db/gpbackup
         make depend
@@ -47,6 +50,7 @@ run:
 
     ssh -t clckwrk@mdw "sudo yum -y install wget git && wget https://storage.googleapis.com/golang/go1.10.3.linux-amd64.tar.gz && tar -xzf go1.10.3.linux-amd64.tar.gz && sudo mv go /usr/local"
     chmod +x /tmp/setup_oracle_env.bash
+    rsync -a gpbackup-dependencies mdw:/home/gpadmin
     scp /tmp/setup_oracle_env.bash mdw:/home/gpadmin/setup_oracle_env.bash
     ssh -t mdw "mkdir -p /home/gpadmin/go/src/github.com/greenplum-db"
     scp -r go/src/github.com/greenplum-db/gpbackup mdw:/home/gpadmin/go/src/github.com/greenplum-db/gpbackup

--- a/ci/tasks/sles-tests.yml
+++ b/ci/tasks/sles-tests.yml
@@ -11,6 +11,7 @@ inputs:
   path: go/src/github.com/greenplum-db/gpbackup
 - name: ccp_src
 - name: cluster_env_files
+- name: gpbackup-dependencies
 
 run:
   path: bash
@@ -27,7 +28,9 @@ run:
     export PGPORT=5432
     export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1
     export PATH=\$GOPATH/bin:/usr/local/go/bin:\$PATH
-
+    
+    tar -zxf gpbackup-dependencies/dependencies.tar.gz -C \$GOPATH/src/github.com/greenplum-db/gpbackup/
+    
     cd \$GOPATH/src/github.com/greenplum-db/gpbackup
     make depend
     source /usr/local/greenplum-db-devel/greenplum_path.sh # We source greenplum_path.sh here to avoid certificate issues during `go get`
@@ -39,6 +42,7 @@ run:
     ssh -t root@mdw "sudo zypper -n install wget git && wget https://storage.googleapis.com/golang/go1.10.3.linux-amd64.tar.gz && sudo tar -C /usr/local -xzf go1.10.3.linux-amd64.tar.gz"
     ssh -t root@mdw "sudo mkdir /home/gpadmin/go && sudo chown gpadmin:gpadmin -R /home/gpadmin/go"
     chmod +x /tmp/run_tests.bash
+    rsync -a gpbackup-dependencies mdw:/home/gpadmin
     scp /tmp/run_tests.bash mdw:/home/gpadmin/run_tests.bash
     ssh -t mdw "mkdir -p /home/gpadmin/go/src/github.com/greenplum-db"
     scp -r go/src/github.com/greenplum-db/gpbackup mdw:/home/gpadmin/go/src/github.com/greenplum-db/gpbackup


### PR DESCRIPTION
* this addition is intended to lessen the impact of failures related
to a known 'make dep' flake. This new pipeline pattern fetches all dependencies in the
build-dependencies job and then passes the 'vendor' directory to other jobs
via an s3 bucket.
* pipeline reformatted – jobs only trigger after build_deps finishes (with the
exception of plugin jobs, which also trigger on new s3 or ddboost
commits)

Co-authored-by: Trevor Yacovone <tyacovone@pivotal.io>
Co-authored-by: Kevin Yeap <kyeap@pivotal.io>
Signed-off-by: Kevin Yeap <kyeap@pivotal.io>