### PR TITLE
Add --redirect-schema flag to gprestore 

### DIFF
--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -130,7 +130,7 @@ func assertRelationsCreated(conn *dbconn.DBConn, expectedNumTables int) {
 	}
 }
 
-func assertRelationsExistForIncremantal(conn *dbconn.DBConn, expectedNumTables int) {
+func assertRelationsExistForIncremental(conn *dbconn.DBConn, expectedNumTables int) {
 	countQuery := `SELECT count(*) AS string FROM pg_class c LEFT JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind IN ('S','v','r') AND n.nspname IN ('old_schema', 'new_schema');`
 	actualTableCount := dbconn.MustSelectString(conn, countQuery)
 	if strconv.Itoa(expectedNumTables) != actualTableCount {
@@ -949,8 +949,7 @@ var _ = Describe("backup end to end integration tests", func() {
 						"old_schema.old_table1": 10,
 						"old_schema.old_table2": 15,
 					}
-					newSchemaTupleCounts = map[string]int{
-					}
+					newSchemaTupleCounts = map[string]int{}
 					baseTimestamp := gpbackup(gpbackupPath, backupHelperPath, "--leaf-partition-data")
 
 					testhelper.AssertQueryRuns(restoreConn, "DROP SCHEMA IF EXISTS new_schema CASCADE; DROP SCHEMA IF EXISTS old_schema CASCADE;")
@@ -960,9 +959,9 @@ var _ = Describe("backup end to end integration tests", func() {
 					testhelper.AssertQueryRuns(backupConn, "DROP SCHEMA IF EXISTS new_schema CASCADE; DROP SCHEMA IF EXISTS old_schema CASCADE;")
 					testhelper.AssertQueryRuns(restoreConn, "DROP SCHEMA IF EXISTS new_schema CASCADE; DROP SCHEMA IF EXISTS old_schema CASCADE;")
 				})
-				Context("Only new schemas and tables", func(){
+				Context("Only new schemas and tables", func() {
 					var timestamp string
-					BeforeEach(func(){
+					BeforeEach(func() {
 						testhelper.AssertQueryRuns(backupConn, "CREATE SCHEMA new_schema;")
 						testhelper.AssertQueryRuns(backupConn, "CREATE TABLE new_schema.new_table1 (mydata int) WITH (appendonly=true) DISTRIBUTED BY (mydata);")
 						testhelper.AssertQueryRuns(backupConn, "CREATE TABLE new_schema.new_table2 (mydata int) WITH (appendonly=true) DISTRIBUTED BY (mydata);")
@@ -970,11 +969,10 @@ var _ = Describe("backup end to end integration tests", func() {
 						testhelper.AssertQueryRuns(backupConn, "INSERT INTO new_schema.new_table2 SELECT generate_series(1, 35);")
 						timestamp = gpbackup(gpbackupPath, backupHelperPath, "--leaf-partition-data", "--incremental")
 					})
-					AfterEach(func(){
+					AfterEach(func() {
 						testhelper.AssertQueryRuns(backupConn, "DROP SCHEMA IF EXISTS new_schema CASCADE;")
 						testhelper.AssertQueryRuns(restoreConn, "DROP SCHEMA IF EXISTS new_schema CASCADE;")
-						newSchemaTupleCounts = map[string]int{
-						}
+						newSchemaTupleCounts = map[string]int{}
 						assertArtifactsCleaned(restoreConn, timestamp)
 					})
 					It("Restores new schemas and tables", func() {
@@ -982,59 +980,57 @@ var _ = Describe("backup end to end integration tests", func() {
 						newSchemaTupleCounts["new_schema.new_table1"] = 30
 						newSchemaTupleCounts["new_schema.new_table2"] = 35
 						assertSchemasExist(restoreConn, 5)
-						assertRelationsExistForIncremantal(restoreConn, 5)
+						assertRelationsExistForIncremental(restoreConn, 5)
 						assertDataRestored(restoreConn, oldSchemaTupleCounts)
 						assertDataRestored(restoreConn, newSchemaTupleCounts)
 					})
 					It("Restores only tables included by use if user input is provided", func() {
-						gprestore(gprestorePath, restoreHelperPath, timestamp,  "--incremental", "--include-table", "new_schema.new_table1", "--redirect-db", "restoredb")
+						gprestore(gprestorePath, restoreHelperPath, timestamp, "--incremental", "--include-table", "new_schema.new_table1", "--redirect-db", "restoredb")
 						newSchemaTupleCounts["new_schema.new_table1"] = 30
 						assertSchemasExist(restoreConn, 5)
-						assertRelationsExistForIncremantal(restoreConn, 4)
+						assertRelationsExistForIncremental(restoreConn, 4)
 						assertDataRestored(restoreConn, oldSchemaTupleCounts)
 						assertDataRestored(restoreConn, newSchemaTupleCounts)
 					})
-					It("Does not restore tables excluded by user if user input is provided", func(){
+					It("Does not restore tables excluded by user if user input is provided", func() {
 						gprestore(gprestorePath, restoreHelperPath, timestamp, "--incremental", "--exclude-table", "new_schema.new_table1", "--redirect-db", "restoredb")
 						newSchemaTupleCounts["new_schema.new_table2"] = 35
 						assertSchemasExist(restoreConn, 5)
-						assertRelationsExistForIncremantal(restoreConn, 4)
+						assertRelationsExistForIncremental(restoreConn, 4)
 						assertDataRestored(restoreConn, oldSchemaTupleCounts)
 						assertDataRestored(restoreConn, newSchemaTupleCounts)
 					})
-					It("Restores only schemas included by user if user input is provided", func(){
+					It("Restores only schemas included by user if user input is provided", func() {
 						gprestore(gprestorePath, restoreHelperPath, timestamp, "--incremental", "--include-schema", "old_schema", "--redirect-db", "restoredb")
 						assertSchemasExist(restoreConn, 4)
-						assertRelationsExistForIncremantal(restoreConn, 3)
+						assertRelationsExistForIncremental(restoreConn, 3)
 						assertDataRestored(restoreConn, oldSchemaTupleCounts)
 						assertDataRestored(restoreConn, newSchemaTupleCounts)
 					})
-					It("Does not restore schemas excluded by user if user input is provided", func(){
+					It("Does not restore schemas excluded by user if user input is provided", func() {
 						gprestore(gprestorePath, restoreHelperPath, timestamp, "--incremental", "--exclude-schema", "new_schema", "--redirect-db", "restoredb")
 						assertSchemasExist(restoreConn, 4)
-						assertRelationsExistForIncremantal(restoreConn, 3)
+						assertRelationsExistForIncremental(restoreConn, 3)
 						assertDataRestored(restoreConn, oldSchemaTupleCounts)
 						assertDataRestored(restoreConn, newSchemaTupleCounts)
 					})
 				})
-				Context("New tables in existing schemas", func(){
+				Context("New tables in existing schemas", func() {
 					var timestamp string
-					BeforeEach(func(){
+					BeforeEach(func() {
 						testhelper.AssertQueryRuns(backupConn, "CREATE TABLE old_schema.new_table1 (mydata int) WITH (appendonly=true) DISTRIBUTED BY (mydata);")
 						testhelper.AssertQueryRuns(backupConn, "CREATE TABLE old_schema.new_table2 (mydata int) WITH (appendonly=true) DISTRIBUTED BY (mydata);")
 						testhelper.AssertQueryRuns(backupConn, "INSERT INTO old_schema.new_table1 SELECT generate_series(1, 20);")
 						testhelper.AssertQueryRuns(backupConn, "INSERT INTO old_schema.new_table2 SELECT generate_series(1, 25);")
 						timestamp = gpbackup(gpbackupPath, backupHelperPath, "--leaf-partition-data", "--incremental")
 					})
-					AfterEach(func(){
+					AfterEach(func() {
 						testhelper.AssertQueryRuns(backupConn, "DROP TABLE IF EXISTS old_schema.new_table1 CASCADE;")
 						testhelper.AssertQueryRuns(backupConn, "DROP TABLE IF EXISTS old_schema.new_table2 CASCADE;")
 						testhelper.AssertQueryRuns(restoreConn, "DROP TABLE IF EXISTS old_schema.new_table1 CASCADE;")
 						testhelper.AssertQueryRuns(restoreConn, "DROP TABLE IF EXISTS old_schema.new_table2 CASCADE;")
-						oldSchemaTupleCounts = map[string]int{
-						}
-						newSchemaTupleCounts = map[string]int{
-						}
+						oldSchemaTupleCounts = map[string]int{}
+						newSchemaTupleCounts = map[string]int{}
 						assertArtifactsCleaned(restoreConn, timestamp)
 					})
 					It("Restores new tables", func() {
@@ -1042,7 +1038,7 @@ var _ = Describe("backup end to end integration tests", func() {
 						oldSchemaTupleCounts["old_schema.new_table1"] = 20
 						oldSchemaTupleCounts["old_schema.new_table2"] = 25
 						assertSchemasExist(restoreConn, 4)
-						assertRelationsExistForIncremantal(restoreConn, 5)
+						assertRelationsExistForIncremental(restoreConn, 5)
 						assertDataRestored(restoreConn, oldSchemaTupleCounts)
 						assertDataRestored(restoreConn, newSchemaTupleCounts)
 					})
@@ -1050,48 +1046,48 @@ var _ = Describe("backup end to end integration tests", func() {
 						gprestore(gprestorePath, restoreHelperPath, timestamp, "--incremental", "--include-table", "old_schema.new_table1", "--redirect-db", "restoredb")
 						oldSchemaTupleCounts["old_schema.new_table1"] = 20
 						assertSchemasExist(restoreConn, 4)
-						assertRelationsExistForIncremantal(restoreConn, 4)
+						assertRelationsExistForIncremental(restoreConn, 4)
 						assertDataRestored(restoreConn, oldSchemaTupleCounts)
 						assertDataRestored(restoreConn, newSchemaTupleCounts)
 					})
-					It("Does not restore tables excluded by user if user input is provided", func(){
+					It("Does not restore tables excluded by user if user input is provided", func() {
 						gprestore(gprestorePath, restoreHelperPath, timestamp, "--incremental", "--exclude-table", "old_schema.new_table1", "--redirect-db", "restoredb")
 						oldSchemaTupleCounts["old_schema.new_table2"] = 25
 						assertSchemasExist(restoreConn, 4)
-						assertRelationsExistForIncremantal(restoreConn, 4)
+						assertRelationsExistForIncremental(restoreConn, 4)
 						assertDataRestored(restoreConn, oldSchemaTupleCounts)
 						assertDataRestored(restoreConn, newSchemaTupleCounts)
 					})
-					It("Does not restore anything if user excluded all new tables", func(){
+					It("Does not restore anything if user excluded all new tables", func() {
 						gprestore(gprestorePath, restoreHelperPath, timestamp, "--incremental", "--exclude-table", "old_schema.new_table1", "--exclude-table", "old_schema.new_table2", "--redirect-db", "restoredb")
 						assertSchemasExist(restoreConn, 4)
-						assertRelationsExistForIncremantal(restoreConn, 3)
+						assertRelationsExistForIncremental(restoreConn, 3)
 						assertDataRestored(restoreConn, oldSchemaTupleCounts)
 						assertDataRestored(restoreConn, newSchemaTupleCounts)
 					})
-					It("Does not restore tables if user input is provided and schema is not included", func(){
+					It("Does not restore tables if user input is provided and schema is not included", func() {
 						gprestore(gprestorePath, restoreHelperPath, timestamp, "--incremental", "--include-schema", "public", "--redirect-db", "restoredb")
 						assertSchemasExist(restoreConn, 4)
-						assertRelationsExistForIncremantal(restoreConn, 3)
+						assertRelationsExistForIncremental(restoreConn, 3)
 						assertDataRestored(restoreConn, oldSchemaTupleCounts)
 						assertDataRestored(restoreConn, newSchemaTupleCounts)
 					})
-					It("Does not restore tables if user input is provide and schema is excluded", func(){
+					It("Does not restore tables if user input is provide and schema is excluded", func() {
 						gprestore(gprestorePath, restoreHelperPath, timestamp, "--incremental", "--exclude-schema", "old_schema", "--redirect-db", "restoredb")
 						assertSchemasExist(restoreConn, 4)
-						assertRelationsExistForIncremantal(restoreConn, 3)
+						assertRelationsExistForIncremental(restoreConn, 3)
 						assertDataRestored(restoreConn, oldSchemaTupleCounts)
 						assertDataRestored(restoreConn, newSchemaTupleCounts)
 					})
 				})
-				Context("Existing tables in existing schemas were updated", func(){
+				Context("Existing tables in existing schemas were updated", func() {
 					var timestamp string
-					BeforeEach(func(){
+					BeforeEach(func() {
 						testhelper.AssertQueryRuns(backupConn, "INSERT INTO old_schema.old_table1 SELECT generate_series(11, 20);")
 						testhelper.AssertQueryRuns(backupConn, "INSERT INTO old_schema.old_table2 SELECT generate_series(16, 30);")
 						timestamp = gpbackup(gpbackupPath, backupHelperPath, "--leaf-partition-data", "--incremental")
 					})
-					AfterEach(func(){
+					AfterEach(func() {
 						testhelper.AssertQueryRuns(backupConn, "DELETE FROM old_schema.old_table1 where mydata>10;")
 						testhelper.AssertQueryRuns(backupConn, "DELETE FROM old_schema.old_table2 where mydata>15;")
 						oldSchemaTupleCounts["old_schema.old_table1"] = 10
@@ -1105,7 +1101,7 @@ var _ = Describe("backup end to end integration tests", func() {
 						oldSchemaTupleCounts["old_schema.old_table1"] = 20
 						oldSchemaTupleCounts["old_schema.old_table2"] = 30
 						assertSchemasExist(restoreConn, 4)
-						assertRelationsExistForIncremantal(restoreConn, 3)
+						assertRelationsExistForIncremental(restoreConn, 3)
 						assertDataRestored(restoreConn, oldSchemaTupleCounts)
 						assertDataRestored(restoreConn, newSchemaTupleCounts)
 					})
@@ -1113,36 +1109,36 @@ var _ = Describe("backup end to end integration tests", func() {
 						gprestore(gprestorePath, restoreHelperPath, timestamp, "--incremental", "--include-table", "old_schema.old_table1", "--redirect-db", "restoredb")
 						oldSchemaTupleCounts["old_schema.old_table1"] = 20
 						assertSchemasExist(restoreConn, 4)
-						assertRelationsExistForIncremantal(restoreConn, 3)
+						assertRelationsExistForIncremental(restoreConn, 3)
 						assertDataRestored(restoreConn, oldSchemaTupleCounts)
 						assertDataRestored(restoreConn, newSchemaTupleCounts)
 					})
-					It("Does not update tables excluded by user if user input is provided", func(){
+					It("Does not update tables excluded by user if user input is provided", func() {
 						gprestore(gprestorePath, restoreHelperPath, timestamp, "--incremental", "--exclude-table", "old_schema.old_table1", "--redirect-db", "restoredb")
 						oldSchemaTupleCounts["old_schema.old_table2"] = 30
 						assertSchemasExist(restoreConn, 4)
-						assertRelationsExistForIncremantal(restoreConn, 3)
+						assertRelationsExistForIncremental(restoreConn, 3)
 						assertDataRestored(restoreConn, oldSchemaTupleCounts)
 						assertDataRestored(restoreConn, newSchemaTupleCounts)
 					})
-					It("Does not update anything if user excluded all tables", func(){
+					It("Does not update anything if user excluded all tables", func() {
 						gprestore(gprestorePath, restoreHelperPath, timestamp, "--incremental", "--exclude-table", "old_schema.old_table1", "--exclude-table", "old_schema.old_table2", "--redirect-db", "restoredb")
 						assertSchemasExist(restoreConn, 4)
-						assertRelationsExistForIncremantal(restoreConn, 3)
+						assertRelationsExistForIncremental(restoreConn, 3)
 						assertDataRestored(restoreConn, oldSchemaTupleCounts)
 						assertDataRestored(restoreConn, newSchemaTupleCounts)
 					})
-					It("Does not update tables if user input is provided and schema is not included", func(){
+					It("Does not update tables if user input is provided and schema is not included", func() {
 						gprestore(gprestorePath, restoreHelperPath, timestamp, "--incremental", "--include-schema", "public", "--redirect-db", "restoredb")
 						assertSchemasExist(restoreConn, 4)
-						assertRelationsExistForIncremantal(restoreConn, 3)
+						assertRelationsExistForIncremental(restoreConn, 3)
 						assertDataRestored(restoreConn, oldSchemaTupleCounts)
 						assertDataRestored(restoreConn, newSchemaTupleCounts)
 					})
-					It("Does not restore tables if user input is provide and schema is excluded by user", func(){
+					It("Does not restore tables if user input is provide and schema is excluded by user", func() {
 						gprestore(gprestorePath, restoreHelperPath, timestamp, "--incremental", "--exclude-schema", "old_schema", "--redirect-db", "restoredb")
 						assertSchemasExist(restoreConn, 4)
-						assertRelationsExistForIncremantal(restoreConn, 3)
+						assertRelationsExistForIncremental(restoreConn, 3)
 						assertDataRestored(restoreConn, oldSchemaTupleCounts)
 						assertDataRestored(restoreConn, newSchemaTupleCounts)
 					})

--- a/options/flag.go
+++ b/options/flag.go
@@ -43,6 +43,7 @@ const (
 	REDIRECT_DB           = "redirect-db"
 	TIMESTAMP             = "timestamp"
 	WITH_GLOBALS          = "with-globals"
+	REDIRECT_SCHEMA       = "redirect-schema"
 )
 
 /*

--- a/options/options.go
+++ b/options/options.go
@@ -57,7 +57,7 @@ func NewOptions(initialFlags *pflag.FlagSet) (*Options, error) {
 
 	return &Options{
 		includedRelations:         includedRelations,
-		excludedRelations:		   excludedRelations,
+		excludedRelations:         excludedRelations,
 		includedSchemas:           includedSchemas,
 		excludedSchemas:           excludedSchemas,
 		isLeafPartitionData:       leafPartitionData,

--- a/options/options.go
+++ b/options/options.go
@@ -12,6 +12,9 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// This is meant to be a read only package. Values inside should only be
+// modified by setters, it's method functions, or initialization function.
+// This package is meant to make mocking flags easier.
 type Options struct {
 	includedRelations         []string
 	excludedRelations         []string
@@ -19,6 +22,7 @@ type Options struct {
 	excludedSchemas           []string
 	includedSchemas           []string
 	originalIncludedRelations []string
+	RedirectSchema            string
 }
 
 func NewOptions(initialFlags *pflag.FlagSet) (*Options, error) {
@@ -55,6 +59,14 @@ func NewOptions(initialFlags *pflag.FlagSet) (*Options, error) {
 		return nil, err
 	}
 
+	redirectSchema := ""
+	if initialFlags.Lookup(REDIRECT_SCHEMA) != nil {
+		redirectSchema, err = initialFlags.GetString(REDIRECT_SCHEMA)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return &Options{
 		includedRelations:         includedRelations,
 		excludedRelations:         excludedRelations,
@@ -62,6 +74,7 @@ func NewOptions(initialFlags *pflag.FlagSet) (*Options, error) {
 		excludedSchemas:           excludedSchemas,
 		isLeafPartitionData:       leafPartitionData,
 		originalIncludedRelations: includedRelations,
+		RedirectSchema:            redirectSchema,
 	}, nil
 }
 

--- a/restore/data.go
+++ b/restore/data.go
@@ -127,6 +127,9 @@ func restoreDataFromTimestamp(fpInfo filepath.FilePathInfo, dataEntries []toc.Ma
 					return
 				}
 				tableName := utils.MakeFQN(entry.Schema, entry.Name)
+				if opts.RedirectSchema != "" {
+					tableName = utils.MakeFQN(opts.RedirectSchema, entry.Name)
+				}
 				err := restoreSingleTableData(&fpInfo, entry, tableName, whichConn)
 
 				atomic.AddInt64(&tableNum, 1)

--- a/restore/global_variables.go
+++ b/restore/global_variables.go
@@ -39,6 +39,7 @@ var (
 	wasTerminated       bool
 	errorTablesMetadata map[string]Empty
 	errorTablesData     map[string]Empty
+	opts                *options.Options
 	/*
 	 * Used for synchronizing DoCleanup.  In DoInit() we increment the group
 	 * and then wait for at least one DoCleanup to finish, either in DoTeardown

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -223,21 +223,21 @@ func restorePredata(metadataFilename string) {
 
 		existingSchemas, err := GetExistingSchemas()
 		gplog.FatalOnError(err)
-        existingTableFQNs, err := GetExistingTableFQNs()
+		existingTableFQNs, err := GetExistingTableFQNs()
 		gplog.FatalOnError(err)
 
 		existingTablesMap := make(map[string]Empty)
-		for _, table := range existingTableFQNs{
+		for _, table := range existingTableFQNs {
 			existingTablesMap[table] = Empty{}
 		}
 
-		var schemasToCreate [] string
-		var tableFQNsToCreate [] string
-		var schemasExcludedByUserInput [] string
-		var tablesExcludedByUserInput [] string
+		var schemasToCreate []string
+		var tableFQNsToCreate []string
+		var schemasExcludedByUserInput []string
+		var tablesExcludedByUserInput []string
 		for _, table := range tableFQNsToRestore {
-			schemaName := strings.Split(table,".")[0]
-			if utils.SchemaIsExcludedByUser(inSchemasUserInput, exSchemasUserInput,schemaName){
+			schemaName := strings.Split(table, ".")[0]
+			if utils.SchemaIsExcludedByUser(inSchemasUserInput, exSchemasUserInput, schemaName) {
 				if !utils.Exists(schemasExcludedByUserInput, schemaName) {
 					schemasExcludedByUserInput = append(schemasExcludedByUserInput, schemaName)
 				}
@@ -249,7 +249,7 @@ func restorePredata(metadataFilename string) {
 				if utils.RelationIsExcludedByUser(inRelationsUserInput, exRelationsUserInput, table) {
 					tablesExcludedByUserInput = append(tablesExcludedByUserInput, table)
 				} else {
-					if!utils.Exists(schemasToCreate, schemaName){
+					if !utils.Exists(schemasToCreate, schemaName) {
 						schemasToCreate = append(schemasToCreate, schemaName)
 					}
 					tableFQNsToCreate = append(tableFQNsToCreate, table)

--- a/restore/restore_internal_test.go
+++ b/restore/restore_internal_test.go
@@ -1,0 +1,58 @@
+package restore
+
+import (
+	"github.com/greenplum-db/gpbackup/toc"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("restore internal tests", func() {
+	Describe("editStatementsRedirectStatements", func() {
+		It("does not alter schemas if no redirect was specified", func() {
+			statements := []toc.StatementWithType{
+				{ // simple table
+					Schema: "foo", Name: "bar", ObjectType: "TABLE",
+					Statement: "\n\nCREATE TABLE foo.bar (\n\ti integer\n) DISTRIBUTED BY (i);\n",
+				},
+				{ // view with mulitple schema replacements
+					Schema: "foo", Name: "myview", ObjectType: "VIEW",
+					Statement: "\n\nCREATE VIEW foo.myview AS  SELECT bar.i\n   FROM foo.bar;\n",
+				},
+				{ // schema and table are the same name
+					Schema: "foo", Name: "foo", ObjectType: "TABLE",
+					Statement: "\n\nCREATE TABLE foo.foo (\n\ti integer\n) DISTRIBUTED BY (i);\n",
+				},
+			}
+
+			editStatementsRedirectSchema(statements, "")
+			Expect(statements).To(Equal(statements))
+		})
+		It("changes schema in the sql statement", func() {
+			statements := []toc.StatementWithType{
+				{ // simple table
+					Schema: "foo", Name: "bar", ObjectType: "TABLE",
+					Statement: "\n\nCREATE TABLE foo.bar (\n\ti integer\n) DISTRIBUTED BY (i);\n",
+				},
+				{ // schema and table are the same name
+					Schema: "foo", Name: "foo", ObjectType: "TABLE",
+					Statement: "\n\nCREATE TABLE foo.foo (\n\ti integer\n) DISTRIBUTED BY (i);\n",
+				},
+			}
+
+			editStatementsRedirectSchema(statements, "foo2")
+
+			expectedStatements := []toc.StatementWithType{
+				{
+					Schema: "foo2", Name: "bar", ObjectType: "TABLE",
+					Statement: "\n\nCREATE TABLE foo2.bar (\n\ti integer\n) DISTRIBUTED BY (i);\n",
+				},
+				{
+					Schema: "foo2", Name: "foo", ObjectType: "TABLE",
+					Statement: "\n\nCREATE TABLE foo2.foo (\n\ti integer\n) DISTRIBUTED BY (i);\n",
+				},
+			}
+			Expect(statements).To(Equal(expectedStatements))
+		})
+	})
+})

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -32,8 +32,8 @@ import (
  * Filter structure to filter schemas and relations
  */
 type Filters struct {
-	includeSchemas []string
-	excludeSchemas []string
+	includeSchemas   []string
+	excludeSchemas   []string
 	includeRelations []string
 	excludeRelations []string
 }
@@ -43,7 +43,7 @@ func NewFilters(inSchema []string, exSchemas []string, inRelations []string, exR
 	f.includeSchemas = inSchema
 	f.excludeSchemas = exSchemas
 	f.includeRelations = inRelations
-	f.excludeRelations  = exRelations
+	f.excludeRelations = exRelations
 	return f
 }
 
@@ -245,7 +245,7 @@ func GetRestoreMetadataStatementsFiltered(section string, filename string, inclu
 	metadataFile := iohelper.MustOpenFileForReading(filename)
 	var statements []toc.StatementWithType
 	var inSchemas, exSchemas, inRelations, exRelations []string
-	if !filtersEmpty(filters)  {
+	if !filtersEmpty(filters) {
 		inSchemas = filters.includeSchemas
 		exSchemas = filters.excludeSchemas
 		inRelations = filters.includeRelations
@@ -337,7 +337,7 @@ func RestoreSchemas(schemaStatements []toc.StatementWithType, progressBar utils.
 	}
 }
 
-func GetExistingTableFQNs() ([]string,  error) {
+func GetExistingTableFQNs() ([]string, error) {
 	existingTableFQNs := make([]string, 0)
 
 	query := `SELECT quote_ident(n.nspname) || '.' || quote_ident(c.relname)
@@ -354,7 +354,7 @@ func GetExistingTableFQNs() ([]string,  error) {
 	return existingTableFQNs, err
 }
 
-func GetExistingSchemas()([]string, error){
+func GetExistingSchemas() ([]string, error) {
 	existingSchemas := make([]string, 0)
 
 	query := `SELECT n.nspname AS "Name"


### PR DESCRIPTION
Add --redirect-schema flag to gprestore

The --redirect-schema flag allows users to restore data into a different
schema than the original schema(s). Restrictions include...

1. The redirected schema should already be present
2. This feature is to be used in conjunction with --include-table or
   --include-table-file
3. This feature is not compatible with any exclude flags,
   --include-schema, or --include-schema-file
4. If the included data is located in multiple schemas, all data will
   redirected into the new schema
5. If the name of an index contains the schema it is under followed by a
   '.' (dot), redirect schema will fail.

Co-authored-by: Kevin Yeap <kyeap@pivotal.io>
Co-authored-by: Lav Jain <ljain@pivotal.io>