### PR TITLE
Add job gpdb6-centos7 which runs in single container

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -102,6 +102,13 @@ resources:
       access_key_id: {{bucket-access-key-id}}
       secret_access_key: {{bucket-secret-access-key}}
 
+- name: dummy_seclabel_gpdb_linux
+  type: gcs
+  source:
+    bucket: dummy_seclabel_gpdb_linux
+    json_key: ((gcp_svc_acct_key))
+    regexp: dummy_seclabel-v(.*).so
+
 - name: bin_gpdb_5x_stable
   type: s3
   source:
@@ -116,6 +123,15 @@ resources:
   source:
       bucket: gpdb-stable-concourse-builds
       versioned_file: release_candidates/bin_gpdb_centos7/gpdb5/bin_gpdb.tar.gz
+      region_name: us-west-2
+      access_key_id: {{bucket-access-key-id}}
+      secret_access_key: {{bucket-secret-access-key}}
+
+- name: bin_gpdb_6x_stable_centos7
+  type: s3
+  source:
+      bucket: gpdb-stable-concourse-builds
+      versioned_file: release_candidates/bin_gpdb_centos7/gpdb6/prod/bin_gpdb.tar.gz
       region_name: us-west-2
       access_key_id: {{bucket-access-key-id}}
       secret_access_key: {{bucket-secret-access-key}}
@@ -662,6 +678,95 @@ jobs:
     *slack_alert
   ensure:
     <<: *set_failed_aws
+
+- name: GPDB6-centos7
+  plan:
+  - aggregate:
+    - get: gpbackup
+      trigger: true
+    - get: gpbackup-dependencies
+      passed:
+       - build_dependencies
+    - get: bin_gpdb_6x_stable_centos7
+    - get: dummy_seclabel_gpdb_linux
+    - get: gpdb6_src
+    - get: nightly-trigger
+      trigger: true
+  - task: integration-tests
+    input_mapping:
+      gpdb_src: gpdb6_src
+      bin_gpdb: bin_gpdb_6x_stable_centos7
+    config:
+      platform: linux
+      inputs:
+      - name: gpdb_src
+      - name: bin_gpdb
+      - name: gpbackup
+      - name: dummy_seclabel_gpdb_linux
+      - name: gpbackup-dependencies
+      image_resource:
+        type: docker-image
+        source:
+          repository: pivotaldata/centos-gpdb-dev
+          tag: '7-gcc6.2-llvm3.7'
+      run:
+        path: bash
+        args:
+          - -c
+          - |
+            set -ex
+            source gpdb_src/concourse/scripts/common.bash
+            time install_gpdb
+            time ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash
+            # Run inside a subshell so it does not pollute the environment after
+            # sourcing greenplum_path
+            time (make_cluster)
+
+            source /usr/local/greenplum-db-devel/greenplum_path.sh
+
+            # dummy security label: copy library from bucket to correct location
+            # (someday this will be part of the bin_gpdb tarball?)
+            mkdir -p "$GPHOME/postgresql"
+            install -m 755 -T dummy_seclabel_gpdb_linux/dummy_seclabel-v6.so "$GPHOME/lib/postgresql/dummy_seclabel.so"
+
+            # copy gpbackup & deps into the GOPATH used by user "gpadmin"
+            export GOPATH=/home/gpadmin/go
+            mkdir -p $GOPATH/src/github.com/greenplum-db
+            cp -R gpbackup $GOPATH/src/github.com/greenplum-db/
+            tar -zxf gpbackup-dependencies/dependencies.tar.gz -C $GOPATH/src/github.com/greenplum-db/gpbackup/
+            chown -R gpadmin $GOPATH
+
+            cat <<SCRIPT > /tmp/run_tests.bash
+              set -ex
+              cd ~
+              source /usr/local/greenplum-db-devel/greenplum_path.sh
+
+              # use "temp build dir" of parent shell
+              source $(pwd)/gpdb_src/gpAux/gpdemo/gpdemo-env.sh
+              export GOPATH=\$HOME/go
+              # reference PATH defined by parent shell
+              export PATH=$PATH:\$PATH:\$GOPATH/bin
+
+              # sec label
+              gpconfig -c shared_preload_libraries -v dummy_seclabel
+              gpstop -ra
+              gpconfig -s shared_preload_libraries | grep dummy_seclabel
+
+              # Build gpbackup
+              pushd \$GOPATH/src/github.com/greenplum-db/gpbackup
+                make depend
+                make build
+                make unit
+                make integration
+              popd
+
+            SCRIPT
+
+            chmod +x /tmp/run_tests.bash
+            sudo su - gpadmin bash -c /tmp/run_tests.bash
+
+  on_failure:
+    *slack_alert
 
 - name: integrations-master
   plan:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -22,7 +22,15 @@ resource_types:
     repository: pivotalcf/pivnet-resource
     tag: latest-final
 
