### PR TITLE
Handle the GUC settings in a function definition

### DIFF
--- a/backup/queries_functions.go
+++ b/backup/queries_functions.go
@@ -87,12 +87,12 @@ func GetFunctionsAllVersions(connectionPool *dbconn.DBConn) []Function {
 			}
 		}
 	} else {
-		functions = GetFunctionsMaster(connectionPool)
+		functions = GetFunctions(connectionPool)
 	}
 	return functions
 }
 
-func GetFunctionsMaster(connectionPool *dbconn.DBConn) []Function {
+func GetFunctions(connectionPool *dbconn.DBConn) []Function {
 	excludeImplicitFunctionsClause := ""
 	masterAtts := "'a' AS proexeclocation,"
 	if connectionPool.Version.AtLeast("6") {

--- a/backup/queries_functions_test.go
+++ b/backup/queries_functions_test.go
@@ -1,0 +1,73 @@
+package backup_test
+
+import (
+	"github.com/greenplum-db/gpbackup/backup"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("backup/queries_acl tests", func() {
+	Describe("PostProcessFunctionConfigs", func() {
+		It("returns correct value for search_path", func() {
+			allFunctions := []backup.Function{
+				{Config: "SET SEARCH_PATH TO bar"},
+			}
+			err := backup.PostProcessFunctionConfigs(allFunctions)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(allFunctions[0].Config).To(Equal(`SET search_path TO 'bar'`))
+		})
+		It("returns error when function config does not parse", func() {
+			allFunctions := []backup.Function{
+				{Config: "SET foo blah blah blah"},
+			}
+			err := backup.PostProcessFunctionConfigs(allFunctions)
+			Expect(err).To(HaveOccurred())
+		})
+		// known bug https://www.pivotaltracker.com/story/show/164575992
+		PIt("returns correct value for multiple GUCs in one function", func() {
+			allFunctions := []backup.Function{
+				// not clear how the native pg_proc.proconfig field will translate into our Config attribute: assuming we get 2 separate strings
+				{Config: `SET search_path TO bar, blah
+SET BAZ TO abc`},
+			}
+			err := backup.PostProcessFunctionConfigs(allFunctions)
+			Expect(err).ToNot(HaveOccurred())
+			// expecting separate lines stored in the Config attribute;
+			// this may not be the perfect solution, TBD: may want to have it become a slice of strings
+			Expect(allFunctions[0].Config).To(Equal(`SET search_path TO 'bar', blah
+SET baz to abc`))
+		})
+	})
+	Describe("QuoteGUCValue", func() {
+		It("returns correct value for a name/value pair", func() {
+			result := backup.QuoteGUCValue("foo", `bar`)
+			Expect(result).To(Equal(`'bar'`))
+		})
+		It("returns correct value for SEARCH_PATH", func() {
+			result := backup.QuoteGUCValue("search_path", `"$user",public`)
+			Expect(result).To(Equal(`'$user', 'public'`))
+		})
+		It("returns correct value for temp_tablespaces", func() {
+			result := backup.QuoteGUCValue("temp_tablespaces", `"tables""pace1%",     tablespace2`)
+			Expect(result).To(Equal(`'tables"pace1%', 'tablespace2'`))
+		})
+	})
+	Describe("UnescapeDoubleQuote", func() {
+		It("removes outside quotes", func() {
+			result := backup.UnescapeDoubleQuote(`"foo"`)
+			Expect(result).To(Equal(`foo`))
+		})
+		It("does nothing if string has no quotes surrounding it", func() {
+			result := backup.UnescapeDoubleQuote(`foo`)
+			Expect(result).To(Equal(`foo`))
+		})
+		It("removes outside quotes and unescapes embedded quote", func() {
+			result := backup.UnescapeDoubleQuote(`"foo"""`)
+			Expect(result).To(Equal(`foo"`))
+		})
+		It("removes outside quotes and unescapes multiple embedded quotes", func() {
+			result := backup.UnescapeDoubleQuote(`"""foo"""`)
+			Expect(result).To(Equal(`"foo"`))
+		})
+	})
+})

--- a/integration/predata_functions_create_test.go
+++ b/integration/predata_functions_create_test.go
@@ -106,7 +106,7 @@ var _ = Describe("backup integration create statement tests", func() {
 				appendFunction := backup.Function{
 					Schema: "public", Name: "append", ReturnsSet: true, FunctionBody: "SELECT ($1, $2)",
 					BinaryPath: "", Arguments: "integer, integer", IdentArgs: "integer, integer", ResultType: "SETOF record",
-					Volatility: "s", IsStrict: true, IsSecurityDefiner: true, Config: "SET search_path TO pg_temp", Cost: 200,
+					Volatility: "s", IsStrict: true, IsSecurityDefiner: true, Config: "SET search_path TO 'pg_temp'", Cost: 200,
 					NumRows: 200, DataAccess: "m", Language: "sql", ExecLocation: "a",
 				}
 

--- a/integration/predata_functions_queries_test.go
+++ b/integration/predata_functions_queries_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 var _ = Describe("backup integration tests", func() {
-	Describe("GetFunctionsMaster", func() {
+	Describe("GetFunctions", func() {
 		BeforeEach(func() {
 			testutils.SkipIfBefore5(connectionPool)
 		})
@@ -35,7 +35,7 @@ MODIFIES SQL DATA
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP FUNCTION public.append(integer, integer)")
 			testhelper.AssertQueryRuns(connectionPool, "COMMENT ON FUNCTION public.append(integer, integer) IS 'this is a function comment'")
 
-			results := backup.GetFunctionsMaster(connectionPool)
+			results := backup.GetFunctions(connectionPool)
 
 			addFunction := backup.Function{
 				Schema: "public", Name: "add", ReturnsSet: false, FunctionBody: "SELECT $1 + $2",
@@ -70,7 +70,7 @@ LANGUAGE SQL`)
 				Volatility: "v", IsStrict: false, IsSecurityDefiner: false, Config: "", Cost: 100, NumRows: 0, DataAccess: "c",
 				Language: "sql", ExecLocation: "a"}
 			backupCmdFlags.Set(utils.INCLUDE_SCHEMA, "testschema")
-			results := backup.GetFunctionsMaster(connectionPool)
+			results := backup.GetFunctions(connectionPool)
 
 			Expect(results).To(HaveLen(1))
 			structmatcher.ExpectStructsToMatchExcluding(&results[0], &addFunction, "Oid")
@@ -82,7 +82,7 @@ AS 'SELECT $1 + $2'
 LANGUAGE SQL WINDOW`)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP FUNCTION public.add(integer, integer)")
 
-			results := backup.GetFunctionsMaster(connectionPool)
+			results := backup.GetFunctions(connectionPool)
 
 			windowFunction := backup.Function{
 				Schema: "public", Name: "add", ReturnsSet: false, FunctionBody: "SELECT $1 + $2",
@@ -106,7 +106,7 @@ LANGUAGE SQL WINDOW
 EXECUTE ON ALL SEGMENTS;`)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP FUNCTION public.srf_on_all_segments(integer, integer)")
 
-			results := backup.GetFunctionsMaster(connectionPool)
+			results := backup.GetFunctions(connectionPool)
 
 			srfOnMasterFunction := backup.Function{
 				Schema: "public", Name: "srf_on_master", ReturnsSet: false, FunctionBody: "SELECT $1 + $2",
@@ -140,7 +140,7 @@ MODIFIES SQL DATA
 `)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP FUNCTION public.append(integer, integer)")
 
-			results := backup.GetFunctionsMaster(connectionPool)
+			results := backup.GetFunctions(connectionPool)
 
 			appendFunction := backup.Function{
 				Schema: "public", Name: "append", ReturnsSet: true, FunctionBody: "SELECT ($1, $2)",
@@ -156,7 +156,7 @@ MODIFIES SQL DATA
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TYPE public.textrange AS RANGE (SUBTYPE = pg_catalog.text)")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TYPE public.textrange")
 
-			results := backup.GetFunctionsMaster(connectionPool)
+			results := backup.GetFunctions(connectionPool)
 
 			Expect(results).To(HaveLen(0))
 		})
@@ -174,7 +174,7 @@ MODIFIES SQL DATA
 `)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP FUNCTION public.myfunc(integer)")
 
-			results := backup.GetFunctionsMaster(connectionPool)
+			results := backup.GetFunctions(connectionPool)
 
 			appendFunction := backup.Function{
 				Schema: "public", Name: "myfunc", ReturnsSet: false, FunctionBody: `
@@ -207,7 +207,7 @@ MODIFIES SQL DATA
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP FUNCTION public.myfunc(integer)")
 			defer testhelper.AssertQueryRuns(connectionPool, `DROP SCHEMA "abc""def"`)
 
-			results := backup.GetFunctionsMaster(connectionPool)
+			results := backup.GetFunctions(connectionPool)
 
 			appendFunction := backup.Function{
 				Schema: "public", Name: "myfunc", ReturnsSet: false, FunctionBody: `


### PR DESCRIPTION
- always quote values, even for integers
- use lower case for GUC name
- reproduce functionality in pg_dump for special case GUCs like
search_path:
   - they have multiple strings as array values
   - each of these needs quoting separately in order to work for SQL

Co-Authored-by: Larry Hamel <lhamel@pivotal.io>
Co-Authored-by: Kevin Yeap <kyeap@pivotal.io>