### PR TITLE
Log out gpbackup/gprestore command

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -78,6 +78,8 @@ func DoFlagValidation(cmd *cobra.Command) {
 // This function handles setup that must be done after parsing flags.
 func DoSetup() {
 	SetLoggerVerbosity()
+	gplog.Verbose("Backup Command: %s", os.Args)
+
 	utils.CheckGpexpandRunning(utils.BackupPreventedByGpexpandMessage)
 	timestamp := backup_history.CurrentTimestamp()
 	CreateBackupLockFile(timestamp)

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -79,6 +79,8 @@ func DoValidation(cmd *cobra.Command) {
 // This function handles setup that must be done after parsing flags.
 func DoSetup() {
 	SetLoggerVerbosity()
+	gplog.Verbose("Restore Command: %s", os.Args)
+
 	utils.CheckGpexpandRunning(utils.RestorePreventedByGpexpandMessage)
 	restoreStartTime = backup_history.CurrentTimestamp()
 	gplog.Info("Restore Key = %s", MustGetFlagString(utils.TIMESTAMP))


### PR DESCRIPTION
It's very useful to have the actual gpbackup/gprestore command in the
log output for debugging purposes. Users will be able to track what
they have actually ran (assuming they don't rotate gpAdminLog
logs). Also, user-provided logs will be much easier to work with since
the executed command will be right at the top.

gpbackup:
```
> gpbackup --dbname postgres --verbose
[DEBUG]:-Backup Command: [gpbackup --dbname postgres --verbose]
```

gprestore:
```
> gprestore --timestamp=20191016150604 --redirect-db foobar --create-db --verbose
[DEBUG]:-Restore Command: [gprestore --timestamp=20191016150604 --redirect-db foobar --create-db --verbose]
```