### PR TITLE
CopyPluginConfigToAllHosts generates unique file names

### DIFF
--- a/restore/wrappers_test.go
+++ b/restore/wrappers_test.go
@@ -294,8 +294,15 @@ withstatistics: false
 			Expect(err).To(Not(HaveOccurred()))
 			_ = os.Chdir(oldWd)
 			_ = os.Remove(testConfigPath)
-			_ = os.Remove(testConfigPath + "_0")
-			_ = os.Remove(testConfigPath + "_1")
+			confDir := filepath.Dir(testConfigPath)
+			confFileName := filepath.Base(testConfigPath)
+			files, _ := ioutil.ReadDir(confDir)
+			for _, f := range files {
+				match, _ := filepath.Match("*" + confFileName + "*", f.Name())
+				if match {
+					_ = os.Remove(confDir + "/" + f.Name())
+				}
+			}
 		})
 		Describe("RecoverMetadataFilesUsingPlugin", func() {
 			It("proceed without warning when plugin version is found", func() {

--- a/utils/plugin.go
+++ b/utils/plugin.go
@@ -7,6 +7,7 @@ import (
 	path "path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/blang/semver"
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
@@ -342,10 +343,12 @@ func (plugin *PluginConfig) DeletePluginConfigWhenEncrypting(c *cluster.Cluster)
 	)
 }
 
+// Creates a valid segment-specific plugin configuration file with unique name
 func (plugin *PluginConfig) createHostPluginConfig(contentIDForSegmentOnHost int,
-	c *cluster.Cluster) (segmentSpecificConfigFilepath string) {
+	c *cluster.Cluster) string {
 	// copy "general" config file to temp, and add segment-specific PGPORT value
-	segmentSpecificConfigFile := plugin.ConfigPath + "_" + strconv.Itoa(contentIDForSegmentOnHost)
+
+	segmentSpecificConfigFile := plugin.ConfigPath + "_" + strconv.FormatInt(time.Now().UnixNano(), 10) + "_" + strconv.Itoa(contentIDForSegmentOnHost)
 	file := iohelper.MustOpenFileForWriting(segmentSpecificConfigFile)
 
 	// add current pgport as attribute
@@ -371,7 +374,7 @@ func (plugin *PluginConfig) createHostPluginConfig(contentIDForSegmentOnHost int
 	gplog.FatalOnError(err)
 	err = file.Close()
 	gplog.FatalOnError(err)
-	gplog.Debug("Wrote %d bytes to plugin config %s", bytes, segmentSpecificConfigFilepath)
+	gplog.Debug("Wrote %d bytes to plugin config %s", bytes, segmentSpecificConfigFile)
 	return segmentSpecificConfigFile
 }
 


### PR DESCRIPTION
 - as a part of this function we generate tmp
   config file on master before copy it to all
   hosts. If we make several calls of this
   function in parallel, we would race condition
   creating/removing the file with the same name.
   To allow parallel calls we change the name
   of tmp config file to unique using timestamp.

Authored-by: Kate Dontsova <edontsova@pivotal.io>