### PR TITLE
resgroup: retire the `10 MB` syntax of memory_spill_ratio

### DIFF
--- a/backup/metadata_globals.go
+++ b/backup/metadata_globals.go
@@ -130,17 +130,6 @@ func PrintResetResourceGroupStatements(metadataFile *utils.FileWithByteCount, to
 func PrintCreateResourceGroupStatements(metadataFile *utils.FileWithByteCount, toc *utils.TOC, resGroups []ResourceGroup, resGroupMetadata MetadataMap) {
 	for _, resGroup := range resGroups {
 
-		/*
-		 * memory_spill_ratio can be set in absolute value format since 5.20,
-		 * such as '1 MB', it has to be set as a quoted string, otherwise set
-		 * it without quotes.
-		 */
-		memorySpillRatio := resGroup.MemorySpillRatio
-		if _, err := strconv.Atoi(memorySpillRatio); err != nil {
-			/* memory_spill_ratio is in absolute value format, set it with quotes */
-			memorySpillRatio = "'" + memorySpillRatio + "'"
-		}
-
 		var start uint64
 		section, entry := resGroup.GetMetadataEntry()
 		if resGroup.Name == "default_group" || resGroup.Name == "admin_group" {
@@ -150,7 +139,7 @@ func PrintCreateResourceGroupStatements(metadataFile *utils.FileWithByteCount, t
 			}{
 				{"MEMORY_LIMIT", resGroup.MemoryLimit},
 				{"MEMORY_SHARED_QUOTA", resGroup.MemorySharedQuota},
-				{"MEMORY_SPILL_RATIO", memorySpillRatio},
+				{"MEMORY_SPILL_RATIO", resGroup.MemorySpillRatio},
 				{"CONCURRENCY", resGroup.Concurrency},
 			}
 			for _, property := range resGroupList {
@@ -200,7 +189,7 @@ func PrintCreateResourceGroupStatements(metadataFile *utils.FileWithByteCount, t
 
 			attributes = append(attributes, fmt.Sprintf("MEMORY_LIMIT=%s", resGroup.MemoryLimit))
 			attributes = append(attributes, fmt.Sprintf("MEMORY_SHARED_QUOTA=%s", resGroup.MemorySharedQuota))
-			attributes = append(attributes, fmt.Sprintf("MEMORY_SPILL_RATIO=%s", memorySpillRatio))
+			attributes = append(attributes, fmt.Sprintf("MEMORY_SPILL_RATIO=%s", resGroup.MemorySpillRatio))
 			attributes = append(attributes, fmt.Sprintf("CONCURRENCY=%s", resGroup.Concurrency))
 			metadataFile.MustPrintf("\n\nCREATE RESOURCE GROUP %s WITH (%s);", resGroup.Name, strings.Join(attributes, ", "))
 

--- a/backup/metadata_globals_test.go
+++ b/backup/metadata_globals_test.go
@@ -186,31 +186,6 @@ GRANT TEMPORARY,CONNECT ON DATABASE testdb TO testrole;`,
 				`CREATE RESOURCE GROUP some_group WITH (CPU_RATE_LIMIT=10, MEMORY_AUDITOR=vmtracker, MEMORY_LIMIT=20, MEMORY_SHARED_QUOTA=25, MEMORY_SPILL_RATIO=30, CONCURRENCY=15);`,
 				`CREATE RESOURCE GROUP some_group2 WITH (CPUSET='0-3', MEMORY_AUDITOR=vmtracker, MEMORY_LIMIT=30, MEMORY_SHARED_QUOTA=35, MEMORY_SPILL_RATIO=10, CONCURRENCY=25);`)
 		})
-		It("prints memory_spill_ratio resource groups in new syntax", func() {
-			testhelper.SetDBVersion(connectionPool, backup.GPDB_TAG_WITH_RES_GROUP_CHANGE)
-
-			default_group := backup.ResourceGroup{Oid: 1, Name: "default_group", CPURateLimit: "10", MemoryLimit: "20", Concurrency: "15", MemorySharedQuota: "25", MemorySpillRatio: "30 MB"}
-			admin_group := backup.ResourceGroup{Oid: 2, Name: "admin_group", CPURateLimit: "10", MemoryLimit: "20", Concurrency: "15", MemorySharedQuota: "25", MemorySpillRatio: "30"}
-			someGroup := backup.ResourceGroup{Oid: 3, Name: "some_group", CPURateLimit: "20", MemoryLimit: "30", Concurrency: "25", MemorySharedQuota: "35", MemorySpillRatio: "40 MB"}
-			someGroup2 := backup.ResourceGroup{Oid: 4, Name: "some_group2", CPURateLimit: "20", MemoryLimit: "30", Concurrency: "25", MemorySharedQuota: "35", MemorySpillRatio: "40"}
-			resGroups := []backup.ResourceGroup{default_group, admin_group, someGroup, someGroup2}
-
-			backup.PrintCreateResourceGroupStatements(backupfile, toc, resGroups, emptyResGroupMetadata)
-			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "", "default_group", "RESOURCE GROUP")
-			testutils.AssertBufferContents(toc.GlobalEntries, buffer,
-				`ALTER RESOURCE GROUP default_group SET MEMORY_LIMIT 20;`,
-				`ALTER RESOURCE GROUP default_group SET MEMORY_SHARED_QUOTA 25;`,
-				`ALTER RESOURCE GROUP default_group SET MEMORY_SPILL_RATIO '30 MB';`,
-				`ALTER RESOURCE GROUP default_group SET CONCURRENCY 15;`,
-				`ALTER RESOURCE GROUP default_group SET CPU_RATE_LIMIT 10;`,
-				`ALTER RESOURCE GROUP admin_group SET MEMORY_LIMIT 20;`,
-				`ALTER RESOURCE GROUP admin_group SET MEMORY_SHARED_QUOTA 25;`,
-				`ALTER RESOURCE GROUP admin_group SET MEMORY_SPILL_RATIO 30;`,
-				`ALTER RESOURCE GROUP admin_group SET CONCURRENCY 15;`,
-				`ALTER RESOURCE GROUP admin_group SET CPU_RATE_LIMIT 10;`,
-				`CREATE RESOURCE GROUP some_group WITH (CPU_RATE_LIMIT=20, MEMORY_AUDITOR=vmtracker, MEMORY_LIMIT=30, MEMORY_SHARED_QUOTA=35, MEMORY_SPILL_RATIO='40 MB', CONCURRENCY=25);`,
-				`CREATE RESOURCE GROUP some_group2 WITH (CPU_RATE_LIMIT=20, MEMORY_AUDITOR=vmtracker, MEMORY_LIMIT=30, MEMORY_SHARED_QUOTA=35, MEMORY_SPILL_RATIO=40, CONCURRENCY=25);`)
-		})
 	})
 	Describe("PrintResetResourceGroupStatements", func() {
 		It("prints prepare resource groups", func() {

--- a/integration/metadata_globals_create_test.go
+++ b/integration/metadata_globals_create_test.go
@@ -13,10 +13,10 @@ import (
 	"github.com/onsi/gomega/gbytes"
 )
 
-const (
+var (
 	concurrencyDefault = "20"
-	memSharedDefault   = "80"
-	memSpillDefault    = "128 MB"
+	memSharedDefault   = "20"
+	memSpillDefault    = "20"
 	memAuditDefault    = "0"
 	cpuSetDefault      = "-1"
 )
@@ -25,6 +25,9 @@ var _ = Describe("backup integration create statement tests", func() {
 	var includeSecurityLabels bool
 	BeforeEach(func() {
 		if connectionPool.Version.AtLeast("6") {
+			memSharedDefault = "80"
+			memSpillDefault = "0"
+
 			includeSecurityLabels = true
 		}
 		toc, backupfile = testutils.InitializeTestTOC(buffer, "predata")
@@ -182,9 +185,6 @@ var _ = Describe("backup integration create statement tests", func() {
 			Fail("Could not find some_group")
 		})
 		It("creates a resource group using old format for MemorySpillRatio", func() {
-			if connectionPool.Version.Before(backup.GPDB_TAG_WITH_RES_GROUP_CHANGE) {
-				Skip("Test only applicable to GPDB 5.20 and above")
-			}
 			expectedDefaults := backup.ResourceGroup{Oid: 1, Name: "some_group", CPURateLimit: "10", MemoryLimit: "20", Concurrency: concurrencyDefault, MemorySharedQuota: memSharedDefault, MemorySpillRatio: "19", MemoryAuditor: memAuditDefault, Cpuset: cpuSetDefault}
 
 			testhelper.AssertQueryRuns(connectionPool, "CREATE RESOURCE GROUP some_group WITH (CPU_RATE_LIMIT=10, MEMORY_LIMIT=20, MEMORY_SPILL_RATIO=19);")


### PR DESCRIPTION
In previous commits of gpdb we introduced a new syntax for
memory_spill_ratio, which allow to set the value in `10 MB` syntax, in
gpbackup we added support for this syntax.

However to simplify the user interface we retired this new syntax in
gpdb, so we now have to change in gpbackup accordingly.

Default resource group settings on gpdb 5 and 6 and later, however, are
different now, so we have to provide different default answer values in
the intergration tests.

Co-authored-by: Hubert Zhang <hzhang@pivotal.io>
Co-authored-by: Ning Yu <nyu@pivotal.io>