### PR TITLE
Set GUC gp_use_legacy_hashops when restoring GPDB 4/5 backups to GPDB 6+

### DIFF
--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -1179,21 +1179,6 @@ PARTITION BY LIST (gender)
 			// stating it belongs to a different segment. This backup was
 			// taken with gpbackup version 1.12.1 and GPDB version 4.3.33.2
 
-			// Temporarily changing the `gp_use_legacy_hashops` GUC allows
-			// GPDB6/7 clusters to distribute data in a way that is consistent
-			// with the backup artifact (generated on GPDB4)
-			if !restoreConn.Version.Before("6") {
-				changeGUCcmd := exec.Command("gpconfig", "-c", "gp_use_legacy_hashops", "-v", "true", "--skipvalidation")
-				mustRunCommand(changeGUCcmd)
-				loadConfigChanges := exec.Command("gpstop", "-u")
-				mustRunCommand(loadConfigChanges)
-
-				defer func() {
-					mustRunCommand(exec.Command("gpconfig", "-r", "gp_use_legacy_hashops", "--skipvalidation"))
-					mustRunCommand(exec.Command("gpstop", "-u"))
-				}()
-			}
-
 			command := exec.Command("tar", "-xzf", "resources/corrupt-db.tar.gz", "-C", backupDir)
 			mustRunCommand(command)
 

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -84,7 +84,7 @@ func DoSetup() {
 	restoreStartTime = backup_history.CurrentTimestamp()
 	gplog.Info("Restore Key = %s", MustGetFlagString(utils.TIMESTAMP))
 
-	InitializeConnectionPool("postgres")
+	CreateConnectionPool("postgres")
 	segConfig := cluster.MustGetSegmentConfiguration(connectionPool)
 	globalCluster = cluster.NewCluster(segConfig)
 	segPrefix := backup_filepath.ParseSegPrefix(MustGetFlagString(utils.BACKUP_DIR), MustGetFlagString(utils.TIMESTAMP))


### PR DESCRIPTION
In GPDB 6, the default hash operators have changed. Because of this,
we must explicitly use the legacy hash operators when restoring GPDB
4/5 tables to a GPDB 6+ cluster.

Added a warning message as well to highlight the GUC usage. It's
recommended that the user would then ALTER TABLE SET DISTRIBUTED BY
their table when possible to use the new default hash operators.

GPDB Reference:
https://github.com/greenplum-db/gpdb/commit/242783ae9f573bb0

Co-authored-by: Lav Jain <ljain@pivotal.io>