### PR TITLE
gprestore restores schemas based on include-tables

### DIFF
--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -431,6 +431,12 @@ var _ = Describe("backup end to end integration tests", func() {
 				assertRelationsCreated(restoreConn, 13)
 				assertDataRestored(restoreConn, map[string]int{"public.sales": 1, "public.sales_1_prt_jan17": 1})
 			})
+			It("runs gpbackup and gprestore with include-table restore flag which implicitly filters schema restore list", func() {
+				timestamp := gpbackup(gpbackupPath, backupHelperPath, "--backup-dir", backupDir)
+				gprestore(gprestorePath, restoreHelperPath, timestamp, "--redirect-db", "restoredb", "--backup-dir", backupDir, "--include-table", "schema2.foo3")
+				assertRelationsCreated(restoreConn, 1)
+				assertDataRestored(restoreConn, map[string]int{"schema2.foo3": 100})
+			})
 		})
 		Describe("Backup exclude filtering", func() {
 			It("runs gpbackup and gprestore with exclude-schema backup flag", func() {

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -197,7 +197,7 @@ func restorePredata(metadataFilename string) {
 	}
 	gplog.Info("Restoring pre-data metadata")
 
-	schemaStatements := GetRestoreMetadataStatements("predata", metadataFilename, []string{"SCHEMA"}, []string{}, true, false)
+	schemaStatements := GetRestoreMetadataStatements("predata", metadataFilename, []string{"SCHEMA"}, []string{}, true, true)
 	statements := GetRestoreMetadataStatements("predata", metadataFilename, []string{}, []string{"SCHEMA"}, true, true)
 
 	progressBar := utils.NewProgressBar(len(schemaStatements)+len(statements), "Pre-data objects restored: ", utils.PB_VERBOSE)

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -242,6 +242,18 @@ func GetRestoreMetadataStatements(section string, filename string, includeObject
 				toc := utils.NewTOC(tocFilename)
 				inRelations = append(inRelations, utils.GetIncludedPartitionRoots(toc.DataEntries, inRelations)...)
 			}
+			// Update include schemas for schema restore if include table is set
+			if utils.Exists(includeObjectTypes, "SCHEMA") {
+				for _, inRelation := range inRelations {
+					schema := inRelation[:strings.Index(inRelation, ".")]
+					if !utils.Exists(inSchemas, schema) {
+						inSchemas = append(inSchemas, schema)
+					}
+				}
+				// reset relation list as these were required only to extract schemas from inRelations
+				inRelations = nil
+				exRelations = nil
+			}
 		}
 	}
 	statements = globalTOC.GetSQLStatementForObjectTypes(section, metadataFile, includeObjectTypes, excludeObjectTypes, inSchemas, exSchemas, inRelations, exRelations)

--- a/utils/util.go
+++ b/utils/util.go
@@ -104,3 +104,12 @@ func LogExecutionTime(start time.Time, name string) {
 	elapsed := time.Since(start)
 	gplog.Debug(fmt.Sprintf("%s took %s", name, elapsed))
 }
+
+func Exists(slice []string, val string) (bool) {
+	for _, item := range slice {
+		if item == val {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
If include-table is configured only schemas in this list will be restored.

`GetRestoreMetadataStatements` used for deriving the schema statements now use the filtered relations to infer the schemas.