### PR TITLE
Support Materialized views in GPDB6.2+

### DIFF
--- a/backup/predata_relations_other_test.go
+++ b/backup/predata_relations_other_test.go
@@ -482,7 +482,7 @@ GRANT ALL ON shamwow.shazam TO testrole;`,
 			emptyMetadata backup.ObjectMetadata
 		)
 		BeforeEach(func() {
-			testhelper.SetDBVersion(connectionPool, "7.0.0")
+			testhelper.SetDBVersion(connectionPool, "6.2.0")
 			defer testhelper.SetDBVersion(connectionPool, "5.1.0")
 			mview = backup.MaterializedView{Oid: 1, Schema: "schema1", Name: "mview1", Definition: "SELECT count(*) FROM pg_tables;"}
 			emptyMetadata = backup.ObjectMetadata{}

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -535,7 +535,7 @@ var _ = Describe("backup end to end integration tests", func() {
 					defer testhelper.AssertQueryRuns(backupConn, "DROP FOREIGN DATA WRAPPER fdw CASCADE;")
 					defer testhelper.AssertQueryRuns(restoreConn, "DROP FOREIGN DATA WRAPPER fdw CASCADE;")
 				}
-				if backupConn.Version.AtLeast("7") {
+				if backupConn.Version.AtLeast("6.2") {
 					testhelper.AssertQueryRuns(backupConn, "CREATE TABLE mview_table1(i int, j text);")
 					defer testhelper.AssertQueryRuns(restoreConn, "DROP TABLE mview_table1;")
 					testhelper.AssertQueryRuns(backupConn, "CREATE MATERIALIZED VIEW mview1 (i2) as select i from mview_table1;")

--- a/integration/dependency_queries_test.go
+++ b/integration/dependency_queries_test.go
@@ -93,7 +93,9 @@ var _ = Describe("backup integration tests", func() {
 			Expect(deps[childEntry]).To(HaveKey(parent2Entry))
 		})
 		It("constructs dependencies correctly for a materialized view that depends on two other materialized views", func() {
-			testutils.SkipIfBefore7(connectionPool)
+			if connectionPool.Version.Before("6.2") {
+				Skip("Test only applicable to GPDB 6.2 and above")
+			}
 			testhelper.AssertQueryRuns(connectionPool, "CREATE MATERIALIZED VIEW public.parent1 AS SELECT relname FROM pg_class")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP MATERIALIZED VIEW public.parent1")
 			testhelper.AssertQueryRuns(connectionPool, "CREATE MATERIALIZED VIEW public.parent2 AS SELECT relname FROM pg_class")

--- a/integration/predata_acl_queries_test.go
+++ b/integration/predata_acl_queries_test.go
@@ -210,7 +210,9 @@ LANGUAGE SQL`)
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a materialized view", func() {
-				testutils.SkipIfBefore7(connectionPool)
+				if connectionPool.Version.Before("6.2") {
+					Skip("Test only applicable to GPDB 6.2 and above")
+				}
 				testhelper.AssertQueryRuns(connectionPool, `CREATE MATERIALIZED VIEW public.testmview AS SELECT * FROM pg_class`)
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP MATERIALIZED VIEW public.testmview")
 				testhelper.AssertQueryRuns(connectionPool, "GRANT ALL ON public.testmview TO testrole")
@@ -579,7 +581,9 @@ LANGUAGE SQL`)
 				structmatcher.ExpectStructsToMatchExcluding(&expectedMetadata, &resultMetadata, "Oid")
 			})
 			It("returns a slice of default metadata for a materialized view in a specific schema", func() {
-				testutils.SkipIfBefore7(connectionPool)
+				if connectionPool.Version.Before("6.2") {
+					Skip("Test only applicable to GPDB 6.2 and above")
+				}
 				testhelper.AssertQueryRuns(connectionPool, `CREATE MATERIALIZED VIEW public.testmview AS SELECT * FROM pg_class`)
 				defer testhelper.AssertQueryRuns(connectionPool, "DROP MATERIALIZED VIEW public.testmview")
 				testhelper.AssertQueryRuns(connectionPool, "CREATE SCHEMA testschema")

--- a/integration/predata_relations_create_test.go
+++ b/integration/predata_relations_create_test.go
@@ -453,7 +453,9 @@ SET SUBPARTITION TEMPLATE ` + `
 	})
 	Describe("PrintMaterializedCreateViewStatements", func() {
 		BeforeEach(func() {
-			testutils.SkipIfBefore7(connectionPool)
+			if connectionPool.Version.Before("6.2") {
+				Skip("test only applicable to GPDB 6.2 and above")
+			}
 		})
 		It("creates a view with privileges, owner, security label, and comment", func() {
 			view := backup.MaterializedView{Oid: 1, Schema: "public", Name: "simplemview", Definition: " SELECT 1;"}

--- a/integration/predata_relations_queries_test.go
+++ b/integration/predata_relations_queries_test.go
@@ -426,7 +426,9 @@ PARTITION BY LIST (gender)
 			structmatcher.ExpectStructsToMatchExcluding(&view, &results[0], "Oid")
 		})
 		It("returns a slice for materialized views", func() {
-			testutils.SkipIfBefore7(connectionPool)
+			if connectionPool.Version.Before("6.2") {
+				Skip("test only applicable to GPDB 6.2 and above")
+			}
 			testhelper.AssertQueryRuns(connectionPool, "CREATE MATERIALIZED VIEW public.simplematerialview AS SELECT 1")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP MATERIALIZED VIEW public.simplematerialview")
 
@@ -438,7 +440,9 @@ PARTITION BY LIST (gender)
 			structmatcher.ExpectStructsToMatchExcluding(&materialView, &results[0], "Oid")
 		})
 		It("returns a slice for materialized views with storage parameters", func() {
-			testutils.SkipIfBefore7(connectionPool)
+			if connectionPool.Version.Before("6.2") {
+				Skip("test only applicable to GPDB 6.2 and above")
+			}
 			testhelper.AssertQueryRuns(connectionPool, "CREATE MATERIALIZED VIEW public.simplematerialview WITH (fillfactor=50, autovacuum_enabled=false) AS SELECT 1")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP MATERIALIZED VIEW public.simplematerialview")
 
@@ -450,7 +454,9 @@ PARTITION BY LIST (gender)
 			structmatcher.ExpectStructsToMatchExcluding(&materialView, &results[0], "Oid")
 		})
 		It("returns a slice for materialized views with tablespaces", func() {
-			testutils.SkipIfBefore7(connectionPool)
+			if connectionPool.Version.Before("6.2") {
+				Skip("test only applicable to GPDB 6.2 and above")
+			}
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLESPACE test_tablespace LOCATION '/tmp/test_dir'")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLESPACE test_tablespace")
 			testhelper.AssertQueryRuns(connectionPool, "CREATE MATERIALIZED VIEW public.simplematerialview TABLESPACE test_tablespace AS SELECT 1")


### PR DESCRIPTION
Materialized views were backported from GPDB7 to GPDB6.2+. We changed
the version control logic to check for matviews on GPDB version 6.2 and
refactored the query to get all views.

Co-authored-by: Kevin Yeap <kyeap@pivotal.io>
Co-authored-by: Lav Jain <ljain@pivotal.io>