### PR TITLE
Fix backwards compatibility job

### DIFF
--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -985,6 +985,7 @@ var _ = Describe("backup end to end integration tests", func() {
 					"--leaf-partition-data",
 					"--include-table=public.sales")
 
+				gpbackupPathOld, backupHelperPathOld := gpbackupPath, backupHelperPath
 				gpbackupPath, backupHelperPath, _ = buildAndInstallBinaries()
 
 				testhelper.AssertQueryRuns(backupConn,
@@ -995,6 +996,7 @@ var _ = Describe("backup end to end integration tests", func() {
 					"--incremental",
 					"--leaf-partition-data",
 					"--include-table=public.sales")
+				gpbackupPath, backupHelperPath = gpbackupPathOld, backupHelperPathOld
 
 				gprestore(gprestorePath, restoreHelperPath, incremental2Timestamp,
 					"--redirect-db", "restoredb")

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -2175,7 +2175,7 @@ PARTITION BY LIST (gender)
 		Describe("ACLs for extensions", func() {
 			It("runs gpbackup and gprestores any user defined ACLs on extensions", func() {
 				testutils.SkipIfBefore5(backupConn)
-				skipIfOldBackupVersionBefore("1.4.0")
+				skipIfOldBackupVersionBefore("1.17.0")
 				currentUser := os.Getenv("USER")
 				testhelper.AssertQueryRuns(backupConn, "CREATE ROLE testrole")
 				defer testhelper.AssertQueryRuns(backupConn,


### PR DESCRIPTION
Commit dump:
```
commit 2256c78fe4f5aed81daae312014cc1bbc388f309
    Skip ACL end_to_end test for backwards compatibility job

    The test expects specific ACL dumps that old gpbackup binaries will
    not be able to give since this is new logic.  Therefore, we should not
    be running this end_to_end test in the backwards compatibility job.

commit 2e430c34983e6f70ded110784f8382d79a0350fa
    Save old gpbackup path in backwards compatibility end_to_end test

    The following happens during this backwards compatibility end_to_end
    test:
    1. Take backup with old gpbackup version
    2. Swap to latest gpbackup and take an incremental backup
    3. Restore incremental backup with latest gprestore

    However, we do not swap back to the old gpbackup version at the end of
    the test.  Save the old path and reset after we're done running the
    latest gpbackup.
```