### PR TITLE
Fix AO incremental backup against GPDB 7+

### DIFF
--- a/backup/queries_incremental.go
+++ b/backup/queries_incremental.go
@@ -64,12 +64,22 @@ func getAOSegTableFQNs(connectionPool *dbconn.DBConn) map[string]string {
 }
 
 func getModCount(connectionPool *dbconn.DBConn, aosegtablefqn string) int64 {
-	query := fmt.Sprintf(`
-	SELECT COALESCE(pg_catalog.sum(modcount), 0) AS modcount FROM %s`, aosegtablefqn)
+	var modCountQuery string
+	if connectionPool.Version.AtLeast("7") {
+		// In GPDB 7+, the master no longer stores AO segment data so we must
+		// query the modcount from the segments. Unfortunately, this does give a
+		// false positive if a VACUUM FULL compaction happens on the AO table.
+		modCountQuery = fmt.Sprintf(`
+			SELECT COALESCE(pg_catalog.sum(modcount), 0) AS modcount FROM gp_dist_random('%s')`, aosegtablefqn)
+	} else {
+		modCountQuery = fmt.Sprintf(`
+			SELECT COALESCE(pg_catalog.sum(modcount), 0) AS modcount FROM %s`, aosegtablefqn)
+	}
+
 	var results []struct {
 		Modcount int64
 	}
-	err := connectionPool.Select(&results, query)
+	err := connectionPool.Select(&results, modCountQuery)
 	gplog.FatalOnError(err)
 
 	return results[0].Modcount

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -770,8 +770,10 @@ var _ = Describe("backup end to end integration tests", func() {
 				var numRows string
 				if backupConn.Version.Before("6") {
 					numRows = dbconn.MustSelectString(backupConn, "SELECT count(*) FROM gp_toolkit.__gp_aoseg_name('foobar')")
-				} else {
+				} else if backupConn.Version.Before("7") {
 					numRows = dbconn.MustSelectString(backupConn, "SELECT count(*) FROM gp_toolkit.__gp_aoseg('foobar'::regclass)")
+				} else {
+					numRows = dbconn.MustSelectString(backupConn, "SELECT count(distinct(segno)) FROM gp_toolkit.__gp_aoseg('foobar'::regclass)")
 				}
 				Expect(numRows).To(Equal(strconv.Itoa(2)))
 


### PR DESCRIPTION
In GPDB 7+, the master no longer stores AO segment data so we must
query the modcount from the segments using gp_dist_random. The summed
modcount will grow much faster now but luckily modcount is stored as a
64-bit integer so it won't be a problem. Unfortunately, false
positives can pop up if a VACUUM FULL compaction happens since that
can create new segment entries with modcount 1 but that will have to
be solved another day... possibly in GPDB itself.