### PR TITLE
Refactor sequences (simplify workflow)

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -226,12 +226,10 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Table, tableO
 	}
 
 	retrieveViews(&objects)
-	sequences, sequenceOwnerColumns := retrieveSequences()
-	backupCreateSequences(metadataFile, sequences, relationMetadata)
+	sequences := retrieveAndBackupSequences(metadataFile, relationMetadata)
 	constraints, conMetadata := retrieveConstraints()
 
-	backupDependentObjects(metadataFile, tables, protocols, metadataMap, constraints, objects, funcInfoMap, tableOnly)
-	PrintAlterSequenceStatements(metadataFile, globalTOC, sequences, sequenceOwnerColumns)
+	backupDependentObjects(metadataFile, tables, protocols, metadataMap, constraints, objects, sequences, funcInfoMap, tableOnly)
 
 	backupConversions(metadataFile)
 	backupConstraints(metadataFile, constraints, conMetadata)

--- a/backup/predata_relations_other_test.go
+++ b/backup/predata_relations_other_test.go
@@ -20,14 +20,14 @@ var _ = Describe("backup/predata_relations tests", func() {
 	})
 	Describe("PrintCreateSequenceStatements", func() {
 		baseSequence := backup.Relation{SchemaOid: 0, Oid: 1, Schema: "public", Name: "seq_name"}
-		seqDefault := backup.Sequence{Relation: baseSequence, SequenceDefinition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: true}}
-		seqNegIncr := backup.Sequence{Relation: baseSequence, SequenceDefinition: backup.SequenceDefinition{LastVal: 7, Increment: -1, MaxVal: -1, MinVal: math.MinInt64, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: true}}
-		seqMaxPos := backup.Sequence{Relation: baseSequence, SequenceDefinition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: 100, MinVal: 1, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: true}}
-		seqMinPos := backup.Sequence{Relation: baseSequence, SequenceDefinition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: math.MaxInt64, MinVal: 10, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: true}}
-		seqMaxNeg := backup.Sequence{Relation: baseSequence, SequenceDefinition: backup.SequenceDefinition{LastVal: 7, Increment: -1, MaxVal: -10, MinVal: math.MinInt64, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: true}}
-		seqMinNeg := backup.Sequence{Relation: baseSequence, SequenceDefinition: backup.SequenceDefinition{LastVal: 7, Increment: -1, MaxVal: -1, MinVal: -100, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: true}}
-		seqCycle := backup.Sequence{Relation: baseSequence, SequenceDefinition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 5, LogCnt: 42, IsCycled: true, IsCalled: true}}
-		seqStart := backup.Sequence{Relation: baseSequence, SequenceDefinition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: false}}
+		seqDefault := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: true}}
+		seqNegIncr := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: -1, MaxVal: -1, MinVal: math.MinInt64, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: true}}
+		seqMaxPos := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: 100, MinVal: 1, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: true}}
+		seqMinPos := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: math.MaxInt64, MinVal: 10, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: true}}
+		seqMaxNeg := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: -1, MaxVal: -10, MinVal: math.MinInt64, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: true}}
+		seqMinNeg := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: -1, MaxVal: -1, MinVal: -100, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: true}}
+		seqCycle := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 5, LogCnt: 42, IsCycled: true, IsCalled: true}}
+		seqStart := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: false}}
 		emptySequenceMetadataMap := backup.MetadataMap{}
 
 		It("can print a sequence with all default options", func() {
@@ -123,7 +123,7 @@ SELECT pg_catalog.setval('public.seq_name', 7, false);`)
 		})
 		It("escapes a sequence containing single quotes", func() {
 			baseSequenceWithQuote := backup.Relation{SchemaOid: 0, Oid: 1, Schema: "public", Name: "seq_'name"}
-			seqWithQuote := backup.Sequence{Relation: baseSequenceWithQuote, SequenceDefinition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: true}}
+			seqWithQuote := backup.Sequence{Relation: baseSequenceWithQuote, Definition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: true}}
 			sequences := []backup.Sequence{seqWithQuote}
 			backup.PrintCreateSequenceStatements(backupfile, tocfile, sequences, emptySequenceMetadataMap)
 			testutils.AssertBufferContents(tocfile.PredataEntries, buffer, `CREATE SEQUENCE public.seq_'name
@@ -252,25 +252,18 @@ GRANT ALL ON shamwow.shazam TO testrole;`,
 	})
 	Describe("PrintAlterSequenceStatements", func() {
 		baseSequence := backup.Relation{Schema: "public", Name: "seq_name"}
-		seqDefault := backup.Sequence{Relation: baseSequence, SequenceDefinition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: true}}
-		emptyColumnOwnerMap := make(map[string]string)
+		seqDefault := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: true}}
 		It("prints nothing for a sequence without an owning column", func() {
+			seqDefault.OwningColumn = ""
 			sequences := []backup.Sequence{seqDefault}
-			backup.PrintAlterSequenceStatements(backupfile, tocfile, sequences, emptyColumnOwnerMap)
-			Expect(tocfile.PredataEntries).To(BeEmpty())
-			testhelper.NotExpectRegexp(buffer, `ALTER SEQUENCE`)
-		})
-		It("does not write an alter sequence statement for a sequence that is not in the backup", func() {
-			columnOwnerMap := map[string]string{"public.seq_name2": "public.tablename.col_one"}
-			sequences := []backup.Sequence{seqDefault}
-			backup.PrintAlterSequenceStatements(backupfile, tocfile, sequences, columnOwnerMap)
+			backup.PrintAlterSequenceStatements(backupfile, tocfile, sequences)
 			Expect(tocfile.PredataEntries).To(BeEmpty())
 			testhelper.NotExpectRegexp(buffer, `ALTER SEQUENCE`)
 		})
 		It("can print an ALTER SEQUENCE statement for a sequence with an owning column", func() {
-			columnOwnerMap := map[string]string{"public.seq_name": "public.tablename.col_one"}
+			seqDefault.OwningColumn = "public.tablename.col_one"
 			sequences := []backup.Sequence{seqDefault}
-			backup.PrintAlterSequenceStatements(backupfile, tocfile, sequences, columnOwnerMap)
+			backup.PrintAlterSequenceStatements(backupfile, tocfile, sequences)
 			testutils.ExpectEntry(tocfile.PredataEntries, 0, "public", "", "seq_name", "SEQUENCE OWNER")
 			testutils.AssertBufferContents(tocfile.PredataEntries, buffer, `ALTER SEQUENCE public.seq_name OWNED BY public.tablename.col_one;`)
 		})

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -217,11 +217,13 @@ func retrieveConstraints(tables ...Relation) ([]Constraint, MetadataMap) {
 	return constraints, conMetadata
 }
 
-func retrieveSequences() ([]Sequence, map[string]string) {
-	gplog.Verbose("Retrieving sequences")
-	sequenceOwnerTables, sequenceOwnerColumns := GetSequenceColumnOwnerMap(connectionPool)
-	sequences := GetAllSequences(connectionPool, sequenceOwnerTables)
-	return sequences, sequenceOwnerColumns
+func retrieveAndBackupSequences(metadataFile *utils.FileWithByteCount,
+	relationMetadata MetadataMap) []Sequence {
+	gplog.Verbose("Writing CREATE SEQUENCE statements to metadata file")
+	sequences := GetAllSequences(connectionPool)
+	objectCounts["Sequences"] = len(sequences)
+	PrintCreateSequenceStatements(metadataFile, globalTOC, sequences, relationMetadata)
+	return sequences
 }
 
 func retrieveProtocols(sortables *[]Sortable, metadataMap MetadataMap) []ExternalProtocol {
@@ -489,12 +491,6 @@ func backupEnumTypes(metadataFile *utils.FileWithByteCount, typeMetadata Metadat
 	PrintCreateEnumTypeStatements(metadataFile, globalTOC, enums, typeMetadata)
 }
 
-func backupCreateSequences(metadataFile *utils.FileWithByteCount, sequences []Sequence, relationMetadata MetadataMap) {
-	gplog.Verbose("Writing CREATE SEQUENCE statements to metadata file")
-	objectCounts["Sequences"] = len(sequences)
-	PrintCreateSequenceStatements(metadataFile, globalTOC, sequences, relationMetadata)
-}
-
 func createBackupSet(objSlice []Sortable) (backupSet map[UniqueID]bool) {
 	backupSet = make(map[UniqueID]bool)
 	for _, obj := range objSlice {
@@ -531,7 +527,7 @@ func addToMetadataMap(newMetadata MetadataMap, metadataMap MetadataMap) {
 // This function is fairly unwieldy, but there's not really a good way to break it down
 func backupDependentObjects(metadataFile *utils.FileWithByteCount, tables []Table,
 	protocols []ExternalProtocol, filteredMetadata MetadataMap, constraints []Constraint,
-	sortables []Sortable, funcInfoMap map[uint32]FunctionInfo, tableOnly bool) {
+	sortables []Sortable, sequences []Sequence, funcInfoMap map[uint32]FunctionInfo, tableOnly bool) {
 
 	gplog.Verbose("Writing CREATE statements for dependent objects to metadata file")
 
@@ -543,6 +539,7 @@ func backupDependentObjects(metadataFile *utils.FileWithByteCount, tables []Tabl
 	sortedSlice := TopologicalSort(sortables, relevantDeps)
 
 	PrintDependentObjectStatements(metadataFile, globalTOC, sortedSlice, filteredMetadata, constraints, funcInfoMap)
+	PrintAlterSequenceStatements(metadataFile, globalTOC, sequences)
 	extPartInfo, partInfoMap := GetExternalPartitionInfo(connectionPool)
 	if len(extPartInfo) > 0 {
 		gplog.Verbose("Writing EXCHANGE PARTITION statements to metadata file")

--- a/integration/predata_relations_queries_test.go
+++ b/integration/predata_relations_queries_test.go
@@ -93,7 +93,7 @@ PARTITION BY LIST (gender)
 			tableFoo := backup.Relation{Schema: "testschema", Name: "foo"}
 
 			Expect(tables).To(HaveLen(1))
-			structmatcher.ExpectStructsToMatchExcluding(&tableFoo, &tables[0], "SchemaOid", "Oid")
+			structmatcher.ExpectStructsToMatchIncluding(&tableFoo, &tables[0], "Name", "Schema")
 		})
 		It("returns user table information for tables in includeTables", func() {
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.foo(i int)")
@@ -111,7 +111,7 @@ PARTITION BY LIST (gender)
 			tableFoo := backup.Relation{Schema: "testschema", Name: "foo"}
 
 			Expect(tables).To(HaveLen(1))
-			structmatcher.ExpectStructsToMatchExcluding(&tableFoo, &tables[0], "SchemaOid", "Oid")
+			structmatcher.ExpectStructsToMatchIncluding(&tableFoo, &tables[0], "Name", "Schema")
 		})
 		It("returns user table information for tables not in excludeTables", func() {
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.foo(i int)")
@@ -127,7 +127,7 @@ PARTITION BY LIST (gender)
 			tableFoo := backup.Relation{Schema: "public", Name: "foo"}
 
 			Expect(tables).To(HaveLen(1))
-			structmatcher.ExpectStructsToMatchExcluding(&tableFoo, &tables[0], "SchemaOid", "Oid")
+			structmatcher.ExpectStructsToMatchIncluding(&tableFoo, &tables[0], "Name", "Schema")
 		})
 		It("returns user table information for tables in includeSchema but not in excludeTables", func() {
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.foo(i int)")
@@ -145,7 +145,7 @@ PARTITION BY LIST (gender)
 
 			tableFoo := backup.Relation{Schema: "testschema", Name: "bar"}
 			Expect(tables).To(HaveLen(1))
-			structmatcher.ExpectStructsToMatchExcluding(&tableFoo, &tables[0], "SchemaOid", "Oid")
+			structmatcher.ExpectStructsToMatchIncluding(&tableFoo, &tables[0], "Name", "Schema")
 		})
 		It("returns user table information for tables even with an non existent excludeTable", func() {
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.foo(i int)")
@@ -157,7 +157,7 @@ PARTITION BY LIST (gender)
 			tableFoo := backup.Relation{Schema: "public", Name: "foo"}
 
 			Expect(tables).To(HaveLen(1))
-			structmatcher.ExpectStructsToMatchExcluding(&tableFoo, &tables[0], "SchemaOid", "Oid")
+			structmatcher.ExpectStructsToMatchIncluding(&tableFoo, &tables[0], "Name", "Schema")
 		})
 	})
 	Describe("GetAllSequenceRelations", func() {
@@ -170,14 +170,14 @@ PARTITION BY LIST (gender)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP SCHEMA testschema CASCADE")
 			testhelper.AssertQueryRuns(connectionPool, "CREATE SEQUENCE testschema.my_sequence2")
 
-			sequences := backup.GetAllSequenceRelations(connectionPool)
+			sequences := backup.GetAllSequences(connectionPool)
 
 			mySequence := backup.Relation{Schema: "public", Name: "my_sequence"}
 			mySequence2 := backup.Relation{Schema: "testschema", Name: "my_sequence2"}
 
 			Expect(sequences).To(HaveLen(2))
-			structmatcher.ExpectStructsToMatchExcluding(&mySequence, &sequences[0], "SchemaOid", "Oid")
-			structmatcher.ExpectStructsToMatchExcluding(&mySequence2, &sequences[1], "SchemaOid", "Oid")
+			structmatcher.ExpectStructsToMatchIncluding(&mySequence, &sequences[0], "Name", "Schema")
+			structmatcher.ExpectStructsToMatchIncluding(&mySequence2, &sequences[1], "Name", "Schema")
 		})
 		It("returns a slice of all sequences in a specific schema", func() {
 			testhelper.AssertQueryRuns(connectionPool, "CREATE SEQUENCE public.my_sequence START 10")
@@ -189,10 +189,10 @@ PARTITION BY LIST (gender)
 			mySequence := backup.Relation{Schema: "testschema", Name: "my_sequence"}
 
 			_ = backupCmdFlags.Set(options.INCLUDE_SCHEMA, "testschema")
-			sequences := backup.GetAllSequenceRelations(connectionPool)
+			sequences := backup.GetAllSequences(connectionPool)
 
 			Expect(sequences).To(HaveLen(1))
-			structmatcher.ExpectStructsToMatchExcluding(&mySequence, &sequences[0], "SchemaOid", "Oid")
+			structmatcher.ExpectStructsToMatchIncluding(&mySequence, &sequences[0], "Name", "Schema")
 		})
 		It("does not return sequences owned by included tables", func() {
 			testhelper.AssertQueryRuns(connectionPool, "CREATE SEQUENCE public.my_sequence START 10")
@@ -202,7 +202,7 @@ PARTITION BY LIST (gender)
 			testhelper.AssertQueryRuns(connectionPool, "ALTER SEQUENCE public.my_sequence OWNED BY public.seq_table.i")
 			_ = backupCmdFlags.Set(options.INCLUDE_RELATION, "public.seq_table")
 
-			sequences := backup.GetAllSequenceRelations(connectionPool)
+			sequences := backup.GetAllSequences(connectionPool)
 
 			Expect(sequences).To(BeEmpty())
 		})
@@ -215,10 +215,10 @@ PARTITION BY LIST (gender)
 			mySequence := backup.Relation{Schema: "public", Name: "my_sequence"}
 
 			_ = backupCmdFlags.Set(options.EXCLUDE_RELATION, "public.seq_table")
-			sequences := backup.GetAllSequenceRelations(connectionPool)
+			sequences := backup.GetAllSequences(connectionPool)
 
 			Expect(sequences).To(HaveLen(1))
-			structmatcher.ExpectStructsToMatchExcluding(&mySequence, &sequences[0], "SchemaOid", "Oid")
+			structmatcher.ExpectStructsToMatchIncluding(&mySequence, &sequences[0], "Name", "Schema")
 		})
 		It("does not return an excluded sequence", func() {
 			testhelper.AssertQueryRuns(connectionPool, "CREATE SEQUENCE public.sequence1 START 10")
@@ -229,10 +229,10 @@ PARTITION BY LIST (gender)
 			sequence2 := backup.Relation{Schema: "public", Name: "sequence2"}
 
 			_ = backupCmdFlags.Set(options.EXCLUDE_RELATION, "public.sequence1")
-			sequences := backup.GetAllSequenceRelations(connectionPool)
+			sequences := backup.GetAllSequences(connectionPool)
 
 			Expect(sequences).To(HaveLen(1))
-			structmatcher.ExpectStructsToMatchExcluding(&sequence2, &sequences[0], "SchemaOid", "Oid")
+			structmatcher.ExpectStructsToMatchIncluding(&sequence2, &sequences[0], "Name", "Schema")
 		})
 		It("returns only the included sequence", func() {
 			testhelper.AssertQueryRuns(connectionPool, "CREATE SEQUENCE public.sequence1 START 10")
@@ -243,10 +243,10 @@ PARTITION BY LIST (gender)
 			sequence1 := backup.Relation{Schema: "public", Name: "sequence1"}
 			_ = backupCmdFlags.Set(options.INCLUDE_RELATION, "public.sequence1")
 
-			sequences := backup.GetAllSequenceRelations(connectionPool)
+			sequences := backup.GetAllSequences(connectionPool)
 
 			Expect(sequences).To(HaveLen(1))
-			structmatcher.ExpectStructsToMatchExcluding(&sequence1, &sequences[0], "SchemaOid", "Oid")
+			structmatcher.ExpectStructsToMatchIncluding(&sequence1, &sequences[0], "Name", "Schema")
 		})
 	})
 	Describe("GetSequenceDefinition", func() {
@@ -290,7 +290,7 @@ PARTITION BY LIST (gender)
 			structmatcher.ExpectStructsToMatch(&expectedSequence, &resultSequenceDef)
 		})
 	})
-	Describe("GetSequenceOwnerMap", func() {
+	Describe("Get sequence owner information", func() {
 		It("returns sequence information for sequences owned by columns", func() {
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.without_sequence(a int, b char(20));")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.without_sequence")
@@ -299,12 +299,11 @@ PARTITION BY LIST (gender)
 			testhelper.AssertQueryRuns(connectionPool, "CREATE SEQUENCE public.my_sequence OWNED BY public.with_sequence.a;")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP SEQUENCE public.my_sequence")
 
-			sequenceOwnerTables, sequenceOwnerColumns := backup.GetSequenceColumnOwnerMap(connectionPool)
+			sequences := backup.GetAllSequences(connectionPool)
 
-			Expect(sequenceOwnerTables).To(HaveLen(1))
-			Expect(sequenceOwnerColumns).To(HaveLen(1))
-			Expect(sequenceOwnerTables["public.my_sequence"]).To(Equal("public.with_sequence"))
-			Expect(sequenceOwnerColumns["public.my_sequence"]).To(Equal("public.with_sequence.a"))
+			Expect(sequences).To(HaveLen(1))
+			Expect(sequences[0].OwningTable).To(Equal("public.with_sequence"))
+			Expect(sequences[0].OwningColumn).To(Equal("public.with_sequence.a"))
 		})
 		It("does not return sequence owner columns if the owning table is not backed up", func() {
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.my_table(a int, b char(20));")
@@ -313,11 +312,11 @@ PARTITION BY LIST (gender)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP SEQUENCE public.my_sequence")
 
 			_ = backupCmdFlags.Set(options.EXCLUDE_RELATION, "public.my_table")
-			sequenceOwnerTables, sequenceOwnerColumns := backup.GetSequenceColumnOwnerMap(connectionPool)
+			sequences := backup.GetAllSequences(connectionPool)
 
-			Expect(sequenceOwnerTables).To(BeEmpty())
-			Expect(sequenceOwnerColumns).To(BeEmpty())
-
+			Expect(sequences).To(HaveLen(1))
+			Expect(sequences[0].OwningTable).To(Equal(""))
+			Expect(sequences[0].OwningColumn).To(Equal(""))
 		})
 		It("returns sequence owner if both table and sequence are backed up", func() {
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.my_table(a int, b char(20));")
@@ -327,9 +326,11 @@ PARTITION BY LIST (gender)
 
 			_ = backupCmdFlags.Set(options.INCLUDE_RELATION, "public.my_sequence")
 			_ = backupCmdFlags.Set(options.INCLUDE_RELATION, "public.my_table")
-			sequenceOwnerTables, sequenceOwnerColumns := backup.GetSequenceColumnOwnerMap(connectionPool)
-			Expect(sequenceOwnerTables).To(HaveLen(1))
-			Expect(sequenceOwnerColumns).To(HaveLen(1))
+			sequences := backup.GetAllSequences(connectionPool)
+
+			Expect(sequences).To(HaveLen(1))
+			Expect(sequences[0].OwningTable).To(Equal("public.my_table"))
+			Expect(sequences[0].OwningColumn).To(Equal("public.my_table.a"))
 		})
 		It("returns sequence owner if only the table is backed up", func() {
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.my_table(a int, b char(20));")
@@ -338,9 +339,8 @@ PARTITION BY LIST (gender)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP SEQUENCE public.my_sequence")
 
 			_ = backupCmdFlags.Set(options.INCLUDE_RELATION, "public.my_table")
-			sequenceOwnerTables, sequenceOwnerColumns := backup.GetSequenceColumnOwnerMap(connectionPool)
-			Expect(sequenceOwnerTables).To(HaveLen(1))
-			Expect(sequenceOwnerColumns).To(HaveLen(1))
+			sequences := backup.GetAllSequences(connectionPool)
+			Expect(sequences).To(HaveLen(0))
 		})
 	})
 	Describe("GetAllSequences", func() {
@@ -368,12 +368,12 @@ PARTITION BY LIST (gender)
 				seqTwoDef.LogCnt = 1
 			}
 
-			results := backup.GetAllSequences(connectionPool, map[string]string{})
+			results := backup.GetAllSequences(connectionPool)
 
 			structmatcher.ExpectStructsToMatchExcluding(&seqOneRelation, &results[0].Relation, "SchemaOid", "Oid")
-			structmatcher.ExpectStructsToMatchExcluding(&seqOneDef, &results[0].SequenceDefinition)
+			structmatcher.ExpectStructsToMatchExcluding(&seqOneDef, &results[0].Definition)
 			structmatcher.ExpectStructsToMatchExcluding(&seqTwoRelation, &results[1].Relation, "SchemaOid", "Oid")
-			structmatcher.ExpectStructsToMatchExcluding(&seqTwoDef, &results[1].SequenceDefinition)
+			structmatcher.ExpectStructsToMatchExcluding(&seqTwoDef, &results[1].Definition)
 		})
 	})
 	Describe("GetAllViews", func() {


### PR DESCRIPTION
Here is a branch that I worked on last week. Opening a PR so it does not become lost/stale

* Got rid of `GetSequenceColumnOwnerMap`