### PR TITLE
Fix pg_class statistics dump

### DIFF
--- a/backup/statistics.go
+++ b/backup/statistics.go
@@ -37,14 +37,12 @@ func GenerateTupleStatisticsQuery(table Table, tupleStat TupleStatistic) string 
 SET
 	relpages = %d::int,
 	reltuples = %f::real
-WHERE relname = '%s'
-AND relnamespace = %d;`
+WHERE oid = '%s'::regclass::oid;`
 	return fmt.Sprintf(
 		tupleQuery,
 		tupleStat.RelPages,
 		tupleStat.RelTuples,
-		utils.EscapeSingleQuotes(tupleStat.Table),
-		table.SchemaOid)
+		utils.EscapeSingleQuotes(table.FQN()))
 }
 
 func GenerateAttributeStatisticsQuery(table Table, attStat AttributeStatistic) string {

--- a/backup/statistics_test.go
+++ b/backup/statistics_test.go
@@ -51,8 +51,7 @@ var _ = Describe("backup/statistics tests", func() {
 SET
 	relpages = 0::int,
 	reltuples = 0.000000::real
-WHERE relname = 'testtable'
-AND relnamespace = 0;`)
+WHERE oid = 'testschema.testtable'::regclass::oid;`)
 		})
 		It("prints tuple and attribute stats for single table with stats", func() {
 			tupleStats = backup.TupleStatistic{Schema: "testschema", Table: "testtable"}
@@ -69,8 +68,7 @@ AND relnamespace = 0;`)
 SET
 	relpages = 0::int,
 	reltuples = 0.000000::real
-WHERE relname = 'testtable'
-AND relnamespace = 0;
+WHERE oid = 'testschema.testtable'::regclass::oid;
 
 
 DELETE FROM pg_statistic WHERE starelid = 'testschema.testtable'::regclass::oid AND staattnum = 0;
@@ -128,16 +126,15 @@ INSERT INTO pg_statistic VALUES (
 		})
 	})
 	Describe("GenerateTupleStatisticsQuery", func() {
-		It("generates tuple statistics query with a single quote in the table name", func() {
-			tableTestTable := backup.Table{Relation: backup.Relation{Schema: "testschema", Name: `"test'table"`}}
-			tupleStats := backup.TupleStatistic{Schema: "testschema", Table: `"test'table"`}
+		It("generates tuple statistics query with double quotes and a single quote in the table name and schema name", func() {
+			tableTestTable := backup.Table{Relation: backup.Relation{Schema: `"""test'schema"""`, Name: `"""test'table"""`}}
+			tupleStats := backup.TupleStatistic{Schema: `"""test'schema"""`, Table: `"""test'table"""`}
 			tupleQuery := backup.GenerateTupleStatisticsQuery(tableTestTable, tupleStats)
 			Expect(tupleQuery).To(Equal(`UPDATE pg_class
 SET
 	relpages = 0::int,
 	reltuples = 0.000000::real
-WHERE relname = '"test''table"'
-AND relnamespace = 0;`))
+WHERE oid = '"""test''schema"""."""test''table"""'::regclass::oid;`))
 		})
 
 	})

--- a/integration/statistics_create_test.go
+++ b/integration/statistics_create_test.go
@@ -60,5 +60,49 @@ var _ = Describe("backup integration tests", func() {
 				structmatcher.ExpectStructsToMatchExcluding(&oldAtts[i], &newAtts[i], "Oid", "Relid")
 			}
 		})
+		It("prints attribute and tuple statistics for a quoted table", func() {
+			tables := []backup.Table{
+				{Relation: backup.Relation{SchemaOid: 2200, Schema: "public", Name: "\"foo'\"\"''bar\""}},
+			}
+
+			// Create and ANALYZE the tables to generate statistics
+			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.\"foo'\"\"''bar\"(i int, j text, k bool)")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.\"foo'\"\"''bar\"")
+			testhelper.AssertQueryRuns(connectionPool, "INSERT INTO public.\"foo'\"\"''bar\" VALUES (1, 'a', 't')")
+			testhelper.AssertQueryRuns(connectionPool, "ANALYZE public.\"foo'\"\"''bar\"")
+
+			oldTableOid := testutils.OidFromObjectName(connectionPool, "public", "foo''\"''''bar", backup.TYPE_RELATION)
+			tables[0].Oid = oldTableOid
+
+			beforeAttStats := backup.GetAttributeStatistics(connectionPool, tables)
+			beforeTupleStats := backup.GetTupleStatistics(connectionPool, tables)
+			beforeTupleStat := beforeTupleStats[oldTableOid]
+
+			// Drop and recreate the table to clear the statistics
+			testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.\"foo'\"\"''bar\"")
+			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.\"foo'\"\"''bar\"(i int, j text, k bool)")
+
+			// Reload the retrieved statistics into the new table
+			backup.PrintStatisticsStatements(backupfile, tocfile, tables, beforeAttStats, beforeTupleStats)
+			testhelper.AssertQueryRuns(connectionPool, buffer.String())
+
+			newTableOid := testutils.OidFromObjectName(connectionPool, "public", "foo''\"''''bar", backup.TYPE_RELATION)
+			tables[0].Oid = newTableOid
+			afterAttStats := backup.GetAttributeStatistics(connectionPool, tables)
+			afterTupleStats := backup.GetTupleStatistics(connectionPool, tables)
+			afterTupleStat := afterTupleStats[newTableOid]
+
+			oldAtts := beforeAttStats[oldTableOid]
+			newAtts := afterAttStats[newTableOid]
+
+			// Ensure the statistics match
+			Expect(afterTupleStats).To(HaveLen(len(beforeTupleStats)))
+			structmatcher.ExpectStructsToMatchExcluding(&beforeTupleStat, &afterTupleStat, "Oid")
+			Expect(oldAtts).To(HaveLen(3))
+			Expect(newAtts).To(HaveLen(3))
+			for i := range oldAtts {
+				structmatcher.ExpectStructsToMatchExcluding(&oldAtts[i], &newAtts[i], "Oid", "Relid")
+			}
+		})
 	})
 })


### PR DESCRIPTION
The relnamespace part of the UPDATE query cannot be the schema's
actual oid. The UPDATE query would always report 0 rows updated for
the majority of cases and only work if restoring to a database with
that exact schema oid for that exact schema name. This was not caught
in production because gp_autostats_mode GUC default setting would
create the statistics for pg_class at the end of COPY FROM
SEGMENT. With a recent commit turning off autostats during gprestore
--with-stats, the pg_class statistics no longer get filled
accidentally. This commit fixes the issue by adding a subquery to get
the proper schema oid for the UPDATE query.

Reference Commit:
https://github.com/greenplum-db/gpbackup/commit/0bf5340e4fc8b70c02361e5024819828e5eb6323