### PR TITLE
Sets gp_autostats_mode to none when restore data

### DIFF
--- a/restore/data.go
+++ b/restore/data.go
@@ -121,6 +121,16 @@ func restoreDataFromTimestamp(fpInfo filepath.FilePathInfo, dataEntries []toc.Ma
 		workerPool.Add(1)
 		go func(whichConn int) {
 			defer workerPool.Done()
+			if MustGetFlagBool(options.WITH_STATS) && backupConfig.WithStatistics {
+				disableAutoStatsForSession := toc.StatementWithType{
+					Schema:          "",
+					Name:            "",
+					ObjectType:      "SESSION",
+					ReferenceObject: "",
+					Statement:       "SET gp_autostats_mode='none';",
+				}
+				gucStatements = append(gucStatements, disableAutoStatsForSession)
+			}
 			setGUCsForConnection(gucStatements, whichConn)
 			for entry := range tasks {
 				if wasTerminated {

--- a/toc/toc.go
+++ b/toc/toc.go
@@ -160,8 +160,8 @@ func shouldIncludeStatement(entry MetadataEntry, objectSet *utils.FilterSet, sch
 	shouldIncludeObject := objectSet.MatchesFilter(entry.ObjectType)
 	shouldIncludeSchema := schemaSet.MatchesFilter(entry.Schema)
 	relationFQN := utils.MakeFQN(entry.Schema, entry.Name)
-	shouldIncludeRelation := (relationSet.IsExclude && entry.ObjectType != "TABLE" && entry.ObjectType != "VIEW" && entry.ObjectType != "MATERIALIZED VIEW" && entry.ObjectType != "SEQUENCE" && entry.ReferenceObject == "") ||
-		((entry.ObjectType == "TABLE" || entry.ObjectType == "VIEW" || entry.ObjectType == "MATERIALIZED VIEW" || entry.ObjectType == "SEQUENCE") && relationSet.MatchesFilter(relationFQN) && entry.ReferenceObject == "") || // Relations should match the filter
+	shouldIncludeRelation := (relationSet.IsExclude && entry.ObjectType != "TABLE" && entry.ObjectType != "VIEW" && entry.ObjectType != "MATERIALIZED VIEW" && entry.ObjectType != "SEQUENCE" && entry.ObjectType != "STATISTICS" && entry.ReferenceObject == "") ||
+		((entry.ObjectType == "TABLE" || entry.ObjectType == "VIEW" || entry.ObjectType == "MATERIALIZED VIEW" || entry.ObjectType == "SEQUENCE" || entry.ObjectType == "STATISTICS") && relationSet.MatchesFilter(relationFQN) && entry.ReferenceObject == "") || // Relations should match the filter
 		(entry.ObjectType != "SEQUENCE OWNER" && entry.ReferenceObject != "" && relationSet.MatchesFilter(entry.ReferenceObject)) || // Include relations that filtered tables depend on
 		(entry.ObjectType == "SEQUENCE OWNER" && relationSet.MatchesFilter(relationFQN) && relationSet.MatchesFilter(entry.ReferenceObject)) //Include sequence owners if both table and sequence are being restored
 


### PR DESCRIPTION
 - By default gp_autostats_mode GUC is set to
   on_no_stats, that means that ANALYSE will
   run every time we insert data. It can slow
   down restore, so we need to set it to none
   before restore data to desable ANALYZE while
   restoring
 - Turns out that autostat covered --redirect-schema
   bug and we had false-positive on --redirect-schema
   end_to_end test while actual statistics was
   not redirected. It happened because of two things:
   1. we had filtered all the statements for restore
   statistics when we had --include-table filter.
   This is fixed in the toc func shouldIncludeStatement.
   2. the way we modify statements for redirect is
   a Strings.Replace and we only replaced the first match
   while in the statistics statement we have several queries.
   The way we modified it only replaced schema for one query, 
   but because insert query never run we did not see it fails.
   Currently replacement is changed to global. 
   Another story could be created for farther improvements.

Authored-by: Kate Dontsova <edontsova@pivotal.io>