### PR TITLE
Fix --include-table for materialized views

### DIFF
--- a/restore/validate.go
+++ b/restore/validate.go
@@ -162,7 +162,7 @@ func getFilterRelationsInBackupSet(relationList []string) []string {
 		relationMap[relation] = true
 	}
 	for _, entry := range globalTOC.PredataEntries {
-		if entry.ObjectType != "TABLE" && entry.ObjectType != "SEQUENCE" && entry.ObjectType != "VIEW" {
+		if entry.ObjectType != "TABLE" && entry.ObjectType != "SEQUENCE" && entry.ObjectType != "VIEW" && entry.ObjectType != "MATERIALIZED VIEW" {
 			continue
 		}
 		fqn := utils.MakeFQN(entry.Schema, entry.Name)

--- a/utils/toc.go
+++ b/utils/toc.go
@@ -196,8 +196,8 @@ func shouldIncludeStatement(entry MetadataEntry, objectSet *FilterSet, schemaSet
 	shouldIncludeObject := objectSet.MatchesFilter(entry.ObjectType)
 	shouldIncludeSchema := schemaSet.MatchesFilter(entry.Schema)
 	relationFQN := MakeFQN(entry.Schema, entry.Name)
-	shouldIncludeRelation := (relationSet.IsExclude && entry.ObjectType != "TABLE" && entry.ObjectType != "VIEW" && entry.ObjectType != "SEQUENCE" && entry.ReferenceObject == "") ||
-		((entry.ObjectType == "TABLE" || entry.ObjectType == "VIEW" || entry.ObjectType == "SEQUENCE") && relationSet.MatchesFilter(relationFQN) && entry.ReferenceObject == "") || // Relations should match the filter
+	shouldIncludeRelation := (relationSet.IsExclude && entry.ObjectType != "TABLE" && entry.ObjectType != "VIEW" && entry.ObjectType != "MATERIALIZED VIEW" && entry.ObjectType != "SEQUENCE" && entry.ReferenceObject == "") ||
+		((entry.ObjectType == "TABLE" || entry.ObjectType == "VIEW" || entry.ObjectType == "MATERIALIZED VIEW" || entry.ObjectType == "SEQUENCE") && relationSet.MatchesFilter(relationFQN) && entry.ReferenceObject == "") || // Relations should match the filter
 		(entry.ObjectType != "SEQUENCE OWNER" && entry.ReferenceObject != "" && relationSet.MatchesFilter(entry.ReferenceObject)) || // Include relations that filtered tables depend on
 		(entry.ObjectType == "SEQUENCE OWNER" && relationSet.MatchesFilter(relationFQN) && relationSet.MatchesFilter(entry.ReferenceObject)) //Include sequence owners if both table and sequence are being restored
 


### PR DESCRIPTION
Authored-by: Kate Dontsova <edontsova@pivotal.io>

When run gprestore with --include-table flag it restored tables and views
but not materialized views. This fix makes --include-table flag to include materialized views.