### PR TITLE
Modify pipeline template for scale tests

### DIFF
--- a/ci/templates/gpbackup-tpl.yml
+++ b/ci/templates/gpbackup-tpl.yml
@@ -30,11 +30,13 @@ groups:
   jobs:
   - GPDB4.3
   - ddboost_plugin_and_boostfs_tests_43
+  - scale-43
 - name: GPDB5
   jobs:
   - GPDB5
   - GPDB5-oracle7
   - GPDB5-sles11
+  - scale-5x
 {% if "gpbackup-release" != pipeline_name %}
   - 5X-head-gpbackup-fixed-test
 {% endif %}
@@ -44,10 +46,12 @@ groups:
 - name: GPDB6
   jobs:
   - GPDB6
+  - scale-6x
 {% if "gpbackup-release" != pipeline_name %}
 - name: Master
   jobs:
   - master
+  - scale-master
 {% endif %}
 - name: Scale
   jobs:


### PR DESCRIPTION
~~1. The template for the pipeline generation does not include the scale
tests as pass conditions for its final validation step.~~

2. Scale jobs were tested against a specific GPDB major versions but were not
    added to the pipeline group for that version. 