### PR TITLE
Publish gpbackup ubuntu debian package to S3 and pivnet

### DIFF
--- a/ci/pivnet_release/metadata.yml
+++ b/ci/pivnet_release/metadata.yml
@@ -52,10 +52,15 @@ product_files:
     file_type: Software
     file_version: <TILE_RELEASE_VERSION>
 
-########## Ubuntu Debian Gppkgs ##########
+########## Ubuntu Debian Gppkgs/Debian ##########
   - file: workspace/files-to-upload/pivotal_greenplum_backup_restore-<TILE_RELEASE_VERSION>-gp6-ubuntu-amd64.gppkg
     description:
     upload_as: Backup and Restore for GP 6 on Ubuntu 18.04
+    file_type: Software
+    file_version: <TILE_RELEASE_VERSION>
+  - file: workspace/files-to-upload/pivotal_greenplum_backup_restore-<TILE_RELEASE_VERSION>-gp6-ubuntu-amd64.deb
+    description:
+    upload_as: Backup and Restore for GP 6 on Ubuntu 18.04 Debian package
     file_type: Software
     file_version: <TILE_RELEASE_VERSION>
 

--- a/ci/scripts/build-gppkgs.bash
+++ b/ci/scripts/build-gppkgs.bash
@@ -51,6 +51,8 @@ if [[ ${OS} == "RHEL" || ${OS} == "SLES" ]]; then
     build_rpm_rhel
 elif [[ ${OS} == "ubuntu" ]]; then
     build_deb_ubuntu
+    # Publish the debian package also
+    cp ${PKG_FILES} gppkgs/
 fi
 
 # Install gpdb binaries


### PR DESCRIPTION
The `.deb` file is included in the gppkgs tarball that we create in the `gpbackup` pipeline. This file will also be uploaded to pivnet by the `gpbackup-release` pipeline along with other gppkgs.