### PR TITLE
Change plugin in history to be binary name

### DIFF
--- a/backup/incremental.go
+++ b/backup/incremental.go
@@ -8,6 +8,7 @@ import (
 	"github.com/greenplum-db/gpbackup/toc"
 	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/pkg/errors"
+	"path"
 )
 
 func FilterTablesForIncremental(lastBackupTOC, currentTOC *toc.TOC, tables []Table) []Table {
@@ -71,10 +72,11 @@ func GetLatestMatchingBackupConfig(history *history.History, currentBackupConfig
 }
 
 func matchesIncrementalFlags(backupConfig *history.BackupConfig, currentBackupConfig *history.BackupConfig) bool {
+	_, pluginBinaryName := path.Split(backupConfig.Plugin)
 	return backupConfig.BackupDir == MustGetFlagString(options.BACKUP_DIR) &&
 		backupConfig.DatabaseName == currentBackupConfig.DatabaseName &&
 		backupConfig.LeafPartitionData == MustGetFlagBool(options.LEAF_PARTITION_DATA) &&
-		backupConfig.Plugin == currentBackupConfig.Plugin &&
+		pluginBinaryName == currentBackupConfig.Plugin &&
 		backupConfig.SingleDataFile == MustGetFlagBool(options.SINGLE_DATA_FILE) &&
 		backupConfig.Compressed == currentBackupConfig.Compressed &&
 		// Expanding of the include list happens before this now so we must compare again current backup config

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/nightlyone/lockfile"
 	"github.com/pkg/errors"
+	"path"
 	"reflect"
 )
 
@@ -106,7 +107,7 @@ func initializeBackupReport(opts options.Options) {
 	escapedDBName := dbconn.MustSelectString(connectionPool, fmt.Sprintf("select quote_ident(datname) AS string FROM pg_database where datname='%s'", utils.EscapeSingleQuotes(connectionPool.DBName)))
 	plugin := ""
 	if pluginConfig != nil {
-		plugin = pluginConfig.ExecutablePath
+		_, plugin = path.Split(pluginConfig.ExecutablePath)
 	}
 	config := NewBackupConfig(escapedDBName, connectionPool.Version.VersionString, version,
 		plugin, globalFPInfo.Timestamp, opts)


### PR DESCRIPTION
Authored-by: Kate Dontsova <edontsova@pivotal.io>

Previously if you create incremental backups using plugin and you have you plugin installed in different location that it was when you have created base backup, gpbackup was not able to find the match for base backup and error out. This PR changes the path ti plugin in history file to binary name, so match the previous backup relies on the plugin name, not on the installation path. It should be backwards compatible (will work for --incremental even if you already have base backup with installation path to plugin in the history file as long as the name of the binary is the same)