### PR TITLE
Optmized the backup query generated for getting indexes

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -111,7 +111,7 @@ func DoSetup() {
 		pluginConfig, err = utils.ReadPluginConfig(pluginConfigFlag)
 		configFilename := filepath.Base(pluginConfig.ConfigPath)
 		configDirname := filepath.Dir(pluginConfig.ConfigPath)
-		pluginConfig.ConfigPath = filepath.Join(configDirname, timestamp + "_" + configFilename)
+		pluginConfig.ConfigPath = filepath.Join(configDirname, timestamp+"_"+configFilename)
 		_ = cmdFlags.Set(utils.PLUGIN_CONFIG, pluginConfig.ConfigPath)
 		gplog.Info("plugin config path: %s", pluginConfig.ConfigPath)
 		gplog.FatalOnError(err)

--- a/backup/queries_postdata.go
+++ b/backup/queries_postdata.go
@@ -8,6 +8,8 @@ package backup
 import (
 	"fmt"
 
+	"time"
+
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gpbackup/utils"
@@ -77,12 +79,18 @@ func (i IndexDefinition) FQN() string {
 	return utils.MakeFQN(i.OwningSchema, i.Name)
 }
 
+func timeTrack(start time.Time, name string) {
+	elapsed := time.Since(start)
+	gplog.Debug(fmt.Sprintf("%s took %s", name, elapsed))
+}
+
 /*
  * GetIndexes queries for all user and implicitly created indexes, since
  * implicitly created indexes could still have metadata to be backed up.
  * e.g. comments on implicitly created indexes
  */
 func GetIndexes(connectionPool *dbconn.DBConn) []IndexDefinition {
+	defer timeTrack(time.Now(), "GetIndexes")
 	resultIndexes := make([]IndexDefinition, 0)
 	if connectionPool.Version.Before("6") {
 		indexNameSet := ConstructImplicitIndexNames(connectionPool)

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -145,7 +145,7 @@ func RecoverMetadataFilesUsingPlugin() {
 	gplog.FatalOnError(err)
 	configFilename := filepath.Base(pluginConfig.ConfigPath)
 	configDirname := filepath.Dir(pluginConfig.ConfigPath)
-	pluginConfig.ConfigPath = filepath.Join(configDirname, backup_history.CurrentTimestamp() + "_" + configFilename)
+	pluginConfig.ConfigPath = filepath.Join(configDirname, backup_history.CurrentTimestamp()+"_"+configFilename)
 	_ = cmdFlags.Set(utils.PLUGIN_CONFIG, pluginConfig.ConfigPath)
 	gplog.Info("plugin config path: %s", pluginConfig.ConfigPath)
 

--- a/utils/util.go
+++ b/utils/util.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
@@ -97,4 +98,9 @@ func ValidateGPDBVersionCompatibility(connectionPool *dbconn.DBConn) {
 	} else if connectionPool.Version.Is("5") && connectionPool.Version.Before(MINIMUM_GPDB5_VERSION) {
 		gplog.Fatal(errors.Errorf(`GPDB version %s is not supported. Please upgrade to GPDB %s or later.`, connectionPool.Version.VersionString, MINIMUM_GPDB5_VERSION), "")
 	}
+}
+
+func LogExecutionTime(start time.Time, name string) {
+	elapsed := time.Since(start)
+	gplog.Debug(fmt.Sprintf("%s took %s", name, elapsed))
 }


### PR DESCRIPTION
Modified query to get index information.
Avoid using pg_partitions view and instead directly query pg_partition and pg_partition_rule relations. This gives us approximately a 5X speedup

Added a timer function utility which is used GetIndexes to log execution time

Co-authored-by: Lav Jain <ljain@pivotal.io>
Co-authored-by: Shivram Mani <shivram.mani@gmail.com>
Co-authored-by: Kevin Yeap <kyeap@pivotal.io>