### PR TITLE
Use precompiled binaries for backward-compatibility tests

### DIFF
--- a/ci/tasks/all-tests.yml
+++ b/ci/tasks/all-tests.yml
@@ -12,6 +12,8 @@ params:
 inputs:
 - name: gpbackup
   path: go/src/github.com/greenplum-db/gpbackup
+- name: bin_gpbackup_1.0.0_and_1.7.1
+  optional: true
 - name: ccp_src
 - name: cluster_env_files
 - name: pgcrypto43
@@ -31,6 +33,12 @@ run:
     mkdir /tmp/untarred
     tar -xzf gppkgs/gpbackup-gppkgs.tar.gz -C /tmp/untarred
     scp /tmp/untarred/gpbackup_tools*gp${GPDB_VERSION}*RHEL*.gppkg mdw:/home/gpadmin
+
+    # place correct tarballs in gpbackup dir for consumption
+    if [ -f "bin_gpbackup_1.0.0_and_1.7.1/gpbackup_bins_1.0.0_and_1.7.1.tar.gz" ] && [ "${GPBACKUP_VERSION}" != "" ] ; then
+      tar -xzf bin_gpbackup_1.0.0_and_1.7.1/gpbackup_bins_1.0.0_and_1.7.1.tar.gz -C /tmp/
+      scp -r /tmp/${GPBACKUP_VERSION} mdw:/tmp
+    fi
 
     cat <<SCRIPT > /tmp/run_tests.bash
       set -ex
@@ -54,7 +62,12 @@ run:
       # NOTE: This is a temporary hotfix intended to skip this test when running on CCP cluster because the backup artifact that this test is using only works on local clusters.
       sed -i 's|It(\`gprestore continues when encountering errors during data load with --single-data-file and --on-error-continue\`, func() {|PIt(\`gprestore continues when encountering errors during data load with --single-data-file and --on-error-continue\`, func() {|g' end_to_end/end_to_end_suite_test.go
 
-      make end_to_end_without_install
+      if [ -z "\$OLD_BACKUP_VERSION" ] ; then
+        make end_to_end_without_install
+      else
+        make install_helper helper_path=/tmp/\${OLD_BACKUP_VERSION}/gpbackup_helper
+        ginkgo -r -randomizeSuites -slowSpecThreshold=10 -noisySkippings=false -randomizeAllSpecs end_to_end -- --custom_backup_dir "/tmp" 2>&1
+      fi
     SCRIPT
 
     chmod +x /tmp/run_tests.bash

--- a/ci/tasks/all-tests.yml
+++ b/ci/tasks/all-tests.yml
@@ -60,7 +60,7 @@ run:
       make integration
 
       # NOTE: This is a temporary hotfix intended to skip this test when running on CCP cluster because the backup artifact that this test is using only works on local clusters.
-      sed -i 's|It(\`gprestore continues when encountering errors during data load with --single-data-file and --on-error-continue\`, func() {|PIt(\`gprestore continues when encountering errors during data load with --single-data-file and --on-error-continue\`, func() {|g' end_to_end/end_to_end_suite_test.go
+      sed -i 's|\tIt(\`gprestore continues when encountering errors during data load with --single-data-file and --on-error-continue\`, func() {|\tPIt(\`gprestore continues when encountering errors during data load with --single-data-file and --on-error-continue\`, func() {|g' end_to_end/end_to_end_suite_test.go
 
       if [ -z "\$OLD_BACKUP_VERSION" ] ; then
         make end_to_end_without_install

--- a/ci/tasks/ddboost-tests.yml
+++ b/ci/tasks/ddboost-tests.yml
@@ -84,7 +84,7 @@ run:
     pushd \$GOPATH/src/github.com/greenplum-db/gpbackup
 
     # NOTE: This is a temporary hotfix intended to skip this test when running on CCP cluster because the backup artifact that this test is using only works on local clusters.
-    sed -i 's|It(\`gprestore continues when encountering errors during data load with --single-data-file and --on-error-continue\`, func() {|PIt(\`gprestore continues when encountering errors during data load with --single-data-file and --on-error-continue\`, func() {|g' end_to_end/end_to_end_suite_test.go
+    sed -i 's|\tIt(\`gprestore continues when encountering errors during data load with --single-data-file and --on-error-continue\`, func() {|\tPIt(\`gprestore continues when encountering errors during data load with --single-data-file and --on-error-continue\`, func() {|g' end_to_end/end_to_end_suite_test.go
 
     make end_to_end CUSTOM_BACKUP_DIR=/data/gpdata/dd_dir/end_to_end_GPDB${GPDB_VERSION}
     SCRIPT

--- a/ci/tasks/integration-tests-fixed-version.yml
+++ b/ci/tasks/integration-tests-fixed-version.yml
@@ -42,7 +42,7 @@ run:
     make integration
 
     # NOTE: This is a temporary hotfix intended to skip this test when running on CCP cluster because the backup artifact that this test is using only works on local clusters.
-    sed -i 's|It(\`gprestore continues when encountering errors during data load with --single-data-file and --on-error-continue\`, func() {|PIt(\`gprestore continues when encountering errors during data load with --single-data-file and --on-error-continue\`, func() {|g' end_to_end/end_to_end_suite_test.go
+    sed -i 's|\tIt(\`gprestore continues when encountering errors during data load with --single-data-file and --on-error-continue\`, func() {|\tPIt(\`gprestore continues when encountering errors during data load with --single-data-file and --on-error-continue\`, func() {|g' end_to_end/end_to_end_suite_test.go
 
     make end_to_end
     SCRIPT

