### PR TITLE
Enable special character usage in filtered restore

### DIFF
--- a/restore/validate.go
+++ b/restore/validate.go
@@ -18,10 +18,10 @@ import (
  */
 
 func validateFilterListsInBackupSet() {
-	ValidateIncludeSchemasInBackupSet(MustGetFlagStringArray(options.INCLUDE_SCHEMA))
-	ValidateExcludeSchemasInBackupSet(MustGetFlagStringArray(options.EXCLUDE_SCHEMA))
-	ValidateIncludeRelationsInBackupSet(MustGetFlagStringArray(options.INCLUDE_RELATION))
-	ValidateExcludeRelationsInBackupSet(MustGetFlagStringArray(options.EXCLUDE_RELATION))
+	ValidateIncludeSchemasInBackupSet(opts.IncludedSchemas)
+	ValidateExcludeSchemasInBackupSet(opts.ExcludedSchemas)
+	ValidateIncludeRelationsInBackupSet(opts.IncludedRelations)
+	ValidateExcludeRelationsInBackupSet(opts.ExcludedRelations)
 }
 
 func ValidateIncludeSchemasInBackupSet(schemaList []string) {
@@ -77,16 +77,16 @@ func getFilterSchemasInBackupSet(schemaList []string) []string {
 	return keys
 }
 
-func GenerateRestoreRelationList() []string {
-	includeRelations := MustGetFlagStringArray(options.INCLUDE_RELATION)
+func GenerateRestoreRelationList(opts options.Options) []string {
+	includeRelations := opts.IncludedRelations
 	if len(includeRelations) > 0 {
 		return includeRelations
 	}
 
 	relationList := make([]string, 0)
-	includedSchemaSet := utils.NewIncludeSet(MustGetFlagStringArray(options.INCLUDE_SCHEMA))
-	excludedSchemaSet := utils.NewExcludeSet(MustGetFlagStringArray(options.EXCLUDE_SCHEMA))
-	excludedRelationsSet := utils.NewExcludeSet(MustGetFlagStringArray(options.EXCLUDE_RELATION))
+	includedSchemaSet := utils.NewIncludeSet(opts.IncludedSchemas)
+	excludedSchemaSet := utils.NewExcludeSet(opts.ExcludedSchemas)
+	excludedRelationsSet := utils.NewExcludeSet(opts.ExcludedRelations)
 
 	if len(globalTOC.DataEntries) == 0 {
 		return []string{}

--- a/restore/validate_test.go
+++ b/restore/validate_test.go
@@ -71,6 +71,7 @@ var _ = Describe("restore/validate tests", func() {
 		})
 	})
 	Describe("GenerateRestoreRelationList", func() {
+		var opts *options.Options
 		BeforeEach(func() {
 			tocfile, _ = testutils.InitializeTestTOC(buffer, "metadata")
 			tocfile.AddMasterDataEntry("s1", "table1", 1, "(j)", 0, "")
@@ -78,55 +79,56 @@ var _ = Describe("restore/validate tests", func() {
 			tocfile.AddMasterDataEntry("s2", "table1", 3, "(j)", 0, "")
 			tocfile.AddMasterDataEntry("s2", "table2", 4, "(j)", 0, "")
 			restore.SetTOC(tocfile)
+
+			opts = &options.Options{}
 		})
 		It("returns all tables if no filtering is used", func() {
+			opts.IncludedRelations = []string{"s1.table1", "s1.table2", "s2.table1", "s2.table2"}
+
+			resultRelations := restore.GenerateRestoreRelationList(*opts)
+
 			expectedRelations := []string{"s1.table1", "s1.table2", "s2.table1", "s2.table2"}
-
-			resultRelations := restore.GenerateRestoreRelationList()
-
 			Expect(resultRelations).To(ConsistOf(expectedRelations))
 		})
 		It("filters on include relations", func() {
-			_ = cmdFlags.Set(options.INCLUDE_RELATION, "s1.table1")
-			_ = cmdFlags.Set(options.INCLUDE_RELATION, "s1.table2")
-			expectedRelations := []string{"s1.table1","s1.table2"}
+			opts.IncludedRelations = []string{"s1.table1", "s1.table2"}
 
-			resultRelations := restore.GenerateRestoreRelationList()
+			resultRelations := restore.GenerateRestoreRelationList(*opts)
 
+			expectedRelations := []string{"s1.table1", "s1.table2"}
 			Expect(resultRelations).To(ConsistOf(expectedRelations))
 		})
 		It("filters on exclude relations", func() {
-			_ = cmdFlags.Set(options.EXCLUDE_RELATION, "s1.table2")
-			_ = cmdFlags.Set(options.EXCLUDE_RELATION, "s2.table1")
-			expectedRelations := []string{"s1.table1","s2.table2"}
+			opts.ExcludedRelations = []string{"s1.table2", "s2.table1"}
 
-			resultRelations := restore.GenerateRestoreRelationList()
+			resultRelations := restore.GenerateRestoreRelationList(*opts)
 
+			expectedRelations := []string{"s1.table1", "s2.table2"}
 			Expect(resultRelations).To(ConsistOf(expectedRelations))
 		})
 		It("filters on include schema", func() {
-			_ = cmdFlags.Set(options.INCLUDE_SCHEMA, "s1")
+			opts.IncludedSchemas = []string{"s1"}
+
+			resultRelations := restore.GenerateRestoreRelationList(*opts)
+
 			expectedRelations := []string{"s1.table1", "s1.table2"}
-
-			resultRelations := restore.GenerateRestoreRelationList()
-
 			Expect(resultRelations).To(ConsistOf(expectedRelations))
 		})
 		It("filters on exclude schema", func() {
-			_ = cmdFlags.Set(options.EXCLUDE_SCHEMA, "s2")
+			opts.ExcludedSchemas = []string{"s2"}
+
+			resultRelations := restore.GenerateRestoreRelationList(*opts)
+
 			expectedRelations := []string{"s1.table1", "s1.table2"}
-
-			resultRelations := restore.GenerateRestoreRelationList()
-
 			Expect(resultRelations).To(ConsistOf(expectedRelations))
 		})
 		It("filters on include schema with exclude relation", func() {
-			_ = cmdFlags.Set(options.INCLUDE_SCHEMA, "s1")
-			_ = cmdFlags.Set(options.EXCLUDE_RELATION, "s1.table1")
+			opts.IncludedSchemas = []string{"s1"}
+			opts.ExcludedRelations = []string{"s1.table1"}
+
+			resultRelations := restore.GenerateRestoreRelationList(*opts)
+
 			expectedRelations := []string{"s1.table2"}
-
-			resultRelations := restore.GenerateRestoreRelationList()
-
 			Expect(resultRelations).To(ConsistOf(expectedRelations))
 		})
 	})


### PR DESCRIPTION
Enable special character usage in filtered restore

Enable gprestore usage of special character for the flags --include-table and
--include-table-file from the command line in the same way as
gpbackup.  Refactored code to use the options package more instead of
the MustGetFlag*(...) functions.