### PR TITLE
Cancel blocked LOCK TABLE query during gpbackup DoCleanup

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,6 +2,14 @@
 
 
 [[projects]]
+  digest = "1:26e56bf1243a3675608f918a1574bf0005d5263b67b84a24a5fb0946ad7a75e3"
+  name = "github.com/DATA-DOG/go-sqlmock"
+  packages = ["."]
+  pruneopts = "NUT"
+  revision = "3f9954f6f6697845b082ca57995849ddf614f450"
+  version = "v1.3.3"
+
+[[projects]]
   digest = "1:45c41cd27a8d986998680bfc86da0bbff5fa4f90d0f446c00636c8b099028ffe"
   name = "github.com/blang/semver"
   packages = ["."]
@@ -295,14 +303,6 @@
   revision = "88ddfcebc769cb7884c38d144ee893cfb4519053"
 
 [[projects]]
-  digest = "1:26e56bf1243a3675608f918a1574bf0005d5263b67b84a24a5fb0946ad7a75e3"
-  name = "gopkg.in/DATA-DOG/go-sqlmock.v1"
-  packages = ["."]
-  pruneopts = "NUT"
-  revision = "3f9954f6f6697845b082ca57995849ddf614f450"
-  version = "v1.3.3"
-
-[[projects]]
   digest = "1:21562b59c496f4cbd7a40beaa257ac6761002dd3e36259f532216082abace8b1"
   name = "gopkg.in/cheggaaa/pb.v1"
   packages = ["."]
@@ -339,6 +339,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/DATA-DOG/go-sqlmock",
     "github.com/blang/semver",
     "github.com/blang/vfs",
     "github.com/blang/vfs/memfs",
@@ -363,7 +364,6 @@
     "github.com/spf13/cobra",
     "github.com/spf13/pflag",
     "golang.org/x/tools/cmd/goimports",
-    "gopkg.in/DATA-DOG/go-sqlmock.v1",
     "gopkg.in/cheggaaa/pb.v1",
     "gopkg.in/yaml.v2",
   ]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -31,7 +31,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:81edcefb618fbdaeee2f471fb67fb78d00704e73259365325ce2bbc65295fb0f"
+  digest = "1:1ed918224645718ea408fec7d64a3bce3834647803ad5ab3726bcb7e172b8540"
   name = "github.com/greenplum-db/gp-common-go-libs"
   packages = [
     "cluster",
@@ -43,7 +43,7 @@
     "testhelper",
   ]
   pruneopts = "NUT"
-  revision = "c535ba3a6e07217feb463f1c6152c934f65f1f36"
+  revision = "39fae54f0b400719275e6c5ae58d0499e6e217d8"
 
 [[projects]]
   digest = "1:41933d387bfa3eaa6a82647914ed7044f7b8355764c24fb920892bc8c03ef0c3"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -52,8 +52,8 @@ required = ["golang.org/x/tools/cmd/goimports", "github.com/onsi/ginkgo/ginkgo"]
   version = "0.8.0"
 
 [[constraint]]
-  name = "gopkg.in/DATA-DOG/go-sqlmock.v1"
-  version = "1.3.0"
+  name = "github.com/DATA-DOG/go-sqlmock"
+  version = "1.3.3"
 
 [[constraint]]
   name = "gopkg.in/cheggaaa/pb.v1"

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -500,6 +500,15 @@ func DoCleanup(backupFailed bool) {
 		gplog.Warn("Failed to remove lock file %s.", backupLockFile)
 	}
 	if connectionPool != nil {
+		// The connection pool might still have an ongoing transaction. Try
+		// to cancel it. We need to queue a ROLLBACK to ensure the transaction
+		// cancel actually happened because the Golang Context cancel function
+		// does not block... nor is there a cancel acknowledgement function.
+		if queryCancelFunc != nil {
+			queryCancelFunc()
+			connectionPool.MustExec("ROLLBACK")
+		}
+
 		connectionPool.Close()
 	}
 }

--- a/backup/backup_suite_test.go
+++ b/backup/backup_suite_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/spf13/pflag"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/backup/data_test.go
+++ b/backup/data_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/greenplum-db/gpbackup/backup"
 	"github.com/greenplum-db/gpbackup/backup_history"
 	"github.com/greenplum-db/gpbackup/utils"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 	"gopkg.in/cheggaaa/pb.v1"
 
 	. "github.com/onsi/ginkgo"

