### PR TITLE
Update Dependencies

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:26e56bf1243a3675608f918a1574bf0005d5263b67b84a24a5fb0946ad7a75e3"
+  name = "github.com/DATA-DOG/go-sqlmock"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "3f9954f6f6697845b082ca57995849ddf614f450"
+  version = "v1.3.3"
+
+[[projects]]
   digest = "1:45c41cd27a8d986998680bfc86da0bbff5fa4f90d0f446c00636c8b099028ffe"
   name = "github.com/blang/semver"
   packages = ["."]
@@ -88,7 +96,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:74fca97eba09e8d0f4ced8e1d80e0377c49b856e4d01fc9580d3605648ddaff9"
+  digest = "1:bebbcf72961feb0c111f6f1d490a91a1973e7db88b06817c8a1f44f85cd5ab55"
   name = "github.com/lib/pq"
   packages = [
     ".",
@@ -96,7 +104,7 @@
     "scram",
   ]
   pruneopts = "NUT"
-  revision = "3427c32cb71afc948325f299f040e53c1dd78979"
+  revision = "78223426e7c66d631117c0a9da1b7f3fde4d23a5"
 
 [[projects]]
   digest = "1:70ef8268170621826f8c111ac1674afe75136f526f449453b4a6631c6dba1946"
@@ -115,7 +123,7 @@
   revision = "0ad87eef1443f64d3d8c50da647e2b1552851124"
 
 [[projects]]
-  digest = "1:dbc24dd0591271d269786adff7458f2c1437305091e41979c5495efe3df09ab8"
+  digest = "1:fe1e78101bb29febcb5dfe55f2a8c2aeaa8adf711e780b8312311d6315ca411d"
   name = "github.com/onsi/ginkgo"
   packages = [
     ".",
@@ -146,11 +154,11 @@
     "types",
   ]
   pruneopts = "NUT"
-  revision = "eea6ad008b96acdaa524f5b409513bf062b500ad"
-  version = "v1.8.0"
+  revision = "974566c482abc93ffd3df6f4626e79076c7ed290"
+  version = "v1.10.1"
 
 [[projects]]
-  digest = "1:01797bb0a7bd98751c65dff3461b9f948e3be09c443d179468781720326b09fe"
+  digest = "1:4f242066f025afdf7ecb7eb7120314131d22cad1e348025b3aab0e8fb437a0c7"
   name = "github.com/onsi/gomega"
   packages = [
     ".",
@@ -169,8 +177,8 @@
     "types",
   ]
   pruneopts = "NUT"
-  revision = "90e289841c1ed79b7a598a7cd9959750cb5e89e2"
-  version = "v1.5.0"
+  revision = "bdebf9e0ece900259084cfa4121b97ce1a540939"
+  version = "v1.7.0"
 
 [[projects]]
   digest = "1:14715f705ff5dfe0ffd6571d7d201dd8e921030f8070321a79380d8ca4ec1a24"
@@ -210,7 +218,7 @@
   name = "golang.org/x/crypto"
   packages = ["pbkdf2"]
   pruneopts = "NUT"
-  revision = "4def268fd1a49955bfb3dda92fe3db4f924f2285"
+  revision = "9756ffdc24725223350eb3266ffb92590d28f278"
 
 [[projects]]
   branch = "master"
@@ -222,15 +230,15 @@
     "html/charset",
   ]
   pruneopts = "NUT"
-  revision = "ca1201d0de80cfde86cb01aea620983605dfe99b"
+  revision = "ba9fcec4b297b415637633c5a6e8fa592e4a16c3"
 
 [[projects]]
   branch = "master"
-  digest = "1:9c684a8c6bb9501591c1ac600e7669fdf4683b1a08be53e17e98e4660985c000"
+  digest = "1:c14a7666f03188f6af4d3dec4aeaaba973ff3365bb1b48c630e1922bfc9c9a0c"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "NUT"
-  revision = "51ab0e2deafac1f46c46ad59cf0921be2f180c3d"
+  revision = "1e83adbbebd0f5dc971915fd7e5db032c3d2b731"
 
 [[projects]]
   digest = "1:24fc27c3b00594289e400127e23d9963f07fec119cc7bb59d4cf7626445104d0"
@@ -275,7 +283,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:fecf9ac9ba4439d3f8ed168a88810ac2fdb11a9c19bc050ae15480dc6074da27"
+  digest = "1:170a5a59770508acf2d5f9a0c643ba1eb6425a9dc7e465d8a355c08693701c62"
   name = "golang.org/x/tools"
   packages = [
     "cmd/goimports",
@@ -292,7 +300,7 @@
     "internal/semver",
   ]
   pruneopts = "NUT"
