### PR TITLE
Fix that DeletePluginConfigWhenEncrypting can't remove plugin config

### DIFF
--- a/utils/plugin.go
+++ b/utils/plugin.go
@@ -328,7 +328,7 @@ func (plugin *PluginConfig) DeletePluginConfigWhenEncrypting(c *cluster.Cluster)
 			//hostConfigFile := plugin.createHostPluginConfig(contentIDForSegmentOnHost, c)
 			return command
 		},
-		cluster.ON_MASTER_TO_HOSTS_AND_MASTER,
+		cluster.ON_HOSTS_AND_MASTER,
 	)
 	gplog.Debug("%s", command)
 	errMsg := "Unable to remove plugin config"

--- a/utils/plugin_test.go
+++ b/utils/plugin_test.go
@@ -303,8 +303,9 @@ options:
 				cc := executor.ClusterCommands[0]
 				Expect(len(cc)).To(Equal(3))
 				Expect(cc[-1][2]).To(Equal("rm -f /tmp/my_plugin_config.yaml"))
-				Expect(cc[0][2]).To(Equal("rm -f /tmp/my_plugin_config.yaml"))
-				Expect(cc[1][2]).To(Equal("rm -f /tmp/my_plugin_config.yaml"))
+				Expect(cc[0][0]).To(Equal("ssh"))
+				Expect(cc[0][4]).To(Equal("rm -f /tmp/my_plugin_config.yaml"))
+				Expect(cc[1][4]).To(Equal("rm -f /tmp/my_plugin_config.yaml"))
 			})
 		})
 		When("config does not have encryption", func() {


### PR DESCRIPTION
We should use `ON_HOSTS_AND_MASTER` to remove the plugin config on ALL segment hosts.

Does it?