### PR TITLE
Incremental restore should filter out existing external tables

### DIFF
--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -340,11 +340,13 @@ func RestoreSchemas(schemaStatements []toc.StatementWithType, progressBar utils.
 func GetExistingTableFQNs() ([]string, error) {
 	existingTableFQNs := make([]string, 0)
 
+	// Note that 'f' for foreign tables only matters for GPDB 6+ but we shouldn't need a GPDB
+	// version check on this since this is catalog and 'f' is new starting from GPDB 6+.
 	query := `SELECT quote_ident(n.nspname) || '.' || quote_ident(c.relname)
 			  FROM pg_catalog.pg_class c
 				LEFT JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
-			  WHERE c.relkind IN ('r','')
-			  AND c.relstorage IN ('h', 'a', 'c','')
+			  WHERE c.relkind IN ('r', 'f')
+			  AND c.relstorage IN ('h', 'a', 'c', 'x', 'f')
 				 AND n.nspname <> 'pg_catalog'
 				 AND n.nspname <> 'information_schema'
 				 AND n.nspname !~ '^pg_toast'


### PR DESCRIPTION
Incremental restore was not properly filtering out existing external
tables. This was because the query for finding existing tables did not
include external tables in the relkind and relstorage query
filters. Fixed by adding them to the filters. Note that 'f' for
foreign tables only matters for GPDB 6+ but we shouldn't need a GPDB
version check on this since this is catalog and 'f' is new starting
from GPDB 6+.

Commit Reference:
https://github.com/greenplum-db/gpbackup/commit/c8ab236ce88b1c94