-  revision = "88ddfcebc769cb7884c38d144ee893cfb4519053"
+  revision = "573d9926052aeaeb5fbebcd3cf10d994c9c6d4f5"
 
 [[projects]]
   digest = "1:26e56bf1243a3675608f918a1574bf0005d5263b67b84a24a5fb0946ad7a75e3"
@@ -339,6 +347,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/DATA-DOG/go-sqlmock",
     "github.com/blang/semver",
     "github.com/blang/vfs",
     "github.com/blang/vfs/memfs",
@@ -363,7 +372,6 @@
     "github.com/spf13/cobra",
     "github.com/spf13/pflag",
     "golang.org/x/tools/cmd/goimports",
-    "gopkg.in/DATA-DOG/go-sqlmock.v1",
     "gopkg.in/cheggaaa/pb.v1",
     "gopkg.in/yaml.v2",
   ]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -52,8 +52,8 @@ required = ["golang.org/x/tools/cmd/goimports", "github.com/onsi/ginkgo/ginkgo"]
   version = "0.8.0"
 
 [[constraint]]
-  name = "gopkg.in/DATA-DOG/go-sqlmock.v1"
-  version = "1.3.0"
+  name = "github.com/DATA-DOG/go-sqlmock"
+  version = "1.3.3"
 
 [[constraint]]
   name = "gopkg.in/cheggaaa/pb.v1"

--- a/backup/backup_suite_test.go
+++ b/backup/backup_suite_test.go
@@ -8,7 +8,7 @@ package backup_test
 import (
 	"testing"
 
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gpbackup/backup"

--- a/backup/data_test.go
+++ b/backup/data_test.go
@@ -11,7 +11,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 	"gopkg.in/cheggaaa/pb.v1"
 )
 

--- a/backup/predata_acl_test.go
+++ b/backup/predata_acl_test.go
@@ -10,7 +10,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 )
 
 var _ = Describe("backup/predata_acl tests", func() {

--- a/backup/predata_relations_other_test.go
+++ b/backup/predata_relations_other_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/greenplum-db/gpbackup/backup"
 	"github.com/greenplum-db/gpbackup/testutils"
 	"github.com/greenplum-db/gpbackup/utils"
-	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/backup/queries_acl_test.go
+++ b/backup/queries_acl_test.go
@@ -9,7 +9,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 )
 
 var _ = Describe("backup/queries_acl tests", func() {

--- a/backup/validate_test.go
+++ b/backup/validate_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup/backup"
 	"github.com/greenplum-db/gpbackup/utils"
-	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
 
 	. "github.com/onsi/ginkgo"
 )

--- a/backup_filepath/backup_filepath_suite_test.go
+++ b/backup_filepath/backup_filepath_suite_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
-	sqlmock "gopkg.in/DATA-DOG/go-sqlmock.v1"
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
 )
 
 var (

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 
 	"github.com/greenplum-db/gpbackup/utils"
 

--- a/restore/data_test.go
+++ b/restore/data_test.go
@@ -10,7 +10,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 )
 
 var _ = Describe("restore/data tests", func() {

--- a/restore/restore_suite_test.go
+++ b/restore/restore_suite_test.go
@@ -8,7 +8,7 @@ package restore_test
 import (
 	"testing"
 
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gpbackup/restore"

--- a/restore/validate_test.go
+++ b/restore/validate_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/greenplum-db/gpbackup/restore"
 	"github.com/greenplum-db/gpbackup/testutils"
 	"github.com/greenplum-db/gpbackup/utils"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/restore/wrappers_test.go
+++ b/restore/wrappers_test.go
@@ -15,7 +15,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/pkg/errors"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 )
 
 var _ = Describe("wrapper tests", func() {

--- a/testutils/functions.go
+++ b/testutils/functions.go
@@ -19,7 +19,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 )
 
 /*

--- a/utils/gpexpand_sensor_test.go
+++ b/utils/gpexpand_sensor_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/blang/vfs"
 	"github.com/blang/vfs/memfs"
 	"github.com/pkg/errors"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/utils/utils_suite_test.go
+++ b/utils/utils_suite_test.go
@@ -3,7 +3,7 @@ package utils_test
 import (
 	"testing"
 
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"


### PR DESCRIPTION
The change to use github.com/DATA-DOG/go-sqlmock was purely so that it
would be compatible with go modules.

Authored-by: Kevin Yeap <kyeap@pivotal.io>