### PR TITLE
Backup and restore any user defined grants for extensions

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -252,25 +252,20 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Table, tableO
 	objects = append(objects, convertToSortableSlice(tables)...)
 	relationMetadata := GetMetadataForObjectType(connectionPool, TYPE_RELATION)
 	addToMetadataMap(relationMetadata, metadataMap)
+	functions, funcInfoMap := retrieveFunctions(&objects, metadataMap)
 
 	var protocols []ExternalProtocol
-	funcInfoMap := GetFunctionOidToInfoMap(connectionPool)
 
 	if !tableOnly {
 		backupSchemas(metadataFile, createAlteredPartitionSchemaSet(tables))
 		if len(MustGetFlagStringArray(options.INCLUDE_SCHEMA)) == 0 && connectionPool.Version.AtLeast("5") {
 			backupExtensions(metadataFile)
 		}
-
 		if connectionPool.Version.AtLeast("6") {
 			backupCollations(metadataFile)
 		}
-
-		procLangs := GetProceduralLanguages(connectionPool)
-		langFuncs, functionMetadata := retrieveFunctions(&objects, metadataMap, procLangs)
-
 		if len(MustGetFlagStringArray(options.INCLUDE_SCHEMA)) == 0 {
-			backupProceduralLanguages(metadataFile, procLangs, langFuncs, functionMetadata, funcInfoMap)
+			backupProceduralLanguages(metadataFile, functions, funcInfoMap, metadataMap)
 		}
 		retrieveAndBackupTypes(metadataFile, &objects, metadataMap)
 

--- a/backup/dependencies.go
+++ b/backup/dependencies.go
@@ -274,5 +274,12 @@ func PrintDependentObjectStatements(metadataFile *utils.FileWithByteCount, toc *
 		case MaterializedView:
 			PrintCreateMaterializedViewStatement(metadataFile, toc, obj, objMetadata)
 		}
+		// Remove ACLs from metadataMap for the current object since they have been processed
+		delete(metadataMap, object.GetUniqueID())
+	}
+	//  Process ACLs for left over objects in the metadata map
+	for uniqueId, objectMeta := range metadataMap {
+		// e.g. Grants for any functions that belong to extensions
+		printObjectMetadataACLs(metadataFile, toc, objectMeta, funcInfoMap[uniqueId.Oid])
 	}
 }

--- a/backup/dependencies.go
+++ b/backup/dependencies.go
@@ -278,8 +278,5 @@ func PrintDependentObjectStatements(metadataFile *utils.FileWithByteCount, toc *
 		delete(metadataMap, object.GetUniqueID())
 	}
 	//  Process ACLs for left over objects in the metadata map
-	for uniqueId, objectMeta := range metadataMap {
-		// e.g. Grants for any functions that belong to extensions
-		printObjectMetadataACLs(metadataFile, toc, objectMeta, funcInfoMap[uniqueId.Oid])
-	}
+	printFunctionACLs(metadataFile, metadataMap, funcInfoMap)
 }

--- a/backup/dependencies.go
+++ b/backup/dependencies.go
@@ -278,5 +278,5 @@ func PrintDependentObjectStatements(metadataFile *utils.FileWithByteCount, toc *
 		delete(metadataMap, object.GetUniqueID())
 	}
 	//  Process ACLs for left over objects in the metadata map
-	printFunctionACLs(metadataFile, metadataMap, funcInfoMap)
+	printExtensionFunctionACLs(metadataFile, toc, metadataMap, funcInfoMap)
 }

