### PR TITLE
Verify plugin config attributes executablepath and options

### DIFF
--- a/backup/data.go
+++ b/backup/data.go
@@ -73,6 +73,7 @@ func CopyTableOut(connectionPool *dbconn.DBConn, table Table, destinationToWrite
 	copyCommand := fmt.Sprintf("PROGRAM '%s%s %s %s'", checkPipeExistsCommand, customPipeThroughCommand, sendToDestinationCommand, destinationToWrite)
 
 	query := fmt.Sprintf("COPY %s TO %s WITH CSV DELIMITER '%s' ON SEGMENT IGNORE EXTERNAL PARTITIONS;", table.FQN(), copyCommand, tableDelim)
+	gplog.Verbose(query)
 	result, err := connectionPool.Exec(query, connNum)
 	if err != nil {
 		return 0, err

--- a/utils/plugin.go
+++ b/utils/plugin.go
@@ -46,6 +46,9 @@ func ReadPluginConfig(configFile string) (*PluginConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+	if config.ExecutablePath == "" {
+		return nil, errors.New("executablepath is required in config file")
+	}
 	config.ExecutablePath = os.ExpandEnv(config.ExecutablePath)
 	err = ValidateFullPath(config.ExecutablePath)
 	if err != nil {

--- a/utils/plugin_test.go
+++ b/utils/plugin_test.go
@@ -28,6 +28,7 @@ var _ = Describe("utils/plugin tests", func() {
 	var tempDir string
 
 	BeforeEach(func() {
+		operating.InitializeSystemFunctions()
 		tempDir, _ = ioutil.TempDir("", "temp")
 		operating.System.Stdout = stdout
 		subject = utils.PluginConfig{
@@ -41,7 +42,7 @@ var _ = Describe("utils/plugin tests", func() {
 		}
 		// set up fake command results
 		apiResponse := make(map[int]string, 3)
-		apiResponse[-1] = utils.RequiredPluginVersion // this is a successful result fpr API version
+		apiResponse[-1] = utils.RequiredPluginVersion // this is a successful result for API version
 		apiResponse[0] = utils.RequiredPluginVersion
 		apiResponse[1] = utils.RequiredPluginVersion
 		executor.ClusterOutputs[0] = &cluster.RemoteOutput{
@@ -336,6 +337,14 @@ options:
 
 			Expect(pluginName).To(Equal(""))
 			Expect(err.Error()).To(Equal("Unexpected plugin version format: \"bad output\"\nExpected: \"[plugin_name] version [git_version]\""))
+		})
+	})
+	Describe("ReadPluginConfig", func() {
+		It("returns an error if executablepath is not specified", func() {
+			operating.System.ReadFile = func(string) ([]byte, error) { return []byte{}, nil }
+
+			_, err := utils.ReadPluginConfig("myconfigpath")
+			Expect(err.Error()).To(Equal("executablepath is required in config file"))
 		})
 	})
 })


### PR DESCRIPTION
Previously, gpbackup would attempt to continue with plugin API call if
the required yaml field 'executablepath' was missing due to being
forgotten or mispelled.  The missing executablepath would then cause
gpbackup to format the plugin API call badly and fail.  This commit add
a validation check which will cause gpbackup to exit early if either
'exectuablepath' and give the users a better error message.

Co-authored-by: Kevin Yeap <kyeap@pivotal.io>
Co-authored-by: Lav Jain <ljain@pivotal.io>