--- a/backup/global_variables.go
+++ b/backup/global_variables.go
@@ -1,6 +1,7 @@
 package backup
 
 import (
+	"context"
 	"sync"
 
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
@@ -22,6 +23,8 @@ import (
 var (
 	backupReport         *utils.Report
 	connectionPool       *dbconn.DBConn
+	queryContext         context.Context
+	queryCancelFunc      context.CancelFunc
 	globalCluster        *cluster.Cluster
 	globalFPInfo         backup_filepath.FilePathInfo
 	globalTOC            *utils.TOC

--- a/backup/predata_acl_test.go
+++ b/backup/predata_acl_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup/backup"
 	"github.com/greenplum-db/gpbackup/testutils"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/backup/queries_acl_test.go
+++ b/backup/queries_acl_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/structmatcher"
 	"github.com/greenplum-db/gpbackup/backup"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/backup/validate_test.go
+++ b/backup/validate_test.go
@@ -4,7 +4,7 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup/backup"
 	"github.com/greenplum-db/gpbackup/utils"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 
 	. "github.com/onsi/ginkgo"
 )

--- a/backup_filepath/backup_filepath_suite_test.go
+++ b/backup_filepath/backup_filepath_suite_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup/testutils"
 	"github.com/onsi/gomega/gbytes"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/greenplum-db/gpbackup/options"
 	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/spf13/pflag"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/restore/data_test.go
+++ b/restore/data_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/greenplum-db/gpbackup/restore"
 	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/jackc/pgx"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/restore/restore_suite_test.go
+++ b/restore/restore_suite_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/greenplum-db/gpbackup/testutils"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/spf13/pflag"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/restore/validate_test.go
+++ b/restore/validate_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/greenplum-db/gpbackup/restore"
 	"github.com/greenplum-db/gpbackup/testutils"
 	"github.com/greenplum-db/gpbackup/utils"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/restore/wrappers_test.go
+++ b/restore/wrappers_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/greenplum-db/gpbackup/testutils"
 	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/pkg/errors"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/testutils/functions.go
+++ b/testutils/functions.go
@@ -16,7 +16,7 @@ import (
 	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/onsi/gomega/gbytes"
 	"github.com/sergi/go-diff/diffmatchpatch"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/utils/gpexpand_sensor_test.go
+++ b/utils/gpexpand_sensor_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/pkg/errors"
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/utils/utils_suite_test.go
+++ b/utils/utils_suite_test.go
@@ -3,7 +3,7 @@ package utils_test
 import (
 	"testing"
 
-	"gopkg.in/DATA-DOG/go-sqlmock.v1"
+	"github.com/DATA-DOG/go-sqlmock"
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"


### PR DESCRIPTION
The gpbackup utility can leak a blocked SQL session when a user sends
SIGINT (Ctrl-C) while gpbackup is executing its LOCK TABLE query. This
only occurs when the query is blocked trying to obtain a simple
AccessShareLock on a table when another session has already acquired
an AccessExclusiveLock on that same table. The AccessExclusiveLock
could have been acquired by the other session explicitly via LOCK
TABLE or implicitly via commands like TRUNCATE and ALTER TABLE.

The reason the SQL session is leaked is because the Golang SQL
libraries do not cancel the queries for you when closing
connections. To do this, we must introduce the concept of Golang
Contexts which gives us a very basic cancel function we can call
during clean up. The query cancel itself does not block and there is
no cancel verification built in so we explicitly queue a ROLLBACK on
the main gpbackup SQL session to make sure the SIGINT makes it through
the libpq connection. The Context and its cancel function are stored
as globals for now as one-off variables but I can see it grow into a
big list since all other gpbackup queries could technically encounter
this too (but unlikely).

----

This PR also updates the DATA-DOG/go-sqlmock dependency since the gp-common-go-libs dependency needs to be updated and the go-sqlmock was not in sync.  I would suggest reviewing this PR by individual commits so that the random go-sqlmock dependency updates don't cause a distraction to the actual fix patch.