### PR TITLE
plugin: record API and plugin version within backup report, and supply this same information (during restore) to the plugin

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -106,7 +106,6 @@ func DoSetup() {
 	pluginConfigFlag := MustGetFlagString(utils.PLUGIN_CONFIG)
 
 	if pluginConfigFlag != "" {
-		var err error
 		pluginConfig, err = utils.ReadPluginConfig(pluginConfigFlag)
 		gplog.FatalOnError(err)
 	}
@@ -114,8 +113,7 @@ func DoSetup() {
 	InitializeBackupReport(*opts)
 
 	if pluginConfigFlag != "" {
-		pluginConfig.CheckPluginExistsOnAllHosts(globalCluster)
-
+		backupReport.PluginVersion = pluginConfig.CheckPluginExistsOnAllHosts(globalCluster)
 		pluginConfig.CopyPluginConfigToAllHosts(globalCluster)
 		pluginConfig.SetupPluginForBackup(globalCluster, globalFPInfo)
 	}

--- a/backup_history/history.go
+++ b/backup_history/history.go
@@ -38,6 +38,7 @@ type BackupConfig struct {
 	LeafPartitionData     bool
 	MetadataOnly          bool
 	Plugin                string
+	PluginVersion         string
 	RestorePlan           []RestorePlanEntry
 	SingleDataFile        bool
 	Timestamp             string
@@ -170,5 +171,14 @@ func (history *History) WriteToFileAndMakeReadOnly(filename string) error {
 		return err
 	}
 
+	return nil
+}
+
+func (history *History) FindBackupConfig(timestamp string) *BackupConfig {
+	for _, backupConfig := range history.BackupConfigs {
+		if backupConfig.Timestamp == timestamp {
+			return &backupConfig
+		}
+	}
 	return nil
 }

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -541,7 +541,7 @@ var _ = Describe("backup end to end integration tests", func() {
 				})
 				It("runs gpbackup and gprestore with plugin, single-data-file, and no-compression", func() {
 					pluginDir := "/tmp/plugin_dest"
-					pluginExecutablePath := fmt.Sprintf("%s/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.sh", os.Getenv("HOME"))
+					pluginExecutablePath := fmt.Sprintf("%s/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("HOME"))
 					copyPluginToAllHosts(backupConn, pluginExecutablePath)
 
 					timestamp := gpbackup(gpbackupPath, backupHelperPath, "--single-data-file", "--no-compression", "--plugin-config", pluginConfigPath)
@@ -558,7 +558,7 @@ var _ = Describe("backup end to end integration tests", func() {
 				})
 				It("runs gpbackup and gprestore with plugin and single-data-file", func() {
 					pluginDir := "/tmp/plugin_dest"
-					pluginExecutablePath := fmt.Sprintf("%s/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.sh", os.Getenv("HOME"))
+					pluginExecutablePath := fmt.Sprintf("%s/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("HOME"))
 					copyPluginToAllHosts(backupConn, pluginExecutablePath)
 
 					timestamp := gpbackup(gpbackupPath, backupHelperPath, "--single-data-file", "--plugin-config", pluginConfigPath)
@@ -575,7 +575,7 @@ var _ = Describe("backup end to end integration tests", func() {
 				})
 				It("runs gpbackup and gprestore with plugin and metadata-only", func() {
 					pluginDir := "/tmp/plugin_dest"
-					pluginExecutablePath := fmt.Sprintf("%s/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.sh", os.Getenv("HOME"))
+					pluginExecutablePath := fmt.Sprintf("%s/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("HOME"))
 					copyPluginToAllHosts(backupConn, pluginExecutablePath)
 
 					timestamp := gpbackup(gpbackupPath, backupHelperPath, "--metadata-only", "--plugin-config", pluginConfigPath)
@@ -598,7 +598,7 @@ var _ = Describe("backup end to end integration tests", func() {
 					Skip("This test is only needed for the most recent backup versions")
 				}
 				pluginDir := "/tmp/plugin_dest"
-				pluginExecutablePath := fmt.Sprintf("%s/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.sh", os.Getenv("HOME"))
+				pluginExecutablePath := fmt.Sprintf("%s/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("HOME"))
 				copyPluginToAllHosts(backupConn, pluginExecutablePath)
 
 				timestamp := gpbackup(gpbackupPath, backupHelperPath, "--no-compression", "--plugin-config", pluginConfigPath)
@@ -619,7 +619,7 @@ var _ = Describe("backup end to end integration tests", func() {
 					Skip("This test is only needed for the most recent backup versions")
 				}
 				pluginDir := "/tmp/plugin_dest"
-				pluginExecutablePath := fmt.Sprintf("%s/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.sh", os.Getenv("HOME"))
+				pluginExecutablePath := fmt.Sprintf("%s/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("HOME"))
 				copyPluginToAllHosts(backupConn, pluginExecutablePath)
 
 				timestamp := gpbackup(gpbackupPath, backupHelperPath, "--plugin-config", pluginConfigPath)
@@ -780,7 +780,7 @@ var _ = Describe("backup end to end integration tests", func() {
 						Skip("This test is only needed for the most recent backup versions")
 					}
 					pluginDir = "/tmp/plugin_dest"
-					pluginExecutablePath := fmt.Sprintf("%s/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.sh", os.Getenv("HOME"))
+					pluginExecutablePath := fmt.Sprintf("%s/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("HOME"))
 					copyPluginToAllHosts(backupConn, pluginExecutablePath)
 				})
 				AfterEach(func() {
@@ -1013,13 +1013,13 @@ var _ = Describe("backup end to end integration tests", func() {
 
 			os.RemoveAll(backupdir)
 		})
-		It("runs example_plugin.sh with plugin_test_bench", func() {
+		It("runs example_plugin.bash with plugin_test_bench", func() {
 			if useOldBackupVersion {
 				Skip("This test is only needed for the latest backup version")
 			}
 			pluginsDir := fmt.Sprintf("%s/go/src/github.com/greenplum-db/gpbackup/plugins", os.Getenv("HOME"))
-			copyPluginToAllHosts(backupConn, fmt.Sprintf("%s/example_plugin.sh", pluginsDir))
-			command := exec.Command("bash", "-c", fmt.Sprintf("%s/plugin_test_bench.sh %s/example_plugin.sh %s/example_plugin_config.yaml", pluginsDir, pluginsDir, pluginsDir))
+			copyPluginToAllHosts(backupConn, fmt.Sprintf("%s/example_plugin.bash", pluginsDir))
+			command := exec.Command("bash", "-c", fmt.Sprintf("%s/plugin_test_bench.sh %s/example_plugin.bash %s/example_plugin_config.yaml", pluginsDir, pluginsDir, pluginsDir))
 			mustRunCommand(command)
 
 			os.RemoveAll("/tmp/plugin_dest")

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -17,15 +17,17 @@ gprestore ... --plugin-config <Absolute path to config file>
 The backup you are restoring must have been taken with the same plugin.
 
 ## Plugin configuration file format
-The plugin configuration must be specified in a yaml file. This yaml file is only required to exist on the master host.
+The plugin configuration must be specified in a yaml file. This yaml file is only required to exist on the master host, and is automatically copied to segment hosts.
 
-The _executablepath_ is a required parameter and must point to the absolute path of the executable on each host. Additional parameters may be specified under the _options_ key as required by the specific plugin. Refer to the documentation for the plugin you are using for additional required paramters.
+The _executablepath_ is a required parameter and must point to the absolute path of the executable on each host. Additional parameters may be specified under the _options_ key as required by the specific plugin. Refer to the documentation for the plugin you are using for additional required paramters. The _options_ section will include "pgport" for one of the segments on a given host, in case the plugin requires usage of a postgres function. Upon a restore, the _options_ section may also contain "backup_plugin_version" if the information is available from historical records.  With this historical version, a newer plugin could possibly support backwards compatibility toward backups created with older versions of plugins.
 
 ```
 executablepath: <Absolute path to plugin executable>
 options:
-  option1: <value1>
-  option2: <value2>
+  my_first_option: <value1>
+  my_second_option: <value2>
+  pgport: 5432
+  backup_plugin_version: 1.3
   <Additional options for the specific plugin>
 ```
 

--- a/plugins/example_plugin.bash
+++ b/plugins/example_plugin.bash
@@ -1,4 +1,4 @@
-  #!/bin/bash
+#!/bin/bash
 set -e
 
 setup_plugin_for_backup(){

--- a/plugins/example_plugin.bash
+++ b/plugins/example_plugin.bash
@@ -86,4 +86,9 @@ plugin_api_version(){
   echo "0.4.0" >> /tmp/plugin_out.txt
 }
 
+--version(){
+  echo "example_plugin version 1.0.0"
+  echo "example_plugin version 1.0.0" >> /tmp/plugin_out.txt
+}
+
 "$@"

--- a/plugins/example_plugin_config.yaml
+++ b/plugins/example_plugin_config.yaml
@@ -1,3 +1,3 @@
-executablepath: $HOME/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.sh
+executablepath: $HOME/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash
 options:
   password: unknown

--- a/plugins/plugin_test_bench.sh
+++ b/plugins/plugin_test_bench.sh
@@ -76,6 +76,15 @@ if (( 0 == $(echo "$MINIMUM_API_VERSION $api_version" | awk '{print ($1 <= $2)}'
 fi
 echo "[PASSED] plugin_api_version"
 
+echo "[RUNNING] --version"
+native_version=`$plugin --version`
+echo "$native_version" | grep --regexp '.* version .*' 2>&1 > /dev/null
+if [[ ! $? -eq 0 ]]; then
+  echo "Plugin --version is not in expected format of <plugin name> version <version>"
+  exit 1
+fi
+echo "[PASSED] --version"
+
 # ----------------------------------------------
 # Setup and Backup/Restore file functions
 # ----------------------------------------------

--- a/restore/global_variables.go
+++ b/restore/global_variables.go
@@ -93,3 +93,11 @@ func MustGetFlagBool(flagName string) bool {
 func MustGetFlagStringSlice(flagName string) []string {
 	return utils.MustGetFlagStringSlice(cmdFlags, flagName)
 }
+
+func GetVersion() string {
+	return version
+}
+
+func SetVersion(v string) {
+	version = v
+}

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -354,7 +354,3 @@ func DoCleanup() {
 		connectionPool.Close()
 	}
 }
-
-func GetVersion() string {
-	return version
-}

--- a/restore/restore_suite_test.go
+++ b/restore/restore_suite_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gpbackup/restore"
 	"github.com/greenplum-db/gpbackup/testutils"
-	"github.com/greenplum-db/gpbackup/utils"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -42,13 +41,6 @@ var _ = BeforeEach(func() {
 	buffer = gbytes.NewBuffer()
 
 	cmdFlags = pflag.NewFlagSet("gprestore", pflag.ExitOnError)
+	restore.SetFlagDefaults(cmdFlags)
 	restore.SetCmdFlags(cmdFlags)
-
-	cmdFlags.Bool(utils.ON_ERROR_CONTINUE, false, "")
-	cmdFlags.Bool(utils.DATA_ONLY, false, "")
-	cmdFlags.String(utils.PLUGIN_CONFIG, "", "")
-	cmdFlags.StringSlice(utils.INCLUDE_RELATION, []string{}, "")
-	cmdFlags.StringSlice(utils.EXCLUDE_RELATION, []string{}, "")
-	cmdFlags.StringSlice(utils.INCLUDE_SCHEMA, []string{}, "")
-	cmdFlags.StringSlice(utils.EXCLUDE_SCHEMA, []string{}, "")
 })


### PR DESCRIPTION
During backup, save to the history file a record of the version of any plugin used.  During restore, add this information via an attribute of the plugin_config file supplied during restore.

* NEW FEATURE: previously, plugins were only checked to exist have sufficient API version, but there was no check that they were all of the same version. Now, there will be a fatal error if plugin versions are not uniform across all segments.

* plugin_config.yaml attribute name is "backup_plugin_version"
* it will have empty "" contents if there is no record of the version used when backing up; output a warning to log file