+
 resources:
+# docker images
+- name: centos7-image
+  type: docker-image
+  source:
+    repository: pivotaldata/centos-gpdb-dev
+    tag: '7-gcc6.2-llvm3.7'
+
 - name: nightly-trigger
   type: time
   source:
@@ -680,6 +688,7 @@ jobs:
 - name: integrations-GPDB6-centos7
   plan:
   - aggregate:
+    - get: centos7-image
     - get: gpbackup
       trigger: true
     - get: gpbackup-dependencies
@@ -690,80 +699,14 @@ jobs:
     - get: gpdb6_src
     - get: nightly-trigger
       trigger: true
-  - task: integration-tests
+  - task: run-tests-locally
+    image: centos7-image
+    file: gpbackup/ci/tasks/test-on-local-cluster.yml
+    params:
+      IS_GPDB6: true
     input_mapping:
       gpdb_src: gpdb6_src
       bin_gpdb: bin_gpdb_6x_stable_centos7
-    config:
-      platform: linux
-      inputs:
-      - name: gpdb_src
-      - name: bin_gpdb
-      - name: gpbackup
-      - name: dummy_seclabel_gpdb_linux
-      - name: gpbackup-dependencies
-      image_resource:
-        type: docker-image
-        source:
-          repository: pivotaldata/centos-gpdb-dev
-          tag: '7-gcc6.2-llvm3.7'
-      run:
-        path: bash
-        args:
-          - -c
-          - |
-            set -ex
-            mv bin_gpdb/*.tar.gz bin_gpdb/bin_gpdb.tar.gz
-
-            source gpdb_src/concourse/scripts/common.bash
-            time install_gpdb
-            time ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash
-            time make_cluster
-
-            source /usr/local/greenplum-db-devel/greenplum_path.sh
-
-            # dummy security label: copy library from bucket to correct location
-            # (someday this will be part of the bin_gpdb tarball?)
-            mkdir -p "$GPHOME/postgresql"
-            install -m 755 -T dummy_seclabel_gpdb_linux/dummy_seclabel-v6.so "$GPHOME/lib/postgresql/dummy_seclabel.so"
-
-            # copy gpbackup & deps into the GOPATH used by user "gpadmin"
-            export GOPATH=/home/gpadmin/go
-            mkdir -p $GOPATH/src/github.com/greenplum-db
-            cp -R gpbackup $GOPATH/src/github.com/greenplum-db/
-            tar -zxf gpbackup-dependencies/dependencies.tar.gz -C $GOPATH/src/github.com/greenplum-db/gpbackup/
-            chown -R gpadmin $GOPATH
-
-            cat <<SCRIPT > /tmp/run_tests.bash
-              set -ex
-              cd ~
-              source /usr/local/greenplum-db-devel/greenplum_path.sh
-
-              # use "temp build dir" of parent shell
-              source $(pwd)/gpdb_src/gpAux/gpdemo/gpdemo-env.sh
-              export GOPATH=\$HOME/go
-              # reference PATH defined by parent shell
-              export PATH=$PATH:\$PATH:\$GOPATH/bin
-
-              # sec label
-              gpconfig -c shared_preload_libraries -v dummy_seclabel
-              gpstop -ra
-              gpconfig -s shared_preload_libraries | grep dummy_seclabel
-
-              # Build gpbackup
-              pushd \$GOPATH/src/github.com/greenplum-db/gpbackup
-                make depend
-                make build
-                make unit
-                make integration
-                make end_to_end
-              popd
-
-            SCRIPT
-
-            chmod +x /tmp/run_tests.bash
-            sudo su - gpadmin bash -c /tmp/run_tests.bash
-
   on_failure:
     *slack_alert
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -86,7 +86,7 @@ resources:
     branch: 6X_STABLE
     tag_filter: 6.*
 
-- name: bin_gpdb6 # centos 7
+- name: bin_gpdb6
   type: gcs
   source:
       bucket: ((gcs-bucket))
@@ -128,13 +128,11 @@ resources:
       secret_access_key: {{bucket-secret-access-key}}
 
 - name: bin_gpdb_6x_stable_centos7
-  type: s3
+  type: gcs
   source:
-      bucket: gpdb-stable-concourse-builds
-      versioned_file: release_candidates/bin_gpdb_centos7/gpdb6/prod/bin_gpdb.tar.gz
-      region_name: us-west-2
-      access_key_id: {{bucket-access-key-id}}
-      secret_access_key: {{bucket-secret-access-key}}
+      bucket: ((gcs-bucket))
+      json_key: ((concourse-gcs-resources-service-account-key))
+      regexp: server/published/gpdb6/server-rc-(.*)-rhel7_x86_64((rc-build-type-gcs)).tar.gz
 
 - name: bin_gpdb_43_stable
   type: s3
@@ -679,7 +677,7 @@ jobs:
   ensure:
     <<: *set_failed_aws
 
-- name: GPDB6-centos7
+- name: integrations-GPDB6-centos7
   plan:
   - aggregate:
     - get: gpbackup
@@ -715,12 +713,12 @@ jobs:
           - -c
           - |
             set -ex
+            mv bin_gpdb/*.tar.gz bin_gpdb/bin_gpdb.tar.gz
+
             source gpdb_src/concourse/scripts/common.bash
             time install_gpdb
             time ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash
-            # Run inside a subshell so it does not pollute the environment after
-            # sourcing greenplum_path
-            time (make_cluster)
+            time make_cluster
 
             source /usr/local/greenplum-db-devel/greenplum_path.sh
 
@@ -758,6 +756,7 @@ jobs:
                 make build
                 make unit
                 make integration
+                make end_to_end
               popd
 
             SCRIPT

--- a/ci/tasks/test-on-local-cluster.yml
+++ b/ci/tasks/test-on-local-cluster.yml
@@ -1,0 +1,75 @@
+platform: linux
+
+params:
+  IS_GPDB6:
+
+inputs:
+- name: gpdb_src
+- name: bin_gpdb
+- name: gpbackup
+- name: dummy_seclabel_gpdb_linux
+  optional: true
+- name: gpbackup-dependencies
+
+run:
+  path: bash
+  args:
+  - -c
+  - |
+    set -ex
+    if [ ! -f bin_gpdb/bin_gpdb.tar.gz ] ; then
+      mv bin_gpdb/*.tar.gz bin_gpdb/bin_gpdb.tar.gz
+    fi
+
+    source gpdb_src/concourse/scripts/common.bash
+    time install_gpdb
+    time ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash
+    time make_cluster
+
+    source /usr/local/greenplum-db-devel/greenplum_path.sh
+
+    if $IS_GPDB6 ; then
+      # dummy security label: copy library from bucket to correct location
+      # (someday this will be part of the bin_gpdb tarball?)
+      mkdir -p "$GPHOME/postgresql"
+      install -m 755 -T dummy_seclabel_gpdb_linux/dummy_seclabel-v6.so "$GPHOME/lib/postgresql/dummy_seclabel.so"
+    fi
+
+    # copy gpbackup & deps into the GOPATH used by user "gpadmin"
+    export GOPATH=/home/gpadmin/go
+    mkdir -p $GOPATH/src/github.com/greenplum-db
+    cp -R gpbackup $GOPATH/src/github.com/greenplum-db/
+    tar -zxf gpbackup-dependencies/dependencies.tar.gz -C $GOPATH/src/github.com/greenplum-db/gpbackup/
+    chown -R gpadmin $GOPATH
+
+    cat <<SCRIPT > /tmp/run_tests.bash
+      set -ex
+      cd ~
+      source /usr/local/greenplum-db-devel/greenplum_path.sh
+
+      # use "temp build dir" of parent shell
+      source $(pwd)/gpdb_src/gpAux/gpdemo/gpdemo-env.sh
+      export GOPATH=\$HOME/go
+      # reference PATH defined by parent shell
+      export PATH=$PATH:\$PATH:\$GOPATH/bin
+
+      if $IS_GPDB6 ; then
+        # sec label
+        gpconfig -c shared_preload_libraries -v dummy_seclabel
+        gpstop -ra
+        gpconfig -s shared_preload_libraries | grep dummy_seclabel
+      fi
+
+      # Build gpbackup
+      pushd \$GOPATH/src/github.com/greenplum-db/gpbackup
+        make depend
+        make build
+        make unit
+        make integration
+        make end_to_end
+      popd
+
+    SCRIPT
+
+    chmod +x /tmp/run_tests.bash
+    sudo su - gpadmin bash -c /tmp/run_tests.bash


### PR DESCRIPTION
* Use common.bash to install GPDB from binary tarball
* Create local demo cluster via gpAux/gpdemo/
* Work around one missing binary component: the "dummy" security label, a test-only version of the GPDB6+ feature for adding labels to control security.  To provide the binary library file, we add a gcs resource. This library is built from GPDB source, but not included in the tarball yet.  Only old copies are available from public RPMs. Perhaps in the future it can be added to the bin_gpdb.tar.gz, but for now, we just build it once and statically download that copy, probably for the life of 6x and perhaps forever.