### PR TITLE
Set extra_float_digits session GUC during backup

### DIFF
--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -62,6 +62,9 @@ func SetSessionGUCs(connNum int) {
 	if connectionPool.Version.AtLeast("6") {
 		connectionPool.MustExec("SET INTERVALSTYLE = POSTGRES", connNum)
 		connectionPool.MustExec("SET lock_timeout = 0", connNum)
+		connectionPool.MustExec("SET extra_float_digits=3")
+	} else {
+		connectionPool.MustExec("SET extra_float_digits=2")
 	}
 }
 


### PR DESCRIPTION
We need to set extra_float_digits GUC when backing up real, double
precision, and geometric data types to preserve the exact data. Without
the GUC, only up to 6 precision points is backed up which is not enough
for Postgres/Greenplum to reconstruct the proper value.

The GUC max value was increased from 2 to 3 in Postgres 9.0. This means
that Greenplum 6 will have the value set to 3 while versions before that
will have max value 2.

End-to-end tests to check the backup functionality for reals are also added.