### PR TITLE
Support Materialized views

### DIFF
--- a/backup/dependencies.go
+++ b/backup/dependencies.go
@@ -297,6 +297,8 @@ func PrintDependentObjectStatements(metadataFile *utils.FileWithByteCount, toc *
 			PrintCreateServerStatement(metadataFile, toc, obj, objMetadata)
 		case UserMapping:
 			PrintCreateUserMappingStatement(metadataFile, toc, obj)
+		case MaterializedView:
+			PrintCreateMaterializedViewStatement(metadataFile, toc, obj, objMetadata)
 		}
 	}
 }

--- a/backup/predata_acl.go
+++ b/backup/predata_acl.go
@@ -233,7 +233,7 @@ func ParseACL(aclStr string) *ACL {
 func (obj ObjectMetadata) GetPrivilegesStatements(objectName string, objectType string, columnName ...string) string {
 	statements := make([]string, 0)
 	typeStr := fmt.Sprintf("%s ", objectType)
-	if objectType == "VIEW" || objectType == "FOREIGN TABLE" {
+	if objectType == "VIEW" || objectType == "FOREIGN TABLE" || objectType == "MATERIALIZED VIEW" {
 		typeStr = ""
 	} else if objectType == "COLUMN" {
 		typeStr = "TABLE "
@@ -311,7 +311,7 @@ func createPrivilegeStrings(acl ACL, objectType string) (string, string) {
 	case "SEQUENCE":
 		hasAllPrivileges = acl.Select && acl.Update && acl.Usage
 		hasAllPrivilegesWithGrant = acl.SelectWithGrant && acl.UpdateWithGrant && acl.UsageWithGrant
-	case "TABLE":
+	case "TABLE", "VIEW", "MATERIALIZED VIEW":
 		hasAllPrivileges = acl.Select && acl.Insert && acl.Update && acl.Delete && acl.Truncate && acl.References && acl.Trigger
 		hasAllPrivilegesWithGrant = acl.SelectWithGrant && acl.InsertWithGrant && acl.UpdateWithGrant && acl.DeleteWithGrant &&
 			acl.TruncateWithGrant && acl.ReferencesWithGrant && acl.TriggerWithGrant
@@ -321,10 +321,6 @@ func createPrivilegeStrings(acl ACL, objectType string) (string, string) {
 	case "TYPE":
 		hasAllPrivileges = acl.Usage
 		hasAllPrivilegesWithGrant = acl.UsageWithGrant
-	case "VIEW":
-		hasAllPrivileges = acl.Select && acl.Insert && acl.Update && acl.Delete && acl.Truncate && acl.References && acl.Trigger
-		hasAllPrivilegesWithGrant = acl.SelectWithGrant && acl.InsertWithGrant && acl.UpdateWithGrant && acl.DeleteWithGrant &&
-			acl.TruncateWithGrant && acl.ReferencesWithGrant && acl.TriggerWithGrant
 	}
 	if hasAllPrivileges {
 		privStr = "ALL"

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -249,10 +249,11 @@ func RetrieveProtocols(sortables *[]Sortable, metadataMap MetadataMap) []Externa
 
 func RetrieveViews(sortables *[]Sortable) {
 	gplog.Verbose("Retrieving views")
-	views := GetViews(connectionPool)
+	views, materializedViews := GetAllViews(connectionPool)
 	objectCounts["Views"] = len(views)
 
 	*sortables = append(*sortables, convertToSortableSlice(views)...)
+	*sortables = append(*sortables, convertToSortableSlice(materializedViews)...)
 }
 
 func RetrieveTSParsers(sortables *[]Sortable, metadataMap MetadataMap) {

--- a/integration/predata_relations_create_test.go
+++ b/integration/predata_relations_create_test.go
@@ -426,7 +426,7 @@ SET SUBPARTITION TEMPLATE ` + `
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP VIEW public.simpleview")
 
-			resultViews := backup.GetViews(connectionPool)
+			resultViews, _ := backup.GetAllViews(connectionPool)
 			resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_RELATION)
 
 			view.Oid = testutils.OidFromObjectName(connectionPool, "public", "simpleview", backup.TYPE_RELATION)
@@ -444,7 +444,7 @@ SET SUBPARTITION TEMPLATE ` + `
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP VIEW public.simpleview")
 
-			resultViews := backup.GetViews(connectionPool)
+			resultViews, _ := backup.GetAllViews(connectionPool)
 
 			view.Oid = testutils.OidFromObjectName(connectionPool, "public", "simpleview", backup.TYPE_RELATION)
 			Expect(resultViews).To(HaveLen(1))

--- a/integration/predata_relations_queries_test.go
+++ b/integration/predata_relations_queries_test.go
@@ -377,7 +377,7 @@ PARTITION BY LIST (gender)
 			structmatcher.ExpectStructsToMatchExcluding(&seqTwoDef, &results[1].SequenceDefinition)
 		})
 	})
-	Describe("GetViews", func() {
+	Describe("GetAllViews", func() {
 		var viewDef string
 		BeforeEach(func() {
 			if connectionPool.Version.Before("6") {
@@ -390,7 +390,7 @@ PARTITION BY LIST (gender)
 			testhelper.AssertQueryRuns(connectionPool, "CREATE VIEW public.simpleview AS SELECT 1")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP VIEW public.simpleview")
 
-			results := backup.GetViews(connectionPool)
+			results, _ := backup.GetAllViews(connectionPool)
 
 			view := backup.View{Oid: 1, Schema: "public", Name: "simpleview", Definition: viewDef}
 
@@ -406,7 +406,7 @@ PARTITION BY LIST (gender)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP VIEW testschema.simpleview")
 			_ = backupCmdFlags.Set(utils.INCLUDE_SCHEMA, "testschema")
 
-			results := backup.GetViews(connectionPool)
+			results, _ := backup.GetAllViews(connectionPool)
 
 			view := backup.View{Oid: 1, Schema: "testschema", Name: "simpleview", Definition: viewDef}
 
@@ -418,7 +418,7 @@ PARTITION BY LIST (gender)
 			testhelper.AssertQueryRuns(connectionPool, "CREATE VIEW public.simpleview WITH (security_barrier=true) AS SELECT 1")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP VIEW public.simpleview")
 
-			results := backup.GetViews(connectionPool)
+			results, _ := backup.GetAllViews(connectionPool)
 
 			view := backup.View{Oid: 1, Schema: "public", Name: "simpleview", Definition: viewDef, Options: " WITH (security_barrier=true)"}
 

--- a/testutils/functions.go
+++ b/testutils/functions.go
@@ -167,6 +167,7 @@ var objNameToClassID = map[string]uint32{
 	"TYPE":                      1247,
 	"USER MAPPING":              1418,
 	"VIEW":                      1259,
+	"MATERIALIZED VIEW":         1259,
 }
 
 func ClassIDFromObjectName(objName string) uint32 {
@@ -176,13 +177,13 @@ func ClassIDFromObjectName(objName string) uint32 {
 func DefaultACLForType(grantee string, objType string) backup.ACL {
 	return backup.ACL{
 		Grantee:    grantee,
-		Select:     objType == "PROTOCOL" || objType == "SEQUENCE" || objType == "TABLE" || objType == "VIEW" || objType == "FOREIGN TABLE",
-		Insert:     objType == "PROTOCOL" || objType == "TABLE" || objType == "VIEW" || objType == "FOREIGN TABLE",
-		Update:     objType == "SEQUENCE" || objType == "TABLE" || objType == "VIEW" || objType == "FOREIGN TABLE",
-		Delete:     objType == "TABLE" || objType == "VIEW" || objType == "FOREIGN TABLE",
-		Truncate:   objType == "TABLE" || objType == "VIEW",
-		References: objType == "TABLE" || objType == "VIEW" || objType == "FOREIGN TABLE",
-		Trigger:    objType == "TABLE" || objType == "VIEW" || objType == "FOREIGN TABLE",
+		Select:     objType == "PROTOCOL" || objType == "SEQUENCE" || objType == "TABLE" || objType == "VIEW" || objType == "FOREIGN TABLE" || objType == "MATERIALIZED VIEW",
+		Insert:     objType == "PROTOCOL" || objType == "TABLE" || objType == "VIEW" || objType == "FOREIGN TABLE" || objType == "MATERIALIZED VIEW",
+		Update:     objType == "SEQUENCE" || objType == "TABLE" || objType == "VIEW" || objType == "FOREIGN TABLE" || objType == "MATERIALIZED VIEW",
+		Delete:     objType == "TABLE" || objType == "VIEW" || objType == "FOREIGN TABLE" || objType == "MATERIALIZED VIEW",
+		Truncate:   objType == "TABLE" || objType == "VIEW" || objType == "MATERIALIZED VIEW",
+		References: objType == "TABLE" || objType == "VIEW" || objType == "FOREIGN TABLE" || objType == "MATERIALIZED VIEW",
+		Trigger:    objType == "TABLE" || objType == "VIEW" || objType == "FOREIGN TABLE" || objType == "MATERIALIZED VIEW",
 		Usage:      objType == "LANGUAGE" || objType == "SCHEMA" || objType == "SEQUENCE" || objType == "FOREIGN DATA WRAPPER" || objType == "FOREIGN SERVER",
 		Execute:    objType == "FUNCTION" || objType == "AGGREGATE",
 		Create:     objType == "DATABASE" || objType == "SCHEMA" || objType == "TABLESPACE",
@@ -194,13 +195,13 @@ func DefaultACLForType(grantee string, objType string) backup.ACL {
 func DefaultACLForTypeWithGrant(grantee string, objType string) backup.ACL {
 	return backup.ACL{
 		Grantee:             grantee,
-		SelectWithGrant:     objType == "PROTOCOL" || objType == "SEQUENCE" || objType == "TABLE" || objType == "VIEW",
-		InsertWithGrant:     objType == "PROTOCOL" || objType == "TABLE" || objType == "VIEW",
-		UpdateWithGrant:     objType == "SEQUENCE" || objType == "TABLE" || objType == "VIEW",
-		DeleteWithGrant:     objType == "TABLE" || objType == "VIEW",
-		TruncateWithGrant:   objType == "TABLE" || objType == "VIEW",
-		ReferencesWithGrant: objType == "TABLE" || objType == "VIEW",
-		TriggerWithGrant:    objType == "TABLE" || objType == "VIEW",
+		SelectWithGrant:     objType == "PROTOCOL" || objType == "SEQUENCE" || objType == "TABLE" || objType == "VIEW" || objType == "MATERIALIZED VIEW",
+		InsertWithGrant:     objType == "PROTOCOL" || objType == "TABLE" || objType == "VIEW" || objType == "MATERIALIZED VIEW",
+		UpdateWithGrant:     objType == "SEQUENCE" || objType == "TABLE" || objType == "VIEW" || objType == "MATERIALIZED VIEW",
+		DeleteWithGrant:     objType == "TABLE" || objType == "VIEW" || objType == "MATERIALIZED VIEW",
+		TruncateWithGrant:   objType == "TABLE" || objType == "VIEW" || objType == "MATERIALIZED VIEW",
+		ReferencesWithGrant: objType == "TABLE" || objType == "VIEW" || objType == "MATERIALIZED VIEW",
+		TriggerWithGrant:    objType == "TABLE" || objType == "VIEW" || objType == "MATERIALIZED VIEW",
 		UsageWithGrant:      objType == "LANGUAGE" || objType == "SCHEMA" || objType == "SEQUENCE" || objType == "FOREIGN DATA WRAPPER" || objType == "FOREIGN SERVER",
 		ExecuteWithGrant:    objType == "FUNCTION",
 		CreateWithGrant:     objType == "DATABASE" || objType == "SCHEMA" || objType == "TABLESPACE",
@@ -444,6 +445,12 @@ func SkipIfBefore5(connectionPool *dbconn.DBConn) {
 func SkipIfBefore6(connectionPool *dbconn.DBConn) {
 	if connectionPool.Version.Before("6") {
 		Skip("Test only applicable to GPDB6 and above")
+	}
+}
+
+func SkipIfBefore7(connectionPool *dbconn.DBConn) {
+	if connectionPool.Version.Before("7") {
+		Skip("Test only applicable to GPDB7 and above")
 	}
 }
 


### PR DESCRIPTION
    Support materialized views

    Add backup support for materialized views in GPDB6.1. Since they are
    closely related to views, the query was reused and GetViews was changed
    to also query information about materialized views. The reason they are
    then sorted into separate object types is to make it easier to implement
    materialized views ACL.