### PR TITLE
gprestore truncate flag for included tables

### DIFF
--- a/options/flag.go
+++ b/options/flag.go
@@ -44,6 +44,7 @@ const (
 	TIMESTAMP             = "timestamp"
 	WITH_GLOBALS          = "with-globals"
 	REDIRECT_SCHEMA       = "redirect-schema"
+	TRUNCATE              = "truncate"
 )
 
 /*

--- a/restore/validate.go
+++ b/restore/validate.go
@@ -258,8 +258,18 @@ func ValidateFlagCombinations(flags *pflag.FlagSet) {
 		options.INCLUDE_SCHEMA, options.INCLUDE_SCHEMA_FILE, options.INCLUDE_RELATION, options.INCLUDE_RELATION_FILE)
 	options.CheckExclusiveFlags(flags, options.METADATA_ONLY, options.DATA_ONLY)
 	options.CheckExclusiveFlags(flags, options.PLUGIN_CONFIG, options.BACKUP_DIR)
-	options.CheckExclusiveFlags(flags, options.REDIRECT_SCHEMA, options.EXCLUDE_SCHEMA, options.EXCLUDE_SCHEMA_FILE, options.EXCLUDE_RELATION, options.EXCLUDE_RELATION_FILE, options.INCLUDE_SCHEMA, options.INCLUDE_SCHEMA_FILE)
-	if flags.Changed(options.REDIRECT_SCHEMA) && !(flags.Changed(options.INCLUDE_RELATION) || flags.Changed(options.INCLUDE_RELATION_FILE)) {
+	options.CheckExclusiveFlags(flags,
+		options.TRUNCATE, options.REDIRECT_SCHEMA, options.EXCLUDE_SCHEMA, options.EXCLUDE_SCHEMA_FILE,
+		options.EXCLUDE_RELATION, options.EXCLUDE_RELATION_FILE, options.INCLUDE_SCHEMA, options.INCLUDE_SCHEMA_FILE)
+	if flags.Changed(options.REDIRECT_SCHEMA) &&
+		!(flags.Changed(options.INCLUDE_RELATION) || flags.Changed(options.INCLUDE_RELATION_FILE)) {
 		gplog.Fatal(errors.Errorf("Cannot use --redirect-schema without --include-table or --include-table-file"), "")
+	}
+	options.CheckExclusiveFlags(flags,
+		options.TRUNCATE, options.METADATA_ONLY, options.INCREMENTAL, options.REDIRECT_SCHEMA)
+	if flags.Changed(options.TRUNCATE) &&
+		!(flags.Changed(options.INCLUDE_RELATION) || flags.Changed(options.INCLUDE_RELATION_FILE)) &&
+		!flags.Changed(options.DATA_ONLY) {
+		gplog.Fatal(errors.Errorf("Cannot use --truncate without --include-table or --include-table-file and without --data-only"), "")
 	}
 }


### PR DESCRIPTION
Added a `--truncate` flag for the purpose of truncating tables
provided in the `--include-table` or `--include-table-file` prior to
restoring data. This works only with gprestore with `--data-only` mode and
`--incremental-restore` mode is not supported.

We don't expect `include-table` specifically in the scenario of restoring with truncate. Truncating serially should be fine.