### PR TITLE
Set enable_mergejoin off for GPDB4

### DIFF
--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -56,6 +56,7 @@ func SetSessionGUCs(connNum int) {
 	connectionPool.MustExec("SET statement_timeout = 0", connNum)
 	connectionPool.MustExec("SET DATESTYLE = ISO", connNum)
 	connectionPool.MustExec("SET standard_conforming_strings = 1", connNum) // Needed for 4.3, default on in 5+
+	connectionPool.MustExec("SET enable_mergejoin TO off", connNum)
 
 	// The fix to raise the max of extra_float_digits GUC is going out with
 	// GPDB 4.3.33.1. This means if we set the GUC using 'SET


### PR DESCRIPTION
Enabling merge join on a GPDB4 system while taking a backup was causing
ACL backups to fail. Turn off the GUC in GPDB4 before taking a backup.

Authored-by: Kevin Yeap <kyeap@pivotal.io>