### PR TITLE
Fix getModCount return a wrong result.

### DIFF
--- a/backup/queries_incremental.go
+++ b/backup/queries_incremental.go
@@ -84,7 +84,7 @@ func getAOSegTableFQNs(connectionPool *dbconn.DBConn) map[string]string {
 
 func getModCount(connectionPool *dbconn.DBConn, aosegtablefqn string) int64 {
 	query := fmt.Sprintf(`
-	SELECT modcount FROM %s
+	SELECT COALESCE(pg_catalog.sum(modcount), 0) AS modcount FROM %s
 `, aosegtablefqn)
 
 	var results []struct {
@@ -93,9 +93,6 @@ func getModCount(connectionPool *dbconn.DBConn, aosegtablefqn string) int64 {
 	err := connectionPool.Select(&results, query)
 	gplog.FatalOnError(err)
 
-	if len(results) == 0 {
-		return 0
-	}
 	return results[0].Modcount
 }
 


### PR DESCRIPTION
There may be multiple segno files for an append-only table.

```
gpadmin=# select * from  pg_aoseg.pg_aoseg_26762;
 segno | eof | tupcount | varblockcount | eofuncompressed | modcount | formatversion | state 
-------+-----+----------+---------------+-----------------+----------+---------------+-------
     1 |   0 |        4 |             0 |               0 |        4 |             3 |     1
     2 |   0 |        2 |             0 |               0 |        2 |             3 |     1
(2 rows)
```