### PR TITLE
Fix replication identity query after external table catalog change

### DIFF
--- a/backup/queries_table_defs.go
+++ b/backup/queries_table_defs.go
@@ -284,7 +284,12 @@ func GetTableReplicaIdentity(connectionPool *dbconn.DBConn) map[uint32]string {
 	if connectionPool.Version.Before("6") {
 		return map[uint32]string{}
 	}
-	query := `SELECT oid, relreplident AS value FROM pg_class`
+	query := fmt.Sprintf(`
+	SELECT oid,
+		relreplident AS value
+	FROM pg_class
+	WHERE relkind IN ('r', 'm')
+		AND oid >= %d`, FIRST_NORMAL_OBJECT_ID)
 	return selectAsOidToStringMap(connectionPool, query)
 }
 


### PR DESCRIPTION
External tables are technically foreign tables now. However, they are
treated special and have their foreign server entries as catalog
entries which we exclude. Because of this, external tables will not
have foreign table definitions and are mistakenly assigned replication
identity ALTER TABLE statements. This will cause the restore to error
out because replication identities can only be altered on regular
tables and materialized views.

Fix this by adding filters to the replication identity query where we
check specifically for entries with relation kind 'r' and 'm' (for
regular tables and materialized views) and oid >= 16384 (the first
normal object id a user can define since everything below 16384 is
reserved for catalog).

gpbackup commit reference:
https://github.com/greenplum-db/gpbackup/commit/f4e8e94fd99ee386

GPDB commit reference:
https://github.com/greenplum-db/gpdb/commit/b62e06014d1237ab