### PR TITLE
Add --without-globals to gpbackup

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -125,12 +125,13 @@ func DoBackup() {
 
 	backupSessionGUC(metadataFile)
 	if !MustGetFlagBool(options.DATA_ONLY) {
-		tableOnlyBackup := true
-		if len(MustGetFlagStringArray(options.INCLUDE_RELATION)) == 0 {
-			tableOnlyBackup = false
-			backupGlobal(metadataFile)
+		isFullBackup := len(MustGetFlagStringArray(options.INCLUDE_RELATION)) == 0
+		if isFullBackup && !MustGetFlagBool(options.WITHOUT_GLOBALS) {
+			backupGlobals(metadataFile)
 		}
-		backupPredata(metadataFile, metadataTables, tableOnlyBackup)
+
+		isFilteredBackup := !isFullBackup
+		backupPredata(metadataFile, metadataTables, isFilteredBackup)
 		backupPostdata(metadataFile)
 	}
 
@@ -178,7 +179,7 @@ func DoBackup() {
 	gplog.FatalOnError(err)
 }
 
-func backupGlobal(metadataFile *utils.FileWithByteCount) {
+func backupGlobals(metadataFile *utils.FileWithByteCount) {
 	gplog.Info("Writing global database metadata")
 
 	backupResourceQueues(metadataFile)
@@ -442,4 +443,3 @@ func logCompletionMessage(msg string) {
 		gplog.Info("%s complete", msg)
 	}
 }
-

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -94,6 +94,7 @@ func NewBackupConfig(dbName string, dbVersion string, backupVersion string, plug
 		Plugin:                plugin,
 		SingleDataFile:        MustGetFlagBool(options.SINGLE_DATA_FILE),
 		Timestamp:             timestamp,
+		WithoutGlobals:        MustGetFlagBool(options.WITHOUT_GLOBALS),
 		WithStatistics:        MustGetFlagBool(options.WITH_STATS),
 	}
 

--- a/history/history.go
+++ b/history/history.go
@@ -41,6 +41,7 @@ type BackupConfig struct {
 	SingleDataFile        bool
 	Timestamp             string
 	EndTime               string
+	WithoutGlobals        bool
 	WithStatistics        bool
 }
 

--- a/options/flag.go
+++ b/options/flag.go
@@ -45,6 +45,7 @@ const (
 	WITH_GLOBALS          = "with-globals"
 	REDIRECT_SCHEMA       = "redirect-schema"
 	TRUNCATE_TABLE        = "truncate-table"
+	WITHOUT_GLOBALS       = "without-globals"
 )
 
 func SetBackupFlagDefaults(flagSet *pflag.FlagSet) {
@@ -74,6 +75,7 @@ func SetBackupFlagDefaults(flagSet *pflag.FlagSet) {
 	flagSet.Bool(SINGLE_DATA_FILE, false, "Back up all data to a single file instead of one per table")
 	flagSet.Bool(VERBOSE, false, "Print verbose log messages")
 	flagSet.Bool(WITH_STATS, false, "Back up query plan statistics")
+	flagSet.Bool(WITHOUT_GLOBALS, false, "Disable backup of global metadata")
 }
 
 func SetRestoreFlagDefaults(flagSet *pflag.FlagSet) {


### PR DESCRIPTION
Add --without-globals to gpbackup

Currently we always backup globals on full database backups.
This flag gives users the options to disable backup of globals when
backing up their database.

Co-authored-by: Kevin Yeap <kyeap@pivotal.io>
Co-authored-by: Adam Berlin <aberlin@pivotal.io>