### PR TITLE
Refactor unit tests to test against all GPDB versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,12 @@ lint : $(GOLANG_LINTER)
 unit : $(GINKGO)
 		$(GO_ENV) ginkgo $(GINKGO_FLAGS) $(SUBDIRS_HAS_UNIT) 2>&1
 
+unit_all_gpdb_versions : $(GINKGO)
+		TEST_GPDB_VERSION=4.3.999 $(GO_ENV) ginkgo $(GINKGO_FLAGS) $(SUBDIRS_HAS_UNIT) 2>&1
+		TEST_GPDB_VERSION=5.999.0 $(GO_ENV) ginkgo $(GINKGO_FLAGS) $(SUBDIRS_HAS_UNIT) 2>&1
+		TEST_GPDB_VERSION=6.999.0 $(GO_ENV) ginkgo $(GINKGO_FLAGS) $(SUBDIRS_HAS_UNIT) 2>&1
+		TEST_GPDB_VERSION=7.0.0 $(GO_ENV) ginkgo $(GINKGO_FLAGS) $(SUBDIRS_HAS_UNIT) 2>&1 # GPDB master
+
 integration : $(GINKGO)
 		$(GO_ENV) ginkgo $(GINKGO_FLAGS) integration 2>&1
 

--- a/backup/predata_functions_test.go
+++ b/backup/predata_functions_test.go
@@ -668,12 +668,16 @@ ALTER FUNCTION pg_catalog.plperl_validator(oid) OWNER TO testrole;`,
 				"CREATE PROCEDURAL LANGUAGE plpythonu HANDLER pg_catalog.plpython_call_handler;",
 				"ALTER FUNCTION pg_catalog.plpython_call_handler() OWNER TO testrole;",
 				"COMMENT ON LANGUAGE plpythonu IS 'This is a language comment.';",
-				"ALTER LANGUAGE plpythonu OWNER TO testrole;",
-				`REVOKE ALL ON LANGUAGE plpythonu FROM PUBLIC;
+			}
+			if connectionPool.Version.AtLeast("5") {
+				// Languages have implicit owners in 4.3, but do not support ALTER OWNER
+				expectedStatements = append(expectedStatements, "ALTER LANGUAGE plpythonu OWNER TO testrole;")
+			}
+			expectedStatements = append(expectedStatements, `REVOKE ALL ON LANGUAGE plpythonu FROM PUBLIC;
 REVOKE ALL ON LANGUAGE plpythonu FROM testrole;
 GRANT ALL ON LANGUAGE plpythonu TO testrole;`,
-				"SECURITY LABEL FOR dummy ON LANGUAGE plpythonu IS 'unclassified';",
-			}
+				"SECURITY LABEL FOR dummy ON LANGUAGE plpythonu IS 'unclassified';")
+
 			testutils.AssertBufferContents(tocfile.PredataEntries, buffer, expectedStatements...)
 		})
 		It("prints a language using a role with % in its name", func() {
@@ -687,12 +691,16 @@ GRANT ALL ON LANGUAGE plpythonu TO testrole;`,
 				"CREATE TRUSTED PROCEDURAL LANGUAGE plperl HANDLER pg_catalog.plperl_call_handler INLINE pg_catalog.plperl_inline_handler VALIDATOR pg_catalog.plperl_validator;",
 				"ALTER FUNCTION pg_catalog.plperl_call_handler() OWNER TO owner%percentage;\nALTER FUNCTION pg_catalog.plperl_inline_handler(internal) OWNER TO owner%percentage;\nALTER FUNCTION pg_catalog.plperl_validator(oid) OWNER TO owner%percentage;",
 				`COMMENT ON LANGUAGE plperl IS 'This is a language comment.';`,
-				`ALTER LANGUAGE plperl OWNER TO testrole;`,
-				`REVOKE ALL ON LANGUAGE plperl FROM PUBLIC;
+			}
+			if connectionPool.Version.AtLeast("5") {
+				// Languages have implicit owners in 4.3, but do not support ALTER OWNER
+				expectedStatements = append(expectedStatements, `ALTER LANGUAGE plperl OWNER TO testrole;`)
+			}
+			expectedStatements = append(expectedStatements, `REVOKE ALL ON LANGUAGE plperl FROM PUBLIC;
 REVOKE ALL ON LANGUAGE plperl FROM testrole;
 GRANT ALL ON LANGUAGE plperl TO testrole;`,
-				"SECURITY LABEL FOR dummy ON LANGUAGE plperl IS 'unclassified';",
-			}
+				"SECURITY LABEL FOR dummy ON LANGUAGE plperl IS 'unclassified';")
+
 			testutils.AssertBufferContents(tocfile.PredataEntries, buffer, expectedStatements...)
 		})
 	})

