### PR TITLE
Report error if gpbackup_helper script fails to write

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -111,7 +111,7 @@ func DoSetup() {
 		pluginConfig, err = utils.ReadPluginConfig(pluginConfigFlag)
 		configFilename := filepath.Base(pluginConfig.ConfigPath)
 		configDirname := filepath.Dir(pluginConfig.ConfigPath)
-		pluginConfig.ConfigPath = filepath.Join(configDirname, timestamp + "_" + configFilename)
+		pluginConfig.ConfigPath = filepath.Join(configDirname, timestamp+"_"+configFilename)
 		_ = cmdFlags.Set(utils.PLUGIN_CONFIG, pluginConfig.ConfigPath)
 		gplog.Info("plugin config path: %s", pluginConfig.ConfigPath)
 		gplog.FatalOnError(err)
@@ -324,7 +324,7 @@ func backupData(tables []Table) {
 			compressStr = " --compression-level 0"
 		}
 		// Do not pass through the --on-error-continue flag because it does not apply to gpbackup
-		utils.StartAgent(globalCluster, globalFPInfo, "--backup-agent",
+		utils.StartGpbackupHelpers(globalCluster, globalFPInfo, "--backup-agent",
 			MustGetFlagString(utils.PLUGIN_CONFIG), compressStr, false)
 	}
 	gplog.Info("Writing data to file")

--- a/restore/data.go
+++ b/restore/data.go
@@ -107,7 +107,7 @@ func restoreDataFromTimestamp(fpInfo backup_filepath.FilePathInfo, dataEntries [
 		if wasTerminated {
 			return
 		}
-		utils.StartAgent(globalCluster, fpInfo, "--restore-agent", MustGetFlagString(utils.PLUGIN_CONFIG), "", MustGetFlagBool(utils.ON_ERROR_CONTINUE))
+		utils.StartGpbackupHelpers(globalCluster, fpInfo, "--restore-agent", MustGetFlagString(utils.PLUGIN_CONFIG), "", MustGetFlagBool(utils.ON_ERROR_CONTINUE))
 	}
 	/*
 	 * We break when an interrupt is received and rely on

--- a/utils/agent_remote_test.go
+++ b/utils/agent_remote_test.go
@@ -121,9 +121,9 @@ var _ = Describe("agent remote", func() {
 			Expect(err).To(Equal(tw.WriteErr))
 		})
 	})
-	Describe("StartAgents()", func() {
+	Describe("StartGpbackupHelpers()", func() {
 		It("Correctly propagates --on-error-continue flag to gpbackup_helper", func() {
-			utils.StartAgent(testCluster, fpInfo, "operation", "/tmp/pluginConfigFile.yml", " compressStr", true)
+			utils.StartGpbackupHelpers(testCluster, fpInfo, "operation", "/tmp/pluginConfigFile.yml", " compressStr", true)
 
 			cc := testExecutor.ClusterCommands[0]
 			Expect(cc[0][4]).To(ContainSubstring(" --on-error-continue"))


### PR DESCRIPTION
Previously, gprestore was writing the script to run gpbackup_helper to the
segments using HEREDOC. It was possible for the writing of the script to
fail due to an issue like a full temp directory. Because the next thing
called after the HEREDOC write was a backgrounded gpbackup_helper call,
a HEREDOC write fail would not be detected and gpbackup could hang
indefinitely. This fix correctly reports an error back to gprestore.

Authored-by: Kevin Yeap <kyeap@pivotal.io>