### PR TITLE
Properly escape text before writing statistics

### DIFF
--- a/backup/statistics_test.go
+++ b/backup/statistics_test.go
@@ -277,8 +277,8 @@ INSERT INTO pg_statistic VALUES (
 	})
 	Describe("SliceToPostgresArray", func() {
 		It("returns properly quoted string representing a Postgres array", func() {
-			arrayString := backup.SliceToPostgresArray([]string{"ab'c", `ef"g`})
-			Expect(arrayString).To(Equal(`'{"ab''c","ef\"g"}'`))
+			arrayString := backup.SliceToPostgresArray([]string{"ab'c", "ab\\c", "ab\"c", "ef\\'\"g"})
+			Expect(arrayString).To(Equal("'{\"ab''c\",\"ab\\\\c\",\"ab\\\"c\",\"ef\\\\''\\\"g\"}'"))
 		})
 	})
 })


### PR DESCRIPTION
When backing up statistics of text, varchar, bpchar, and bytea column
types, gpbackup was not properly escaping the column samples. This
caused the resulting stats written to the backup stats file to be
incorrect when sample strings had escapable characters (e.g. backslashes
or double quotes). This would cause gprestore to fail when attempting to
restore statistics because the SQL could be malformed.

Co-authored-by: Kevin Yeap <kyeap@pivotal.io>
Co-authored-by: Jimmy Yih <jyih@pivotal.io>