### PR TITLE
Fix some psql calls when using .psqlrc file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ build_linux :
 		env GOOS=linux GOARCH=amd64 go build -tags '$(HELPER)' $(GOFLAGS) -o $(HELPER) -ldflags $(HELPER_VERSION_STR)
 
 install :
-		@psql -t -d template1 -c 'select distinct hostname from gp_segment_configuration where content != -1' > /tmp/seg_hosts 2>/dev/null; \
+		@psql -X -t -d template1 -c 'select distinct hostname from gp_segment_configuration where content != -1' > /tmp/seg_hosts 2>/dev/null; \
 		if [ $$? -eq 0 ]; then \
 			gpscp -f /tmp/seg_hosts $(helper_path) =:$(GPHOME)/bin/$(HELPER); \
 			if [ $$? -eq 0 ]; then \

--- a/plugins/plugin_test_bench.sh
+++ b/plugins/plugin_test_bench.sh
@@ -315,9 +315,9 @@ test_backup_and_restore_with_plugin() {
     test_db=plugin_test_db
     log_file="$logdir/plugin_test_log_file"
 
-    psql -d postgres -qc "DROP DATABASE IF EXISTS $test_db" 2>/dev/null
+    psql -X -d postgres -qc "DROP DATABASE IF EXISTS $test_db" 2>/dev/null
     createdb $test_db
-    psql -d $test_db -qc "CREATE TABLE test_table(i int) DISTRIBUTED RANDOMLY; INSERT INTO test_table select generate_series(1,50000)"
+    psql -X -d $test_db -qc "CREATE TABLE test_table(i int) DISTRIBUTED RANDOMLY; INSERT INTO test_table select generate_series(1,50000)"
 
     set +e
     # save the encrypt key file, if it exists
@@ -347,7 +347,7 @@ test_backup_and_restore_with_plugin() {
         echo "gprestore failed. Check gprestore log file in ~/gpAdminLogs for details."
         exit 1
     fi
-    num_rows=`psql -d $test_db -tc "SELECT count(*) FROM test_table" | xargs`
+    num_rows=`psql -X -d $test_db -tc "SELECT count(*) FROM test_table" | xargs`
     if [ "$num_rows" != "50000" ]; then
         echo "Expected to restore 50000 rows, got $num_rows"
         exit 1
@@ -364,7 +364,7 @@ test_backup_and_restore_with_plugin() {
             echo "gprestore from secondary destination failed. Check gprestore log file in ~/gpAdminLogs for details."
             exit 1
         fi
-        num_rows=`psql -d $test_db -tc "SELECT count(*) FROM test_table" | xargs`
+        num_rows=`psql -X -d $test_db -tc "SELECT count(*) FROM test_table" | xargs`
         if [ "$num_rows" != "50000" ]; then
           echo "Expected to restore 50000 rows, got $num_rows"
           exit 1


### PR DESCRIPTION
After the Postgres 9.6 merge into GPDB master, the .psqlrc file is
always parsed if the -X flag is not given to psql. This will make any
psql call to also print out the .psqlrc file parsing. We have a couple
areas where we depend on only obtaining the query output but this
extra parsing text is breaking the logic. Adding the -X flag will make
it always work as expected.

GPDB commit reference:
https://github.com/greenplum-db/gpdb/commit/5a92cefbcf35b8bc