### PR TITLE
Pass in same endtime for history and report file

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/greenplum-db/gp-common-go-libs/operating"
 	"github.com/greenplum-db/gpbackup/backup_filepath"
 	"github.com/greenplum-db/gpbackup/backup_history"
 	"github.com/greenplum-db/gpbackup/utils"
@@ -419,7 +420,8 @@ func DoTeardown() {
 		if backupReport != nil {
 			backupReport.ConstructBackupParamsString()
 			backup_history.WriteConfigFile(&backupReport.BackupConfig, configFilename)
-			backupReport.WriteBackupReportFile(reportFilename, globalFPInfo.Timestamp, objectCounts, errMsg)
+			endtime, _ := time.ParseInLocation("20060102150405", backupReport.BackupConfig.EndTime, operating.System.Local)
+			backupReport.WriteBackupReportFile(reportFilename, globalFPInfo.Timestamp, endtime, objectCounts, errMsg)
 			utils.EmailReport(globalCluster, globalFPInfo.Timestamp, reportFilename, "gpbackup")
 			if pluginConfig != nil {
 				err := pluginConfig.BackupFile(configFilename)

--- a/utils/report.go
+++ b/utils/report.go
@@ -114,7 +114,7 @@ incremental backup set:
 %s`, strings.Join(backupTimestamps, "\n"))
 }
 
-func (report *Report) WriteBackupReportFile(reportFilename string, timestamp string, objectCounts map[string]int, errMsg string) {
+func (report *Report) WriteBackupReportFile(reportFilename string, timestamp string, endtime time.Time, objectCounts map[string]int, errMsg string) {
 	reportFile, err := iohelper.OpenFileForWriting(reportFilename)
 	if err != nil {
 		gplog.Error("Unable to open backup report file %s", reportFilename)
@@ -122,7 +122,7 @@ func (report *Report) WriteBackupReportFile(reportFilename string, timestamp str
 	}
 
 	gpbackupCommandLine := strings.Join(os.Args, " ")
-	start, end, duration := GetDurationInfo(timestamp, operating.System.Now())
+	start, end, duration := GetDurationInfo(timestamp, endtime)
 
 	reportInfo := make([]LineInfo, 0)
 	reportInfo = append(reportInfo,

--- a/utils/report_test.go
+++ b/utils/report_test.go
@@ -44,6 +44,7 @@ var _ = Describe("utils/report tests", func() {
     })
     Describe("WriteBackupReportFile", func() {
         timestamp := "20170101010101"
+        endtime := time.Date(2017, 1, 1, 5, 4, 3, 2, time.Local)
         config := backup_history.BackupConfig{
             BackupVersion:   "0.1.0",
             DatabaseName:    "testdb",
@@ -74,7 +75,7 @@ data file format: Single Data File Per Segment`,
         })
 
         It("writes a report for a successful backup", func() {
-            backupReport.WriteBackupReportFile("filename", timestamp, objectCounts, "")
+            backupReport.WriteBackupReportFile("filename", timestamp, endtime, objectCounts, "")
             Expect(buffer).To(gbytes.Say(`Greenplum Database Backup Report
 
 timestamp key:         20170101010101
@@ -103,7 +104,7 @@ tables      42
 types       1000`))
         })
         It("writes a report for a failed backup", func() {
-            backupReport.WriteBackupReportFile("filename", timestamp, objectCounts, "Cannot access /tmp/backups: Permission denied")
+            backupReport.WriteBackupReportFile("filename", timestamp, endtime, objectCounts, "Cannot access /tmp/backups: Permission denied")
             Expect(buffer).To(gbytes.Say(`Greenplum Database Backup Report
 
 timestamp key:         20170101010101
@@ -134,7 +135,7 @@ types       1000`))
         })
         It("writes a report without database size information", func() {
             backupReport.DatabaseSize = ""
-            backupReport.WriteBackupReportFile("filename", timestamp, objectCounts, "")
+            backupReport.WriteBackupReportFile("filename", timestamp, endtime, objectCounts, "")
             Expect(buffer).To(gbytes.Say(`Greenplum Database Backup Report
 
 timestamp key:         20170101010101


### PR DESCRIPTION
The backup-history and backup-report files were previously resolving
each of its endtime field individually, which created inconsistencies
for the same backup. We now pass in the endtime field of the history
file into the report file to sync up the two files.

Co-authored-by: Jimmy Yih <jyih@pivotal.io>
Co-authored-by: Junkeun Yi <juyi@pivotal.io>