### PR TITLE
Fix gprestore verbose output when using --jobs flag

### DIFF
--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -222,6 +222,7 @@ var _ = Describe("backup end to end integration tests", func() {
 	const (
 		TOTAL_RELATIONS               = 37
 		TOTAL_RELATIONS_AFTER_EXCLUDE = 21
+		TOTAL_CREATE_STATEMENTS       = 9
 	)
 
 	var gpbackupPath, backupHelperPath, restoreHelperPath, gprestorePath, pluginConfigPath string
@@ -992,8 +993,10 @@ var _ = Describe("backup end to end integration tests", func() {
 		It("runs gpbackup and gprestore with jobs flag", func() {
 			skipIfOldBackupVersionBefore("1.3.0")
 			timestamp := gpbackup(gpbackupPath, backupHelperPath, "--backup-dir", backupDir, "--jobs", "4")
-			gprestore(gprestorePath, restoreHelperPath, timestamp, "--redirect-db", "restoredb", "--backup-dir", backupDir, "--jobs", "4")
+			output := gprestore(gprestorePath, restoreHelperPath, timestamp, "--redirect-db", "restoredb", "--backup-dir", backupDir, "--jobs", "4", "--verbose")
 
+			expectedString := fmt.Sprintf("table %d of %d", TOTAL_CREATE_STATEMENTS, TOTAL_CREATE_STATEMENTS)
+			Expect(string(output)).To(ContainSubstring(expectedString))
 			assertRelationsCreated(restoreConn, TOTAL_RELATIONS)
 			assertDataRestored(restoreConn, schema2TupleCounts)
 			assertDataRestored(restoreConn, publicSchemaTupleCounts)

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -264,8 +264,11 @@ var _ = Describe("backup end to end integration tests", func() {
 				gpbackupPath, backupHelperPath = buildOldBinaries(oldBackupVersionStr)
 			}
 		} else {
-			gpbackupPath, backupHelperPath, gprestorePath = buildAndInstallBinaries()
+			binDir := fmt.Sprintf("%s/go/bin", operating.System.Getenv("HOME"))
+			gpbackupPath = fmt.Sprintf("%s/gpbackup", binDir)
+			backupHelperPath = fmt.Sprintf("%s/gpbackup_helper", binDir)
 			restoreHelperPath = backupHelperPath
+			gprestorePath = fmt.Sprintf("%s/gprestore", binDir)
 		}
 		segConfig := cluster.MustGetSegmentConfiguration(backupConn)
 		backupCluster = cluster.NewCluster(segConfig)

--- a/restore/data.go
+++ b/restore/data.go
@@ -108,7 +108,7 @@ func restoreDataFromTimestamp(fpInfo backup_filepath.FilePathInfo, dataEntries [
 	 * TerminateHangingCopySessions to kill any COPY
 	 * statements in progress if they don't finish on their own.
 	 */
-	var tableNum uint32 = 0
+	var tableNum int64 = 0
 	tasks := make(chan utils.MasterDataEntry, totalTables)
 	var workerPool sync.WaitGroup
 	var numErrors int32
@@ -126,7 +126,7 @@ func restoreDataFromTimestamp(fpInfo backup_filepath.FilePathInfo, dataEntries [
 				tableName := utils.MakeFQN(entry.Schema, entry.Name)
 				err := restoreSingleTableData(&fpInfo, entry, tableName, whichConn)
 
-				atomic.AddUint32(&tableNum, 1)
+				atomic.AddInt64(&tableNum, 1)
 				if gplog.GetVerbosity() > gplog.LOGINFO {
 					// No progress bar at this log level, so we note table count here
 					gplog.Verbose("Restored data to table %s from file (table %d of %d)", tableName, tableNum, totalTables)


### PR DESCRIPTION
When the --jobs flag is given, gprestore would output "(table 1 of N)"
multiple times depending on the --jobs input. The last table to be
restored would also not output the expected "(table N of N)". This is
because the first restore for each parallel worker gets the same table
number (in this case 1) which will be outputted before restoring
data. After the restore is finished, each parallel worker atomically
increments the table number.

To fix the incorrect gprestore output, we initialize the table number
to 0 and have each parallel worker atomically increment the table
number after they are done with their restore.

---

Also, do not build automatically when running end_to_end tests

The end_to_end tests were still automatically building and installing
gpbackup and gprestore. This is not always desirable since we may want
to run current tests with old binaries. This somewhat relates to how
we earlier separated the `end_to_end` Makefile target to have an
`end_to_end_without_install` target that doesn't call the `build`
target.

Reference:
https://github.com/greenplum-db/gpbackup/commit/bf60576277b621bc