### PR TITLE
Fixed handling of dropped grantors during backup

### DIFF
--- a/backup/metadata_globals.go
+++ b/backup/metadata_globals.go
@@ -340,7 +340,10 @@ func PrintRoleMembershipStatements(metadataFile *utils.FileWithByteCount, toc *u
 		if roleMember.IsAdmin {
 			metadataFile.MustPrintf(" WITH ADMIN OPTION")
 		}
-		metadataFile.MustPrintf(" GRANTED BY %s;", roleMember.Grantor)
+		if roleMember.Grantor != "" {
+			metadataFile.MustPrintf(" GRANTED BY %s", roleMember.Grantor)
+		}
+		metadataFile.MustPrintf(";")
 
 		section, entry := roleMember.GetMetadataEntry()
 		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)

--- a/backup/metadata_globals_test.go
+++ b/backup/metadata_globals_test.go
@@ -320,6 +320,7 @@ ALTER ROLE "testRole2" WITH SUPERUSER INHERIT CREATEROLE CREATEDB LOGIN REPLICAT
 	Describe("PrintRoleMembershipStatements", func() {
 		roleWith := backup.RoleMember{Role: "group", Member: "rolewith", Grantor: "grantor", IsAdmin: true}
 		roleWithout := backup.RoleMember{Role: "group", Member: "rolewithout", Grantor: "grantor", IsAdmin: false}
+		roleWithoutGrantor := backup.RoleMember{Role: "group", Member: "rolewithoutgrantor", Grantor: "", IsAdmin: false}
 		It("prints a role without ADMIN OPTION", func() {
 			backup.PrintRoleMembershipStatements(backupfile, toc, []backup.RoleMember{roleWithout})
 			testutils.ExpectEntry(toc.GlobalEntries, 0, "", "", "rolewithout", "ROLE GRANT")
@@ -334,6 +335,10 @@ ALTER ROLE "testRole2" WITH SUPERUSER INHERIT CREATEROLE CREATEDB LOGIN REPLICAT
 			testutils.AssertBufferContents(toc.GlobalEntries, buffer,
 				`GRANT group TO rolewith WITH ADMIN OPTION GRANTED BY grantor;`,
 				`GRANT group TO rolewithout GRANTED BY grantor;`)
+		})
+		It("prints a role without a grantor", func() {
+			backup.PrintRoleMembershipStatements(backupfile, toc, []backup.RoleMember{roleWithoutGrantor})
+			testutils.AssertBufferContents(toc.GlobalEntries, buffer, `GRANT group TO rolewithoutgrantor;`)
 		})
 	})
 	Describe("PrintRoleGUCStatements", func() {

--- a/backup/queries_globals.go
+++ b/backup/queries_globals.go
@@ -491,11 +491,11 @@ func (rm RoleMember) GetMetadataEntry() (string, utils.MetadataEntry) {
 func GetRoleMembers(connectionPool *dbconn.DBConn) []RoleMember {
 	query := `
 SELECT
-	quote_ident(pg_get_userbyid(roleid)) AS role,
-	quote_ident(pg_get_userbyid(member)) AS member,
-	quote_ident(pg_get_userbyid(grantor)) AS grantor,
-	admin_option as isadmin
-FROM pg_auth_members
+	quote_ident(pg_get_userbyid(pga.roleid)) AS role,
+	quote_ident(pg_get_userbyid(pga.member)) AS member,
+	CASE WHEN pg_get_userbyid(pga.grantor) like 'unknown (OID='||pga.grantor||')' THEN '' ELSE quote_ident(pg_get_userbyid(pga.grantor)) END AS grantor,
+	admin_option AS isadmin
+FROM pg_auth_members pga
 ORDER BY roleid, member;`
 
 	results := make([]RoleMember, 0)


### PR DESCRIPTION
When we create a role and add it to a member and a grantor and
subsequently drop the grantor, backup incorrectly logs the grantor as
'unknown (OID=xxx)'. This happens since pg_get_userbyid returns the
unknown string instead of NULL or empty string.

We could alternatively updated the existing query as follows
```
SELECT
quote_ident(pg_get_userbyid(pga.roleid)) AS a,
quote_ident(pg_get_userbyid(pga.member)) AS b,
case when pg_get_userbyid(pga.grantor) like 'unknown (OID='||pga.grantor||')' then '' else quote_ident(pg_get_userbyid(pga.grantor)) end AS c,
admin_option as isadmin
FROM pg_auth_members pga
ORDER BY roleid, member;
```
The issue with this is that we explictly look for a grantor string. We could actually have a grantor with the name 'unknown (OID='||{GRANTOR_OID}||') which would be returned incorrectly as an empty string.


Co-authored-by: Kevin Yeap <kyeap@pivotal.io>