### PR TITLE
Avoid redundant calls of GetOidsFromRelationList against include/excluse list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ depend : $(GOLANG_LINTER) $(DEP)
 		@cd vendor/github.com/onsi/ginkgo/ginkgo; go install .
 
 format :
-		goimports -w .
+		@goimports -w $(shell find . -type f -name '*.go' -not -path "./vendor/*")	
 
 LINTER_VERSION=1.16.0
 $(GOLANG_LINTER) :

--- a/backup/global_variables.go
+++ b/backup/global_variables.go
@@ -21,16 +21,17 @@ import (
  * Non-flag variables
  */
 var (
-	backupReport   *utils.Report
-	connectionPool *dbconn.DBConn
-	globalCluster  *cluster.Cluster
-	globalFPInfo   backup_filepath.FilePathInfo
-	globalTOC      *utils.TOC
-	objectCounts   map[string]int
-	pluginConfig   *utils.PluginConfig
-	version        string
-	wasTerminated  bool
-	backupLockFile lockfile.Lockfile
+	backupReport         *utils.Report
+	connectionPool       *dbconn.DBConn
+	globalCluster        *cluster.Cluster
+	globalFPInfo         backup_filepath.FilePathInfo
+	globalTOC            *utils.TOC
+	objectCounts         map[string]int
+	pluginConfig         *utils.PluginConfig
+	version              string
+	wasTerminated        bool
+	backupLockFile       lockfile.Lockfile
+	filterRelationClause string
 
 	/*
 	 * Used for synchronizing DoCleanup.  In DoInit() we increment the group

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -17,11 +17,14 @@ import (
 )
 
 func relationAndSchemaFilterClause() string {
-	filterClause := SchemaFilterClause("n")
+	if filterRelationClause != "" {
+		return filterRelationClause
+	}
+	filterRelationClause = SchemaFilterClause("n")
 	if len(MustGetFlagStringSlice(utils.EXCLUDE_RELATION)) > 0 {
 		excludeOids := GetOidsFromRelationList(connectionPool, MustGetFlagStringSlice(utils.EXCLUDE_RELATION))
 		if len(excludeOids) > 0 {
-			filterClause += fmt.Sprintf("\nAND c.oid NOT IN (%s)", strings.Join(excludeOids, ", "))
+			filterRelationClause += fmt.Sprintf("\nAND c.oid NOT IN (%s)", strings.Join(excludeOids, ", "))
 		}
 	}
 	if len(MustGetFlagStringArray(utils.INCLUDE_RELATION)) > 0 {
@@ -29,9 +32,9 @@ func relationAndSchemaFilterClause() string {
 		gplog.FatalOnError(err)
 
 		includeOids := GetOidsFromRelationList(connectionPool, quotedIncludeRelations)
-		filterClause += fmt.Sprintf("\nAND c.oid IN (%s)", strings.Join(includeOids, ", "))
+		filterRelationClause += fmt.Sprintf("\nAND c.oid IN (%s)", strings.Join(includeOids, ", "))
 	}
-	return filterClause
+	return filterRelationClause
 }
 
 func GetOidsFromRelationList(connectionPool *dbconn.DBConn, quotedIncludeRelations []string) []string {


### PR DESCRIPTION
We have up to 17 calls to the relationAndSchemaFilterClause and we unnecessarily query the catalog for oid list. 

Also updated `make format` to avoid formatting vendor code when running `goimports` 

Co-authored-by: Lav Jain <ljain@pivotal.io>
Co-authored-by: Shivram Mani <shivram.mani@gmail.com>