### PR TITLE
Handle backup of child partitions with different schema than the root

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -258,7 +258,7 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Table, tableO
 	funcInfoMap := GetFunctionOidToInfoMap(connectionPool)
 
 	if !tableOnly {
-		BackupSchemas(metadataFile)
+		BackupSchemas(metadataFile, CreateAlteredPartitionSchemaSet(tables))
 		if len(MustGetFlagStringArray(options.INCLUDE_SCHEMA)) == 0 && connectionPool.Version.AtLeast("5") {
 			BackupExtensions(metadataFile)
 		}

--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -224,6 +224,12 @@ func PrintPostCreateTableStatements(metadataFile *utils.FileWithByteCount, toc *
 		}
 	}
 
+	for _, alteredPartitionRelation := range table.PartitionAlteredSchemas {
+		statements = append(statements,
+			fmt.Sprintf("ALTER TABLE %s SET SCHEMA %s;",
+				utils.MakeFQN(alteredPartitionRelation.OldSchema, alteredPartitionRelation.Name), alteredPartitionRelation.NewSchema))
+	}
+
 	PrintStatements(metadataFile, toc, table, statements)
 }
 

--- a/backup/predata_relations_tables_test.go
+++ b/backup/predata_relations_tables_test.go
@@ -656,5 +656,18 @@ SECURITY LABEL FOR dummy ON COLUMN public.tablename.i IS 'unclassified';
 
 SECURITY LABEL FOR dummy ON COLUMN public.tablename.j IS 'unclassified';`)
 		})
+		It("prints altered schemas of child partitions different from the root partition", func() {
+			testTable.PartitionAlteredSchemas = []backup.AlteredPartitionRelation{
+				{OldSchema: "schema1", NewSchema: "schema2", Name: "table1"},
+				{OldSchema: "schema2", NewSchema: "schema1", Name: "table2"},
+			}
+			backup.PrintPostCreateTableStatements(backupfile, tocfile, testTable, backup.ObjectMetadata{})
+			testhelper.ExpectRegexp(buffer, `
+
+ALTER TABLE schema1.table1 SET SCHEMA schema2;
+
+
+ALTER TABLE schema2.table2 SET SCHEMA schema1;`)
+		})
 	})
 })

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -434,9 +434,9 @@ func BackupRoleGrants(metadataFile *utils.FileWithByteCount) {
  * Predata wrapper functions
  */
 
-func BackupSchemas(metadataFile *utils.FileWithByteCount) {
+func BackupSchemas(metadataFile *utils.FileWithByteCount, partitionAlteredSchemas map[string]bool) {
 	gplog.Verbose("Writing CREATE SCHEMA statements to metadata file")
-	schemas := GetAllUserSchemas(connectionPool)
+	schemas := GetAllUserSchemas(connectionPool, partitionAlteredSchemas)
 	objectCounts["Schemas"] = len(schemas)
 	schemaMetadata := GetMetadataForObjectType(connectionPool, TYPE_SCHEMA)
 	PrintCreateSchemaStatements(metadataFile, globalTOC, schemas, schemaMetadata)

--- a/integration/predata_shared_create_test.go
+++ b/integration/predata_shared_create_test.go
@@ -15,6 +15,10 @@ var _ = Describe("backup integration create statement tests", func() {
 		tocfile, backupfile = testutils.InitializeTestTOC(buffer, "predata")
 	})
 	Describe("PrintCreateSchemaStatements", func() {
+		var partitionAlteredSchemas map[string]bool
+		BeforeEach(func() {
+			partitionAlteredSchemas = make(map[string]bool)
+		})
 		It("creates a non public schema", func() {
 			schemas := []backup.Schema{{Oid: 0, Name: "test_schema"}}
 			schemaMetadata := testutils.DefaultMetadataMap("SCHEMA", true, true, true, includeSecurityLabels)
@@ -24,7 +28,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP SCHEMA test_schema")
 
-			resultSchemas := backup.GetAllUserSchemas(connectionPool)
+			resultSchemas := backup.GetAllUserSchemas(connectionPool, partitionAlteredSchemas)
 
 			Expect(resultSchemas).To(HaveLen(2))
 			Expect(resultSchemas[0].Name).To(Equal("public"))
@@ -42,7 +46,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			defer testhelper.AssertQueryRuns(connectionPool, "ALTER SCHEMA public OWNER TO anothertestrole")
 			defer testhelper.AssertQueryRuns(connectionPool, "COMMENT ON SCHEMA public IS 'standard public schema'")
 
-			resultSchemas := backup.GetAllUserSchemas(connectionPool)
+			resultSchemas := backup.GetAllUserSchemas(connectionPool, partitionAlteredSchemas)
 
 			Expect(resultSchemas).To(HaveLen(1))
 			structmatcher.ExpectStructsToMatchExcluding(&schemas[0], &resultSchemas[0])


### PR DESCRIPTION
It is possible to have child partitions existing in different schemas
than their root partition's schema. Without logic to handle this
scenario, gpbackup was creating metadata that would put those child
partitions back onto the same root partition schema. Fix this issue by
keeping track of which child partitions have had their schema modified
and dump ALTER TABLE SET SCHEMA statements for them.

One big thing to note is that this is a bit complex when involving the
--leaf-partition-data flag and/or the schema/table filtering flags. If
a filter is given which would exclude the schema of the child
partition, we will make an exception to the filter and add the CREATE
SCHEMA statement(s) needed to guarantee table/catalog integrity for
the partition table DDL.