### PR TITLE
Fix incremental backup panic with no data change

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -111,7 +111,7 @@ func DoSetup() {
 		pluginConfig, err = utils.ReadPluginConfig(pluginConfigFlag)
 		configFilename := filepath.Base(pluginConfig.ConfigPath)
 		configDirname := filepath.Dir(pluginConfig.ConfigPath)
-		pluginConfig.ConfigPath = filepath.Join(configDirname, timestamp + "_" + configFilename)
+		pluginConfig.ConfigPath = filepath.Join(configDirname, timestamp+"_"+configFilename)
 		_ = cmdFlags.Set(utils.PLUGIN_CONFIG, pluginConfig.ConfigPath)
 		gplog.Info("plugin config path: %s", pluginConfig.ConfigPath)
 		gplog.FatalOnError(err)
@@ -308,6 +308,13 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Table, tableO
 }
 
 func backupData(tables []Table) {
+	if len(tables) == 0 {
+		// No incremental data changes to backup
+		gplog.Info("No tables to backup")
+		gplog.Info("Data backup complete")
+		return
+	}
+
 	if MustGetFlagBool(utils.SINGLE_DATA_FILE) {
 		gplog.Verbose("Initializing pipes and gpbackup_helper on segments for single data file backup")
 		utils.VerifyHelperVersionOnSegments(version, globalCluster)

--- a/backup/backup_internal_test.go
+++ b/backup/backup_internal_test.go
@@ -1,0 +1,24 @@
+package backup
+
+import (
+	"github.com/greenplum-db/gp-common-go-libs/testhelper"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+)
+
+var _ = Describe("backup internal tests", func() {
+	var log *gbytes.Buffer
+	BeforeEach(func() {
+		_, _, log = testhelper.SetupTestLogger()
+	})
+
+	Describe("backupData", func() {
+		It("returns successfully immediately if there is no table data to backup", func() {
+			emptyTableSlice := []Table{}
+
+			backupData(emptyTableSlice)
+			Expect(string(log.Contents())).To(ContainSubstring("Data backup complete"))
+		})
+	})
+})


### PR DESCRIPTION
gpbackup_helper setup assumed there would always be table data to
be backed up, which was causing a panic when trying to create the
first pipe for the first table. Now, backupData will check if there is any table data to backup and return immediately if there is none. If it does return immediately that
means there are no incremental data changes to backup.

Authored-by: Kevin Yeap <kyeap@pivotal.io>