### PR TITLE
Properly close TOC, history, report, and config files

### DIFF
--- a/backup_history/history.go
+++ b/backup_history/history.go
@@ -60,6 +60,8 @@ func WriteConfigFile(config *BackupConfig, configFilename string) {
 	configContents, _ := yaml.Marshal(config)
 	_, err := configFile.Write(configContents)
 	gplog.FatalOnError(err)
+	err = configFile.Close()
+	gplog.FatalOnError(err)
 	err = operating.System.Chmod(configFilename, 0444)
 	gplog.FatalOnError(err)
 }
@@ -156,13 +158,11 @@ func (history *History) WriteToFileAndMakeReadOnly(filename string) error {
 		return err
 	}
 	historyFile := iohelper.MustOpenFileForWriting(filename)
-	defer func() {
-		err = historyFile.Close()
-		if err != nil {
-			gplog.Warn("cannot close history file: %v", err)
-		}
-	}()
 	_, err = historyFile.Write(historyFileContents)
+	if err != nil {
+		return err
+	}
+	err = historyFile.Close()
 	if err != nil {
 		return err
 	}
@@ -170,7 +170,6 @@ func (history *History) WriteToFileAndMakeReadOnly(filename string) error {
 	if err != nil {
 		return err
 	}
-
 	return nil
 }
 

--- a/utils/report.go
+++ b/utils/report.go
@@ -166,6 +166,9 @@ func (report *Report) WriteBackupReportFile(reportFilename string, timestamp str
 	logOutputReport(reportFile, reportInfo)
 
 	PrintObjectCounts(reportFile, objectCounts)
+
+	err = reportFile.Close()
+	gplog.FatalOnError(err)
 	_ = operating.System.Chmod(reportFilename, 0444)
 }
 
@@ -213,6 +216,8 @@ func WriteRestoreReportFile(reportFilename string, backupTimestamp string, start
 
 	logOutputReport(reportFile, reportInfo)
 
+	err = reportFile.Close()
+	gplog.FatalOnError(err)
 	_ = operating.System.Chmod(reportFilename, 0444)
 }
 


### PR DESCRIPTION
Explicitly fsync and call close on TOC file
```
    It is possible that the write() succeeds but the underlying buffer flush
    to disk fails because we chmod 0444 the TOC file immediately after the
    write(). To prevent TOC data loss, explicitly fsync() and close the
    file before making the file read-only.
```

Close history, report, and config files after write
```
    Files should always be closed anyways so explicitly call them instead of
    leaving it up to the OS when the program exits.

    Disclaimer: A chmod 0444 happens at the end for these specific files. A
    file close does not guarantee that the OS buffers have flushed to disk
    before the file permissions change (based on the underlying filesystem
    and its buffer implementation). We should change this later to
    explicitly fsync() but that requires refactoring everything to not use
    io.Writer.
```