--- a/backup/predata_acl.go
+++ b/backup/predata_acl.go
@@ -18,6 +18,9 @@ var ACLRegex = regexp.MustCompile(`^(.*)=([a-zA-Z\*]*)/(.*)$`)
 
 type ObjectMetadata struct {
 	Privileges            []ACL
+	Name                  string
+	ObjectType            string
+	Schema                string
 	Owner                 string
 	Comment               string
 	SecurityLabelProvider string
@@ -54,6 +57,25 @@ type ACL struct {
 
 type MetadataMap map[UniqueID]ObjectMetadata
 
+func (obj ObjectMetadata) GetMetadataEntry() (string, toc.MetadataEntry) {
+	return "predata",
+		toc.MetadataEntry{
+			Schema:          obj.Schema,
+			Name:            obj.Name,
+			ObjectType:      obj.ObjectType,
+			ReferenceObject: "",
+			StartByte:       0,
+			EndByte:         0,
+		}
+}
+
+func (obj ObjectMetadata) FQN() string {
+	if obj.Schema == "" {
+		return obj.Name
+	}
+	return utils.MakeFQN(obj.Schema, obj.Name)
+}
+
 func PrintStatements(metadataFile *utils.FileWithByteCount, toc *toc.TOC,
 	obj toc.TOCObject, statements []string) {
 	for _, statement := range statements {
@@ -89,6 +111,23 @@ func PrintObjectMetadata(file *utils.FileWithByteCount, toc *toc.TOC,
 	PrintStatements(file, toc, obj, statements)
 }
 
+// Only print owner and grant statements
+func printObjectMetadataACLs(file *utils.FileWithByteCount, toc *toc.TOC,
+	obj ObjectMetadata, info FunctionInfo) {
+	_, entry := obj.GetMetadataEntry()
+	if entry.ObjectType == "FUNCTION" || entry.ObjectType == "AGGREGATE" {
+		statements := make([]string, 0)
+		fqn := fmt.Sprintf("%s.%s(%s)", entry.Schema, entry.Name, info.IdentArgs)
+		if owner := obj.GetOwnerStatement(fqn, entry.ObjectType); owner != "" {
+			statements = append(statements, strings.TrimSpace(owner))
+		}
+		if privileges := obj.GetPrivilegesStatements(fqn, "FUNCTION"); privileges != "" {
+			statements = append(statements, strings.TrimSpace(privileges))
+		}
+		PrintStatements(file, toc, obj, statements)
+	}
+}
+
 func ConstructMetadataMap(results []MetadataQueryStruct) MetadataMap {
 	metadataMap := make(MetadataMap)
 	if len(results) == 0 {
@@ -113,6 +152,9 @@ func ConstructMetadataMap(results []MetadataQueryStruct) MetadataMap {
 			metadata = ObjectMetadata{}
 			metadata.Privileges = make([]ACL, 0)
 			metadata.Owner = result.Owner
+			metadata.Name = result.Name
+			metadata.ObjectType = result.ObjectType
+			metadata.Schema = result.Schema
 			metadata.Comment = result.Comment
 			metadata.SecurityLabelProvider = result.SecurityLabelProvider
 			metadata.SecurityLabel = result.SecurityLabel

--- a/backup/queries_acl.go
+++ b/backup/queries_acl.go
@@ -22,12 +22,14 @@ import (
 type MetadataQueryParams struct {
 	NameField    string
 	SchemaField  string
+	ObjectType   string
 	OidField     string
 	ACLField     string
 	OwnerField   string
 	OidTable     string
 	CommentTable string
 	CatalogTable string
+	FilterClause string
 	Shared       bool
 }
 
@@ -65,41 +67,41 @@ var (
 )
 
 func InitializeMetadataParams(connectionPool *dbconn.DBConn) {
-	TYPE_AGGREGATE = MetadataQueryParams{NameField: "proname", SchemaField: "pronamespace", ACLField: "proacl", OwnerField: "proowner", CatalogTable: "pg_proc"}
-	TYPE_CAST = MetadataQueryParams{NameField: "typname", OidField: "oid", OidTable: "pg_type", CatalogTable: "pg_cast"}
-	TYPE_COLLATION = MetadataQueryParams{NameField: "collname", OidField: "oid", SchemaField: "collnamespace", OwnerField: "collowner", CatalogTable: "pg_collation"}
-	TYPE_CONSTRAINT = MetadataQueryParams{NameField: "conname", SchemaField: "connamespace", OidField: "oid", CatalogTable: "pg_constraint"}
-	TYPE_CONVERSION = MetadataQueryParams{NameField: "conname", OidField: "oid", SchemaField: "connamespace", OwnerField: "conowner", CatalogTable: "pg_conversion"}
-	TYPE_DATABASE = MetadataQueryParams{NameField: "datname", ACLField: "datacl", OwnerField: "datdba", CatalogTable: "pg_database", Shared: true}
-	TYPE_EVENTTRIGGER = MetadataQueryParams{NameField: "evtname", OidField: "oid", OwnerField: "evtowner", CatalogTable: "pg_event_trigger"}
-	TYPE_EXTENSION = MetadataQueryParams{NameField: "extname", OidField: "oid", CatalogTable: "pg_extension"}
-	TYPE_FOREIGNDATAWRAPPER = MetadataQueryParams{NameField: "fdwname", ACLField: "fdwacl", OwnerField: "fdwowner", CatalogTable: "pg_foreign_data_wrapper"}
-	TYPE_FOREIGNSERVER = MetadataQueryParams{NameField: "srvname", ACLField: "srvacl", OwnerField: "srvowner", CatalogTable: "pg_foreign_server"}
-	TYPE_FUNCTION = TYPE_AGGREGATE // Aggregates are functions. So the metadata call to get them are the same.
-	TYPE_INDEX = MetadataQueryParams{NameField: "relname", OidField: "indexrelid", OidTable: "pg_class", CommentTable: "pg_class", CatalogTable: "pg_index"}
-	TYPE_PROCLANGUAGE = MetadataQueryParams{NameField: "lanname", ACLField: "lanacl", CatalogTable: "pg_language"}
+	TYPE_AGGREGATE = MetadataQueryParams{ObjectType: "AGGREGATE", NameField: "proname", SchemaField: "pronamespace", ACLField: "proacl", OwnerField: "proowner", CatalogTable: "pg_proc", FilterClause: "proisagg = 't'"}
+	TYPE_CAST = MetadataQueryParams{ObjectType: "CAST", NameField: "typname", OidField: "oid", OidTable: "pg_type", CatalogTable: "pg_cast"}
+	TYPE_COLLATION = MetadataQueryParams{ObjectType: "COLLATION", NameField: "collname", OidField: "oid", SchemaField: "collnamespace", OwnerField: "collowner", CatalogTable: "pg_collation"}
+	TYPE_CONSTRAINT = MetadataQueryParams{ObjectType: "CONSTRAINT", NameField: "conname", SchemaField: "connamespace", OidField: "oid", CatalogTable: "pg_constraint"}
+	TYPE_CONVERSION = MetadataQueryParams{ObjectType: "CONVERSION", NameField: "conname", OidField: "oid", SchemaField: "connamespace", OwnerField: "conowner", CatalogTable: "pg_conversion"}
+	TYPE_DATABASE = MetadataQueryParams{ObjectType: "DATABASE", NameField: "datname", ACLField: "datacl", OwnerField: "datdba", CatalogTable: "pg_database", Shared: true}
+	TYPE_EVENTTRIGGER = MetadataQueryParams{ObjectType: "EVENT TRIGGER", NameField: "evtname", OidField: "oid", OwnerField: "evtowner", CatalogTable: "pg_event_trigger"}
+	TYPE_EXTENSION = MetadataQueryParams{ObjectType: "EXTENSION", NameField: "extname", OidField: "oid", CatalogTable: "pg_extension"}
+	TYPE_FOREIGNDATAWRAPPER = MetadataQueryParams{ObjectType: "FOREIGN DATA WRAPPER", NameField: "fdwname", ACLField: "fdwacl", OwnerField: "fdwowner", CatalogTable: "pg_foreign_data_wrapper"}
+	TYPE_FOREIGNSERVER = MetadataQueryParams{ObjectType: "SERVER", NameField: "srvname", ACLField: "srvacl", OwnerField: "srvowner", CatalogTable: "pg_foreign_server"}
+	TYPE_FUNCTION = MetadataQueryParams{ObjectType: "FUNCTION", NameField: "proname", SchemaField: "pronamespace", ACLField: "proacl", OwnerField: "proowner", CatalogTable: "pg_proc", FilterClause: "proisagg = 'f'"}
+	TYPE_INDEX = MetadataQueryParams{ObjectType: "INDEX", NameField: "relname", OidField: "indexrelid", OidTable: "pg_class", CommentTable: "pg_class", CatalogTable: "pg_index"}
+	TYPE_PROCLANGUAGE = MetadataQueryParams{ObjectType: "LANGUAGE", NameField: "lanname", ACLField: "lanacl", CatalogTable: "pg_language"}
 	if connectionPool.Version.Before("5") {
 		TYPE_PROCLANGUAGE.OwnerField = "10" // In GPDB 4.3, there is no lanowner field in pg_language, but languages have an implicit owner
 	} else {
 		TYPE_PROCLANGUAGE.OwnerField = "lanowner"
 	}
-	TYPE_OPERATOR = MetadataQueryParams{NameField: "oprname", SchemaField: "oprnamespace", OidField: "oid", OwnerField: "oprowner", CatalogTable: "pg_operator"}
-	TYPE_OPERATORCLASS = MetadataQueryParams{NameField: "opcname", SchemaField: "opcnamespace", OidField: "oid", OwnerField: "opcowner", CatalogTable: "pg_opclass"}
-	TYPE_OPERATORFAMILY = MetadataQueryParams{NameField: "opfname", SchemaField: "opfnamespace", OidField: "oid", OwnerField: "opfowner", CatalogTable: "pg_opfamily"}
-	TYPE_PROTOCOL = MetadataQueryParams{NameField: "ptcname", ACLField: "ptcacl", OwnerField: "ptcowner", CatalogTable: "pg_extprotocol"}
-	TYPE_RELATION = MetadataQueryParams{NameField: "relname", SchemaField: "relnamespace", ACLField: "relacl", OwnerField: "relowner", CatalogTable: "pg_class"}
-	TYPE_RESOURCEGROUP = MetadataQueryParams{NameField: "rsgname", OidField: "oid", CatalogTable: "pg_resgroup", Shared: true}
-	TYPE_RESOURCEQUEUE = MetadataQueryParams{NameField: "rsqname", OidField: "oid", CatalogTable: "pg_resqueue", Shared: true}
-	TYPE_ROLE = MetadataQueryParams{NameField: "rolname", OidField: "oid", CatalogTable: "pg_authid", Shared: true}
-	TYPE_RULE = MetadataQueryParams{NameField: "rulename", OidField: "oid", CatalogTable: "pg_rewrite"}
-	TYPE_SCHEMA = MetadataQueryParams{NameField: "nspname", ACLField: "nspacl", OwnerField: "nspowner", CatalogTable: "pg_namespace"}
-	TYPE_TABLESPACE = MetadataQueryParams{NameField: "spcname", ACLField: "spcacl", OwnerField: "spcowner", CatalogTable: "pg_tablespace", Shared: true}
-	TYPE_TSCONFIGURATION = MetadataQueryParams{NameField: "cfgname", OidField: "oid", SchemaField: "cfgnamespace", OwnerField: "cfgowner", CatalogTable: "pg_ts_config"}
-	TYPE_TSDICTIONARY = MetadataQueryParams{NameField: "dictname", OidField: "oid", SchemaField: "dictnamespace", OwnerField: "dictowner", CatalogTable: "pg_ts_dict"}
-	TYPE_TSPARSER = MetadataQueryParams{NameField: "prsname", OidField: "oid", SchemaField: "prsnamespace", CatalogTable: "pg_ts_parser"}
-	TYPE_TSTEMPLATE = MetadataQueryParams{NameField: "tmplname", OidField: "oid", SchemaField: "tmplnamespace", CatalogTable: "pg_ts_template"}
-	TYPE_TRIGGER = MetadataQueryParams{NameField: "tgname", OidField: "oid", CatalogTable: "pg_trigger"}
-	TYPE_TYPE = MetadataQueryParams{NameField: "typname", SchemaField: "typnamespace", OwnerField: "typowner", CatalogTable: "pg_type"}
+	TYPE_OPERATOR = MetadataQueryParams{ObjectType: "OPERATOR", NameField: "oprname", SchemaField: "oprnamespace", OidField: "oid", OwnerField: "oprowner", CatalogTable: "pg_operator"}
+	TYPE_OPERATORCLASS = MetadataQueryParams{ObjectType: "OPERATOR CLASS", NameField: "opcname", SchemaField: "opcnamespace", OidField: "oid", OwnerField: "opcowner", CatalogTable: "pg_opclass"}
+	TYPE_OPERATORFAMILY = MetadataQueryParams{ObjectType: "OPERATOR FAMILY", NameField: "opfname", SchemaField: "opfnamespace", OidField: "oid", OwnerField: "opfowner", CatalogTable: "pg_opfamily"}
+	TYPE_PROTOCOL = MetadataQueryParams{ObjectType: "PROTOCOL", NameField: "ptcname", ACLField: "ptcacl", OwnerField: "ptcowner", CatalogTable: "pg_extprotocol"}
+	TYPE_RELATION = MetadataQueryParams{ObjectType: "RELATION", NameField: "relname", SchemaField: "relnamespace", ACLField: "relacl", OwnerField: "relowner", CatalogTable: "pg_class"}
+	TYPE_RESOURCEGROUP = MetadataQueryParams{ObjectType: "RESOURCE GROUP", NameField: "rsgname", OidField: "oid", CatalogTable: "pg_resgroup", Shared: true}
+	TYPE_RESOURCEQUEUE = MetadataQueryParams{ObjectType: "RESOURCE QUEUE", NameField: "rsqname", OidField: "oid", CatalogTable: "pg_resqueue", Shared: true}
+	TYPE_ROLE = MetadataQueryParams{ObjectType: "ROLE", NameField: "rolname", OidField: "oid", CatalogTable: "pg_authid", Shared: true}
+	TYPE_RULE = MetadataQueryParams{ObjectType: "RULE", NameField: "rulename", OidField: "oid", CatalogTable: "pg_rewrite"}
+	TYPE_SCHEMA = MetadataQueryParams{ObjectType: "SCHEMA", NameField: "nspname", ACLField: "nspacl", OwnerField: "nspowner", CatalogTable: "pg_namespace"}
+	TYPE_TABLESPACE = MetadataQueryParams{ObjectType: "TABLESPACE", NameField: "spcname", ACLField: "spcacl", OwnerField: "spcowner", CatalogTable: "pg_tablespace", Shared: true}
+	TYPE_TSCONFIGURATION = MetadataQueryParams{ObjectType: "TEXT SEARCH CONFIGURATION", NameField: "cfgname", OidField: "oid", SchemaField: "cfgnamespace", OwnerField: "cfgowner", CatalogTable: "pg_ts_config"}
+	TYPE_TSDICTIONARY = MetadataQueryParams{ObjectType: "TEXT SEARCH DICTIONARY", NameField: "dictname", OidField: "oid", SchemaField: "dictnamespace", OwnerField: "dictowner", CatalogTable: "pg_ts_dict"}
+	TYPE_TSPARSER = MetadataQueryParams{ObjectType: "TEXT SEARCH PARSER", NameField: "prsname", OidField: "oid", SchemaField: "prsnamespace", CatalogTable: "pg_ts_parser"}
+	TYPE_TSTEMPLATE = MetadataQueryParams{ObjectType: "TEXT SEARCH TEMPLATE", NameField: "tmplname", OidField: "oid", SchemaField: "tmplnamespace", CatalogTable: "pg_ts_template"}
+	TYPE_TRIGGER = MetadataQueryParams{ObjectType: "TRIGGER", NameField: "tgname", OidField: "oid", CatalogTable: "pg_trigger"}
+	TYPE_TYPE = MetadataQueryParams{ObjectType: "TYPE", NameField: "typname", SchemaField: "typnamespace", OwnerField: "typowner", CatalogTable: "pg_type"}
 	if connectionPool.Version.AtLeast("6") {
 		TYPE_TYPE.ACLField = "typacl"
 	}
@@ -107,10 +109,13 @@ func InitializeMetadataParams(connectionPool *dbconn.DBConn) {
 
 type MetadataQueryStruct struct {
 	UniqueID
-	Privileges            sql.NullString
-	Kind                  string
+	Name                  string
+	ObjectType            string
+	Schema                string
 	Owner                 string
 	Comment               string
+	Privileges            sql.NullString
+	Kind                  string
 	SecurityLabel         string
 	SecurityLabelProvider string
 }
@@ -118,64 +123,77 @@ type MetadataQueryStruct struct {
 func GetMetadataForObjectType(connectionPool *dbconn.DBConn, params MetadataQueryParams) MetadataMap {
 	gplog.Verbose("Getting object type metadata from " + params.CatalogTable)
 
-	aclStr := "''"
-	kindStr := "''"
+	tableName := params.CatalogTable
+	nameCol := params.NameField
+	aclCols := "''"
+	kindCol := "''"
 	if params.ACLField != "" {
-		aclStr = fmt.Sprintf(`CASE
+		aclCols = fmt.Sprintf(`CASE
 		WHEN %[1]s IS NULL THEN NULL
 		WHEN array_upper(%[1]s, 1) = 0 THEN %[1]s[0]
 		ELSE unnest(%[1]s) END`, params.ACLField)
-		kindStr = fmt.Sprintf(`CASE
+		kindCol = fmt.Sprintf(`CASE
 		WHEN %[1]s IS NULL THEN ''
 		WHEN array_upper(%[1]s, 1) = 0 THEN 'Empty'
 		ELSE '' END`, params.ACLField)
 	}
-	schemaStr := ""
+	schemaCol := "''"
+	joinClause := ""
+	filterClause := "1 = 1"
 	if params.SchemaField != "" {
-		schemaStr = fmt.Sprintf(`JOIN pg_namespace n ON o.%s = n.oid
-	WHERE %s`, params.SchemaField, SchemaFilterClause("n"))
+		schemaCol = "n.nspname"
+		joinClause = fmt.Sprintf(`JOIN pg_namespace n ON o.%s = n.oid`, params.SchemaField)
+		filterClause = SchemaFilterClause("n")
 	}
-	descFunc := "pg_description"
-	subidStr := " AND d.objsubid = 0"
+	descTable := "pg_description"
+	subidFilter := " AND d.objsubid = 0"
 	if params.Shared {
-		descFunc = "pg_shdescription"
-		subidStr = ""
+		descTable = "pg_shdescription"
+		subidFilter = ""
 	}
-	ownerStr := "''"
+	ownerCol := "''"
 	if params.OwnerField != "" {
-		ownerStr = fmt.Sprintf("quote_ident(pg_get_userbyid(%s))", params.OwnerField)
+		ownerCol = fmt.Sprintf("quote_ident(pg_get_userbyid(%s))", params.OwnerField)
 	}
 	secCols := ""
-	secStr := ""
 	if connectionPool.Version.AtLeast("6") {
-		secCols = "coalesce(sec.label,'') AS securitylabel, coalesce(sec.provider, '') AS securitylabelprovider,"
+		secCols = `coalesce(sec.label,'') AS securitylabel,
+		coalesce(sec.provider, '') AS securitylabelprovider,`
 		secTable := "pg_seclabel"
-		secSubidStr := " AND sec.objsubid = 0"
+		secSubidFilter := " AND sec.objsubid = 0"
 		if params.Shared {
 			secTable = "pg_shseclabel"
-			secSubidStr = ""
+			secSubidFilter = ""
 		}
-		secStr = fmt.Sprintf("LEFT JOIN %s sec ON (sec.objoid = o.oid AND sec.classoid = '%s'::regclass%s)", secTable, params.CatalogTable, secSubidStr)
+		joinClause += fmt.Sprintf(
+			` LEFT JOIN %s sec ON (sec.objoid = o.oid AND sec.classoid = '%s'::regclass%s)`,
+			secTable, tableName, secSubidFilter)
+	}
+	if params.FilterClause != "" {
+		filterClause += " AND " + params.FilterClause
 	}
 
-	query := fmt.Sprintf(`
-	SELECT
+	query := fmt.Sprintf(`SELECT
 		'%s'::regclass::oid AS classid,
 		o.oid,
-		%s AS privileges,
+		quote_ident(%s) AS name,
 		%s AS kind,
+		coalesce(quote_ident(%s),'') AS schema,
 		%s AS owner,
+		%s AS privileges,
 		%s
 		coalesce(description,'') AS comment
 	FROM %s o LEFT JOIN %s d ON (d.objoid = o.oid AND d.classoid = '%s'::regclass%s)
 		%s
-		%s
-		AND o.oid NOT IN (SELECT objid FROM pg_depend WHERE deptype='e')
-	ORDER BY o.oid`, params.CatalogTable, aclStr, kindStr, ownerStr, secCols,
-	params.CatalogTable, descFunc, params.CatalogTable, subidStr, secStr, schemaStr)
-
+	WHERE %s
+	ORDER BY o.oid`,
+		tableName, nameCol, kindCol, schemaCol, ownerCol, aclCols, secCols,
+		tableName, descTable, tableName, subidFilter, joinClause, filterClause)
 	results := make([]MetadataQueryStruct, 0)
 	err := connectionPool.Select(&results, query)
+	for i := range results {
+		results[i].ObjectType = params.ObjectType
+	}
 	gplog.FatalOnError(err)
 
 	return ConstructMetadataMap(results)
@@ -223,7 +241,15 @@ func GetCommentsForObjectType(connectionPool *dbconn.DBConn, params MetadataQuer
 	metadataMap := make(MetadataMap)
 	if len(results) > 0 {
 		for _, result := range results {
-			metadataMap[result.UniqueID] = ObjectMetadata{[]ACL{}, "", result.Comment, "", ""}
+			metadataMap[result.UniqueID] = ObjectMetadata{
+				[]ACL{},
+				"",
+				"",
+				"",
+				"",
+				result.Comment,
+				"",
+				""}
 		}
 	}
 	return metadataMap

--- a/backup/queries_acl.go
+++ b/backup/queries_acl.go
@@ -174,6 +174,7 @@ func GetMetadataForObjectType(connectionPool *dbconn.DBConn, params MetadataQuer
 	}
 
 	query := fmt.Sprintf(`SELECT
+		'%s' AS objecttype,
 		'%s'::regclass::oid AS classid,
 		o.oid,
 		quote_ident(%s) AS name,
@@ -187,13 +188,10 @@ func GetMetadataForObjectType(connectionPool *dbconn.DBConn, params MetadataQuer
 		%s
 	WHERE %s
 	ORDER BY o.oid`,
-		tableName, nameCol, kindCol, schemaCol, ownerCol, aclCols, secCols,
+		params.ObjectType, tableName, nameCol, kindCol, schemaCol, ownerCol, aclCols, secCols,
 		tableName, descTable, tableName, subidFilter, joinClause, filterClause)
 	results := make([]MetadataQueryStruct, 0)
 	err := connectionPool.Select(&results, query)
-	for i := range results {
-		results[i].ObjectType = params.ObjectType
-	}
 	gplog.FatalOnError(err)
 
 	return ConstructMetadataMap(results)
@@ -243,9 +241,7 @@ func GetCommentsForObjectType(connectionPool *dbconn.DBConn, params MetadataQuer
 		for _, result := range results {
 			metadataMap[result.UniqueID] = ObjectMetadata{
 				[]ACL{},
-				"",
-				"",
-				"",
+				params.ObjectType,
 				"",
 				result.Comment,
 				"",

--- a/backup/queries_acl_test.go
+++ b/backup/queries_acl_test.go
@@ -22,65 +22,71 @@ var _ = Describe("backup/queries_acl tests", func() {
 			params = backup.MetadataQueryParams{NameField: "name", OwnerField: "owner", CatalogTable: "table"}
 		})
 		It("queries metadata for an object with default params", func() {
-			mock.ExpectQuery(regexp.QuoteMeta(`
-	SELECT 'table'::regclass::oid AS classid,
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT
+		'table'::regclass::oid AS classid,
 		o.oid,
-		'' AS privileges,
+		quote_ident(name) AS name,
 		'' AS kind,
+		coalesce(quote_ident(''),'') AS schema,
 		quote_ident(pg_get_userbyid(owner)) AS owner,
+		'' AS privileges,
 		coalesce(description,'') AS comment
 	FROM table o LEFT JOIN pg_description d ON (d.objoid = o.oid AND d.classoid = 'table'::regclass AND d.objsubid = 0)
-	AND o.oid NOT IN (SELECT objid FROM pg_depend WHERE deptype='e')
+	WHERE 1 = 1
 	ORDER BY o.oid`)).WillReturnRows(emptyRows)
 			backup.GetMetadataForObjectType(connectionPool, params)
 		})
 		It("queries metadata for an object with a schema field", func() {
-			mock.ExpectQuery(regexp.QuoteMeta(`
-	SELECT 'table'::regclass::oid AS classid,
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT
+		'table'::regclass::oid AS classid,
 		o.oid,
-		'' AS privileges,
+		quote_ident(name) AS name,
 		'' AS kind,
+		coalesce(quote_ident(n.nspname),'') AS schema,
 		quote_ident(pg_get_userbyid(owner)) AS owner,
+		'' AS privileges,
 		coalesce(description,'') AS comment
 	FROM table o LEFT JOIN pg_description d ON (d.objoid = o.oid AND d.classoid = 'table'::regclass AND d.objsubid = 0)
-	JOIN pg_namespace n ON o.schema = n.oid
+		JOIN pg_namespace n ON o.schema = n.oid
 	WHERE n.nspname NOT LIKE 'pg_temp_%' AND n.nspname NOT LIKE 'pg_toast%' AND n.nspname NOT IN ('gp_toolkit', 'information_schema', 'pg_aoseg', 'pg_bitmapindex', 'pg_catalog')
-	AND o.oid NOT IN (SELECT objid FROM pg_depend WHERE deptype='e')
 	ORDER BY o.oid`)).WillReturnRows(emptyRows)
 			params.SchemaField = "schema"
 			backup.GetMetadataForObjectType(connectionPool, params)
 		})
 		It("queries metadata for an object with an ACL field", func() {
-			mock.ExpectQuery(regexp.QuoteMeta(`
-	SELECT 'table'::regclass::oid AS classid,
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT
+		'table'::regclass::oid AS classid,
 		o.oid,
+		quote_ident(name) AS name,
 		CASE
-			WHEN acl IS NULL THEN NULL
-			WHEN array_upper(acl, 1) = 0 THEN acl[0]
-			ELSE unnest(acl)
-			END AS privileges,
-		CASE
-			WHEN acl IS NULL THEN ''
-			WHEN array_upper(acl, 1) = 0 THEN 'Empty'
-			ELSE '' END AS kind,
+		WHEN acl IS NULL THEN ''
+		WHEN array_upper(acl, 1) = 0 THEN 'Empty'
+		ELSE '' END AS kind,
+		coalesce(quote_ident(''),'') AS schema,
 		quote_ident(pg_get_userbyid(owner)) AS owner,
+		CASE
+		WHEN acl IS NULL THEN NULL
+		WHEN array_upper(acl, 1) = 0 THEN acl[0]
+		ELSE unnest(acl) END AS privileges,
 		coalesce(description,'') AS comment
 	FROM table o LEFT JOIN pg_description d ON (d.objoid = o.oid AND d.classoid = 'table'::regclass AND d.objsubid = 0)
-	AND o.oid NOT IN (SELECT objid FROM pg_depend WHERE deptype='e')
+	WHERE 1 = 1
 	ORDER BY o.oid`)).WillReturnRows(emptyRows)
 			params.ACLField = "acl"
 			backup.GetMetadataForObjectType(connectionPool, params)
 		})
 		It("queries metadata for a shared object", func() {
-			mock.ExpectQuery(regexp.QuoteMeta(`
-	SELECT 'table'::regclass::oid AS classid,
+			mock.ExpectQuery(regexp.QuoteMeta(`SELECT
+		'table'::regclass::oid AS classid,
 		o.oid,
-		'' AS privileges,
+		quote_ident(name) AS name,
 		'' AS kind,
+		coalesce(quote_ident(''),'') AS schema,
 		quote_ident(pg_get_userbyid(owner)) AS owner,
+		'' AS privileges,
 		coalesce(description,'') AS comment
 	FROM table o LEFT JOIN pg_shdescription d ON (d.objoid = o.oid AND d.classoid = 'table'::regclass)
-	AND o.oid NOT IN (SELECT objid FROM pg_depend WHERE deptype='e')
+	WHERE 1 = 1
 	ORDER BY o.oid`)).WillReturnRows(emptyRows)
 			params.Shared = true
 			backup.GetMetadataForObjectType(connectionPool, params)

--- a/backup/queries_acl_test.go
+++ b/backup/queries_acl_test.go
@@ -19,10 +19,11 @@ var _ = Describe("backup/queries_acl tests", func() {
 		emptyRows := sqlmock.NewRows(header)
 
 		BeforeEach(func() {
-			params = backup.MetadataQueryParams{NameField: "name", OwnerField: "owner", CatalogTable: "table"}
+			params = backup.MetadataQueryParams{ObjectType: "RELATION", NameField: "name", OwnerField: "owner", CatalogTable: "table"}
 		})
 		It("queries metadata for an object with default params", func() {
 			mock.ExpectQuery(regexp.QuoteMeta(`SELECT
+		'RELATION' AS objecttype,
 		'table'::regclass::oid AS classid,
 		o.oid,
 		quote_ident(name) AS name,
@@ -38,6 +39,7 @@ var _ = Describe("backup/queries_acl tests", func() {
 		})
 		It("queries metadata for an object with a schema field", func() {
 			mock.ExpectQuery(regexp.QuoteMeta(`SELECT
+		'RELATION' AS objecttype,
 		'table'::regclass::oid AS classid,
 		o.oid,
 		quote_ident(name) AS name,
@@ -55,6 +57,7 @@ var _ = Describe("backup/queries_acl tests", func() {
 		})
 		It("queries metadata for an object with an ACL field", func() {
 			mock.ExpectQuery(regexp.QuoteMeta(`SELECT
+		'RELATION' AS objecttype,
 		'table'::regclass::oid AS classid,
 		o.oid,
 		quote_ident(name) AS name,
@@ -77,6 +80,7 @@ var _ = Describe("backup/queries_acl tests", func() {
 		})
 		It("queries metadata for a shared object", func() {
 			mock.ExpectQuery(regexp.QuoteMeta(`SELECT
+		'RELATION' AS objecttype,
 		'table'::regclass::oid AS classid,
 		o.oid,
 		quote_ident(name) AS name,

--- a/backup/queries_functions.go
+++ b/backup/queries_functions.go
@@ -498,6 +498,10 @@ type FunctionInfo struct {
 	IsInternal    bool
 }
 
+func (info FunctionInfo) fqn() string {
+	return fmt.Sprintf("%s(%s)", info.QualifiedName, info.IdentArgs)
+}
+
 func GetFunctionOidToInfoMap(connectionPool *dbconn.DBConn) map[uint32]FunctionInfo {
 	version4query := `
 	SELECT p.oid,

--- a/backup/queries_functions.go
+++ b/backup/queries_functions.go
@@ -492,14 +492,30 @@ func GetAggregates(connectionPool *dbconn.DBConn) []Aggregate {
 }
 
 type FunctionInfo struct {
+	Oid           uint32
+	Name          string
+	Schema        string
 	QualifiedName string
 	Arguments     string
 	IdentArgs     string
 	IsInternal    bool
 }
 
-func (info FunctionInfo) fqn() string {
+func (info FunctionInfo) FQN() string {
 	return fmt.Sprintf("%s(%s)", info.QualifiedName, info.IdentArgs)
+}
+
+func (info FunctionInfo) GetMetadataEntry() (string, toc.MetadataEntry) {
+	nameWithArgs := fmt.Sprintf("%s(%s)", info.Name, info.IdentArgs)
+	return "predata",
+		toc.MetadataEntry{
+			Schema:          info.Schema,
+			Name:            nameWithArgs,
+			ObjectType:      "FUNCTION",
+			ReferenceObject: "",
+			StartByte:       0,
+			EndByte:         0,
+		}
 }
 
 func GetFunctionOidToInfoMap(connectionPool *dbconn.DBConn) map[uint32]FunctionInfo {
@@ -518,13 +534,7 @@ func GetFunctionOidToInfoMap(connectionPool *dbconn.DBConn) map[uint32]FunctionI
 	FROM pg_proc p
 		LEFT JOIN pg_namespace n ON p.pronamespace = n.oid`
 
-	results := make([]struct {
-		Oid       uint32
-		Schema    string
-		Name      string
-		Arguments string
-		IdentArgs string
-	}, 0)
+	results := make([]FunctionInfo, 0)
 	funcMap := make(map[uint32]FunctionInfo)
 	var err error
 	if connectionPool.Version.Before("5") {
@@ -532,24 +542,18 @@ func GetFunctionOidToInfoMap(connectionPool *dbconn.DBConn) map[uint32]FunctionI
 		arguments, _ := GetFunctionArgsAndIdentArgs(connectionPool)
 		for i := range results {
 			results[i].Arguments = arguments[results[i].Oid]
+			results[i].IdentArgs = arguments[results[i].Oid]
 		}
 	} else {
 		err = connectionPool.Select(&results, query)
 	}
 	gplog.FatalOnError(err)
-	for _, function := range results {
-		fqn := utils.MakeFQN(function.Schema, function.Name)
-
-		isInternal := false
-		if function.Schema == "pg_catalog" {
-			isInternal = true
+	for _, funcInfo := range results {
+		if funcInfo.Schema == "pg_catalog" {
+			funcInfo.IsInternal = true
 		}
-		funcInfo := FunctionInfo{
-			QualifiedName: fqn,
-			Arguments: function.Arguments,
-			IdentArgs: function.IdentArgs,
-			IsInternal: isInternal}
-		funcMap[function.Oid] = funcInfo
+		funcInfo.QualifiedName = utils.MakeFQN(funcInfo.Schema, funcInfo.Name)
+		funcMap[funcInfo.Oid] = funcInfo
 	}
 	return funcMap
 }

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -310,11 +310,6 @@ func retrieveAggregates(sortables *[]Sortable, metadataMap MetadataMap) {
 	gplog.Verbose("Retrieving AGGREGATE information")
 	aggregates := GetAggregates(connectionPool)
 	objectCounts["Aggregates"] = len(aggregates)
-	/* This call to get Metadata for Aggregates, although redundant, is preserved for
-	 * consistency with other, similar methods.  The metadata for aggregate
-	 * are located on the same catalog table as functions (pg_proc). This means that when we
-	 * get function metadata we also get aggregate metadata at the same time.
-	 */
 	aggMetadata := GetMetadataForObjectType(connectionPool, TYPE_AGGREGATE)
 
 	*sortables = append(*sortables, convertToSortableSlice(aggregates)...)

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -3,9 +3,6 @@ package end_to_end_test
 import (
 	"flag"
 	"fmt"
-	"github.com/greenplum-db/gp-common-go-libs/structmatcher"
-	"github.com/greenplum-db/gpbackup/backup"
-	"github.com/spf13/pflag"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -23,10 +20,13 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/iohelper"
 	"github.com/greenplum-db/gp-common-go-libs/operating"
+	"github.com/greenplum-db/gp-common-go-libs/structmatcher"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
+	"github.com/greenplum-db/gpbackup/backup"
 	"github.com/greenplum-db/gpbackup/filepath"
 	"github.com/greenplum-db/gpbackup/testutils"
 	"github.com/greenplum-db/gpbackup/utils"
+	"github.com/spf13/pflag"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -286,11 +286,11 @@ var _ = Describe("backup end to end integration tests", func() {
 		if err != nil {
 			Fail(fmt.Sprintf("Could not create restoredb: %v", err))
 		}
+		backupConn = testutils.SetupTestDbConn("testdb")
+		restoreConn = testutils.SetupTestDbConn("restoredb")
 		backupCmdFlags := pflag.NewFlagSet("gpbackup", pflag.ExitOnError)
 		backup.SetFlagDefaults(backupCmdFlags)
 		backup.SetCmdFlags(backupCmdFlags)
-		backupConn = testutils.SetupTestDbConn("testdb")
-		restoreConn = testutils.SetupTestDbConn("restoredb")
 		backup.InitializeMetadataParams(backupConn)
 		backup.SetFilterRelationClause("")
 		testutils.ExecuteSQLFile(backupConn, "test_tables_ddl.sql")
@@ -467,7 +467,6 @@ var _ = Describe("backup end to end integration tests", func() {
 
 				_ = os.Remove("/tmp/include-schema.txt")
 			})
-
 		})
 		Describe("Restore include filtering", func() {
 			It("runs gpbackup and gprestore with include-schema restore flag", func() {
@@ -480,7 +479,6 @@ var _ = Describe("backup end to end integration tests", func() {
 
 				assertRelationsCreated(restoreConn, 17)
 				assertDataRestored(restoreConn, schema2TupleCounts)
-
 			})
 			It("runs gpbackup and gprestore with include-schema-file restore flag", func() {
 				includeFile := iohelper.MustOpenFileForWriting("/tmp/include-schema.txt")
@@ -495,7 +493,6 @@ var _ = Describe("backup end to end integration tests", func() {
 
 				assertRelationsCreated(restoreConn, 37)
 				assertDataRestored(restoreConn, schema2TupleCounts)
-
 			})
 			It("runs gpbackup and gprestore with include-table restore flag", func() {
 				timestamp := gpbackup(gpbackupPath, backupHelperPath)
@@ -786,7 +783,6 @@ var _ = Describe("backup end to end integration tests", func() {
 					if useOldBackupVersion {
 						Skip("This test is only needed for the most recent backup versions")
 					}
-
 				})
 				It("runs gpbackup and gprestore with plugin, single-data-file, and no-compression", func() {
 					pluginExecutablePath := fmt.Sprintf("%s/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("HOME"))
@@ -886,29 +882,6 @@ var _ = Describe("backup end to end integration tests", func() {
 				assertRelationsCreated(restoreConn, TOTAL_RELATIONS)
 				assertDataRestored(restoreConn, publicSchemaTupleCounts)
 				assertDataRestored(restoreConn, schema2TupleCounts)
-			})
-		})
-		Describe("ACLs for extensions", func() {
-			FIt("runs gpbackup and gprestores any user defined ACLs on extensions", func() {
-				testhelper.AssertQueryRuns(backupConn, "DROP SCHEMA IF EXISTS schema2 CASCADE; DROP SCHEMA public CASCADE; CREATE SCHEMA public;")
-				testhelper.AssertQueryRuns(backupConn, "CREATE ROLE testrole")
-				defer testhelper.AssertQueryRuns(backupConn, "DROP ROLE testrole")
-				testhelper.AssertQueryRuns(backupConn, "CREATE EXTENSION dblink")
-				defer testhelper.AssertQueryRuns(backupConn, "DROP EXTENSION dblink")
-				testhelper.AssertQueryRuns(backupConn, "GRANT EXECUTE ON FUNCTION dblink_get_pkey(text) to testrole WITH GRANT OPTION")
-				testutils.ExecuteSQLFile(backupConn, "gpdb4_objects.sql")
-
-				timestamp := gpbackup(gpbackupPath, backupHelperPath, "--metadata-only")
-				gprestore(gprestorePath, restoreHelperPath, timestamp, "--redirect-db", "restoredb")
-
-				extensionMetadata := testutils.DefaultMetadata("FUNCTION", true, true, false, false)
-				uniqueID := testutils.UniqueIDFromObjectName(restoreConn, "public", "dblink_get_pkey", backup.TYPE_FUNCTION)
-				resultMetadataMap := backup.GetMetadataForObjectType(restoreConn, backup.TYPE_FUNCTION)
-
-				Expect(resultMetadataMap).To(Not(BeEmpty()))
-				resultMetadata := resultMetadataMap[uniqueID]
-				structmatcher.ExpectStructsToMatch(&extensionMetadata, &resultMetadata)
-				assertArtifactsCleaned(restoreConn, timestamp)
 			})
 		})
 		Describe("Incremental backup", func() {
@@ -1608,7 +1581,6 @@ var _ = Describe("backup end to end integration tests", func() {
 			assertDataRestored(restoreConn, publicSchemaTupleCounts)
 			assertDataRestored(restoreConn, schema2TupleCounts)
 		})
-
 		It("runs gpbackup and gprestore with the data-only restore flag", func() {
 			testutils.ExecuteSQLFile(restoreConn, "test_tables_ddl.sql")
 			timestamp := gpbackup(gpbackupPath, backupHelperPath)
@@ -1640,7 +1612,6 @@ var _ = Describe("backup end to end integration tests", func() {
 
 			assertDataRestored(restoreConn, publicSchemaTupleCounts)
 			assertDataRestored(restoreConn, schema2TupleCounts)
-
 		})
 		It("runs gpbackup and gprestore with no-compression flag", func() {
 			timestamp := gpbackup(gpbackupPath, backupHelperPath,
@@ -1661,7 +1632,6 @@ var _ = Describe("backup end to end integration tests", func() {
 			assertRelationsCreated(restoreConn, TOTAL_RELATIONS)
 			assertDataRestored(restoreConn, publicSchemaTupleCounts)
 			assertDataRestored(restoreConn, schema2TupleCounts)
-
 		})
 		It("runs gpbackup and gprestore with with-stats flag", func() {
 			timestamp := gpbackup(gpbackupPath, backupHelperPath,
@@ -1680,7 +1650,6 @@ var _ = Describe("backup end to end integration tests", func() {
 			Expect(string(output)).To(ContainSubstring("Query planner statistics restore complete"))
 			assertDataRestored(restoreConn, publicSchemaTupleCounts)
 			assertDataRestored(restoreConn, schema2TupleCounts)
-
 		})
 		It("runs gprestore with --include-table flag to only restore tables specified ", func() {
 			testhelper.AssertQueryRuns(backupConn,
@@ -1743,7 +1712,6 @@ var _ = Describe("backup end to end integration tests", func() {
 			assertRelationsCreated(restoreConn, TOTAL_RELATIONS)
 			assertDataRestored(restoreConn, schema2TupleCounts)
 			assertDataRestored(restoreConn, publicSchemaTupleCounts)
-
 		})
 		It("runs gpbackup and sends a SIGINT to ensure cleanup functions successfully", func() {
 			if useOldBackupVersion {
@@ -1771,7 +1739,6 @@ var _ = Describe("backup end to end integration tests", func() {
 			Expect(stdout).To(ContainSubstring("Received a termination signal, aborting backup process"))
 			Expect(stdout).To(ContainSubstring("Cleanup complete"))
 			Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
-
 		})
 		It("runs gprestore and sends a SIGINT to ensure cleanup functions successfully", func() {
 			if useOldBackupVersion {
@@ -1805,7 +1772,6 @@ var _ = Describe("backup end to end integration tests", func() {
 			Expect(stdout).To(ContainSubstring("Cleanup complete"))
 			Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
 			assertArtifactsCleaned(restoreConn, timestamp)
-
 		})
 		It("runs gpbackup and sends a SIGINT to ensure blocked LOCK TABLE query is canceled", func() {
 			if useOldBackupVersion {
@@ -1878,7 +1844,6 @@ var _ = Describe("backup end to end integration tests", func() {
 			output := mustRunCommand(command)
 			Expect(string(output)).To(MatchRegexp(`gprestore version \w+`))
 		})
-
 		It("runs gpbackup with --include-table flag with CAPS special characters", func() {
 			skipIfOldBackupVersionBefore("1.9.1")
 			timestamp := gpbackup(gpbackupPath, backupHelperPath,
@@ -1889,7 +1854,6 @@ var _ = Describe("backup end to end integration tests", func() {
 				"--backup-dir", backupDir)
 
 			assertRelationsCreated(restoreConn, 1)
-
 			localSchemaTupleCounts := map[string]int{
 				`public."FOObar"`: 1,
 			}
@@ -1923,7 +1887,6 @@ PARTITION BY LIST (gender)
 				"--backup-dir", backupDir)
 
 			assertRelationsCreated(restoreConn, 4)
-
 			localSchemaTupleCounts := map[string]int{
 				`public.testparent_1_prt_girls`: 1,
 				`public.testparent`:             1,
@@ -1957,7 +1920,6 @@ PARTITION BY LIST (gender)
 				"--backup-dir", backupDir)
 
 			assertRelationsCreated(restoreConn, 4)
-
 			localSchemaTupleCounts := map[string]int{
 				`public."CAPparent_1_prt_girls"`: 1,
 				`public."CAPparent"`:             1,
@@ -2033,9 +1995,7 @@ PARTITION BY LIST (gender)
 				"public.corrupt_table": 0,
 				"public.good_table1": 10,
 				"public.good_table2": 10})
-
 		})
-
 		It("backup and restore all data when NOT VALID option on constraints is specified", func() {
 			testutils.SkipIfBefore6(backupConn)
 			testhelper.AssertQueryRuns(backupConn,
@@ -2044,7 +2004,6 @@ PARTITION BY LIST (gender)
 				"DROP TABLE legacy_table_violate_constraints")
 			testhelper.AssertQueryRuns(backupConn,
 				"INSERT INTO legacy_table_violate_constraints values (0), (1), (2), (3), (4), (5), (6), (7)")
-
 			testhelper.AssertQueryRuns(backupConn,
 				"ALTER TABLE legacy_table_violate_constraints ADD CONSTRAINT new_constraint_not_valid CHECK (a > 4) NOT VALID")
 			defer testhelper.AssertQueryRuns(backupConn,
@@ -2067,10 +2026,8 @@ PARTITION BY LIST (gender)
 
 			_, err := restoreConn.Exec("INSERT INTO legacy_table_violate_constraints VALUES (1)")
 			Expect(err).To(HaveOccurred())
-
 			assertArtifactsCleaned(restoreConn, timestamp)
 		})
-
 		It(`ensure gprestore on corrupt backup with --on-error-continue logs error tables`, func() {
 			command := exec.Command("tar", "-xzf",
 				"resources/corrupt-db.tar.gz", "-C", backupDir)
@@ -2130,7 +2087,6 @@ PARTITION BY LIST (gender)
 			Expect(tables).To(HaveLen(len(expectedErrorTablesMetadata)))
 			_ = os.Remove(files[0])
 		})
-
 		It(`ensure successful gprestore with --on-error-continue does not log error tables`, func() {
 			// Ensure no error tables with successful restore
 			timestamp := gpbackup(gpbackupPath, backupHelperPath,
@@ -2149,7 +2105,6 @@ PARTITION BY LIST (gender)
 				"DROP SCHEMA IF EXISTS schema3 CASCADE; CREATE SCHEMA schema3;")
 			defer testhelper.AssertQueryRuns(backupConn,
 				"DROP SCHEMA schema3 CASCADE")
-
 			testhelper.AssertQueryRuns(backupConn,
 				"CREATE INDEX foo3_idx1 ON schema2.foo3(i)")
 			defer testhelper.AssertQueryRuns(backupConn,
@@ -2182,7 +2137,6 @@ PARTITION BY LIST (gender)
 				"DROP SCHEMA IF EXISTS schema3 CASCADE; CREATE SCHEMA schema3;")
 			defer testhelper.AssertQueryRuns(restoreConn,
 				"DROP SCHEMA schema3 CASCADE")
-
 			testhelper.AssertQueryRuns(backupConn,
 				"CREATE SCHEMA \"FOO\"")
 			defer testhelper.AssertQueryRuns(backupConn,
@@ -2211,6 +2165,48 @@ PARTITION BY LIST (gender)
 			}
 			assertDataRestored(restoreConn, schema3TupleCounts)
 			assertRelationsCreatedInSchema(restoreConn, "schema2", 0)
+		})
+		Describe("ACLs for extensions", func() {
+			It("runs gpbackup and gprestores any user defined ACLs on extensions", func() {
+				testutils.SkipIfBefore5(backupConn)
+				skipIfOldBackupVersionBefore("1.4.0")
+				currentUser := os.Getenv("USER")
+				testhelper.AssertQueryRuns(backupConn, "CREATE ROLE testrole")
+				defer testhelper.AssertQueryRuns(backupConn,
+					"DROP ROLE testrole")
+				testhelper.AssertQueryRuns(backupConn, "CREATE EXTENSION pgcrypto")
+				defer testhelper.AssertQueryRuns(backupConn,
+					"DROP EXTENSION pgcrypto")
+				// Create a grant on a function that belongs to the extension
+				testhelper.AssertQueryRuns(backupConn,
+					"GRANT EXECUTE ON FUNCTION gen_random_bytes(integer) to testrole WITH GRANT OPTION")
+
+				timestamp := gpbackup(gpbackupPath, backupHelperPath,
+					"--metadata-only")
+				gprestore(gprestorePath, restoreHelperPath, timestamp,
+					"--redirect-db", "restoredb")
+
+				extensionMetadata := backup.ObjectMetadata{
+					ObjectType: "FUNCTION", Privileges: []backup.ACL{
+						{Grantee: "", Execute: true},
+						{Grantee: currentUser, Execute: true},
+						{Grantee: "testrole", ExecuteWithGrant: true},
+					}, Owner: currentUser}
+
+				// Check for the corresponding grants in restored database
+				uniqueID := testutils.UniqueIDFromObjectName(restoreConn,
+					"public", "gen_random_bytes", backup.TYPE_FUNCTION)
+				resultMetadataMap := backup.GetMetadataForObjectType(restoreConn, backup.TYPE_FUNCTION)
+
+				Expect(resultMetadataMap).To(Not(BeEmpty()))
+				resultMetadata := resultMetadataMap[uniqueID]
+				match, err := structmatcher.MatchStruct(&extensionMetadata).Match(&resultMetadata)
+				Expect(err).To(Not(HaveOccurred()))
+				Expect(match).To(BeTrue())
+				// Following statement is needed in order to drop testrole
+				testhelper.AssertQueryRuns(restoreConn, "DROP EXTENSION pgcrypto")
+				assertArtifactsCleaned(restoreConn, timestamp)
+			})
 		})
 	})
 })

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -3,6 +3,9 @@ package end_to_end_test
 import (
 	"flag"
 	"fmt"
+	"github.com/greenplum-db/gp-common-go-libs/structmatcher"
+	"github.com/greenplum-db/gpbackup/backup"
+	"github.com/spf13/pflag"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -283,8 +286,13 @@ var _ = Describe("backup end to end integration tests", func() {
 		if err != nil {
 			Fail(fmt.Sprintf("Could not create restoredb: %v", err))
 		}
+		backupCmdFlags := pflag.NewFlagSet("gpbackup", pflag.ExitOnError)
+		backup.SetFlagDefaults(backupCmdFlags)
+		backup.SetCmdFlags(backupCmdFlags)
 		backupConn = testutils.SetupTestDbConn("testdb")
 		restoreConn = testutils.SetupTestDbConn("restoredb")
+		backup.InitializeMetadataParams(backupConn)
+		backup.SetFilterRelationClause("")
 		testutils.ExecuteSQLFile(backupConn, "test_tables_ddl.sql")
 		testutils.ExecuteSQLFile(backupConn, "test_tables_data.sql")
 		if useOldBackupVersion {
@@ -878,6 +886,29 @@ var _ = Describe("backup end to end integration tests", func() {
 				assertRelationsCreated(restoreConn, TOTAL_RELATIONS)
 				assertDataRestored(restoreConn, publicSchemaTupleCounts)
 				assertDataRestored(restoreConn, schema2TupleCounts)
+			})
+		})
+		Describe("ACLs for extensions", func() {
+			FIt("runs gpbackup and gprestores any user defined ACLs on extensions", func() {
+				testhelper.AssertQueryRuns(backupConn, "DROP SCHEMA IF EXISTS schema2 CASCADE; DROP SCHEMA public CASCADE; CREATE SCHEMA public;")
+				testhelper.AssertQueryRuns(backupConn, "CREATE ROLE testrole")
+				defer testhelper.AssertQueryRuns(backupConn, "DROP ROLE testrole")
+				testhelper.AssertQueryRuns(backupConn, "CREATE EXTENSION dblink")
+				defer testhelper.AssertQueryRuns(backupConn, "DROP EXTENSION dblink")
+				testhelper.AssertQueryRuns(backupConn, "GRANT EXECUTE ON FUNCTION dblink_get_pkey(text) to testrole WITH GRANT OPTION")
+				testutils.ExecuteSQLFile(backupConn, "gpdb4_objects.sql")
+
+				timestamp := gpbackup(gpbackupPath, backupHelperPath, "--metadata-only")
+				gprestore(gprestorePath, restoreHelperPath, timestamp, "--redirect-db", "restoredb")
+
+				extensionMetadata := testutils.DefaultMetadata("FUNCTION", true, true, false, false)
+				uniqueID := testutils.UniqueIDFromObjectName(restoreConn, "public", "dblink_get_pkey", backup.TYPE_FUNCTION)
+				resultMetadataMap := backup.GetMetadataForObjectType(restoreConn, backup.TYPE_FUNCTION)
+
+				Expect(resultMetadataMap).To(Not(BeEmpty()))
+				resultMetadata := resultMetadataMap[uniqueID]
+				structmatcher.ExpectStructsToMatch(&extensionMetadata, &resultMetadata)
+				assertArtifactsCleaned(restoreConn, timestamp)
 			})
 		})
 		Describe("Incremental backup", func() {

--- a/integration/predata_functions_create_test.go
+++ b/integration/predata_functions_create_test.go
@@ -433,7 +433,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			var langMetadata backup.ObjectMetadata
 			if connectionPool.Version.Before("5") {
 				langOwner = testutils.GetUserByID(connectionPool, 10)
-				langMetadata = backup.ObjectMetadata{Privileges: []backup.ACL{}, Owner: langOwner, Comment: "This is a language comment"}
+				langMetadata = backup.ObjectMetadata{ObjectType: "LANGUAGE", Privileges: []backup.ACL{}, Owner: langOwner, Comment: "This is a language comment"}
 			} else {
 				langOwner = "testrole"
 				langMetadata = testutils.DefaultMetadata("LANGUAGE", false, true, true, includeSecurityLabels)

--- a/integration/predata_relations_create_test.go
+++ b/integration/predata_relations_create_test.go
@@ -325,7 +325,7 @@ SET SUBPARTITION TEMPLATE ` + `
 		)
 		BeforeEach(func() {
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.testtable(i int)")
-			tableMetadata = backup.ObjectMetadata{Privileges: []backup.ACL{}}
+			tableMetadata = backup.ObjectMetadata{Privileges: []backup.ACL{}, ObjectType: "RELATION"}
 			testTable = backup.Table{
 				Relation:        backup.Relation{Schema: "public", Name: "testtable"},
 				TableDefinition: backup.TableDefinition{DistPolicy: "DISTRIBUTED BY (i)", ColumnDefs: []backup.ColumnDefinition{tableRow}, ExtTableDef: extTableEmpty, Inherits: []string{}},

--- a/testutils/functions.go
+++ b/testutils/functions.go
@@ -122,7 +122,22 @@ func DefaultMetadata(objType string, hasPrivileges bool, hasOwner bool, hasComme
 		securityLabelProvider = "dummy"
 		securityLabel = "unclassified"
 	}
-	return backup.ObjectMetadata{Privileges: privileges, Owner: owner, Comment: comment, SecurityLabelProvider: securityLabelProvider, SecurityLabel: securityLabel}
+	switch objType {
+	case "DOMAIN": objType = "TYPE"
+	case "FOREIGN SERVER": objType = "SERVER"
+	case "MATERIALIZED VIEW": objType = "RELATION"
+	case "SEQUENCE": objType = "RELATION"
+	case "TABLE": objType = "RELATION"
+	case "VIEW": objType = "RELATION"
+	}
+	return backup.ObjectMetadata{
+		Privileges: privileges,
+		ObjectType: objType,
+		Owner: owner,
+		Comment: comment,
+		SecurityLabelProvider: securityLabelProvider,
+		SecurityLabel: securityLabel,
+	}
 
 }
 


### PR DESCRIPTION
Currently, any grants given on functions that belong to an extension are not being backed up.

This commit allows backing up of any grants that were given on such objects.

e.g.:
```
CREATE EXTENSION IF NOT EXISTS pgcrypto ;
GRANT EXECUTE ON FUNCTION gen_random_bytes(integer) to testrole WITH GRANT OPTION;
```
Result: (added by this commit)
```
REVOKE ALL ON FUNCTION gen_random_bytes(integer) FROM PUBLIC;
REVOKE ALL ON FUNCTION gen_random_bytes(integer) FROM ljain;
GRANT ALL ON FUNCTION gen_random_bytes(integer) TO PUBLIC;
GRANT ALL ON FUNCTION gen_random_bytes(integer) TO testrole WITH GRANT OPTION;
GRANT ALL ON FUNCTION gen_random_bytes(integer) TO ljain;
```
The owner statement is not generated on purpose:
```
ALTER FUNCTION gen_random_bytes(integer OWNER TO ljain;
```