### PR TITLE
Batch lock queries

### DIFF
--- a/backup/queries_relation_internal_test.go
+++ b/backup/queries_relation_internal_test.go
@@ -1,0 +1,33 @@
+package backup
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("backup internal tests", func() {
+	Describe("generateLockQueries", func() {
+		It("batches tables together and generates lock queries", func() {
+			tables := []Relation{}
+			for i := 0; i < 200; i++ {
+				tables = append(tables, Relation{0, 0, "public", fmt.Sprintf("foo%d", i)})
+			}
+
+			batchSize := 100
+			lockQueries := generateTableBatches(tables, batchSize)
+			Expect(len(lockQueries)).To(Equal(2))
+		})
+		It("batches up remaining leftover tables together in a single lock query", func() {
+			tables := []Relation{}
+			for i := 0; i < 101; i++ {
+				tables = append(tables, Relation{0, 0, "public", fmt.Sprintf("foo%d", i)})
+			}
+
+			batchSize := 50
+			lockQueries := generateTableBatches(tables, batchSize)
+			Expect(len(lockQueries)).To(Equal(3))
+		})
+	})
+})

--- a/utils/progress_bar.go
+++ b/utils/progress_bar.go
@@ -52,6 +52,7 @@ type ProgressBar interface {
 	Start() *pb.ProgressBar
 	Finish()
 	Increment() int
+	Add(int) int
 }
 
 type VerboseProgressBar struct {


### PR DESCRIPTION
Previously, gpbackup was dispatching 1 LOCK TABLE query for each table. This
can cause strain on the network as the master would have to dispatch N
amount of LOCK TABLE queries. This change batches table LOCKs so that there
are at most 100 LOCK dispatches.

Co-authored-by: Kevin Yeap <kyeap@pivotal.io>
Co-authored-by: Kate Dontsova <edontsova@pivotal.io>