--- a/backup/predata_types_test.go
+++ b/backup/predata_types_test.go
@@ -1,6 +1,8 @@
 package backup_test
 
 import (
+	"fmt"
+
 	"github.com/greenplum-db/gpbackup/backup"
 	"github.com/greenplum-db/gpbackup/testutils"
 
@@ -113,28 +115,38 @@ var _ = Describe("backup/predata_types tests", func() {
 );`)
 		})
 		It("prints a base type where all optional arguments have default values where possible", func() {
+			expectedArgsReplace := ""
+			if connectionPool.Version.AtLeast("5") {
+				expectedArgsReplace = `
+	TYPMOD_IN = modin_fn,
+	TYPMOD_OUT = modout_fn,`
+			}
+
 			backup.PrintCreateBaseTypeStatement(backupfile, tocfile, basePartial, emptyMetadata)
-			testutils.AssertBufferContents(tocfile.PredataEntries, buffer, `CREATE TYPE public.base_type (
+			testutils.AssertBufferContents(tocfile.PredataEntries, buffer, fmt.Sprintf(`CREATE TYPE public.base_type (
 	INPUT = input_fn,
 	OUTPUT = output_fn,
 	RECEIVE = receive_fn,
-	SEND = send_fn,
-	TYPMOD_IN = modin_fn,
-	TYPMOD_OUT = modout_fn,
+	SEND = send_fn,%s
 	DEFAULT = '42',
 	ELEMENT = int4,
 	DELIMITER = ','
-);`)
+);`, expectedArgsReplace))
 		})
 		It("prints a base type with all optional arguments provided", func() {
+			expectedArgsReplace := ""
+			if connectionPool.Version.AtLeast("5") {
+				expectedArgsReplace = `
+	TYPMOD_IN = modin_fn,
+	TYPMOD_OUT = modout_fn,`
+			}
+
 			backup.PrintCreateBaseTypeStatement(backupfile, tocfile, baseFull, emptyMetadata)
-			testutils.AssertBufferContents(tocfile.PredataEntries, buffer, `CREATE TYPE public.base_type (
+			testutils.AssertBufferContents(tocfile.PredataEntries, buffer, fmt.Sprintf(`CREATE TYPE public.base_type (
 	INPUT = input_fn,
 	OUTPUT = output_fn,
 	RECEIVE = receive_fn,
-	SEND = send_fn,
-	TYPMOD_IN = modin_fn,
-	TYPMOD_OUT = modout_fn,
+	SEND = send_fn,%s
 	INTERNALLENGTH = 16,
 	PASSEDBYVALUE,
 	ALIGNMENT = int2,
@@ -148,7 +160,7 @@ var _ = Describe("backup/predata_types tests", func() {
 );
 
 ALTER TYPE public.base_type
-	SET DEFAULT ENCODING (compresstype=zlib, compresslevel=1, blocksize=32768);`)
+	SET DEFAULT ENCODING (compresstype=zlib, compresslevel=1, blocksize=32768);`, expectedArgsReplace))
 		})
 		It("prints a base type with double alignment and main storage", func() {
 			backup.PrintCreateBaseTypeStatement(backupfile, tocfile, basePermOne, emptyMetadata)

--- a/ci/scripts/all-tests.bash
+++ b/ci/scripts/all-tests.bash
@@ -5,7 +5,8 @@ set -ex
 # setup cluster and install gpbackup tools using gppkg
 ccp_src/scripts/setup_ssh_to_cluster.sh
 out=$(ssh -t mdw 'source env.sh && psql postgres -c "select version();"')
-GPDB_VERSION=$(echo ${out} | sed -n 's/.*Greenplum Database \([0-9]\).*/\1/p')
+TEST_GPDB_VERSION=$(echo ${out} | sed -n 's/.*Greenplum Database \([0-9].[0-9]\+.[0-9]\+\).*/\1/p')
+GPDB_VERSION=$(echo ${TEST_GPDB_VERSION} | head -c 1)
 mkdir -p /tmp/untarred
 tar -xzf gppkgs/gpbackup-gppkgs.tar.gz -C /tmp/untarred
 scp /tmp/untarred/gpbackup_tools*gp${GPDB_VERSION}*RHEL*.gppkg mdw:/home/gpadmin
@@ -26,6 +27,9 @@ cat <<SCRIPT > /tmp/run_tests.bash
 
   cd \${GOPATH}/src/github.com/greenplum-db/gpbackup
   export OLD_BACKUP_VERSION="${GPBACKUP_VERSION}"
+
+  # Set the GPDB version to use for the unit tests
+  export TEST_GPDB_VERSION=${TEST_GPDB_VERSION}
 
   make unit integration
 

--- a/ci/scripts/test-on-local-cluster.bash
+++ b/ci/scripts/test-on-local-cluster.bash
@@ -55,6 +55,9 @@ out=\$(psql postgres -c "select version();")
 GPDB_VERSION=\$(echo \$out | sed -n 's/.*Greenplum Database \([0-9]\).*/\1/p')
 gppkg -i /tmp/untarred/gpbackup*gp\${GPDB_VERSION}*${OS}*.gppkg
 
+# Get the GPDB version to use for the unit tests
+export TEST_GPDB_VERSION=\$(echo \$out | sed -n 's/.*Greenplum Database \([0-9].[0-9]\+.[0-9]\+\).*/\1/p')
+
 # Test gpbackup
 pushd \${GOPATH}/src/github.com/greenplum-db/gpbackup
   make unit integration end_to_end

--- a/restore/wrappers_test.go
+++ b/restore/wrappers_test.go
@@ -151,7 +151,7 @@ backupconfigs:
   backupversion: 1.11.0+dev.28.g10571fd
   compressed: false
   databasename: plugin_test_db
-  databaseversion: 5.15.0+dev.18.gb29642fb22 build dev
+  databaseversion: 4.3.99.0+dev.18.gb29642fb22 build dev
   dataonly: false
   deleted: false
   excluderelations: []
@@ -177,7 +177,7 @@ backupconfigs:
   backupversion: 1.11.0+dev.28.g10571fd
   compressed: false
   databasename: plugin_test_db
-  databaseversion: 5.15.0+dev.18.gb29642fb22 build dev
+  databaseversion: 4.3.99.0+dev.18.gb29642fb22 build dev
   dataonly: false
   deleted: false
   excluderelations: []
@@ -207,7 +207,7 @@ backupdir: ""
 backupversion: 1.11.0+dev.28.g10571fd
 compressed: false
 databasename: plugin_test_db
-databaseversion: 5.15.0+dev.18.gb29642fb22 build dev
+databaseversion: 4.3.99.0+dev.18.gb29642fb22 build dev
 dataonly: false
 deleted: false
 excluderelations: []

--- a/testutils/functions.go
+++ b/testutils/functions.go
@@ -3,6 +3,7 @@ package testutils
 import (
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -29,6 +30,13 @@ import (
 
 func SetupTestEnvironment() (*dbconn.DBConn, sqlmock.Sqlmock, *Buffer, *Buffer, *Buffer) {
 	connectionPool, mock, testStdout, testStderr, testLogfile := testhelper.SetupTestEnvironment()
+
+	// Default if not set is GPDB version `5.1.0`
+	envTestGpdbVersion := os.Getenv("TEST_GPDB_VERSION")
+	if (envTestGpdbVersion != "") {
+		testhelper.SetDBVersion(connectionPool, envTestGpdbVersion)
+	}
+
 	SetupTestCluster()
 	backup.SetVersion("0.1.0")
 	return connectionPool, mock, testStdout, testStderr, testLogfile

--- a/utils/gpexpand_sensor_test.go
+++ b/utils/gpexpand_sensor_test.go
@@ -27,9 +27,11 @@ var _ = Describe("gpexpand_sensor", func() {
 		memoryfs = memfs.Create()
 		mddPathRow = sqlmock.NewRows([]string{"datadir"}).AddRow(sampleMasterDataDir)
 		tableExistsRow = sqlmock.NewRows([]string{"relname"}).AddRow("some table name")
-		// simulate that database connection is to postgres database, with Greenplum 6+
 		connectionPool.DBName = "postgres"
-		testhelper.SetDBVersion(connectionPool, "6.0.0")
+
+		if connectionPool.Version.Before("6") {
+			Skip("gpexpand sensor only runs against GPDB 6+")
+		}
 	})
 	Context("IsGpexpandRunning", func() {
 		Describe("happy path", func() {

--- a/utils/utils_suite_test.go
+++ b/utils/utils_suite_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
+	"github.com/greenplum-db/gpbackup/testutils"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -26,6 +26,6 @@ func TestUtils(t *testing.T) {
 }
 
 var _ = BeforeEach(func() {
-	connectionPool, mock, stdout, _, logfile = testhelper.SetupTestEnvironment()
+	connectionPool, mock, stdout, _, logfile = testutils.SetupTestEnvironment()
 	buffer = NewBuffer()
 })


### PR DESCRIPTION
The unit tests were all hardcoded to GPDB 5.1.0 (done from the
gp-common-go-libs library) which made test confidence a bit
shakey. There were a lot of duplicate test code as well to test GPDB
version-specific changes. Also, it was a bit weird to run unit tests
in the pipeline jobs since the jobs were GPDB version-specific yet the
unit tests were exactly the same across each job.

To make sure we do not miss any unit test coverage against any version
of GPDB, we introduce an environment variable TEST_GPDB_VERSION that
will make the unit tests run against that specific GPDB version. All
duplicate unit tests have been consolidated into one with GPDB
version-specific logic for the expected outputs. A new Makefile target
`unit_all_gpdb_versions` has been added to make it easier for
developers to run. We keep the original `unit` target to make it
easier to integrate this change into the current pipeline.