### PR TITLE
Fix restore --with-stats behaviour when --include-table is specified

### DIFF
--- a/restore/restore.go
+++ b/restore/restore.go
@@ -270,7 +270,7 @@ func restoreStatistics() {
 	}
 	statisticsFilename := globalFPInfo.GetStatisticsFilePath()
 	gplog.Info("Restoring query planner statistics from %s", statisticsFilename)
-	statements := GetRestoreMetadataStatements("statistics", statisticsFilename, []string{}, []string{}, true, false)
+	statements := GetRestoreMetadataStatements("statistics", statisticsFilename, []string{}, []string{}, true, true)
 	ExecuteRestoreMetadataStatements(statements, "Table statistics", nil, utils.PB_VERBOSE, false)
 	gplog.Info("Query planner statistics restore complete")
 }


### PR DESCRIPTION
Co-authored-by: Kevin Yeap <kyeap@pivotal.io>
Co-authored-by: Kate Dontsova <edontsova@pivotal.io>

Previously when run gprestore --with-stats it ignored --include-table flag for restore statistics.

This happened because we set `filterRelations` to `false` when call `GetRestoreMetadataStatement` in `restoreStatistics`, so it didn't filter relations and restored statistics for all the tables.

We set it to `true` and added end-to-end tests for:

- runs gprestore with --include-table flag to only restore tables specified
- restores statistics only for tables specified in --include-table flag when runs gprestore with with-stats flag
