### PR TITLE
Add testing gpbackup with metadata-only flag to plugin test bench

### DIFF
--- a/plugins/plugin_test_bench.sh
+++ b/plugins/plugin_test_bench.sh
@@ -348,7 +348,7 @@ test_backup_and_restore_with_plugin() {
         exit 1
     fi
     num_rows=`psql -X -d $test_db -tc "SELECT count(*) FROM test_table" | xargs`
-    if [ "$num_rows" != "50000" ]; then
+    if [ "$flags" != "--metadata-only" ] && [ "$num_rows" != "50000" ]; then
         echo "Expected to restore 50000 rows, got $num_rows"
         exit 1
     fi
@@ -380,6 +380,7 @@ test_backup_and_restore_with_plugin() {
 
 test_backup_and_restore_with_plugin "--no-compression --single-data-file"
 test_backup_and_restore_with_plugin "--no-compression"
+test_backup_and_restore_with_plugin "--metadata-only"
 
 # ----------------------------------------------
 # Cleanup test artifacts


### PR DESCRIPTION
This would test the regression that was missed recently with s3-plugin