--- a/ci/tasks/sles-tests.yml
+++ b/ci/tasks/sles-tests.yml
@@ -61,7 +61,7 @@ run:
       source /usr/local/greenplum-db-devel/greenplum_path.sh
 
       # NOTE: This is a temporary hotfix intended to skip this test when running on CCP cluster because the backup artifact that this test is using only works on local clusters.
-      sed -i 's|It(\`gprestore continues when encountering errors during data load with --single-data-file and --on-error-continue\`, func() {|PIt(\`gprestore continues when encountering errors during data load with --single-data-file and --on-error-continue\`, func() {|g' end_to_end/end_to_end_suite_test.go
+      sed -i 's|\tIt(\`gprestore continues when encountering errors during data load with --single-data-file and --on-error-continue\`, func() {|\tPIt(\`gprestore continues when encountering errors during data load with --single-data-file and --on-error-continue\`, func() {|g' end_to_end/end_to_end_suite_test.go
 
       make end_to_end_without_install
     SCRIPT

--- a/ci/templates/gpbackup-tpl.yml
+++ b/ci/templates/gpbackup-tpl.yml
@@ -234,6 +234,16 @@ resources:
       access_key_id: {{bucket-access-key-id}}
       secret_access_key: {{bucket-secret-access-key}}
 
+# These binaries are used for backwards-compatibility testing only
+- name: bin_gpbackup_1.0.0_and_1.7.1
+  type: s3
+  source:
+      bucket: gpbackup-dependencies
+      versioned_file: gpbackup_bins_1.0.0_and_1.7.1.tar.gz
+      region_name: us-west-2
+      access_key_id: {{bucket-access-key-id}}
+      secret_access_key: {{bucket-secret-access-key}}
+
 # This is specifically for sles11 images because it cannot connect to github due to TLS issues
 - name: libyaml-0.1.7
   type: s3
@@ -1461,6 +1471,7 @@ jobs:
 {% if "gpbackup-release" != pipeline_name %}
       trigger: true
 {% endif %}
+    - get: bin_gpbackup_1.0.0_and_1.7.1
     - get: ccp_src
     - get: gpdb5_src
     - get: gpbackup-dependencies

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -248,8 +248,17 @@ var _ = Describe("backup end to end integration tests", func() {
 		testutils.ExecuteSQLFile(backupConn, "test_tables_data.sql")
 		if useOldBackupVersion {
 			oldBackupSemVer = semver.MustParse(os.Getenv("OLD_BACKUP_VERSION"))
+			oldBackupVersionStr := os.Getenv("OLD_BACKUP_VERSION")
+
 			_, restoreHelperPath, gprestorePath = buildAndInstallBinaries()
-			gpbackupPath, backupHelperPath = buildOldBinaries(os.Getenv("OLD_BACKUP_VERSION"))
+
+			// Precompiled binaries will exist when running the ci job, `backward-compatibility`
+			if _, err := os.Stat(fmt.Sprintf("/tmp/%s", oldBackupVersionStr)); err == nil {
+				gpbackupPath = filepath.Join("/tmp", oldBackupVersionStr, "gpbackup")
+				backupHelperPath = filepath.Join("/tmp", oldBackupVersionStr, "gpbackup_helper")
+			} else {
+				gpbackupPath, backupHelperPath = buildOldBinaries(oldBackupVersionStr)
+			}
 		} else {
 			gpbackupPath, backupHelperPath, gprestorePath = buildAndInstallBinaries()
 			restoreHelperPath = backupHelperPath
@@ -775,13 +784,14 @@ var _ = Describe("backup end to end integration tests", func() {
 						_ = gpbackup(gpbackupPath, backupHelperPath,
 							"--incremental", "--leaf-partition-data")
 
+						gpbackupPathOld, backupHelperPathOld := gpbackupPath, backupHelperPath
 						gpbackupPath, backupHelperPath, _ = buildAndInstallBinaries()
 
 						testhelper.AssertQueryRuns(backupConn, "INSERT into schema2.ao1 values(1002)")
 						defer testhelper.AssertQueryRuns(backupConn, "DELETE from schema2.ao1 where i=1002")
 						incremental2Timestamp := gpbackup(gpbackupPath, backupHelperPath,
 							"--incremental", "--leaf-partition-data")
-						gpbackupPath, backupHelperPath = buildOldBinaries(os.Getenv("OLD_BACKUP_VERSION"))
+						gpbackupPath, backupHelperPath = gpbackupPathOld, backupHelperPathOld
 
 						gprestore(gprestorePath, restoreHelperPath, incremental2Timestamp, "--redirect-db", "restoredb")
 


### PR DESCRIPTION
1. Use precompiled binaries for backward-compatibility tests _(flake fix)_

Rather than recompiling old versions of gpbackup for testing(1.0.0,
1.7.1), we've uploaded a tarball of the necessary binaries.

2. Update the "skip test for ccp clusters" temp hotfix

The previous regexp wouldnt allow us to run the testing script twice
within the same job.
