### PR TITLE
gprestore ability to discard or seek or scan subset data

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -268,7 +268,7 @@ func backupData(tables []Table) {
 		}
 		// Do not pass through the --on-error-continue flag because it does not apply to gpbackup
 		utils.StartGpbackupHelpers(globalCluster, globalFPInfo, "--backup-agent",
-			MustGetFlagString(options.PLUGIN_CONFIG), compressStr, false)
+			MustGetFlagString(options.PLUGIN_CONFIG), compressStr, false, false)
 	}
 	gplog.Info("Writing data to file")
 	rowsCopiedMaps := backupDataForAllTables(tables)

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -50,6 +50,7 @@ var (
 	printVersion     *bool
 	restoreAgent     *bool
 	tocFile          *string
+	isFilter		 *bool
 )
 
 func DoHelper() {
@@ -105,6 +106,7 @@ func InitializeGlobals() {
 	printVersion = flag.Bool("version", false, "Print version number and exit")
 	restoreAgent = flag.Bool("restore-agent", false, "Use gpbackup_helper as an agent for restore")
 	tocFile = flag.String("toc-file", "", "Absolute path to the table of contents file")
+	isFilter = flag.Bool("with-filters", false, "Used with table/schema filters")
 
 	if *onErrorContinue && !*restoreAgent {
 		fmt.Printf("--on-error-continue flag can only be used with --restore-agent flag")

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -50,7 +50,7 @@ var (
 	printVersion     *bool
 	restoreAgent     *bool
 	tocFile          *string
-	isFilter		 *bool
+	isFiltered       *bool
 )
 
 func DoHelper() {
@@ -106,7 +106,7 @@ func InitializeGlobals() {
 	printVersion = flag.Bool("version", false, "Print version number and exit")
 	restoreAgent = flag.Bool("restore-agent", false, "Use gpbackup_helper as an agent for restore")
 	tocFile = flag.String("toc-file", "", "Absolute path to the table of contents file")
-	isFilter = flag.Bool("with-filters", false, "Used with table/schema filters")
+	isFiltered = flag.Bool("with-filters", false, "Used with table/schema filters")
 
 	if *onErrorContinue && !*restoreAgent {
 		fmt.Printf("--on-error-continue flag can only be used with --restore-agent flag")

--- a/plugins/plugin_test_bench.sh
+++ b/plugins/plugin_test_bench.sh
@@ -206,40 +206,45 @@ cleanup_test_dir $testdir
 # ----------------------------------------------
 # Restore subset data functions
 # ----------------------------------------------
-echo "[RUNNING] backup_data of large data for subset restore"
-echo $data_large | $plugin backup_data $plugin_config $testdatalarge
+if [[ "$plugin" == *gpbackup_ddboost_plugin ]]; then
+  echo "[RUNNING] backup_data of large data for subset restore"
+  echo $data_large | $plugin backup_data $plugin_config $testdatalarge
 
-echo "1 3 10" > "$testdir/offsets"
-echo "[RUNNING] restore_data_subset"
-output=`$plugin restore_data_subset $plugin_config $testdata "$testdir/offsets"`
-data_subset=$(echo $data | cut -c4-10)
-if [ "$output" != "$data_subset" ]; then
-  echo "Failure in restore_data_subset of small data using plugin"
-  exit 1
-fi
-echo "[PASSED] restore_data_subset with small data"
+  echo "1 3 10" > "$testdir/offsets"
+  echo "[RUNNING] restore_data_subset"
+  echo $plugin restore_data_subset $plugin_config $testdata "$testdir/offsets"
+  output=`$plugin restore_data_subset $plugin_config $testdata "$testdir/offsets"`
+  echo "---------------"
+  data_subset=$(echo $data | cut -c4-10)
+  echo "---------------"
+  if [ "$output" != "$data_subset" ]; then
+    echo "Failure in restore_data_subset of small data using plugin"
+    exit 1
+  fi
+  echo "[PASSED] restore_data_subset with small data"
 
-echo "1 900000 900001" > "$testdir/offsets"
-echo "[RUNNING] restore_data_subset"
-output=`$plugin restore_data_subset $plugin_config $testdatalarge "$testdir/offsets"`
-data_part=$(echo $data_large | cut -c900001-900001)
-if [ "$output" != "$data_part" ]; then
-  echo "Failure restore_data_subset of one partition from large data $output $data_part"
-  exit 1
-fi
-echo "[PASSED] restore_data_subset of one partition from large data"
+  echo "1 900000 900001" > "$testdir/offsets"
+  echo "[RUNNING] restore_data_subset"
+  output=`$plugin restore_data_subset $plugin_config $testdatalarge "$testdir/offsets"`
+  data_part=$(echo $data_large | cut -c900001-900001)
+  if [ "$output" != "$data_part" ]; then
+    echo "Failure restore_data_subset of one partition from large data $output $data_part"
+    exit 1
+  fi
+  echo "[PASSED] restore_data_subset of one partition from large data"
 
-echo "2 0 700000 900000 900001" > "$testdir/offsets"
-echo "[RUNNING] restore_data_subset"
-output=`$plugin restore_data_subset $plugin_config $testdatalarge "$testdir/offsets"`
-data_part1=$(echo $data_large | cut -c1-700000)
-data_part2=$(echo $data_large | cut -c900001-900001)
-if [ "$output" != "$data_part1$data_part2" ]; then
-  echo "Failure restore_data_subset of two partitions from large data"
-  exit 1
+  echo "2 0 700000 900000 900001" > "$testdir/offsets"
+  echo "[RUNNING] restore_data_subset"
+  output=`$plugin restore_data_subset $plugin_config $testdatalarge "$testdir/offsets"`
+  data_part1=$(echo $data_large | cut -c1-700000)
+  data_part2=$(echo $data_large | cut -c900001-900001)
+  if [ "$output" != "$data_part1$data_part2" ]; then
+    echo "Failure restore_data_subset of two partitions from large data"
+    exit 1
+  fi
+  echo "[PASSED] restore_data_subset of two partitions from large data"
+  cleanup_test_dir $testdir
 fi
-echo "[PASSED] restore_data_subset of two partitions from large data"
-cleanup_test_dir $testdir
 
 # ----------------------------------------------
 # Delete backup directory function

--- a/plugins/plugin_test_bench.sh
+++ b/plugins/plugin_test_bench.sh
@@ -34,11 +34,13 @@ testdir="/tmp/testseg/backups/${current_date}/${time_second}"
 testfile="$testdir/testfile_$time_second.txt"
 testdata="$testdir/testdata_$time_second.txt"
 test_no_data="$testdir/test_no_data_$time_second.txt"
+testdatalarge="$testdir/testdatalarge_$time_second.txt"
 
-logdir="/tmp/test_bench_logs"
+logdir="/tmp/test_bench_logs"$
 
 text="this is some text"
 data=`LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 1000 ; echo`
+data_large=`LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 1000000 ; echo`
 mkdir -p $testdir
 mkdir -p $logdir
 echo $text > $testfile
@@ -202,6 +204,44 @@ echo "[PASSED] restore_data with no data"
 cleanup_test_dir $testdir
 
 # ----------------------------------------------
+# Restore subset data functions
+# ----------------------------------------------
+echo "[RUNNING] backup_data of large data for subset restore"
+echo $data_large | $plugin backup_data $plugin_config $testdatalarge
+
+echo "1 3 10" > "$testdir/offsets"
+echo "[RUNNING] restore_data_subset"
+output=`$plugin restore_data_subset $plugin_config $testdata "$testdir/offsets"`
+data_subset=$(echo $data | cut -c4-10)
+if [ "$output" != "$data_subset" ]; then
+  echo "Failure in restore_data_subset of small data using plugin"
+  exit 1
+fi
+echo "[PASSED] restore_data_subset with small data"
+
+echo "1 900000 900001" > "$testdir/offsets"
+echo "[RUNNING] restore_data_subset"
+output=`$plugin restore_data_subset $plugin_config $testdatalarge "$testdir/offsets"`
+data_part=$(echo $data_large | cut -c900001-900001)
+if [ "$output" != "$data_part" ]; then
+  echo "Failure restore_data_subset of one partition from large data $output $data_part"
+  exit 1
+fi
+echo "[PASSED] restore_data_subset of one partition from large data"
+
+echo "2 0 700000 900000 900001" > "$testdir/offsets"
+echo "[RUNNING] restore_data_subset"
+output=`$plugin restore_data_subset $plugin_config $testdatalarge "$testdir/offsets"`
+data_part1=$(echo $data_large | cut -c1-700000)
+data_part2=$(echo $data_large | cut -c900001-900001)
+if [ "$output" != "$data_part1$data_part2" ]; then
+  echo "Failure restore_data_subset of two partitions from large data"
+  exit 1
+fi
+echo "[PASSED] restore_data_subset of two partitions from large data"
+cleanup_test_dir $testdir
+
+# ----------------------------------------------
 # Delete backup directory function
 # ----------------------------------------------
 time_second_for_del=$(expr 99999999999999 - $(od -vAn -N5 -tu < /dev/urandom | tr -d ' \n'))
@@ -306,18 +346,21 @@ set -e
 # ----------------------------------------------
 # Run test gpbackup and gprestore with plugin
 # ----------------------------------------------
-
 #gpbackup --dbname $test_db --plugin-config $plugin_config $further_options > $log_file
-
 
 test_backup_and_restore_with_plugin() {
     flags=$1
+    restore_filter=$2
     test_db=plugin_test_db
     log_file="$logdir/plugin_test_log_file"
 
     psql -X -d postgres -qc "DROP DATABASE IF EXISTS $test_db" 2>/dev/null
     createdb $test_db
-    psql -X -d $test_db -qc "CREATE TABLE test_table(i int) DISTRIBUTED RANDOMLY; INSERT INTO test_table select generate_series(1,50000)"
+    psql -X -d $test_db -qc "CREATE TABLE test1(i int) DISTRIBUTED RANDOMLY; INSERT INTO test1 select generate_series(1,50000)"
+    if [ "$restore_filter" == "restore-filter" ] ; then
+      psql -X -d $test_db -qc "CREATE TABLE test2(i int) DISTRIBUTED RANDOMLY; INSERT INTO test2 VALUES(3333)"
+      flags_restore="--include-table public.test2"
+    fi
 
     set +e
     # save the encrypt key file, if it exists
@@ -326,7 +369,7 @@ test_backup_and_restore_with_plugin() {
     fi
     echo "gpbackup_ddboost_plugin: 66706c6c6e677a6965796f68343365303133336f6c73366b316868326764" > $MASTER_DATA_DIRECTORY/.encrypt
 
-    echo "[RUNNING] gpbackup with test database (using ${flags})"
+    echo "[RUNNING] gpbackup with test database (using ${flags} ${flags_restore})"
     gpbackup --dbname $test_db --plugin-config $plugin_config $flags &> $log_file
     if [ ! $? -eq 0 ]; then
         echo
@@ -339,7 +382,7 @@ test_backup_and_restore_with_plugin() {
     dropdb $test_db
 
     echo "[RUNNING] gprestore with test database"
-    gprestore --timestamp $timestamp --plugin-config $plugin_config --create-db &> $log_file
+    gprestore --timestamp $timestamp --plugin-config $plugin_config --create-db $flags_restore &> $log_file
     if [ ! $? -eq 0 ]; then
         echo
         cat $log_file
@@ -347,10 +390,24 @@ test_backup_and_restore_with_plugin() {
         echo "gprestore failed. Check gprestore log file in ~/gpAdminLogs for details."
         exit 1
     fi
-    num_rows=`psql -X -d $test_db -tc "SELECT count(*) FROM test_table" | xargs`
-    if [ "$flags" != "--metadata-only" ] && [ "$num_rows" != "50000" ]; then
-        echo "Expected to restore 50000 rows, got $num_rows"
-        exit 1
+
+    if [ "$restore_filter" == "restore-filter" ] ; then
+      result=`psql -X -d $test_db -tc "SELECT table_name FROM information_schema.tables WHERE table_schema='public'" | xargs`
+      if [ "$result" == *"test1"* ]; then
+          echo "Expected relation test1 to not exist"
+          exit 1
+      fi
+      result=`psql -X -d $test_db -tc "SELECT * FROM test2" | xargs`
+      if [ "$flags" != "--metadata-only" ] && [ "$result" != "3333" ]; then
+          echo "Expected relation test2 value: 3333, got %result"
+          exit 1
+      fi
+    else
+      result=`psql -X -d $test_db -tc "SELECT count(*) FROM test1" | xargs`
+      if [ "$flags" != "--metadata-only" ] && [ "$result" != "50000" ]; then
+          echo "Expected to restore 50000 rows, got $result"
+          exit 1
+      fi
     fi
 
     if [ -n "$secondary_plugin_config" ]; then
@@ -364,9 +421,9 @@ test_backup_and_restore_with_plugin() {
             echo "gprestore from secondary destination failed. Check gprestore log file in ~/gpAdminLogs for details."
             exit 1
         fi
-        num_rows=`psql -X -d $test_db -tc "SELECT count(*) FROM test_table" | xargs`
-        if [ "$flags" != "--metadata-only" ] && [ "$num_rows" != "50000" ]; then
-          echo "Expected to restore 50000 rows, got $num_rows"
+        result=`psql -X -d $test_db -tc "SELECT count(*) FROM test1" | xargs`
+        if [ "$flags" != "--metadata-only" ] && [ "$result" != "50000" ]; then
+          echo "Expected to restore 50000 rows, got $result"
           exit 1
         fi
     fi
@@ -381,6 +438,7 @@ test_backup_and_restore_with_plugin() {
 test_backup_and_restore_with_plugin "--no-compression --single-data-file"
 test_backup_and_restore_with_plugin "--no-compression"
 test_backup_and_restore_with_plugin "--metadata-only"
+test_backup_and_restore_with_plugin "--no-compression --single-data-file" "restore-filter"
 
 # ----------------------------------------------
 # Cleanup test artifacts

--- a/plugins/plugin_test_scale.sh
+++ b/plugins/plugin_test_scale.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+set -e
+set -o pipefail
+
+plugin=$1
+plugin_config=$2
+MINIMUM_API_VERSION="0.3.0"
+
+# ----------------------------------------------
+# Test suite setup
+# This will put small amounts of data in the
+# plugin destination location
+# ----------------------------------------------
+if [ $# -lt 2 ] || [ $# -gt 3 ]
+  then
+    echo "Usage: plugin_test_scale.sh [path_to_executable] [plugin_config] [optional_config_for_secondary_destination]"
+    exit 1
+fi
+
+if [[ "$plugin_config" != /* ]] ; then
+    echo "Must provide an absolute path to the plugin config"
+    exit 1
+fi
+
+logdir="/tmp/test_scale_logs"$
+mkdir -p $logdir
+test_db=plugin_test_db
+
+test_preparedata() {
+    set +e
+    echo "Preparing test data for plugin scale test"
+    psql -X -d postgres -qc "DROP DATABASE IF EXISTS $test_db" 2>/dev/null
+    createdb $test_db
+    psql -X -d $test_db -qc "CREATE TABLE test1(i int) DISTRIBUTED RANDOMLY; INSERT INTO test1 select generate_series(1,20000000)"
+    psql -X -d $test_db -qc "CREATE TABLE test2(i int) DISTRIBUTED RANDOMLY; INSERT INTO test2 VALUES(3333)"
+    psql -X -d $test_db -qc "CREATE TABLE test3(i int) DISTRIBUTED RANDOMLY; INSERT INTO test3 select generate_series(1,20000000)"
+    psql -X -d $test_db -qc "CREATE TABLE test4(i int) DISTRIBUTED RANDOMLY; INSERT INTO test4 VALUES(9999)"
+}
+
+test_backup_and_restore_with_plugin() {
+    config=$1
+    flags=$2
+    restore_filter=$3
+    log_file="$logdir/plugin_test_log_file"
+    TIMEFORMAT=%R
+
+    set +e
+    # save the encrypt key file, if it exists
+    if [ -f "$MASTER_DATA_DIRECTORY/.encrypt" ] ; then
+        mv $MASTER_DATA_DIRECTORY/.encrypt /tmp/.encrypt_saved
+    fi
+    echo "gpbackup_ddboost_plugin: 66706c6c6e677a6965796f68343365303133336f6c73366b316868326764" > $MASTER_DATA_DIRECTORY/.encrypt
+
+    echo "[RUNNING] gpbackup with test database (using ${flags})"
+    time gpbackup --dbname $test_db --plugin-config $config $flags &> $log_file
+    if [ ! $? -eq 0 ]; then
+        echo
+        cat $log_file
+        echo
+        echo "gpbackup failed. Check gpbackup log file in ~/gpAdminLogs for details."
+        exit 1
+    fi
+    timestamp=`head -4 $log_file | grep "Backup Timestamp " | grep -Eo "[[:digit:]]{14}"`
+
+    if [ "$restore_filter" == "restore-filter" ] ; then
+      flags_restore=" --include-table public.test2 --include-table public.test4"
+    fi
+    echo "[RUNNING] gprestore with test database (using ${flags}${flags_restore})"
+
+    time gprestore --timestamp $timestamp --plugin-config $config --create-db --redirect-db ${test_db}_restore $flags_restore &> $log_file
+
+    dropdb ${test_db}_restore
+
+    if [ ! $? -eq 0 ]; then
+        echo
+        cat $log_file
+        echo
+        echo "gprestore failed. Check gprestore log file in ~/gpAdminLogs for details."
+        exit 1
+    fi
+
+    # replace the encrypt key file to its proper location
+    if [ -f "/tmp/.encrypt_saved" ] ; then
+        mv /tmp/.encrypt_saved $MASTER_DATA_DIRECTORY/.encrypt
+    fi
+    set -e
+}
+
+# ----------------------------------------------
+# Run scale test for gpbackup and gprestore with plugin
+# ----------------------------------------------
+test_preparedata
+test_backup_and_restore_with_plugin "$plugin_config"
+test_backup_and_restore_with_plugin "$plugin_config" "--single-data-file"
+test_backup_and_restore_with_plugin "$plugin_config" "--single-data-file" "restore-filter"
+test_backup_and_restore_with_plugin "$plugin_config" "--single-data-file --no-compression" "restore-filter"
+
+echo "Testing with plugin config with restore_subset disabled"
+plugin_config_temp=$(mktemp)
+cat $plugin_config > $plugin_config_temp
+echo "  restore_subset: \"false\"" >> $plugin_config_temp
+test_backup_and_restore_with_plugin "$plugin_config_temp" "--single-data-file --no-compression" "restore-filter"
+
+# ----------------------------------------------
+# Cleanup test artifacts
+# ----------------------------------------------
+echo "Cleaning up leftover test artifacts"
+
+dropdb $test_db
+rm -r $logdir
+
+if (( 1 == $(echo "0.4.0 $api_version" | awk '{print ($1 > $2)}') )) ; then
+  echo "[SKIPPING] cleanup of uploaded test artifacts using plugins (only compatible with version >= 0.4.0)"
+else
+  $plugin delete_backup $plugin_config $time_second
+fi
+
+echo "# ----------------------------------------------"
+echo "# Finished gpbackup plugin scale tests"
+echo "# ----------------------------------------------"

--- a/restore/data.go
+++ b/restore/data.go
@@ -104,7 +104,11 @@ func restoreDataFromTimestamp(fpInfo filepath.FilePathInfo, dataEntries []toc.Ma
 		if wasTerminated {
 			return
 		}
-		utils.StartGpbackupHelpers(globalCluster, fpInfo, "--restore-agent", MustGetFlagString(options.PLUGIN_CONFIG), "", MustGetFlagBool(options.ON_ERROR_CONTINUE))
+		isFilter := false
+		if len(opts.IncludedRelations) > 0 || len(opts.ExcludedRelations) > 0 || len(opts.IncludedSchemas) > 0 || len(opts.ExcludedSchemas) > 0 {
+			isFilter = true
+		}
+		utils.StartGpbackupHelpers(globalCluster, fpInfo, "--restore-agent", MustGetFlagString(options.PLUGIN_CONFIG), "", MustGetFlagBool(options.ON_ERROR_CONTINUE), isFilter)
 	}
 	/*
 	 * We break when an interrupt is received and rely on

--- a/utils/agent_remote.go
+++ b/utils/agent_remote.go
@@ -111,7 +111,7 @@ func VerifyHelperVersionOnSegments(version string, c *cluster.Cluster) {
 	}
 }
 
-func StartGpbackupHelpers(c *cluster.Cluster, fpInfo filepath.FilePathInfo, operation string, pluginConfigFile string, compressStr string, onErrorContinue bool) {
+func StartGpbackupHelpers(c *cluster.Cluster, fpInfo filepath.FilePathInfo, operation string, pluginConfigFile string, compressStr string, onErrorContinue bool, isFilter bool) {
 	gphomePath := operating.System.Getenv("GPHOME")
 	pluginStr := ""
 	if pluginConfigFile != "" {
@@ -122,13 +122,17 @@ func StartGpbackupHelpers(c *cluster.Cluster, fpInfo filepath.FilePathInfo, oper
 	if onErrorContinue {
 		onErrorContinueStr = " --on-error-continue"
 	}
+	isFilterStr := ""
+	if isFilter {
+		isFilterStr = " --with-filters"
+	}
 	remoteOutput := c.GenerateAndExecuteCommand("Starting gpbackup_helper agent", func(contentID int) string {
 		tocFile := fpInfo.GetSegmentTOCFilePath(contentID)
 		oidFile := fpInfo.GetSegmentHelperFilePath(contentID, "oid")
 		scriptFile := fpInfo.GetSegmentHelperFilePath(contentID, "script")
 		pipeFile := fpInfo.GetSegmentPipeFilePath(contentID)
 		backupFile := fpInfo.GetTableBackupFilePath(contentID, 0, GetPipeThroughProgram().Extension, true)
-		helperCmdStr := fmt.Sprintf("gpbackup_helper %s --toc-file %s --oid-file %s --pipe-file %s --data-file %s --content %d%s%s%s", operation, tocFile, oidFile, pipeFile, backupFile, contentID, pluginStr, compressStr, onErrorContinueStr)
+		helperCmdStr := fmt.Sprintf("gpbackup_helper %s --toc-file %s --oid-file %s --pipe-file %s --data-file %s --content %d%s%s%s%s", operation, tocFile, oidFile, pipeFile, backupFile, contentID, pluginStr, compressStr, onErrorContinueStr, isFilterStr)
 		// we run these commands in sequence to ensure that any failure is critical; the last command ensures the agent process was successfully started
 		return fmt.Sprintf(`cat << HEREDOC > %[1]s && chmod +x %[1]s && ( nohup %[1]s &> /dev/null &)
 #!/bin/bash

--- a/utils/agent_remote.go
+++ b/utils/agent_remote.go
@@ -122,9 +122,9 @@ func StartGpbackupHelpers(c *cluster.Cluster, fpInfo filepath.FilePathInfo, oper
 	if onErrorContinue {
 		onErrorContinueStr = " --on-error-continue"
 	}
-	isFilterStr := ""
+	filterStr := ""
 	if isFilter {
-		isFilterStr = " --with-filters"
+		filterStr = " --with-filters"
 	}
 	remoteOutput := c.GenerateAndExecuteCommand("Starting gpbackup_helper agent", func(contentID int) string {
 		tocFile := fpInfo.GetSegmentTOCFilePath(contentID)
@@ -132,7 +132,7 @@ func StartGpbackupHelpers(c *cluster.Cluster, fpInfo filepath.FilePathInfo, oper
 		scriptFile := fpInfo.GetSegmentHelperFilePath(contentID, "script")
 		pipeFile := fpInfo.GetSegmentPipeFilePath(contentID)
 		backupFile := fpInfo.GetTableBackupFilePath(contentID, 0, GetPipeThroughProgram().Extension, true)
-		helperCmdStr := fmt.Sprintf("gpbackup_helper %s --toc-file %s --oid-file %s --pipe-file %s --data-file %s --content %d%s%s%s%s", operation, tocFile, oidFile, pipeFile, backupFile, contentID, pluginStr, compressStr, onErrorContinueStr, isFilterStr)
+		helperCmdStr := fmt.Sprintf("gpbackup_helper %s --toc-file %s --oid-file %s --pipe-file %s --data-file %s --content %d%s%s%s%s", operation, tocFile, oidFile, pipeFile, backupFile, contentID, pluginStr, compressStr, onErrorContinueStr, filterStr)
 		// we run these commands in sequence to ensure that any failure is critical; the last command ensures the agent process was successfully started
 		return fmt.Sprintf(`cat << HEREDOC > %[1]s && chmod +x %[1]s && ( nohup %[1]s &> /dev/null &)
 #!/bin/bash

--- a/utils/agent_remote_test.go
+++ b/utils/agent_remote_test.go
@@ -123,7 +123,7 @@ var _ = Describe("agent remote", func() {
 	})
 	Describe("StartGpbackupHelpers()", func() {
 		It("Correctly propagates --on-error-continue flag to gpbackup_helper", func() {
-			utils.StartGpbackupHelpers(testCluster, fpInfo, "operation", "/tmp/pluginConfigFile.yml", " compressStr", true)
+			utils.StartGpbackupHelpers(testCluster, fpInfo, "operation", "/tmp/pluginConfigFile.yml", " compressStr", true, false)
 
 			cc := testExecutor.ClusterCommands[0]
 			Expect(cc[0][4]).To(ContainSubstring(" --on-error-continue"))

--- a/utils/plugin.go
+++ b/utils/plugin.go
@@ -473,3 +473,7 @@ func (plugin *PluginConfig) SetBackupPluginVersion(timestamp string, historicalP
 		plugin.backupPluginVersion = historicalPluginVersion
 	}
 }
+
+func (plugin *PluginConfig) CanRestoreSubset() bool {
+	return plugin.Options["restore_subset"] == "true"
+}

--- a/utils/plugin.go
+++ b/utils/plugin.go
@@ -475,6 +475,7 @@ func (plugin *PluginConfig) SetBackupPluginVersion(timestamp string, historicalP
 }
 
 func (plugin *PluginConfig) CanRestoreSubset() bool {
-	return strings.HasSuffix(plugin.ExecutablePath, "ddboost_plugin") &&
-		plugin.Options["restore_subset"] != "false"
+	return (plugin.Options["restore_subset"] == "on") ||
+			(strings.HasSuffix(plugin.ExecutablePath, "ddboost_plugin") &&
+				plugin.Options["restore_subset"] != "off")
 }

--- a/utils/plugin.go
+++ b/utils/plugin.go
@@ -475,5 +475,6 @@ func (plugin *PluginConfig) SetBackupPluginVersion(timestamp string, historicalP
 }
 
 func (plugin *PluginConfig) CanRestoreSubset() bool {
-	return plugin.Options["restore_subset"] == "true"
+	return strings.HasSuffix(plugin.ExecutablePath, "ddboost_plugin") &&
+		plugin.Options["restore_subset"] != "false"
 }


### PR DESCRIPTION
Enhanced `gprestore` to optimize the way we scan the backup data during restore specifically in the scenario when we have an uncompressed single file backup with table/schema filters

- Introduced `RestoreReader` which encapsulates both reader types `io.ReadSeeker` and `bufio.Reader`. We will use the appropriate reader based on the `ReaderType`. The reader can be one one of the following types
- reader that can directly seek during restore (restore from a filesystem)
- reader that can read subset data based on the target table offsets from `toc` (when we use plugin)
-reader that read entire data and based on offsets from toc, data will need to be discarded.

The functions to move to a specific reader offset or copy data from the reader are now functions of the `RestoreReader`

- Introduced a new function to the plugin interface named `restore_data_subset` which is optimized for reading subset data. In order to make use of this the plugin config file needs to set `restore_subset: "on"`
This takes in an offset file containing all the start and end byte offsets of the relevant `oids` that need to be restored. 

- ddboost plugin tests have been added to plugin_test_bench.sh
- ddboost scale tests have been newly introduced in plugin_test_scale.sh
- s3_plugin doesn't support the new api