### PR TITLE
Fix --redirect-schema when restoring to original database

### DIFF
--- a/restore/restore.go
+++ b/restore/restore.go
@@ -144,6 +144,15 @@ func DoSetup() {
 	 */
 	if !MustGetFlagBool(options.CREATE_DB) && !MustGetFlagBool(options.ON_ERROR_CONTINUE) && !MustGetFlagBool(options.INCREMENTAL) {
 		relationsToRestore := GenerateRestoreRelationList()
+		if opts.RedirectSchema != "" {
+			fqns, err := options.SeparateSchemaAndTable(relationsToRestore)
+			gplog.FatalOnError(err)
+			redirectRelationsToRestore := make([]string, 0)
+			for _, fqn := range fqns {
+				redirectRelationsToRestore = append(redirectRelationsToRestore, utils.MakeFQN(opts.RedirectSchema, fqn.TableName))
+			}
+			relationsToRestore = redirectRelationsToRestore
+		}
 		ValidateRelationsInRestoreDatabase(connectionPool, relationsToRestore)
 	}
 


### PR DESCRIPTION
The previous --redirect-schema tests did not account for the main use
case of redirecting back into the original database that is expected to
still contain the original tables.  When --redirect-db is not specified,
gprestore will validate the tables we want to restore into do not exist.
When --redirect-schema is being used without --redirect-db, check
redirected tables do not exist.

gpbackup reference commit:
https://github.com/greenplum-db/gpbackup/commit/35e8262e59adb02e

Authored-by: Kevin Yeap <kyeap@pivotal.io>