### PR TITLE
Create savepoint before getting view definition to avoid locking

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -162,6 +162,7 @@ func DoBackup() {
 
 	globalTOC.WriteToFileAndMakeReadOnly(globalFPInfo.GetTOCFilePath())
 	for connNum := 0; connNum < connectionPool.NumConns; connNum++ {
+		// COMMIT TRANSACTION
 		connectionPool.MustCommit(connNum)
 	}
 	metadataFile.Close()

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -42,6 +42,7 @@ func initializeConnectionPool() {
 	InitializeMetadataParams(connectionPool)
 	for connNum := 0; connNum < connectionPool.NumConns; connNum++ {
 		connectionPool.MustExec("SET application_name TO 'gpbackup'", connNum)
+		// BEGIN TRANSACTION
 		connectionPool.MustBegin(connNum)
 		SetSessionGUCs(connNum)
 	}


### PR DESCRIPTION
When querying the view definition using pg_get_viewdef(), this function
obtains dependency locks that are not released until the transaction is
committed at the end of gpbackup session. This blocks other sessions
from commands that need AccessExclusiveLock (e.g. TRUNCATE)

Creating a SAVEPOINT allows the locks to be released once the savepoint
is released or rolled back.