### PR TITLE
Output COPY ON SEGMENT error CONTEXT string

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -326,6 +326,7 @@
     "github.com/greenplum-db/gp-common-go-libs/operating",
     "github.com/greenplum-db/gp-common-go-libs/structmatcher",
     "github.com/greenplum-db/gp-common-go-libs/testhelper",
+    "github.com/jackc/pgx",
     "github.com/lib/pq",
     "github.com/nightlyone/lockfile",
     "github.com/onsi/ginkgo",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -75,3 +75,7 @@ required = ["golang.org/x/tools/cmd/goimports", "github.com/onsi/ginkgo/ginkgo"]
   branch = "master"
   name = "github.com/blang/vfs"
   source = "https://github.com/dsharp-pivotal/vfs.git"
+
+[[constraint]]
+  name = "github.com/jackc/pgx"
+  version = "v3.3.0"

--- a/restore/data_test.go
+++ b/restore/data_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/greenplum-db/gpbackup/backup"
 	"github.com/greenplum-db/gpbackup/restore"
 	"github.com/greenplum-db/gpbackup/utils"
+	"github.com/jackc/pgx"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -68,6 +69,22 @@ var _ = Describe("restore/data tests", func() {
 			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
 
 			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("will output expected error string from COPY ON SEGMENT failure", func() {
+			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456 | cat -' WITH CSV DELIMITER ',' ON SEGMENT;")
+			pgErr := pgx.PgError{
+				Severity: "ERROR",
+				Code: "22P04",
+				Message: "value of distribution key doesn't belong to segment with ID 0, it belongs to segment with ID 1",
+				Where: "COPY foo, line 1: \"5\"",
+			}
+			mock.ExpectExec(execStr).WillReturnError(pgErr)
+			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456"
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
+
+			Expect(err.Error()).To(Equal("Error loading data into table public.foo: " +
+				"COPY foo, line 1: \"5\": " +
+				"ERROR: value of distribution key doesn't belong to segment with ID 0, it belongs to segment with ID 1 (SQLSTATE 22P04)"))
 		})
 	})
 	Describe("CheckRowsRestored", func() {


### PR DESCRIPTION
When COPY ON SEGMENT errors out on distribution key issues, the error
CONTEXT contains the actual tuple that COPY was having issues
with. This is not outputted by default though in pgx.PgError.Error()
so we have to output it ourselves.

Before:
Error loading data into table public.foobar: ERROR: value of distribution key doesn't belong to segment with ID 0, it belongs to segment with ID 1  (seg0 127.0.0.1:25432 pid=18337) (SQLSTATE 22P04)

After:
Error loading data into table public.foobar: COPY foobar, line 1: "5": ERROR: value of distribution key doesn't belong to segment with ID 0, it belongs to segment with ID 1  (seg0 127.0.0.1:25432 pid=18337) (SQLSTATE 22P04)

Co-authored-by: Trevor Yacovone <tyacovone@pivotal.io>