### PR TITLE
Correct GetSegPrefix() in gp6.x

### DIFF
--- a/backup_filepath/filepath.go
+++ b/backup_filepath/filepath.go
@@ -165,7 +165,7 @@ func GetSegPrefix(connectionPool *dbconn.DBConn) string {
 	if connectionPool.Version.Before("6") {
 		query = "SELECT fselocation FROM pg_filespace_entry WHERE fsedbid = 1;"
 	} else {
-		query = "SELECT datadir FROM gp_segment_configuration WHERE dbid = 1;"
+		query = "SELECT datadir FROM gp_segment_configuration WHERE content = -1 AND role = 'p';"
 	}
 	result := ""
 	err := connectionPool.Get(&result, query)


### PR DESCRIPTION
The conversion that the master's dbid equals 1 is broken after gpactivatestandby in gp6.x.

![image](https://user-images.githubusercontent.com/17427025/63277815-9a5cac80-c2d8-11e9-9572-27dae6f43a00.png)
