### PR TITLE
Drop table created in real-type precision test

### DIFF
--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -1151,6 +1151,7 @@ PARTITION BY LIST (gender)
 				backupdir := filepath.Join(customBackupDir, "real_precision") // Must be unique
 				tableName := "test_real_precision"
 				testhelper.AssertQueryRuns(backupConn, fmt.Sprintf(`CREATE TABLE public.%s (val real)`, tableName))
+				defer testhelper.AssertQueryRuns(backupConn, fmt.Sprintf(`DROP TABLE public.%s`, tableName))
 				testhelper.AssertQueryRuns(backupConn, fmt.Sprintf(`INSERT INTO public.%s VALUES (0.24006299674511::real)`, tableName))
 				timestamp := gpbackup(gpbackupPath, backupHelperPath, "--backup-dir", backupdir, "--dbname", "testdb", "--include-table", fmt.Sprintf("public.%s", tableName))
 				gprestore(gprestorePath, restoreHelperPath, timestamp, "--redirect-db", "restoredb", "--backup-dir", backupdir)


### PR DESCRIPTION
A relation created during the "precise backup of reals" end_to_end
test was not dropped, interfering with other tests that counted the
number of relations as an assertion. The reals test relation is now
being dropped so that the number of relations counted in the other
tests stay the same.