### PR TITLE
Fix flaking resource group test

### DIFF
--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -31,6 +31,13 @@ var (
 	testCluster             *cluster.Cluster
 	gpbackupHelperPath      string
 	stdout, stderr, logFile *gbytes.Buffer
+
+	// GUC defaults. Initially set to GPDB4 values
+	concurrencyDefault = "20"
+	memSharedDefault   = "20"
+	memSpillDefault    = "20"
+	memAuditDefault    = "0"
+	cpuSetDefault      = "-1"
 )
 
 func TestQueries(t *testing.T) {
@@ -78,6 +85,12 @@ var _ = BeforeSuite(func() {
 	}
 
 	gpbackupHelperPath = buildAndInstallBinaries()
+
+	// Set GUC Defaults
+	if connectionPool.Version.AtLeast("6") {
+		memSharedDefault = "80"
+		memSpillDefault = "0"
+	}
 })
 
 var backupCmdFlags *pflag.FlagSet

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -33,11 +33,12 @@ var (
 	stdout, stderr, logFile *gbytes.Buffer
 
 	// GUC defaults. Initially set to GPDB4 values
-	concurrencyDefault = "20"
-	memSharedDefault   = "20"
-	memSpillDefault    = "20"
-	memAuditDefault    = "0"
-	cpuSetDefault      = "-1"
+	concurrencyDefault    = "20"
+	memSharedDefault      = "20"
+	memSpillDefault       = "20"
+	memAuditDefault       = "0"
+	cpuSetDefault         = "-1"
+	includeSecurityLabels = false
 )
 
 func TestQueries(t *testing.T) {
@@ -86,10 +87,12 @@ var _ = BeforeSuite(func() {
 
 	gpbackupHelperPath = buildAndInstallBinaries()
 
-	// Set GUC Defaults
+	// Set GUC Defaults and version logic
 	if connectionPool.Version.AtLeast("6") {
 		memSharedDefault = "80"
 		memSpillDefault = "0"
+
+		includeSecurityLabels = true
 	}
 })
 

--- a/integration/metadata_globals_create_test.go
+++ b/integration/metadata_globals_create_test.go
@@ -14,11 +14,7 @@ import (
 )
 
 var _ = Describe("backup integration create statement tests", func() {
-	var includeSecurityLabels bool
 	BeforeEach(func() {
-		if connectionPool.Version.AtLeast("6") {
-			includeSecurityLabels = true
-		}
 		toc, backupfile = testutils.InitializeTestTOC(buffer, "predata")
 	})
 	Describe("PrintCreateDatabaseStatement", func() {

--- a/integration/metadata_globals_create_test.go
+++ b/integration/metadata_globals_create_test.go
@@ -13,20 +13,10 @@ import (
 	"github.com/onsi/gomega/gbytes"
 )
 
-var (
-	concurrencyDefault = "20"
-	memSharedDefault   = "20"
-	memSpillDefault    = "20"
-	memAuditDefault    = "0"
-	cpuSetDefault      = "-1"
-)
-
 var _ = Describe("backup integration create statement tests", func() {
 	var includeSecurityLabels bool
 	BeforeEach(func() {
 		if connectionPool.Version.AtLeast("6") {
-			memSharedDefault = "80"
-			memSpillDefault = "0"
 			includeSecurityLabels = true
 		}
 		toc, backupfile = testutils.InitializeTestTOC(buffer, "predata")

--- a/integration/postdata_create_test.go
+++ b/integration/postdata_create_test.go
@@ -11,11 +11,7 @@ import (
 )
 
 var _ = Describe("backup integration create statement tests", func() {
-	var includeSecurityLabels bool
 	BeforeEach(func() {
-		if connectionPool.Version.AtLeast("6") {
-			includeSecurityLabels = true
-		}
 		toc, backupfile = testutils.InitializeTestTOC(buffer, "predata")
 	})
 	Describe("PrintCreateIndexStatements", func() {

--- a/integration/predata_acl_queries_test.go
+++ b/integration/predata_acl_queries_test.go
@@ -14,12 +14,6 @@ import (
 var _ = Describe("backup integration tests", func() {
 	Describe("GetMetadataForObjectType", func() {
 		Context("default metadata for all objects of one type", func() {
-			var includeSecurityLabels bool
-			BeforeEach(func() {
-				if connectionPool.Version.AtLeast("6") {
-					includeSecurityLabels = true
-				}
-			})
 			It("returns a slice of metadata with modified privileges", func() {
 				testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.foo(i int)")
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.foo")

--- a/integration/predata_functions_create_test.go
+++ b/integration/predata_functions_create_test.go
@@ -11,11 +11,7 @@ import (
 )
 
 var _ = Describe("backup integration create statement tests", func() {
-	var includeSecurityLabels bool
 	BeforeEach(func() {
-		if connectionPool.Version.AtLeast("6") {
-			includeSecurityLabels = true
-		}
 		toc, backupfile = testutils.InitializeTestTOC(buffer, "predata")
 	})
 	Describe("PrintCreateFunctionStatement", func() {

--- a/integration/predata_relations_create_test.go
+++ b/integration/predata_relations_create_test.go
@@ -15,11 +15,7 @@ import (
 )
 
 var _ = Describe("backup integration create statement tests", func() {
-	var includeSecurityLabels bool
 	BeforeEach(func() {
-		if connectionPool.Version.AtLeast("6") {
-			includeSecurityLabels = true
-		}
 		toc, backupfile = testutils.InitializeTestTOC(buffer, "predata")
 	})
 	Describe("PrintRegularTableCreateStatement", func() {

--- a/integration/predata_shared_create_test.go
+++ b/integration/predata_shared_create_test.go
@@ -11,11 +11,7 @@ import (
 )
 
 var _ = Describe("backup integration create statement tests", func() {
-	var includeSecurityLabels bool
 	BeforeEach(func() {
-		if connectionPool.Version.AtLeast("6") {
-			includeSecurityLabels = true
-		}
 		toc, backupfile = testutils.InitializeTestTOC(buffer, "predata")
 	})
 	Describe("PrintCreateSchemaStatements", func() {

--- a/integration/predata_types_create_test.go
+++ b/integration/predata_types_create_test.go
@@ -12,14 +12,10 @@ import (
 
 var _ = Describe("backup integration create statement tests", func() {
 	var (
-		includeSecurityLabels bool
-		emptyMetadata         backup.ObjectMetadata
-		emptyMetadataMap      backup.MetadataMap
+		emptyMetadata    backup.ObjectMetadata
+		emptyMetadataMap backup.MetadataMap
 	)
 	BeforeEach(func() {
-		if connectionPool.Version.AtLeast("6") {
-			includeSecurityLabels = true
-		}
 		toc, backupfile = testutils.InitializeTestTOC(buffer, "predata")
 		emptyMetadata = backup.ObjectMetadata{}
 		emptyMetadataMap = backup.MetadataMap{}


### PR DESCRIPTION
The correct global variable defaults were not being properly set for one
of test. Depending on the order in which tests ran, a default resource
group test had the potential to flake. Move the setting of the GUCs to
before when all integration tests run.

The other test using the global defaults variables `memSharedDefault` and `memSpillDefault` are in metadata_globals_queries_test.go
