### PR TITLE
Use manually cached gpbackup 1.12.1 dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,26 +52,26 @@ $(GOLANG_LINTER) :
 lint : $(GOLANG_LINTER)
 		golangci-lint run --tests=false
 
-unit : depend $(GINKGO)
+unit : $(GINKGO)
 		ginkgo -r -keepGoing -randomizeSuites -noisySkippings=false -randomizeAllSpecs $(SUBDIRS_HAS_UNIT) 2>&1
 
-integration : depend $(GINKGO)
+integration : $(GINKGO)
 		ginkgo -r -randomizeSuites -noisySkippings=false -randomizeAllSpecs integration 2>&1
 
 test : unit integration
 
-end_to_end : depend $(GINKGO)
+end_to_end : $(GINKGO)
 		ginkgo -r -randomizeSuites -slowSpecThreshold=10 -noisySkippings=false -randomizeAllSpecs end_to_end -- --custom_backup_dir $(CUSTOM_BACKUP_DIR) 2>&1
 
 coverage :
 		@./show_coverage.sh
 
-build : depend
+build :
 		go build -tags '$(BACKUP)' $(GOFLAGS) -o $(BIN_DIR)/$(BACKUP) -ldflags $(BACKUP_VERSION_STR)
 		go build -tags '$(RESTORE)' $(GOFLAGS) -o $(BIN_DIR)/$(RESTORE) -ldflags $(RESTORE_VERSION_STR)
 		go build -tags '$(HELPER)' $(GOFLAGS) -o $(BIN_DIR)/$(HELPER) -ldflags $(HELPER_VERSION_STR)
 
-build_linux : depend
+build_linux :
 		env GOOS=linux GOARCH=amd64 go build -tags '$(BACKUP)' $(GOFLAGS) -o $(BACKUP) -ldflags $(BACKUP_VERSION_STR)
 		env GOOS=linux GOARCH=amd64 go build -tags '$(RESTORE)' $(GOFLAGS) -o $(RESTORE) -ldflags $(RESTORE_VERSION_STR)
 		env GOOS=linux GOARCH=amd64 go build -tags '$(HELPER)' $(GOFLAGS) -o $(HELPER) -ldflags $(HELPER_VERSION_STR)

--- a/Makefile
+++ b/Makefile
@@ -30,14 +30,11 @@ $(DEP) :
 		mkdir -p $(GOPATH)/bin
 		curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 
-depend :
-		go mod download
-
 $(GINKGO) :
-		go get github.com/onsi/ginkgo/ginkgo
+		go install github.com/onsi/ginkgo/ginkgo
 
-$(GOIMPORTS) : depend
-		@cd vendor/golang.org/x/tools/cmd/goimports; go install .
+$(GOIMPORTS) :
+		go install golang.org/x/tools/cmd/goimports
 
 format : $(GOIMPORTS)
 		@goimports -w $(shell find . -type f -name '*.go' -not -path "./vendor/*")

--- a/ci/scripts/integration-tests-fixed-version.bash
+++ b/ci/scripts/integration-tests-fixed-version.bash
@@ -18,6 +18,8 @@ git checkout ${GPBACKUP_VERSION}
 # with gpdb5, we've decided to simply cherry-pick the commit prior to running tests.
 git cherry-pick c149e8b7b671e931ca892f22c8cdef906512d591
 
+tar -zxf ~/gpbackup_1.12.1_dependencies.tar.gz
+
 make depend build integration
 
 # NOTE: This is a temporary hotfix intended to skip these tests when running on CCP cluster
@@ -29,4 +31,7 @@ SCRIPT
 
 chmod +x /tmp/run_tests.bash
 scp /tmp/run_tests.bash mdw:/home/gpadmin/run_tests.bash
+
+rsync -a gpbackup_1.12.1_dependencies/gpbackup_1.12.1_dependencies.tar.gz mdw:/home/gpadmin
+
 ssh -t mdw "bash /home/gpadmin/run_tests.bash"

