### PR TITLE
Add newline before gplog error when gprestore fails with progress bar

### DIFF
--- a/restore/data.go
+++ b/restore/data.go
@@ -157,8 +157,10 @@ func restoreDataFromTimestamp(fpInfo backup_filepath.FilePathInfo, dataEntries [
 	}
 
 	if fatalErr != nil {
+		fmt.Println("")
 		gplog.Fatal(fatalErr, "")
 	} else if numErrors > 0 {
+		fmt.Println("")
 		gplog.Error("Encountered %d errors during table data restore; see log file %s for a list of table errors.", numErrors, gplog.GetLogFilePath())
 	}
 }

--- a/restore/parallel.go
+++ b/restore/parallel.go
@@ -61,8 +61,10 @@ func ExecuteStatements(statements []utils.StatementWithType, progressBar utils.P
 		workerPool.Wait()
 	}
 	if fatalErr != nil {
+		fmt.Println("")
 		gplog.Fatal(fatalErr, "")
 	} else if numErrors > 0 {
+		fmt.Println("")
 		gplog.Error("Encountered %d errors during metadata restore; see log file %s for a list of failed statements.", numErrors, gplog.GetLogFilePath())
 	}
 }


### PR DESCRIPTION
When gprestore errors on some restore operation where a progress bar
is involved, the gplog error or fatal message is outputted to the
stderr without a newline before it. This causes the gplog message to
be appended to the progress bar output because the progress bar does
not newline if it's interrupted. Add some newlines to fix this.

Issue example:
```
Pre-data objects restored:  0 / 14 [-------------------------------------------------------]   0.00%20190712:14:09:13 gprestore:user:host:024793-[ERROR]:-Encountered 8 errors during metadata restore; see log file /mylog.log for a list of failed statements.
```

Co-authored-by: Junkeun Yi <juyi@pivotal.io>