### PR TITLE
Fix resource group logic

### DIFF
--- a/backup/metadata_globals.go
+++ b/backup/metadata_globals.go
@@ -168,7 +168,7 @@ func PrintCreateResourceGroupStatements(metadataFile *utils.FileWithByteCount, t
 			if !strings.HasPrefix(resGroup.CPURateLimit, "-") {
 				/* cpu rate mode */
 				metadataFile.MustPrintf("\n\nALTER RESOURCE GROUP %s SET CPU_RATE_LIMIT %s;", resGroup.Name, resGroup.CPURateLimit)
-			} else {
+			} else if connectionPool.Version.AtLeast("5.9.0") {
 				/* cpuset mode */
 				metadataFile.MustPrintf("\n\nALTER RESOURCE GROUP %s SET CPUSET '%s';", resGroup.Name, resGroup.Cpuset)
 			}
@@ -183,21 +183,19 @@ func PrintCreateResourceGroupStatements(metadataFile *utils.FileWithByteCount, t
 			if !strings.HasPrefix(resGroup.CPURateLimit, "-") {
 				/* cpu rate mode */
 				attributes = append(attributes, fmt.Sprintf("CPU_RATE_LIMIT=%s", resGroup.CPURateLimit))
-			} else {
+			} else if connectionPool.Version.AtLeast("5.9.0") {
 				/* cpuset mode */
 				attributes = append(attributes, fmt.Sprintf("CPUSET='%s'", resGroup.Cpuset))
 			}
 
 			/*
 			 * Possible values of memory_auditor:
-			 * - "1": cgroup;
-			 * - "0": vmtracker;
-			 * - "": not set, e.g. created on an older version which does not
-			 *   support memory_auditor yet, consider it as vmtracker;
+			 * - "1": cgroup
+			 * - "0": vmtracker (default)
 			 */
 			if resGroup.MemoryAuditor == "1" {
 				attributes = append(attributes, fmt.Sprintf("MEMORY_AUDITOR=cgroup"))
-			} else {
+			} else if connectionPool.Version.AtLeast("5.8.0"){
 				attributes = append(attributes, fmt.Sprintf("MEMORY_AUDITOR=vmtracker"))
 			}
 


### PR DESCRIPTION
When gpbackup is run against GPDB 5.2.X through GPDB 5.8.X, the
resource group query was constructed incorrectly. This would cause
gpbackup to error out on those versions even if the database did not
have any resource groups. Along with that, old resource groups created
in GPDB 5.2.X through GPDB 5.9.X which were carried forward to newer
versions of GPDB 5.X via binary swap were not being dumped because the
resource group query was filtering them out. Even if they weren't
filtered out, the CREATE RESOURCE GROUP statement printing logic did
not properly construct the CREATE statements when run against GPDB
5.2.X through GPDB 5.8.X (they would improperly add memory auditor and
cpuset which were added in GPDB 5.8.X and GPDB 5.9.X respectively).

This is fixed in this patch by correcting the resource group query and
adding version check logic to the CREATE RESOURCE GROUP statement
printing logic.

Although there are some unit tests added here for the CREATE RESOURCE
GROUP statement printing, some manual testing was necessary to fully
validate this patch. This was done in the following manner:
1. Create resource group in GPDB 5.2. Run gpbackup and check the
   metadata file.
2. Binary swap to GPDB 5.8. Create another resource group with cgroup
   memory auditor. Run gpbackup and check the metadata file.
3. Binary swap to GPDB 5.9. Create another resource group with cpuset
   defined instead of cpu_rate_limit. Run gpbackup and check the
   metadata file.

gpbackup 1.15 commit reference for GetResourceGroups() refactor:
https://github.com/greenplum-db/gpbackup/commit/6c6f5038ae42d49f

GPDB 5.8.0 commit reference for memory auditor addition:
https://github.com/greenplum-db/gpdb/commit/23cd8b1ebd939dfb

GPDB 5.9.0 commit reference for cpuset addition:
https://github.com/greenplum-db/gpdb/commit/0e53f33e56be5e2d