### PR TITLE
Fix backup report End Time and Duration when gpbackup errors out

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -451,6 +451,9 @@ func DoTeardown() {
 		if backupReport != nil {
 			backupReport.ConstructBackupParamsString()
 			history.WriteConfigFile(&backupReport.BackupConfig, configFilename)
+			if (backupReport.BackupConfig.EndTime == "") {
+				backupReport.BackupConfig.EndTime = history.CurrentTimestamp()
+			}
 			endtime, _ := time.ParseInLocation("20060102150405", backupReport.BackupConfig.EndTime, operating.System.Local)
 			backupReport.WriteBackupReportFile(reportFilename, globalFPInfo.Timestamp, endtime, objectCounts, errMsg)
 			report.EmailReport(globalCluster, globalFPInfo.Timestamp, reportFilename, "gpbackup")


### PR DESCRIPTION
When gpbackup errored out, the backup report would have incorrect
values for the End Time and Duration fields. This was mainly due to an
empty variable being passed around which was introduced in a previous
patch fix to synchronize the End Time fields between the backup
history file and the backup report file.

Issue Example:
```
start time:            Wed Feb 12 2020 12:02:09
end time:              Mon Jan 01 0001 00:00:00
duration:              -2562047:-47:-16

backup status:         Failure
```

gpbackup commit reference:
https://github.com/greenplum-db/gpbackup/commit/72e5278f64d4b1f2