### PR TITLE
Streamline gpbackup code to simplify workflow

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -75,8 +75,8 @@ func DoInit(cmd *cobra.Command) {
 }
 
 func DoFlagValidation(cmd *cobra.Command) {
-	ValidateFlagCombinations(cmd.Flags())
-	ValidateFlagValues()
+	validateFlagCombinations(cmd.Flags())
+	validateFlagValues()
 }
 
 // This function handles setup that must be done after parsing flags.
@@ -86,8 +86,8 @@ func DoSetup() {
 
 	utils.CheckGpexpandRunning(utils.BackupPreventedByGpexpandMessage)
 	timestamp := history.CurrentTimestamp()
-	CreateBackupLockFile(timestamp)
-	InitializeConnectionPool()
+	createBackupLockFile(timestamp)
+	initializeConnectionPool()
 
 	gplog.Info("Starting backup of database %s", MustGetFlagString(options.DBNAME))
 	opts, err := options.NewOptions(cmdFlags)
@@ -106,12 +106,12 @@ func DoSetup() {
 		_, err = globalCluster.ExecuteLocalCommand(fmt.Sprintf("mkdir -p %s", globalFPInfo.GetDirForContent(-1)))
 		gplog.FatalOnError(err)
 	} else {
-		CreateBackupDirectoriesOnAllHosts()
+		createBackupDirectoriesOnAllHosts()
 	}
 	globalTOC = &toc.TOC{}
 	globalTOC.InitializeMetadataEntryMap()
 	utils.InitializePipeThroughParameters(!MustGetFlagBool(options.NO_COMPRESSION), MustGetFlagInt(options.COMPRESSION_LEVEL))
-	GetQuotedRoleNames(connectionPool)
+	getQuotedRoleNames(connectionPool)
 
 	pluginConfigFlag := MustGetFlagString(options.PLUGIN_CONFIG)
 
@@ -125,7 +125,7 @@ func DoSetup() {
 		gplog.Debug("Plugin config path: %s", pluginConfig.ConfigPath)
 	}
 
-	InitializeBackupReport(*opts)
+	initializeBackupReport(*opts)
 
 	if pluginConfigFlag != "" {
 		backupReport.PluginVersion = pluginConfig.CheckPluginExistsOnAllHosts(globalCluster)
@@ -156,16 +156,16 @@ func DoBackup() {
 	}
 
 	gplog.Info("Gathering table state information")
-	metadataTables, dataTables := RetrieveAndProcessTables()
+	metadataTables, dataTables := retrieveAndProcessTables()
 	if !(MustGetFlagBool(options.METADATA_ONLY) || MustGetFlagBool(options.DATA_ONLY)) {
-		BackupIncrementalMetadata()
+		backupIncrementalMetadata()
 	}
 	CheckTablesContainData(dataTables)
 	metadataFilename := globalFPInfo.GetMetadataFilePath()
 	gplog.Info("Metadata will be written to %s", metadataFilename)
 	metadataFile := utils.NewFileWithByteCountFromFile(metadataFilename)
 
-	BackupSessionGUCs(metadataFile)
+	backupSessionGUC(metadataFile)
 	if !MustGetFlagBool(options.DATA_ONLY) {
 		tableOnlyBackup := true
 		if len(MustGetFlagStringArray(options.INCLUDE_RELATION)) == 0 {
@@ -194,7 +194,6 @@ func DoBackup() {
 		}
 
 		backupReport.RestorePlan = PopulateRestorePlan(backupSetTables, targetBackupRestorePlan, dataTables)
-
 		backupData(backupSetTables)
 	}
 
@@ -224,16 +223,16 @@ func DoBackup() {
 func backupGlobal(metadataFile *utils.FileWithByteCount) {
 	gplog.Info("Writing global database metadata")
 
-	BackupResourceQueues(metadataFile)
+	backupResourceQueues(metadataFile)
 	if connectionPool.Version.AtLeast("5") {
-		BackupResourceGroups(metadataFile)
+		backupResourceGroups(metadataFile)
 	}
-	BackupRoles(metadataFile)
-	BackupRoleGrants(metadataFile)
-	BackupTablespaces(metadataFile)
-	BackupCreateDatabase(metadataFile)
-	BackupDatabaseGUCs(metadataFile)
-	BackupRoleGUCs(metadataFile)
+	backupRoles(metadataFile)
+	backupRoleGrants(metadataFile)
+	backupTablespaces(metadataFile)
+	backupCreateDatabase(metadataFile)
+	backupDatabaseGUCs(metadataFile)
+	backupRoleGUCs(metadataFile)
 
 	if wasTerminated {
 		gplog.Info("Global database metadata backup incomplete")
@@ -248,9 +247,9 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Table, tableO
 	}
 	gplog.Info("Writing pre-data metadata")
 
-	sortables := make([]Sortable, 0)
+	objects := make([]Sortable, 0)
 	metadataMap := make(MetadataMap)
-	sortables = append(sortables, convertToSortableSlice(tables)...)
+	objects = append(objects, convertToSortableSlice(tables)...)
 	relationMetadata := GetMetadataForObjectType(connectionPool, TYPE_RELATION)
 	addToMetadataMap(relationMetadata, metadataMap)
 
@@ -258,58 +257,56 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Table, tableO
 	funcInfoMap := GetFunctionOidToInfoMap(connectionPool)
 
 	if !tableOnly {
-		BackupSchemas(metadataFile, CreateAlteredPartitionSchemaSet(tables))
+		backupSchemas(metadataFile, createAlteredPartitionSchemaSet(tables))
 		if len(MustGetFlagStringArray(options.INCLUDE_SCHEMA)) == 0 && connectionPool.Version.AtLeast("5") {
-			BackupExtensions(metadataFile)
+			backupExtensions(metadataFile)
 		}
 
 		if connectionPool.Version.AtLeast("6") {
-			BackupCollations(metadataFile)
+			backupCollations(metadataFile)
 		}
 
 		procLangs := GetProceduralLanguages(connectionPool)
-		langFuncs, functionMetadata := RetrieveFunctions(&sortables, metadataMap, procLangs)
+		langFuncs, functionMetadata := retrieveFunctions(&objects, metadataMap, procLangs)
 
 		if len(MustGetFlagStringArray(options.INCLUDE_SCHEMA)) == 0 {
-			BackupProceduralLanguages(metadataFile, procLangs, langFuncs, functionMetadata, funcInfoMap)
+			backupProceduralLanguages(metadataFile, procLangs, langFuncs, functionMetadata, funcInfoMap)
 		}
-		RetrieveAndBackupTypes(metadataFile, &sortables, metadataMap)
+		retrieveAndBackupTypes(metadataFile, &objects, metadataMap)
 
 		if len(MustGetFlagStringArray(options.INCLUDE_SCHEMA)) == 0 &&
 			connectionPool.Version.AtLeast("6") {
-			RetrieveForeignDataWrappers(&sortables, metadataMap)
-			RetrieveForeignServers(&sortables, metadataMap)
-			RetrieveUserMappings(&sortables)
+			retrieveForeignDataWrappers(&objects, metadataMap)
+			retrieveForeignServers(&objects, metadataMap)
+			retrieveUserMappings(&objects)
 		}
 
-		protocols = RetrieveProtocols(&sortables, metadataMap)
+		protocols = retrieveProtocols(&objects, metadataMap)
 
 		if connectionPool.Version.AtLeast("5") {
-			RetrieveTSParsers(&sortables, metadataMap)
-			RetrieveTSConfigurations(&sortables, metadataMap)
-			RetrieveTSTemplates(&sortables, metadataMap)
-			RetrieveTSDictionaries(&sortables, metadataMap)
+			retrieveTSParsers(&objects, metadataMap)
+			retrieveTSConfigurations(&objects, metadataMap)
+			retrieveTSTemplates(&objects, metadataMap)
+			retrieveTSDictionaries(&objects, metadataMap)
 
-			BackupOperatorFamilies(metadataFile)
+			backupOperatorFamilies(metadataFile)
 		}
 
-		RetrieveOperators(&sortables, metadataMap)
-		RetrieveOperatorClasses(&sortables, metadataMap)
-		RetrieveAggregates(&sortables, metadataMap)
-		RetrieveCasts(&sortables, metadataMap)
+		retrieveOperators(&objects, metadataMap)
+		retrieveOperatorClasses(&objects, metadataMap)
+		retrieveAggregates(&objects, metadataMap)
+		retrieveCasts(&objects, metadataMap)
 	}
 
-	RetrieveViews(&sortables)
-	sequences, sequenceOwnerColumns := RetrieveSequences()
-	BackupCreateSequences(metadataFile, sequences, relationMetadata)
-	constraints, conMetadata := RetrieveConstraints()
+	retrieveViews(&objects)
+	sequences, sequenceOwnerColumns := retrieveSequences()
+	backupCreateSequences(metadataFile, sequences, sequenceOwnerColumns, relationMetadata)
+	constraints, conMetadata := retrieveConstraints()
 
-	BackupDependentObjects(metadataFile, tables, protocols, metadataMap, constraints, sortables, funcInfoMap, tableOnly)
+	backupDependentObjects(metadataFile, tables, protocols, metadataMap, constraints, objects, funcInfoMap, tableOnly)
 
-	PrintAlterSequenceStatements(metadataFile, globalTOC, sequences, sequenceOwnerColumns)
-
-	BackupConversions(metadataFile)
-	BackupConstraints(metadataFile, constraints, conMetadata)
+	backupConversions(metadataFile)
+	backupConstraints(metadataFile, constraints, conMetadata)
 	if wasTerminated {
 		gplog.Info("Pre-data metadata backup incomplete")
 	} else {
@@ -345,7 +342,7 @@ func backupData(tables []Table) {
 			MustGetFlagString(options.PLUGIN_CONFIG), compressStr, false)
 	}
 	gplog.Info("Writing data to file")
-	rowsCopiedMaps := BackupDataForAllTables(tables)
+	rowsCopiedMaps := backupDataForAllTables(tables)
 	AddTableDataEntriesToTOC(tables, rowsCopiedMaps)
 	if MustGetFlagBool(options.SINGLE_DATA_FILE) && MustGetFlagString(options.PLUGIN_CONFIG) != "" {
 		pluginConfig.BackupSegmentTOCs(globalCluster, globalFPInfo)
@@ -363,13 +360,13 @@ func backupPostdata(metadataFile *utils.FileWithByteCount) {
 	}
 	gplog.Info("Writing post-data metadata")
 
-	BackupIndexes(metadataFile)
-	BackupRules(metadataFile)
-	BackupTriggers(metadataFile)
+	backupIndexes(metadataFile)
+	backupRules(metadataFile)
+	backupTriggers(metadataFile)
 	if connectionPool.Version.AtLeast("6") {
-		BackupDefaultPrivileges(metadataFile)
+		backupDefaultPrivileges(metadataFile)
 		if len(MustGetFlagStringArray(options.INCLUDE_SCHEMA)) == 0 {
-			BackupEventTriggers(metadataFile)
+			backupEventTriggers(metadataFile)
 		}
 	}
 	if wasTerminated {
@@ -387,7 +384,7 @@ func backupStatistics(tables []Table) {
 	gplog.Info("Writing query planner statistics to %s", statisticsFilename)
 	statisticsFile := utils.NewFileWithByteCountFromFile(statisticsFilename)
 	defer statisticsFile.Close()
-	BackupStatistics(statisticsFile, tables)
+	backupTableStatistics(statisticsFile, tables)
 	if wasTerminated {
 		gplog.Info("Query planner statistics backup incomplete")
 	} else {

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -156,7 +156,7 @@ func DoBackup() {
 	}
 
 	gplog.Info("Gathering table state information")
-	metadataTables, dataTables := retrieveAndProcessTables()
+	metadataTables, dataTables := RetrieveAndProcessTables()
 	if !(MustGetFlagBool(options.METADATA_ONLY) || MustGetFlagBool(options.DATA_ONLY)) {
 		backupIncrementalMetadata()
 	}
@@ -304,6 +304,7 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Table, tableO
 	constraints, conMetadata := retrieveConstraints()
 
 	backupDependentObjects(metadataFile, tables, protocols, metadataMap, constraints, objects, funcInfoMap, tableOnly)
+	PrintAlterSequenceStatements(metadataFile, globalTOC, sequences, sequenceOwnerColumns)
 
 	backupConversions(metadataFile)
 	backupConstraints(metadataFile, constraints, conMetadata)

--- a/backup/data.go
+++ b/backup/data.go
@@ -113,7 +113,7 @@ func BackupSingleTableData(table Table, rowsCopiedMap map[uint32]int64, counters
 	return nil
 }
 
-func BackupDataForAllTables(tables []Table) []map[uint32]int64 {
+func backupDataForAllTables(tables []Table) []map[uint32]int64 {
 	var numExtOrForeignTables int64
 	for _, table := range tables {
 		if table.SkipDataBackup() {

--- a/backup/dependencies.go
+++ b/backup/dependencies.go
@@ -76,35 +76,6 @@ var (
 	FIRST_NORMAL_OBJECT_ID      uint32 = 16384
 )
 
-func ConstructDependentObjectMetadataMap(functions MetadataMap, types MetadataMap, tables MetadataMap, protocols MetadataMap, tsParsers MetadataMap, tsConfigs MetadataMap, tsTemplates MetadataMap, tsDicts MetadataMap) MetadataMap {
-	metadataMap := make(MetadataMap)
-	for k, v := range functions {
-		metadataMap[k] = v
-	}
-	for k, v := range types {
-		metadataMap[k] = v
-	}
-	for k, v := range tables {
-		metadataMap[k] = v
-	}
-	for k, v := range protocols {
-		metadataMap[k] = v
-	}
-	for k, v := range tsParsers {
-		metadataMap[k] = v
-	}
-	for k, v := range tsConfigs {
-		metadataMap[k] = v
-	}
-	for k, v := range tsTemplates {
-		metadataMap[k] = v
-	}
-	for k, v := range tsDicts {
-		metadataMap[k] = v
-	}
-	return metadataMap
-}
-
 /*
  * Structs and functions for topological sort
  */
@@ -173,7 +144,7 @@ type UniqueID struct {
 }
 
 // This function only returns dependencies that are referenced in the backup set
-func GetDependencies(connectionPool *dbconn.DBConn, backupSet map[UniqueID]bool) DependencyMap {
+func GetDependencies(connectionPool *dbconn.DBConn, backupSet map[UniqueID]Sortable) DependencyMap {
 	query := fmt.Sprintf(`SELECT
 	coalesce(id1.refclassid, d.classid) AS classid,
 	coalesce(id1.refobjid, d.objid) AS objid,
@@ -222,7 +193,7 @@ AND typelem != 0`)
 		_, objInBackup := backupSet[object]
 		_, referenceInBackup := backupSet[referenceObject]
 
-		if (object == referenceObject) || (!objInBackup || !referenceInBackup) {
+		if object == referenceObject || !objInBackup || !referenceInBackup {
 			continue
 		}
 

--- a/backup/dependencies.go
+++ b/backup/dependencies.go
@@ -144,7 +144,7 @@ type UniqueID struct {
 }
 
 // This function only returns dependencies that are referenced in the backup set
-func GetDependencies(connectionPool *dbconn.DBConn, backupSet map[UniqueID]Sortable) DependencyMap {
+func GetDependencies(connectionPool *dbconn.DBConn, backupSet map[UniqueID]bool) DependencyMap {
 	query := fmt.Sprintf(`SELECT
 	coalesce(id1.refclassid, d.classid) AS classid,
 	coalesce(id1.refobjid, d.objid) AS objid,

--- a/backup/dependencies_test.go
+++ b/backup/dependencies_test.go
@@ -94,30 +94,6 @@ var _ = Describe("backup/dependencies tests", func() {
 			sortable = backup.TopologicalSort(sortable, depMap)
 		})
 	})
-	Describe("ConstructDependentObjectMetadataMap", func() {
-		It("composes metadata maps for functions, types, and tables into one map", func() {
-			funcMap := backup.MetadataMap{backup.UniqueID{Oid: 1}: backup.ObjectMetadata{Comment: "function"}}
-			typeMap := backup.MetadataMap{backup.UniqueID{Oid: 2}: backup.ObjectMetadata{Comment: "type"}}
-			tableMap := backup.MetadataMap{backup.UniqueID{Oid: 3}: backup.ObjectMetadata{Comment: "relation"}}
-			protoMap := backup.MetadataMap{backup.UniqueID{Oid: 4}: backup.ObjectMetadata{Comment: "protocol"}}
-			tsParserMap := backup.MetadataMap{backup.UniqueID{Oid: 5}: backup.ObjectMetadata{Comment: "text search parser"}}
-			tsConfigMap := backup.MetadataMap{backup.UniqueID{Oid: 6}: backup.ObjectMetadata{Comment: "text search config"}}
-			tsTemplateMap := backup.MetadataMap{backup.UniqueID{Oid: 7}: backup.ObjectMetadata{Comment: "text search template"}}
-			tsDictionaryMap := backup.MetadataMap{backup.UniqueID{Oid: 8}: backup.ObjectMetadata{Comment: "text search dictionary"}}
-			result := backup.ConstructDependentObjectMetadataMap(funcMap, typeMap, tableMap, protoMap, tsParserMap, tsConfigMap, tsTemplateMap, tsDictionaryMap)
-			expected := backup.MetadataMap{
-				backup.UniqueID{Oid: 1}: backup.ObjectMetadata{Comment: "function"},
-				backup.UniqueID{Oid: 2}: backup.ObjectMetadata{Comment: "type"},
-				backup.UniqueID{Oid: 3}: backup.ObjectMetadata{Comment: "relation"},
-				backup.UniqueID{Oid: 4}: backup.ObjectMetadata{Comment: "protocol"},
-				backup.UniqueID{Oid: 5}: backup.ObjectMetadata{Comment: "text search parser"},
-				backup.UniqueID{Oid: 6}: backup.ObjectMetadata{Comment: "text search config"},
-				backup.UniqueID{Oid: 7}: backup.ObjectMetadata{Comment: "text search template"},
-				backup.UniqueID{Oid: 8}: backup.ObjectMetadata{Comment: "text search dictionary"},
-			}
-			Expect(result).To(Equal(expected))
-		})
-	})
 	Describe("PrintDependentObjectStatements", func() {
 		var (
 			objects     []backup.Sortable

--- a/backup/incremental.go
+++ b/backup/incremental.go
@@ -31,7 +31,7 @@ func FilterTablesForIncremental(lastBackupTOC, currentTOC *toc.TOC, tables []Tab
 func GetTargetBackupTimestamp() string {
 	targetTimestamp := ""
 	if fromTimestamp := MustGetFlagString(options.FROM_TIMESTAMP); fromTimestamp != "" {
-		ValidateFromTimestamp(fromTimestamp)
+		validateFromTimestamp(fromTimestamp)
 		targetTimestamp = fromTimestamp
 	} else {
 		targetTimestamp = GetLatestMatchingBackupTimestamp()
@@ -62,7 +62,7 @@ func GetLatestMatchingBackupTimestamp() string {
 
 func GetLatestMatchingBackupConfig(history *history.History, currentBackupConfig *history.BackupConfig) *history.BackupConfig {
 	for _, backupConfig := range history.BackupConfigs {
-		if MatchesIncrementalFlags(&backupConfig, currentBackupConfig) {
+		if matchesIncrementalFlags(&backupConfig, currentBackupConfig) {
 			return &backupConfig
 		}
 	}
@@ -70,7 +70,7 @@ func GetLatestMatchingBackupConfig(history *history.History, currentBackupConfig
 	return nil
 }
 
-func MatchesIncrementalFlags(backupConfig *history.BackupConfig, currentBackupConfig *history.BackupConfig) bool {
+func matchesIncrementalFlags(backupConfig *history.BackupConfig, currentBackupConfig *history.BackupConfig) bool {
 	return backupConfig.BackupDir == MustGetFlagString(options.BACKUP_DIR) &&
 		backupConfig.DatabaseName == currentBackupConfig.DatabaseName &&
 		backupConfig.LeafPartitionData == MustGetFlagBool(options.LEAF_PARTITION_DATA) &&

--- a/backup/predata_acl.go
+++ b/backup/predata_acl.go
@@ -54,7 +54,8 @@ type ACL struct {
 
 type MetadataMap map[UniqueID]ObjectMetadata
 
-func PrintStatements(metadataFile *utils.FileWithByteCount, toc *toc.TOC, obj toc.TOCObject, statements []string) {
+func PrintStatements(metadataFile *utils.FileWithByteCount, toc *toc.TOC,
+	obj toc.TOCObject, statements []string) {
 	for _, statement := range statements {
 		start := metadataFile.ByteCount
 		metadataFile.MustPrintf("\n\n%s\n", statement)
@@ -63,7 +64,8 @@ func PrintStatements(metadataFile *utils.FileWithByteCount, toc *toc.TOC, obj to
 	}
 }
 
-func PrintObjectMetadata(file *utils.FileWithByteCount, toc *toc.TOC, metadata ObjectMetadata, obj toc.TOCObjectWithMetadata, owningTable string) {
+func PrintObjectMetadata(file *utils.FileWithByteCount, toc *toc.TOC,
+	metadata ObjectMetadata, obj toc.TOCObjectWithMetadata, owningTable string) {
 	_, entry := obj.GetMetadataEntry()
 	if entry.ObjectType == "DATABASE METADATA" {
 		entry.ObjectType = "DATABASE"

--- a/backup/predata_types.go
+++ b/backup/predata_types.go
@@ -154,10 +154,10 @@ func PrintCreateCompositeTypeStatement(metadataFile *utils.FileWithByteCount, to
 
 	section, entry := composite.GetMetadataEntry()
 	toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
-	PrintPostCreateCompositeTypeStatement(metadataFile, toc, composite, typeMetadata)
+	printPostCreateCompositeTypeStatement(metadataFile, toc, composite, typeMetadata)
 }
 
-func PrintPostCreateCompositeTypeStatement(metadataFile *utils.FileWithByteCount, toc *toc.TOC, composite CompositeType, typeMetadata ObjectMetadata) {
+func printPostCreateCompositeTypeStatement(metadataFile *utils.FileWithByteCount, toc *toc.TOC, composite CompositeType, typeMetadata ObjectMetadata) {
 	PrintObjectMetadata(metadataFile, toc, typeMetadata, composite, "")
 	statements := make([]string, 0)
 	for _, att := range composite.Attributes {

--- a/backup/queries_acl.go
+++ b/backup/queries_acl.go
@@ -284,7 +284,7 @@ func GetDefaultPrivileges(connectionPool *dbconn.DBConn) []DefaultPrivileges {
 	return ConstructDefaultPrivileges(results)
 }
 
-func GetQuotedRoleNames(connectionPool *dbconn.DBConn) map[string]string {
+func getQuotedRoleNames(connectionPool *dbconn.DBConn) map[string]string {
 	results := make([]struct {
 		RoleName       string
 		QuotedRoleName string

--- a/backup/queries_functions.go
+++ b/backup/queries_functions.go
@@ -20,7 +20,7 @@ type Function struct {
 	Oid               uint32
 	Schema            string
 	Name              string
-	ReturnsSet        bool `db:"proretset"`
+	ReturnsSet        bool    `db:"proretset"`
 	FunctionBody      string
 	BinaryPath        string
 	Arguments         string
@@ -35,8 +35,8 @@ type Function struct {
 	NumRows           float32 `db:"prorows"`
 	DataAccess        string  `db:"prodataaccess"`
 	Language          string
-	IsWindow          bool   `db:"proiswindow"`
-	ExecLocation      string `db:"proexeclocation"`
+	IsWindow          bool    `db:"proiswindow"`
+	ExecLocation      string  `db:"proexeclocation"`
 }
 
 func (f Function) GetMetadataEntry() (string, toc.MetadataEntry) {
@@ -124,13 +124,17 @@ func GetFunctions(connectionPool *dbconn.DBConn) []Function {
 		procost,
 		prorows,
 		prodataaccess,
-		(SELECT lanname FROM pg_catalog.pg_language WHERE oid = prolang) AS language
+		l.lanname AS language
 	FROM pg_proc p
+		JOIN pg_catalog.pg_language l ON p.prolang = l.oid
 		LEFT JOIN pg_namespace n ON p.pronamespace = n.oid
 	WHERE %s
 		AND proisagg = 'f'
 		AND %s%s
-	ORDER BY nspname, proname, identargs`, masterAtts, SchemaFilterClause("n"), ExtensionFilterClause("p"), excludeImplicitFunctionsClause)
+	ORDER BY nspname, proname, identargs`, masterAtts,
+		SchemaFilterClause("n"),
+		ExtensionFilterClause("p"),
+		excludeImplicitFunctionsClause)
 
 	results := make([]Function, 0)
 	err := connectionPool.Select(&results, query)
@@ -332,7 +336,7 @@ type Aggregate struct {
 	SortOperatorSchema         string
 	Hypothetical               bool
 	TransitionDataType         string
-	TransitionDataSize         int `db:"aggtransspace"`
+	TransitionDataSize         int    `db:"aggtransspace"`
 	InitialValue               string
 	InitValIsNull              bool
 	IsOrdered                  bool   `db:"aggordered"`

--- a/backup/queries_table_defs.go
+++ b/backup/queries_table_defs.go
@@ -45,7 +45,7 @@ func (t Table) GetMetadataEntry() (string, toc.MetadataEntry) {
 /*
  * Extract all the unique schemas out from a Table array.
  */
-func CreateAlteredPartitionSchemaSet(tables []Table) map[string]bool {
+func createAlteredPartitionSchemaSet(tables []Table) map[string]bool {
 	partitionAlteredSchemas := make(map[string]bool)
 	for _, table := range tables {
 		for _, alteredPartitionRelation := range table.PartitionAlteredSchemas {

--- a/backup/statistics.go
+++ b/backup/statistics.go
@@ -139,11 +139,11 @@ func generateAttributeSlotsQueryMaster(attStat AttributeStatistic) string {
 			attStat.Operator3,
 			attStat.Operator4,
 			attStat.Operator5,
-			RealValues(attStat.Numbers1),
-			RealValues(attStat.Numbers2),
-			RealValues(attStat.Numbers3),
-			RealValues(attStat.Numbers4),
-			RealValues(attStat.Numbers5),
+			realValues(attStat.Numbers1),
+			realValues(attStat.Numbers2),
+			realValues(attStat.Numbers3),
+			realValues(attStat.Numbers4),
+			realValues(attStat.Numbers5),
 			AnyValues(attStat.Values1, attStat.Type),
 			AnyValues(attStat.Values2, attStat.Type),
 			AnyValues(attStat.Values3, attStat.Type),
@@ -196,10 +196,10 @@ func generateAttributeSlotsQuery4(attStat AttributeStatistic) string {
 			attStat.Operator2,
 			attStat.Operator3,
 			attStat.Operator4,
-			RealValues(attStat.Numbers1),
-			RealValues(attStat.Numbers2),
-			RealValues(attStat.Numbers3),
-			RealValues(attStat.Numbers4),
+			realValues(attStat.Numbers1),
+			realValues(attStat.Numbers2),
+			realValues(attStat.Numbers3),
+			realValues(attStat.Numbers4),
 			AnyValues(attStat.Values1, attStat.Type),
 			AnyValues(attStat.Values2, attStat.Type),
 			AnyValues(attStat.Values3, attStat.Type),
@@ -221,7 +221,7 @@ func SliceToPostgresArray(slice []string) string {
 	return fmt.Sprintf(`'{%s}'`, strings.Join(quotedStrings, ","))
 }
 
-func RealValues(reals pq.StringArray) string {
+func realValues(reals pq.StringArray) string {
 	if len(reals) > 0 {
 		return SliceToPostgresArray(reals)
 	}

--- a/backup/validate_test.go
+++ b/backup/validate_test.go
@@ -177,20 +177,4 @@ var _ = Describe("backup/validate tests", func() {
 			})
 		})
 	})
-	Describe("ValidateCompressionLevel", func() {
-		It("validates a compression level between 1 and 9", func() {
-			compressLevel := 5
-			backup.ValidateCompressionLevel(compressLevel)
-		})
-		It("panics if given a compression level < 1", func() {
-			compressLevel := 0
-			defer testhelper.ShouldPanicWithMessage("Compression level must be between 1 and 9")
-			backup.ValidateCompressionLevel(compressLevel)
-		})
-		It("panics if given a compression level > 9", func() {
-			compressLevel := 11
-			defer testhelper.ShouldPanicWithMessage("Compression level must be between 1 and 9")
-			backup.ValidateCompressionLevel(compressLevel)
-		})
-	})
 })

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -150,7 +150,7 @@ func createBackupDirectoriesOnAllHosts() {
  * Metadata retrieval wrapper functions
  */
 
-func retrieveAndProcessTables() ([]Table, []Table) {
+func RetrieveAndProcessTables() ([]Table, []Table) {
 	quotedIncludeRelations, err := options.QuoteTableNames(connectionPool, MustGetFlagStringArray(options.INCLUDE_RELATION))
 	gplog.FatalOnError(err)
 
@@ -468,13 +468,12 @@ func backupCreateSequences(metadataFile *utils.FileWithByteCount, sequences []Se
 	gplog.Verbose("Writing CREATE SEQUENCE statements to metadata file")
 	objectCounts["Sequences"] = len(sequences)
 	PrintCreateSequenceStatements(metadataFile, globalTOC, sequences, relationMetadata)
-	PrintAlterSequenceStatements(metadataFile, globalTOC, sequences, sequenceOwnerColumns)
 }
 
-func createBackupSet(objSlice []Sortable) (backupSet map[UniqueID]Sortable) {
-	backupSet = make(map[UniqueID]Sortable)
+func createBackupSet(objSlice []Sortable) (backupSet map[UniqueID]bool) {
+	backupSet = make(map[UniqueID]bool)
 	for _, obj := range objSlice {
-		backupSet[obj.GetUniqueID()] = obj
+		backupSet[obj.GetUniqueID()] = true
 	}
 
 	return backupSet

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -35,7 +35,7 @@ func SetLoggerVerbosity() {
 	}
 }
 
-func InitializeConnectionPool() {
+func initializeConnectionPool() {
 	connectionPool = dbconn.NewDBConnFromEnvironment(MustGetFlagString(options.DBNAME))
 	connectionPool.MustConnect(MustGetFlagInt(options.JOBS))
 	utils.ValidateGPDBVersionCompatibility(connectionPool)
@@ -100,7 +100,7 @@ func NewBackupConfig(dbName string, dbVersion string, backupVersion string, plug
 	return &backupConfig
 }
 
-func InitializeBackupReport(opts options.Options) {
+func initializeBackupReport(opts options.Options) {
 	escapedDBName := dbconn.MustSelectString(connectionPool, fmt.Sprintf("select quote_ident(datname) AS string FROM pg_database where datname='%s'", utils.EscapeSingleQuotes(connectionPool.DBName)))
 	plugin := ""
 	if pluginConfig != nil {
@@ -125,7 +125,7 @@ func InitializeBackupReport(opts options.Options) {
 	backupReport.ConstructBackupParamsString()
 }
 
-func CreateBackupLockFile(timestamp string) {
+func createBackupLockFile(timestamp string) {
 	var err error
 	timestampLockFile := fmt.Sprintf("/tmp/%s.lck", timestamp)
 	backupLockFile, err = lockfile.New(timestampLockFile)
@@ -137,7 +137,7 @@ func CreateBackupLockFile(timestamp string) {
 	}
 }
 
-func CreateBackupDirectoriesOnAllHosts() {
+func createBackupDirectoriesOnAllHosts() {
 	remoteOutput := globalCluster.GenerateAndExecuteCommand("Creating backup directories", func(contentID int) string {
 		return fmt.Sprintf("mkdir -p %s", globalFPInfo.GetDirForContent(contentID))
 	}, cluster.ON_SEGMENTS_AND_MASTER)
@@ -150,7 +150,7 @@ func CreateBackupDirectoriesOnAllHosts() {
  * Metadata retrieval wrapper functions
  */
 
-func RetrieveAndProcessTables() ([]Table, []Table) {
+func retrieveAndProcessTables() ([]Table, []Table) {
 	quotedIncludeRelations, err := options.QuoteTableNames(connectionPool, MustGetFlagStringArray(options.INCLUDE_RELATION))
 	gplog.FatalOnError(err)
 
@@ -169,7 +169,7 @@ func RetrieveAndProcessTables() ([]Table, []Table) {
 	return metadataTables, dataTables
 }
 
-func RetrieveFunctions(sortables *[]Sortable, metadataMap MetadataMap, procLangs []ProceduralLanguage) ([]Function, MetadataMap) {
+func retrieveFunctions(sortables *[]Sortable, metadataMap MetadataMap, procLangs []ProceduralLanguage) ([]Function, MetadataMap) {
 	gplog.Verbose("Retrieving function information")
 	functions := GetFunctionsAllVersions(connectionPool)
 	objectCounts["Functions"] = len(functions)
@@ -182,7 +182,7 @@ func RetrieveFunctions(sortables *[]Sortable, metadataMap MetadataMap, procLangs
 	return langFuncs, functionMetadata
 }
 
-func RetrieveAndBackupTypes(metadataFile *utils.FileWithByteCount, sortables *[]Sortable, metadataMap MetadataMap) {
+func retrieveAndBackupTypes(metadataFile *utils.FileWithByteCount, sortables *[]Sortable, metadataMap MetadataMap) {
 	gplog.Verbose("Retrieving type information")
 	shells := GetShellTypes(connectionPool)
 	bases := GetBaseTypes(connectionPool)
@@ -194,9 +194,9 @@ func RetrieveAndBackupTypes(metadataFile *utils.FileWithByteCount, sortables *[]
 	}
 	typeMetadata := GetMetadataForObjectType(connectionPool, TYPE_TYPE)
 
-	BackupShellTypes(metadataFile, shells, bases, rangeTypes)
+	backupShellTypes(metadataFile, shells, bases, rangeTypes)
 	if connectionPool.Version.AtLeast("5") {
-		BackupEnumTypes(metadataFile, typeMetadata)
+		backupEnumTypes(metadataFile, typeMetadata)
 	}
 
 	objectCounts["Types"] += len(shells)
@@ -211,21 +211,21 @@ func RetrieveAndBackupTypes(metadataFile *utils.FileWithByteCount, sortables *[]
 	addToMetadataMap(typeMetadata, metadataMap)
 }
 
-func RetrieveConstraints(tables ...Relation) ([]Constraint, MetadataMap) {
+func retrieveConstraints(tables ...Relation) ([]Constraint, MetadataMap) {
 	gplog.Verbose("Retrieving constraints")
 	constraints := GetConstraints(connectionPool, tables...)
 	conMetadata := GetCommentsForObjectType(connectionPool, TYPE_CONSTRAINT)
 	return constraints, conMetadata
 }
 
-func RetrieveSequences() ([]Sequence, map[string]string) {
+func retrieveSequences() ([]Sequence, map[string]string) {
 	gplog.Verbose("Retrieving sequences")
 	sequenceOwnerTables, sequenceOwnerColumns := GetSequenceColumnOwnerMap(connectionPool)
 	sequences := GetAllSequences(connectionPool, sequenceOwnerTables)
 	return sequences, sequenceOwnerColumns
 }
 
-func RetrieveProtocols(sortables *[]Sortable, metadataMap MetadataMap) []ExternalProtocol {
+func retrieveProtocols(sortables *[]Sortable, metadataMap MetadataMap) []ExternalProtocol {
 	gplog.Verbose("Retrieving protocols")
 	protocols := GetExternalProtocols(connectionPool)
 	objectCounts["Protocols"] = len(protocols)
@@ -237,7 +237,7 @@ func RetrieveProtocols(sortables *[]Sortable, metadataMap MetadataMap) []Externa
 	return protocols
 }
 
-func RetrieveViews(sortables *[]Sortable) {
+func retrieveViews(sortables *[]Sortable) {
 	gplog.Verbose("Retrieving views")
 	views, materializedViews := GetAllViews(connectionPool)
 	objectCounts["Views"] = len(views)
@@ -246,7 +246,7 @@ func RetrieveViews(sortables *[]Sortable) {
 	*sortables = append(*sortables, convertToSortableSlice(materializedViews)...)
 }
 
-func RetrieveTSParsers(sortables *[]Sortable, metadataMap MetadataMap) {
+func retrieveTSParsers(sortables *[]Sortable, metadataMap MetadataMap) {
 	gplog.Verbose("Retrieving Text Search Parsers")
 	parsers := GetTextSearchParsers(connectionPool)
 	objectCounts["Text Search Parsers"] = len(parsers)
@@ -256,7 +256,7 @@ func RetrieveTSParsers(sortables *[]Sortable, metadataMap MetadataMap) {
 	addToMetadataMap(parserMetadata, metadataMap)
 }
 
-func RetrieveTSTemplates(sortables *[]Sortable, metadataMap MetadataMap) {
+func retrieveTSTemplates(sortables *[]Sortable, metadataMap MetadataMap) {
 	gplog.Verbose("Retrieving TEXT SEARCH TEMPLATE information")
 	templates := GetTextSearchTemplates(connectionPool)
 	objectCounts["Text Search Templates"] = len(templates)
@@ -266,7 +266,7 @@ func RetrieveTSTemplates(sortables *[]Sortable, metadataMap MetadataMap) {
 	addToMetadataMap(templateMetadata, metadataMap)
 }
 
-func RetrieveTSDictionaries(sortables *[]Sortable, metadataMap MetadataMap) {
+func retrieveTSDictionaries(sortables *[]Sortable, metadataMap MetadataMap) {
 	gplog.Verbose("Retrieving TEXT SEARCH DICTIONARY information")
 	dictionaries := GetTextSearchDictionaries(connectionPool)
 	objectCounts["Text Search Dictionaries"] = len(dictionaries)
@@ -276,7 +276,7 @@ func RetrieveTSDictionaries(sortables *[]Sortable, metadataMap MetadataMap) {
 	addToMetadataMap(dictionaryMetadata, metadataMap)
 }
 
-func RetrieveTSConfigurations(sortables *[]Sortable, metadataMap MetadataMap) {
+func retrieveTSConfigurations(sortables *[]Sortable, metadataMap MetadataMap) {
 	gplog.Verbose("Retrieving TEXT SEARCH CONFIGURATION information")
 	configurations := GetTextSearchConfigurations(connectionPool)
 	objectCounts["Text Search Configurations"] = len(configurations)
@@ -286,7 +286,7 @@ func RetrieveTSConfigurations(sortables *[]Sortable, metadataMap MetadataMap) {
 	addToMetadataMap(configurationMetadata, metadataMap)
 }
 
-func RetrieveOperators(sortables *[]Sortable, metadataMap MetadataMap) {
+func retrieveOperators(sortables *[]Sortable, metadataMap MetadataMap) {
 	gplog.Verbose("Retrieving OPERATOR information")
 	operators := GetOperators(connectionPool)
 	objectCounts["Operators"] = len(operators)
@@ -296,7 +296,7 @@ func RetrieveOperators(sortables *[]Sortable, metadataMap MetadataMap) {
 	addToMetadataMap(operatorMetadata, metadataMap)
 }
 
-func RetrieveOperatorClasses(sortables *[]Sortable, metadataMap MetadataMap) {
+func retrieveOperatorClasses(sortables *[]Sortable, metadataMap MetadataMap) {
 	gplog.Verbose("Retrieving OPERATOR CLASS information")
 	operatorClasses := GetOperatorClasses(connectionPool)
 	objectCounts["Operator Classes"] = len(operatorClasses)
@@ -306,7 +306,7 @@ func RetrieveOperatorClasses(sortables *[]Sortable, metadataMap MetadataMap) {
 	addToMetadataMap(operatorClassMetadata, metadataMap)
 }
 
-func RetrieveAggregates(sortables *[]Sortable, metadataMap MetadataMap) {
+func retrieveAggregates(sortables *[]Sortable, metadataMap MetadataMap) {
 	gplog.Verbose("Retrieving AGGREGATE information")
 	aggregates := GetAggregates(connectionPool)
 	objectCounts["Aggregates"] = len(aggregates)
@@ -321,7 +321,7 @@ func RetrieveAggregates(sortables *[]Sortable, metadataMap MetadataMap) {
 	addToMetadataMap(aggMetadata, metadataMap)
 }
 
-func RetrieveCasts(sortables *[]Sortable, metadataMap MetadataMap) {
+func retrieveCasts(sortables *[]Sortable, metadataMap MetadataMap) {
 	gplog.Verbose("Retrieving CAST information")
 	casts := GetCasts(connectionPool)
 	objectCounts["Casts"] = len(casts)
@@ -331,7 +331,7 @@ func RetrieveCasts(sortables *[]Sortable, metadataMap MetadataMap) {
 	addToMetadataMap(castMetadata, metadataMap)
 }
 
-func RetrieveForeignDataWrappers(sortables *[]Sortable, metadataMap MetadataMap) {
+func retrieveForeignDataWrappers(sortables *[]Sortable, metadataMap MetadataMap) {
 	gplog.Verbose("Writing CREATE FOREIGN DATA WRAPPER statements to metadata file")
 	wrappers := GetForeignDataWrappers(connectionPool)
 	objectCounts["Foreign Data Wrappers"] = len(wrappers)
@@ -341,7 +341,7 @@ func RetrieveForeignDataWrappers(sortables *[]Sortable, metadataMap MetadataMap)
 	addToMetadataMap(fdwMetadata, metadataMap)
 }
 
-func RetrieveForeignServers(sortables *[]Sortable, metadataMap MetadataMap) {
+func retrieveForeignServers(sortables *[]Sortable, metadataMap MetadataMap) {
 	gplog.Verbose("Writing CREATE SERVER statements to metadata file")
 	servers := GetForeignServers(connectionPool)
 	objectCounts["Foreign Servers"] = len(servers)
@@ -351,7 +351,7 @@ func RetrieveForeignServers(sortables *[]Sortable, metadataMap MetadataMap) {
 	addToMetadataMap(serverMetadata, metadataMap)
 }
 
-func RetrieveUserMappings(sortables *[]Sortable) {
+func retrieveUserMappings(sortables *[]Sortable) {
 	gplog.Verbose("Writing CREATE USER MAPPING statements to metadata file")
 	mappings := GetUserMappings(connectionPool)
 	objectCounts["User Mappings"] = len(mappings)
@@ -360,7 +360,7 @@ func RetrieveUserMappings(sortables *[]Sortable) {
 	*sortables = append(*sortables, convertToSortableSlice(mappings)...)
 }
 
-func BackupSessionGUCs(metadataFile *utils.FileWithByteCount) {
+func backupSessionGUC(metadataFile *utils.FileWithByteCount) {
 	gplog.Verbose("Writing Session Configuration Parameters to metadata file")
 	gucs := GetSessionGUCs(connectionPool)
 	PrintSessionGUCs(metadataFile, globalTOC, gucs)
@@ -370,7 +370,7 @@ func BackupSessionGUCs(metadataFile *utils.FileWithByteCount) {
  * Global metadata wrapper functions
  */
 
-func BackupTablespaces(metadataFile *utils.FileWithByteCount) {
+func backupTablespaces(metadataFile *utils.FileWithByteCount) {
 	gplog.Verbose("Writing CREATE TABLESPACE statements to metadata file")
 	tablespaces := GetTablespaces(connectionPool)
 	objectCounts["Tablespaces"] = len(tablespaces)
@@ -378,7 +378,7 @@ func BackupTablespaces(metadataFile *utils.FileWithByteCount) {
 	PrintCreateTablespaceStatements(metadataFile, globalTOC, tablespaces, tablespaceMetadata)
 }
 
-func BackupCreateDatabase(metadataFile *utils.FileWithByteCount) {
+func backupCreateDatabase(metadataFile *utils.FileWithByteCount) {
 	gplog.Verbose("Writing CREATE DATABASE statement to metadata file")
 	defaultDB := GetDefaultDatabaseEncodingInfo(connectionPool)
 	db := GetDatabaseInfo(connectionPool)
@@ -386,14 +386,14 @@ func BackupCreateDatabase(metadataFile *utils.FileWithByteCount) {
 	PrintCreateDatabaseStatement(metadataFile, globalTOC, defaultDB, db, dbMetadata)
 }
 
-func BackupDatabaseGUCs(metadataFile *utils.FileWithByteCount) {
+func backupDatabaseGUCs(metadataFile *utils.FileWithByteCount) {
 	gplog.Verbose("Writing Database Configuration Parameters to metadata file")
 	databaseGucs := GetDatabaseGUCs(connectionPool)
 	objectCounts["Database GUCs"] = len(databaseGucs)
 	PrintDatabaseGUCs(metadataFile, globalTOC, databaseGucs, connectionPool.DBName)
 }
 
-func BackupResourceQueues(metadataFile *utils.FileWithByteCount) {
+func backupResourceQueues(metadataFile *utils.FileWithByteCount) {
 	gplog.Verbose("Writing CREATE RESOURCE QUEUE statements to metadata file")
 	resQueues := GetResourceQueues(connectionPool)
 	objectCounts["Resource Queues"] = len(resQueues)
@@ -401,7 +401,7 @@ func BackupResourceQueues(metadataFile *utils.FileWithByteCount) {
 	PrintCreateResourceQueueStatements(metadataFile, globalTOC, resQueues, resQueueMetadata)
 }
 
-func BackupResourceGroups(metadataFile *utils.FileWithByteCount) {
+func backupResourceGroups(metadataFile *utils.FileWithByteCount) {
 	gplog.Verbose("Writing CREATE RESOURCE GROUP statements to metadata file")
 	resGroups := GetResourceGroups(connectionPool)
 	objectCounts["Resource Groups"] = len(resGroups)
@@ -410,7 +410,7 @@ func BackupResourceGroups(metadataFile *utils.FileWithByteCount) {
 	PrintCreateResourceGroupStatements(metadataFile, globalTOC, resGroups, resGroupMetadata)
 }
 
-func BackupRoles(metadataFile *utils.FileWithByteCount) {
+func backupRoles(metadataFile *utils.FileWithByteCount) {
 	gplog.Verbose("Writing CREATE ROLE statements to metadata file")
 	roles := GetRoles(connectionPool)
 	objectCounts["Roles"] = len(roles)
@@ -418,13 +418,13 @@ func BackupRoles(metadataFile *utils.FileWithByteCount) {
 	PrintCreateRoleStatements(metadataFile, globalTOC, roles, roleMetadata)
 }
 
-func BackupRoleGUCs(metadataFile *utils.FileWithByteCount) {
+func backupRoleGUCs(metadataFile *utils.FileWithByteCount) {
 	gplog.Verbose("Writing ROLE Configuration Parameter to meadata file")
 	roleGUCs := GetRoleGUCs(connectionPool)
 	PrintRoleGUCStatements(metadataFile, globalTOC, roleGUCs)
 }
 
-func BackupRoleGrants(metadataFile *utils.FileWithByteCount) {
+func backupRoleGrants(metadataFile *utils.FileWithByteCount) {
 	gplog.Verbose("Writing GRANT ROLE statements to metadata file")
 	roleMembers := GetRoleMembers(connectionPool)
 	PrintRoleMembershipStatements(metadataFile, globalTOC, roleMembers)
@@ -434,7 +434,7 @@ func BackupRoleGrants(metadataFile *utils.FileWithByteCount) {
  * Predata wrapper functions
  */
 
-func BackupSchemas(metadataFile *utils.FileWithByteCount, partitionAlteredSchemas map[string]bool) {
+func backupSchemas(metadataFile *utils.FileWithByteCount, partitionAlteredSchemas map[string]bool) {
 	gplog.Verbose("Writing CREATE SCHEMA statements to metadata file")
 	schemas := GetAllUserSchemas(connectionPool, partitionAlteredSchemas)
 	objectCounts["Schemas"] = len(schemas)
@@ -442,7 +442,7 @@ func BackupSchemas(metadataFile *utils.FileWithByteCount, partitionAlteredSchema
 	PrintCreateSchemaStatements(metadataFile, globalTOC, schemas, schemaMetadata)
 }
 
-func BackupProceduralLanguages(metadataFile *utils.FileWithByteCount, procLangs []ProceduralLanguage, langFuncs []Function, functionMetadata MetadataMap, funcInfoMap map[uint32]FunctionInfo) {
+func backupProceduralLanguages(metadataFile *utils.FileWithByteCount, procLangs []ProceduralLanguage, langFuncs []Function, functionMetadata MetadataMap, funcInfoMap map[uint32]FunctionInfo) {
 	gplog.Verbose("Writing CREATE PROCEDURAL LANGUAGE statements to metadata file")
 	objectCounts["Procedural Languages"] = len(procLangs)
 	for _, langFunc := range langFuncs {
@@ -452,28 +452,29 @@ func BackupProceduralLanguages(metadataFile *utils.FileWithByteCount, procLangs 
 	PrintCreateLanguageStatements(metadataFile, globalTOC, procLangs, funcInfoMap, procLangMetadata)
 }
 
-func BackupShellTypes(metadataFile *utils.FileWithByteCount, shellTypes []ShellType, baseTypes []BaseType, rangeTypes []RangeType) {
+func backupShellTypes(metadataFile *utils.FileWithByteCount, shellTypes []ShellType, baseTypes []BaseType, rangeTypes []RangeType) {
 	gplog.Verbose("Writing CREATE TYPE statements for shell types to metadata file")
 	PrintCreateShellTypeStatements(metadataFile, globalTOC, shellTypes, baseTypes, rangeTypes)
 }
 
-func BackupEnumTypes(metadataFile *utils.FileWithByteCount, typeMetadata MetadataMap) {
+func backupEnumTypes(metadataFile *utils.FileWithByteCount, typeMetadata MetadataMap) {
 	gplog.Verbose("Writing CREATE TYPE statements for enum types to metadata file")
 	enums := GetEnumTypes(connectionPool)
 	objectCounts["Types"] += len(enums)
 	PrintCreateEnumTypeStatements(metadataFile, globalTOC, enums, typeMetadata)
 }
 
-func BackupCreateSequences(metadataFile *utils.FileWithByteCount, sequences []Sequence, relationMetadata MetadataMap) {
+func backupCreateSequences(metadataFile *utils.FileWithByteCount, sequences []Sequence, sequenceOwnerColumns map[string]string, relationMetadata MetadataMap) {
 	gplog.Verbose("Writing CREATE SEQUENCE statements to metadata file")
 	objectCounts["Sequences"] = len(sequences)
 	PrintCreateSequenceStatements(metadataFile, globalTOC, sequences, relationMetadata)
+	PrintAlterSequenceStatements(metadataFile, globalTOC, sequences, sequenceOwnerColumns)
 }
 
-func createBackupSet(objSlice []Sortable) (backupSet map[UniqueID]bool) {
-	backupSet = make(map[UniqueID]bool)
+func createBackupSet(objSlice []Sortable) (backupSet map[UniqueID]Sortable) {
+	backupSet = make(map[UniqueID]Sortable)
 	for _, obj := range objSlice {
-		backupSet[obj.GetUniqueID()] = true
+		backupSet[obj.GetUniqueID()] = obj
 	}
 
 	return backupSet
@@ -504,10 +505,9 @@ func addToMetadataMap(newMetadata MetadataMap, metadataMap MetadataMap) {
 }
 
 // This function is fairly unwieldy, but there's not really a good way to break it down
-func BackupDependentObjects(metadataFile *utils.FileWithByteCount, tables []Table,
-	protocols []ExternalProtocol, filteredMetadata MetadataMap,
-	constraints []Constraint, sortables []Sortable, funcInfoMap map[uint32]FunctionInfo,
-	tableOnly bool) {
+func backupDependentObjects(metadataFile *utils.FileWithByteCount, tables []Table,
+	protocols []ExternalProtocol, filteredMetadata MetadataMap, constraints []Constraint,
+	sortables []Sortable, funcInfoMap map[uint32]FunctionInfo, tableOnly bool) {
 
 	gplog.Verbose("Writing CREATE statements for dependent objects to metadata file")
 
@@ -526,7 +526,7 @@ func BackupDependentObjects(metadataFile *utils.FileWithByteCount, tables []Tabl
 	}
 }
 
-func BackupConversions(metadataFile *utils.FileWithByteCount) {
+func backupConversions(metadataFile *utils.FileWithByteCount) {
 	gplog.Verbose("Writing CREATE CONVERSION statements to metadata file")
 	conversions := GetConversions(connectionPool)
 	objectCounts["Conversions"] = len(conversions)
@@ -534,7 +534,7 @@ func BackupConversions(metadataFile *utils.FileWithByteCount) {
 	PrintCreateConversionStatements(metadataFile, globalTOC, conversions, convMetadata)
 }
 
-func BackupOperatorFamilies(metadataFile *utils.FileWithByteCount) {
+func backupOperatorFamilies(metadataFile *utils.FileWithByteCount) {
 	gplog.Verbose("Writing CREATE OPERATOR FAMILY statements to metadata file")
 	operatorFamilies := GetOperatorFamilies(connectionPool)
 	objectCounts["Operator Families"] = len(operatorFamilies)
@@ -542,7 +542,7 @@ func BackupOperatorFamilies(metadataFile *utils.FileWithByteCount) {
 	PrintCreateOperatorFamilyStatements(metadataFile, globalTOC, operatorFamilies, operatorFamilyMetadata)
 }
 
-func BackupCollations(metadataFile *utils.FileWithByteCount) {
+func backupCollations(metadataFile *utils.FileWithByteCount) {
 	gplog.Verbose("Writing CREATE COLLATION statements to metadata file")
 	collations := GetCollations(connectionPool)
 	objectCounts["Collations"] = len(collations)
@@ -550,7 +550,7 @@ func BackupCollations(metadataFile *utils.FileWithByteCount) {
 	PrintCreateCollationStatements(metadataFile, globalTOC, collations, collationMetadata)
 }
 
-func BackupExtensions(metadataFile *utils.FileWithByteCount) {
+func backupExtensions(metadataFile *utils.FileWithByteCount) {
 	gplog.Verbose("Writing CREATE EXTENSION statements to metadata file")
 	extensions := GetExtensions(connectionPool)
 	objectCounts["Extensions"] = len(extensions)
@@ -558,7 +558,7 @@ func BackupExtensions(metadataFile *utils.FileWithByteCount) {
 	PrintCreateExtensionStatements(metadataFile, globalTOC, extensions, extensionMetadata)
 }
 
-func BackupConstraints(metadataFile *utils.FileWithByteCount, constraints []Constraint, conMetadata MetadataMap) {
+func backupConstraints(metadataFile *utils.FileWithByteCount, constraints []Constraint, conMetadata MetadataMap) {
 	gplog.Verbose("Writing ADD CONSTRAINT statements to metadata file")
 	objectCounts["Constraints"] = len(constraints)
 	PrintConstraintStatements(metadataFile, globalTOC, constraints, conMetadata)
@@ -568,7 +568,7 @@ func BackupConstraints(metadataFile *utils.FileWithByteCount, constraints []Cons
  * Postdata wrapper functions
  */
 
-func BackupIndexes(metadataFile *utils.FileWithByteCount) {
+func backupIndexes(metadataFile *utils.FileWithByteCount) {
 	gplog.Verbose("Writing CREATE INDEX statements to metadata file")
 	indexes := GetIndexes(connectionPool)
 	objectCounts["Indexes"] = len(indexes)
@@ -576,7 +576,7 @@ func BackupIndexes(metadataFile *utils.FileWithByteCount) {
 	PrintCreateIndexStatements(metadataFile, globalTOC, indexes, indexMetadata)
 }
 
-func BackupRules(metadataFile *utils.FileWithByteCount) {
+func backupRules(metadataFile *utils.FileWithByteCount) {
 	gplog.Verbose("Writing CREATE RULE statements to metadata file")
 	rules := GetRules(connectionPool)
 	objectCounts["Rules"] = len(rules)
@@ -584,7 +584,7 @@ func BackupRules(metadataFile *utils.FileWithByteCount) {
 	PrintCreateRuleStatements(metadataFile, globalTOC, rules, ruleMetadata)
 }
 
-func BackupTriggers(metadataFile *utils.FileWithByteCount) {
+func backupTriggers(metadataFile *utils.FileWithByteCount) {
 	gplog.Verbose("Writing CREATE TRIGGER statements to metadata file")
 	triggers := GetTriggers(connectionPool)
 	objectCounts["Triggers"] = len(triggers)
@@ -592,7 +592,7 @@ func BackupTriggers(metadataFile *utils.FileWithByteCount) {
 	PrintCreateTriggerStatements(metadataFile, globalTOC, triggers, triggerMetadata)
 }
 
-func BackupEventTriggers(metadataFile *utils.FileWithByteCount) {
+func backupEventTriggers(metadataFile *utils.FileWithByteCount) {
 	gplog.Verbose("Writing CREATE EVENT TRIGGER statements to metadata file")
 	eventTriggers := GetEventTriggers(connectionPool)
 	objectCounts["Event Triggers"] = len(eventTriggers)
@@ -600,7 +600,7 @@ func BackupEventTriggers(metadataFile *utils.FileWithByteCount) {
 	PrintCreateEventTriggerStatements(metadataFile, globalTOC, eventTriggers, eventTriggerMetadata)
 }
 
-func BackupDefaultPrivileges(metadataFile *utils.FileWithByteCount) {
+func backupDefaultPrivileges(metadataFile *utils.FileWithByteCount) {
 	gplog.Verbose("Writing ALTER DEFAULT PRIVILEGES statements to metadata file")
 	defaultPrivileges := GetDefaultPrivileges(connectionPool)
 	objectCounts["DEFAULT PRIVILEGES"] = len(defaultPrivileges)
@@ -611,15 +611,15 @@ func BackupDefaultPrivileges(metadataFile *utils.FileWithByteCount) {
  * Data wrapper functions
  */
 
-func BackupStatistics(statisticsFile *utils.FileWithByteCount, tables []Table) {
+func backupTableStatistics(statisticsFile *utils.FileWithByteCount, tables []Table) {
 	attStats := GetAttributeStatistics(connectionPool, tables)
 	tupleStats := GetTupleStatistics(connectionPool, tables)
 
-	BackupSessionGUCs(statisticsFile)
+	backupSessionGUC(statisticsFile)
 	PrintStatisticsStatements(statisticsFile, globalTOC, tables, attStats, tupleStats)
 }
 
-func BackupIncrementalMetadata() {
+func backupIncrementalMetadata() {
 	aoTableEntries := GetAOIncrementalMetadata(connectionPool)
 	globalTOC.IncrementalMetadata.AO = aoTableEntries
 }

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -42,6 +42,7 @@ var oldBackupSemVer semver.Version
 var backupCluster *cluster.Cluster
 var historyFilePath string
 var saveHistoryFilePath = "/tmp/end_to_end_save_history_file.yaml"
+var testFailure bool
 
 // This function is run automatically by ginkgo before any tests are run.
 func init() {
@@ -170,6 +171,7 @@ func assertArtifactsCleaned(conn *dbconn.DBConn, timestamp string) {
 func mustRunCommand(cmd *exec.Cmd) []byte {
 	output, err := cmd.CombinedOutput()
 	if err != nil {
+		testFailure = true
 		fmt.Printf("%s", output)
 		Fail(fmt.Sprintf("%v", err))
 	}
@@ -327,6 +329,9 @@ var _ = Describe("backup end to end integration tests", func() {
 
 	})
 	AfterSuite(func() {
+		if testFailure {
+			return
+		}
 		_ = utils.CopyFile(saveHistoryFilePath, historyFilePath)
 
 		if backupConn.Version.Before("6") {

--- a/integration/options_integration_test.go
+++ b/integration/options_integration_test.go
@@ -153,7 +153,7 @@ bar";
 			Expect(subject.GetIncludedTables()).To(ContainElement("public.CAPpart"))
 
 			// ensure that ExpandIncludesForPartitions does not disturb the original value
-			// that the user typed in, which is used by InitializeBackupReport() and
+			// that the user typed in, which is used by initializeBackupReport() and
 			// is important for incremental backups which must exactly match all flag input
 			Expect(subject.GetOriginalIncludedTables()).To(Equal([]string{`public.CAPpart_1_prt_girls`}))
 		})

--- a/utils/util.go
+++ b/utils/util.go
@@ -93,6 +93,13 @@ func ValidateFullPath(path string) error {
 	return nil
 }
 
+func ValidateCompressionLevel(compressionLevel int) error {
+	if compressionLevel < 1 || compressionLevel > 9 {
+		return errors.Errorf("Compression level must be between 1 and 9")
+	}
+	return nil
+}
+
 func InitializeSignalHandler(cleanupFunc func(bool), procDesc string, termFlag *bool) {
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, syscall.SIGINT, syscall.SIGTERM)

--- a/utils/util_test.go
+++ b/utils/util_test.go
@@ -113,4 +113,22 @@ var _ = Describe("utils/util tests", func() {
 			utils.ValidateGPDBVersionCompatibility(connectionPool)
 		})
 	})
+	Describe("ValidateCompressionLevel", func() {
+		It("validates a compression level between 1 and 9", func() {
+			compressLevel := 5
+			err := utils.ValidateCompressionLevel(compressLevel)
+			Expect(err).To(Not(HaveOccurred()))
+		})
+		It("panics if given a compression level < 1", func() {
+			compressLevel := 0
+			err := utils.ValidateCompressionLevel(compressLevel)
+			Expect(err).To(MatchError("Compression level must be between 1 and 9"))
+		})
+		It("panics if given a compression level > 9", func() {
+			compressLevel := 11
+			err := utils.ValidateCompressionLevel(compressLevel)
+			Expect(err).To(MatchError("Compression level must be between 1 and 9"))
+		})
+	})
+
 })


### PR DESCRIPTION
1. Lowercase functions that are supposed to be private
2. Remove unused function (ConstructDependentObjectMetadataMap)
3. Move ValidateCompressionLevel to the utils package