### PR TITLE
Optimize composites

### DIFF
--- a/backup/queries_types.go
+++ b/backup/queries_types.go
@@ -258,16 +258,18 @@ type Attribute struct {
 }
 
 func getCompositeTypeAttributes(connectionPool *dbconn.DBConn) map[uint32][]Attribute {
+	gplog.Verbose("Getting composite type attributes")
+
 	before6query := `SELECT
 	t.oid AS compositetypeoid,
 	quote_ident(a.attname) AS name,
 	pg_catalog.format_type(a.atttypid, a.atttypmod) AS type,
 	coalesce(quote_literal(d.description),'') AS comment
 	FROM pg_type t
+	JOIN pg_class c ON t.typrelid = c.oid
 	JOIN pg_attribute a ON t.typrelid = a.attrelid
 	LEFT JOIN pg_description d ON (d.objoid = a.attrelid AND d.classoid = 'pg_class'::regclass AND d.objsubid = a.attnum)
-	WHERE t.typtype = 'c'
-	ORDER BY t.oid, a.attnum;`
+	WHERE t.typtype = 'c' AND c.relkind = 'c';`
 
 	masterQuery := `SELECT
 	t.oid AS compositetypeoid,

--- a/backup/queries_types.go
+++ b/backup/queries_types.go
@@ -283,12 +283,12 @@ func getCompositeTypeAttributes(connectionPool *dbconn.DBConn) map[uint32][]Attr
 	coalesce(quote_literal(d.description),'') AS comment
 	FROM pg_type t
 	JOIN pg_attribute a ON t.typrelid = a.attrelid
+	JOIN pg_class c ON t.typrelid = c.oid
+	LEFT JOIN pg_description d ON (d.objoid = a.attrelid AND d.classoid = 'pg_class'::regclass AND d.objsubid = a.attnum)
 	LEFT JOIN pg_type at ON at.oid = a.atttypid
 	LEFT JOIN pg_collation coll ON a.attcollation = coll.oid
 	LEFT JOIN pg_namespace cn on (coll.collnamespace = cn.oid)
-	LEFT JOIN pg_description d ON (d.objoid = a.attrelid AND d.classoid = 'pg_class'::regclass AND d.objsubid = a.attnum)
-	WHERE t.typtype = 'c'
-	ORDER BY t.oid, a.attnum;`
+	WHERE t.typtype = 'c' AND c.relkind = 'c';`
 
 	results := make([]Attribute, 0)
 	var err error


### PR DESCRIPTION
This makes the following changes to getCompositeTypeAttributes queries:

- filters out implicitly created attributes
- removes ordering as we put data in hashmap after that anyway

This allows to increase query performance from 25 to 90%