### PR TITLE
Fix gpbackup queries after external table catalog changes

### DIFF
--- a/backup/dependencies.go
+++ b/backup/dependencies.go
@@ -72,6 +72,8 @@ var (
 	PG_TS_TEMPLATE_OID          uint32 = 3764
 	PG_TYPE_OID                 uint32 = 1247
 	PG_USER_MAPPING_OID         uint32 = 1418
+
+	FIRST_NORMAL_OBJECT_ID      uint32 = 16384
 )
 
 func ConstructDependentObjectMetadataMap(functions MetadataMap, types MetadataMap, tables MetadataMap, protocols MetadataMap, tsParsers MetadataMap, tsConfigs MetadataMap, tsTemplates MetadataMap, tsDicts MetadataMap) MetadataMap {

--- a/backup/queries_functions.go
+++ b/backup/queries_functions.go
@@ -830,7 +830,7 @@ func GetForeignDataWrappers(connectionPool *dbconn.DBConn) []ForeignDataWrapper 
 			SELECT pg_catalog.quote_ident(option_name) || ' ' || pg_catalog.quote_literal(option_value)
 			FROM pg_options_to_table(fdwoptions) ORDER BY option_name), ', ') AS options
 	FROM pg_foreign_data_wrapper
-	WHERE %s`, ExtensionFilterClause(""))
+	WHERE oid >= %d AND %s`, FIRST_NORMAL_OBJECT_ID, ExtensionFilterClause(""))
 
 	err := connectionPool.Select(&results, query)
 	gplog.FatalOnError(err)
@@ -879,7 +879,7 @@ func GetForeignServers(connectionPool *dbconn.DBConn) []ForeignServer {
 			FROM pg_options_to_table(fs.srvoptions) ORDER BY option_name), ', ') AS options
 	FROM pg_foreign_server fs
 		LEFT JOIN pg_foreign_data_wrapper fdw ON fdw.oid = srvfdw
-	WHERE %s`, ExtensionFilterClause("fs"))
+	WHERE fs.oid >= %d AND %s`, FIRST_NORMAL_OBJECT_ID, ExtensionFilterClause("fs"))
 
 	err := connectionPool.Select(&results, query)
 	gplog.FatalOnError(err)

--- a/options/options.go
+++ b/options/options.go
@@ -309,7 +309,7 @@ AND (
 	)
 	%s
 )
-AND (relkind = 'r')
+AND (relkind = 'r' OR relkind = 'f')
 AND %s
 ORDER BY c.oid;`, o.schemaFilterClause("n"), oidStr, oidStr, oidStr, childPartitionFilter, ExtensionFilterClause("c"))
 


### PR DESCRIPTION
External tables in GPDB master (7devel) were recently changed in how
they are represented in the catalog. They are now represented as
foreign tables from special foreign servers. Because of this, we need
to exclude catalog entries that now show up when querying
pg_foreign_data_wrapper and pg_foreign_server. We also need to check
for relkind 'f' in pg_class because external tables are no longer
relkind 'r' (relstorage is also 'f' instead of 'x' now).

GPDB commit reference:
https://github.com/greenplum-db/gpdb/commit/b62e06014d1237ab