### PR TITLE
Fix function and protocol filtering

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -201,15 +201,19 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Table, tableO
 	}
 	gplog.Info("Writing pre-data metadata")
 
+	var protocols []ExternalProtocol
+	var functions []Function
+	var funcInfoMap map[uint32]FunctionInfo
 	objects := make([]Sortable, 0)
 	metadataMap := make(MetadataMap)
+
 	objects = append(objects, convertToSortableSlice(tables)...)
 	relationMetadata := GetMetadataForObjectType(connectionPool, TYPE_RELATION)
 	addToMetadataMap(relationMetadata, metadataMap)
-	functions, funcInfoMap := retrieveFunctions(&objects, metadataMap)
-	protocols := retrieveProtocols(&objects, metadataMap)
 
 	if !tableOnly {
+		functions, funcInfoMap = retrieveFunctions(&objects, metadataMap)
+		protocols = retrieveProtocols(&objects, metadataMap)
 		backupSchemas(metadataFile, createAlteredPartitionSchemaSet(tables))
 		backupExtensions(metadataFile)
 		backupCollations(metadataFile)


### PR DESCRIPTION
Fixes a regression where a backup taken using the flag `--include-table`
does not correctly filter out functions and protocols.

gpbackup reference regression commits:
functions: 5db5e23b
protocols: abdf8cf2

Authored-by: Kevin Yeap <kyeap@pivotal.io>