--- a/ci/scripts/setup-centos-env.bash
+++ b/ci/scripts/setup-centos-env.bash
@@ -42,10 +42,6 @@ if test -f ${GPHOME}/lib/postgresql/dummy_seclabel.so; then
     gpconfig -c shared_preload_libraries -v dummy_seclabel
 fi
 gpstop -ar
-
-pushd \${GOPATH}/src/github.com/greenplum-db/gpbackup
-    make depend # Needed to install ginkgo
-popd
 SCRIPT
 
 chmod +x /tmp/setup_env.bash

--- a/ci/tasks/integration-tests-fixed-version.yml
+++ b/ci/tasks/integration-tests-fixed-version.yml
@@ -7,6 +7,7 @@ inputs:
 - name: gpbackup
 - name: ccp_src
 - name: cluster_env_files
+- name: gpbackup_1.12.1_dependencies
 
 params:
   GPBACKUP_VERSION:

--- a/ci/templates/gpbackup-tpl.yml
+++ b/ci/templates/gpbackup-tpl.yml
@@ -492,6 +492,17 @@ resources:
     access_key_id: {{bucket-access-key-id}}
     secret_access_key: {{bucket-secret-access-key}}
 
+# Manual caching to prevent dep flakes when downloading dependencies
+- name: gpbackup_1.12.1_dependencies
+  type: s3
+  icon: amazon
+  source:
+    bucket: gpbackup-dependencies
+    versioned_file: gpbackup_1.12.1_dependencies.tar.gz
+    region_name: us-west-2
+    access_key_id: {{bucket-access-key-id}}
+    secret_access_key: {{bucket-secret-access-key}}
+
 - name: pgcrypto43
   type: s3
   icon: amazon
@@ -1296,7 +1307,7 @@ jobs:
     <<: *set_failed
 
 {% if "gpbackup-release" != pipeline_name %}
-# Ensure compatibility between a new gpdb5 binary and a fixed version of gpbackup
+# Ensure compatibility between a new GPDB5 binary and a fixed version of gpbackup
 - name: 5X-head-gpbackup-fixed-test
   plan:
   - in_parallel:
@@ -1312,6 +1323,7 @@ jobs:
     - get: ccp_src
     - get: gpdb_src
       resource: gpdb5_src
+    - get: gpbackup_1.12.1_dependencies
   - put: terraform
     params:
       <<: *ccp_default_params

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	golang.org/x/crypto v0.0.0-20191105034135-c7e5f84aec59 // indirect
 	golang.org/x/net v0.0.0-20191105084925-a882066a44e0 // indirect
 	golang.org/x/sys v0.0.0-20191105231009-c1f44814a5cd // indirect
+	golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e
 	google.golang.org/appengine v1.6.5 // indirect
 	gopkg.in/cheggaaa/pb.v1 v1.0.28
 	gopkg.in/yaml.v2 v2.2.6-0.20191105165536-770b8dae4cf0

--- a/go.sum
+++ b/go.sum
@@ -22,7 +22,6 @@ github.com/go-sql-driver/mysql v1.4.0 h1:7LxgVwFb2hIQtMm87NdgAVfXjnt4OePseqT1tKx
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
-github.com/golang/protobuf v1.2.0 h1:P3YflyNX/ehuJFLhxviNdFxQPkGK5cDcApsge1SqnvM=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -103,6 +102,7 @@ golang.org/x/sys v0.0.0-20191105231009-c1f44814a5cd/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e h1:FDhOuMEY4JVRztM/gsbk+IKUQ8kj74bxZrgw87eMMVc=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=

--- a/tools.go
+++ b/tools.go
@@ -1,0 +1,8 @@
+// +build tools
+
+package tools
+
+import (
+	_ "github.com/onsi/ginkgo"
+	_ "golang.org/x/tools/cmd/goimports"
+)


### PR DESCRIPTION
The gpbackup version 1.12.1 is tested against the latest version of GPDB5
    to ensure the version of gpbackup shipped with GPDB5X is not broken.
    Unfortunately, dep struggles to successfully download gpbackup
    dependencies sometimes so we implement a manual cache workaround. This
    commit unpacks the gpbackup 1.12.1 dependencies so it does not need to be
    downloaded by dep.