### PR TITLE
Support incremental restore without DDL

### DIFF
--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -108,7 +108,6 @@ func GetUserTableRelations(connectionPool *dbconn.DBConn) []Relation {
 
 func GetUserTableRelationsWithIncludeFiltering(connectionPool *dbconn.DBConn, includedRelationsQuoted []string) []Relation {
 	includeOids := GetOidsFromRelationList(connectionPool, includedRelationsQuoted)
-
 	oidStr := strings.Join(includeOids, ", ")
 	query := fmt.Sprintf(`
 	SELECT n.oid AS schemaoid,

--- a/utils/util.go
+++ b/utils/util.go
@@ -113,3 +113,15 @@ func Exists(slice []string, val string) bool {
 	}
 	return false
 }
+
+func SchemaIsExcludedByUser(inSchemasUserInput []string, exSchemasUserInput []string, schemaName string) bool{
+	included := Exists(inSchemasUserInput, schemaName) || len(inSchemasUserInput) == 0
+	excluded := Exists(exSchemasUserInput, schemaName)
+	return excluded || !included
+}
+
+func RelationIsExcludedByUser(inRelationsUserInput []string, exRelationsUserInput []string, tableFQN string) bool{
+	included := Exists(inRelationsUserInput, tableFQN) || len(inRelationsUserInput) == 0
+	excluded := Exists(exRelationsUserInput, tableFQN)
+	return excluded || !included
+}


### PR DESCRIPTION
Co-authored-by: Kate Dontsova <edontsova@pivotal.io>

 - Adds --incremental flag for gprestore
 - Only restores the last entry fro restore plan
 - Filters schemas and relations based on DB state (existing schemas and relations) 
    and restore plan
- Respects --include/exclude-schemas/tables flag if provided