### PR TITLE
Add gpbackup-manager to gppkgs and create CI test job

### DIFF
--- a/ci/tasks/test-gpbackup-manager.yml
+++ b/ci/tasks/test-gpbackup-manager.yml
@@ -1,0 +1,86 @@
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: pivotaldata/centos-gpdb-dev
+    tag: '7-gcc6.2-llvm3.7'
+
+inputs:
+- name: gpbackup_manager_src
+  path: go/src/github.com/pivotal/gp-backup-manager
+- name: gpdb_src
+- name: bin_gpdb
+- name: gppkgs
+
+params:
+  GOLANG_VERSION: 1.12.7
+
+run:
+  path: bash
+  args:
+  - -c
+  - |
+    set -ex
+    if [ ! -f bin_gpdb/bin_gpdb.tar.gz ] ; then
+      mv bin_gpdb/*.tar.gz bin_gpdb/bin_gpdb.tar.gz
+    fi
+
+    # We download a fixed version GOLANG_VERSION of Go to run ginkgo, our testing framework, on gpbackup_manager.
+    # This is because gpbackup_manager has tests that require Go 1.12+
+    # TODO: bake a new image with Go 1.12+ pre-installed.
+    wget https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz && \
+    sudo rm -rf /usr/local/go && \
+    tar -xzf go${GOLANG_VERSION}.linux-amd64.tar.gz -C /usr/local
+
+    source gpdb_src/concourse/scripts/common.bash
+    time install_gpdb
+    time ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash
+    time make_cluster
+
+    source /usr/local/greenplum-db-devel/greenplum_path.sh
+
+    # copy gpbackup-manager into the GOPATH used by user "gpadmin"
+    export GOPATH=/home/gpadmin/go
+    mkdir -p $GOPATH/src/github.com/pivotal
+    cp -R go/src/github.com/pivotal/gp-backup-manager $GOPATH/src/github.com/pivotal/
+
+    chown -R gpadmin $GOPATH
+
+    cat <<SCRIPT > /tmp/run_tests.bash
+    #!/bin/bash
+    set -ex
+    cd ~
+    source /usr/local/greenplum-db-devel/greenplum_path.sh
+
+    # use "temp build dir" of parent shell
+    source $(pwd)/gpdb_src/gpAux/gpdemo/gpdemo-env.sh
+    export GOPATH=\$HOME/go
+    mkdir -p \$GOPATH/bin
+    mkdir -p \$GOPATH/src
+    # reference PATH defined by parent shell
+    export PATH=/usr/local/go/bin:$PATH:\$PATH:\$GOPATH/bin
+
+    # Install gppkgs
+    mkdir /tmp/untarred
+    tar -xzf gppkgs/gpbackup-gppkgs.tar.gz -C /tmp/untarred
+    out=\$(psql postgres -c "select version();")
+    GPDB_VERSION=\$(echo \$out | sed -n 's/.*Greenplum Database \([0-9]\).*/\1/p')
+    gppkg -i /tmp/untarred/gpbackup*gp\${GPDB_VERSION}*RHEL*.gppkg
+
+    # install pgcrypto; works for GPDB 6+
+    psql -d postgres -c "create extension pgcrypto"
+
+    # Test gpbackup manager
+    pushd \$GOPATH/src/github.com/pivotal/gp-backup-manager
+      make depend
+      make unit
+      make integration
+      make end_to_end_without_install
+    popd
+
+    SCRIPT
+
+    cp -r gppkgs /home/gpadmin
+    chmod +x /tmp/run_tests.bash
+    su - gpadmin bash -c /tmp/run_tests.bash

--- a/ci/templates/gpbackup-tpl.yml
+++ b/ci/templates/gpbackup-tpl.yml
@@ -7,6 +7,7 @@ groups:
   - GPDB5
   - GPDB5-oracle7
   - GPDB5-sles11
+  - gpbackup-manager-tests
 {% if "gpbackup-release" != pipeline_name %}
   - 5X-head-gpbackup-fixed-test
 {% endif %}
@@ -859,6 +860,25 @@ jobs:
 {% endif %}
   ensure:
     <<: *set_failed
+
+- name: gpbackup-manager-tests
+  plan:
+    - aggregate:
+        - get: gpbackup_manager_src
+        - get: gpbackup
+        - get: bin_gpdb_6x_stable_centos6
+        - get: ccp_src
+        - get: gpdb6_src
+        - get: gppkgs
+          trigger: true
+          passed:
+            - build_binaries
+    - task: run_tests
+      file: gpbackup/ci/tasks/test-gpbackup-manager.yml
+      input_mapping:
+        gpdb_src: gpdb6_src
+        bin_gpdb: bin_gpdb_6x_stable_centos6
+
 
 - name: ddboost_plugin_and_boostfs_tests_43
   plan:
@@ -1888,6 +1908,7 @@ jobs:
         - backward-compatibility
         - ddboost_plugin_and_boostfs_tests_43
         - ddboost_plugin_and_boostfs_tests_5x
+        - gpbackup-manager-tests
     - get: gpbackup
   - aggregate:
     - put: gppkgs
@@ -2058,6 +2079,7 @@ jobs:
         - 5X-head-gpbackup-fixed-test
         - ddboost_plugin_and_boostfs_tests_43
         - ddboost_plugin_and_boostfs_tests_5x
+        - gpbackup-manager-tests
 {% endif %}
 
 ccp_default_params_anchor: &ccp_default_params

--- a/gppkg/gpbackup_tools.spec.in
+++ b/gppkg/gpbackup_tools.spec.in
@@ -18,11 +18,12 @@ Backup and restore utilities for Greenplum
 
 %install
 mkdir -p $RPM_BUILD_ROOT%{prefix}/bin
-cp bin/gpbackup bin/gprestore bin/gpbackup_helper bin/gpbackup_ddboost_plugin bin/gpbackup_s3_plugin $RPM_BUILD_ROOT%{prefix}/bin
+cp bin/gpbackup bin/gprestore bin/gpbackup_helper bin/gpbackup_manager bin/gpbackup_ddboost_plugin bin/gpbackup_s3_plugin $RPM_BUILD_ROOT%{prefix}/bin
 
 %files
 %{prefix}/bin/gpbackup
 %{prefix}/bin/gprestore
 %{prefix}/bin/gpbackup_helper
+%{prefix}/bin/gpbackup_manager
 %{prefix}/bin/gpbackup_ddboost_plugin
 %{prefix}/bin/gpbackup_s3_plugin


### PR DESCRIPTION
The gpbackup-manager binary is now packaged with the other binaries into
a single gppkg. The test for gpbackup-manager runs against GPDB6.

Co-authored-by: Junkeun Yi <juyi@pivotal.io>
Co-authored-by: Lav Jain <ljain@pivotal.io>
Co-authored-by: Trevor Yacovone <tyacovone@pivotal.io>
Co-authored-by: Kevin Yeap <kyeap@pivotal.io>