### PR TITLE
Remove undocumented external table option attribute

### DIFF
--- a/backup/predata_externals.go
+++ b/backup/predata_externals.go
@@ -36,7 +36,6 @@ type ExternalTableDefinition struct {
 	ExecLocation    string
 	FormatType      string
 	FormatOpts      string
-	Options         string
 	Command         string
 	RejectLimit     int
 	RejectLimitType string
@@ -296,9 +295,6 @@ func PrintExternalTableStatements(metadataFile *utils.FileWithByteCount, tableNa
 	metadataFile.MustPrintln()
 	metadataFile.MustPrint(GenerateFormatStatement(extTableDef))
 	metadataFile.MustPrintln()
-	if extTableDef.Options != "" {
-		metadataFile.MustPrintf("OPTIONS (\n\t%s\n)\n", extTableDef.Options)
-	}
 	metadataFile.MustPrintf("ENCODING '%s'", extTableDef.Encoding)
 	if extTableDef.Type == READABLE || extTableDef.Type == READABLE_WEB {
 		metadataFile.MustPrint(generateLogErrorStatement(extTableDef, tableName))

--- a/backup/predata_externals_test.go
+++ b/backup/predata_externals_test.go
@@ -2,6 +2,7 @@ package backup_test
 
 import (
 	"database/sql"
+
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup/backup"
 	"github.com/greenplum-db/gpbackup/testutils"
@@ -293,19 +294,6 @@ FORMAT 'TEXT'
 ENCODING 'UTF-8'
 LOG ERRORS
 SEGMENT REJECT LIMIT 2 ROWS`)
-			})
-			It("prints a CREATE block for a table with custom options", func() {
-				extTableDef.Options = "foo 'bar'\n\tbar 'baz'"
-				backup.PrintExternalTableStatements(backupfile, tableName, extTableDef)
-				testhelper.ExpectRegexp(buffer, `LOCATION (
-	'file://host:port/path/file'
-)
-FORMAT 'TEXT'
-OPTIONS (
-	foo 'bar'
-	bar 'baz'
-)
-ENCODING 'UTF-8'`)
 			})
 		})
 	})

--- a/backup/predata_relations_tables_test.go
+++ b/backup/predata_relations_tables_test.go
@@ -19,7 +19,7 @@ var _ = Describe("backup/predata_relations tests", func() {
 	var testTable backup.Table
 	BeforeEach(func() {
 		tocfile, backupfile = testutils.InitializeTestTOC(buffer, "predata")
-		extTableEmpty := backup.ExternalTableDefinition{Oid: 0, Type: -2, Protocol: -2, Location: "", ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "", Options: "", Command: "", RejectLimit: 0, RejectLimitType: "", ErrTableName: "", ErrTableSchema: "", Encoding: "UTF-8", Writable: false, URIs: nil}
+		extTableEmpty := backup.ExternalTableDefinition{Oid: 0, Type: -2, Protocol: -2, Location: "", ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "", Command: "", RejectLimit: 0, RejectLimitType: "", ErrTableName: "", ErrTableSchema: "", Encoding: "UTF-8", Writable: false, URIs: nil}
 		testTable = backup.Table{
 			Relation:        backup.Relation{Schema: "public", Name: "tablename"},
 			TableDefinition: backup.TableDefinition{DistPolicy: "DISTRIBUTED RANDOMLY", PartDef: "", PartTemplateDef: "", StorageOpts: "", ExtTableDef: extTableEmpty},

--- a/integration/predata_externals_create_test.go
+++ b/integration/predata_externals_create_test.go
@@ -25,7 +25,7 @@ var _ = Describe("backup integration create statement tests", func() {
 		BeforeEach(func() {
 			extTable = backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: backup.FILE, Location: "file://tmp/ext_table_file",
 				ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "delimiter '	' null '\\N' escape '\\'",
-				Options: "", Command: "", RejectLimit: 0, RejectLimitType: "", ErrTableName: "", ErrTableSchema: "", Encoding: "UTF8",
+				Command: "", RejectLimit: 0, RejectLimitType: "", ErrTableName: "", ErrTableSchema: "", Encoding: "UTF8",
 				Writable: false, URIs: []string{"file://tmp/ext_table_file"}}
 			testTable = backup.Table{
 				Relation:        backup.Relation{Schema: "public", Name: "testtable"},
@@ -102,6 +102,9 @@ var _ = Describe("backup integration create statement tests", func() {
 			extTable.Writable = false
 			extTable.FormatType = "b"
 			extTable.FormatOpts = "formatter 'fixedwidth_out' i '20' "
+			if connectionPool.Version.AtLeast("7") {
+				extTable.FormatOpts = "formatter 'fixedwidth_out'i '20' "
+			}
 			testTable.ExtTableDef = extTable
 
 			backup.PrintExternalTableCreateStatement(backupfile, tocfile, testTable)

--- a/integration/predata_externals_queries_test.go
+++ b/integration/predata_externals_queries_test.go
@@ -26,7 +26,7 @@ FORMAT 'TEXT'`)
 
 			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: "file://tmp/myfile.txt",
 				ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "delimiter '	' null '\\N' escape '\\'",
-				Options: "", Command: "", RejectLimit: 0, RejectLimitType: "", ErrTableName: "", ErrTableSchema: "", Encoding: "UTF8",
+				Command: "", RejectLimit: 0, RejectLimitType: "", ErrTableName: "", ErrTableSchema: "", Encoding: "UTF8",
 				Writable: false, URIs: []string{"file://tmp/myfile.txt"}}
 			structmatcher.ExpectStructsToMatchExcluding(&extTable, &result, "Oid")
 		})
@@ -44,7 +44,7 @@ FORMAT 'TEXT'`)
 
 			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: "",
 				ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "delimiter '	' null '\\N' escape '\\'",
-				Options: "", Command: "hostname", RejectLimit: 0, RejectLimitType: "", ErrTableName: "", ErrTableSchema: "", Encoding: "UTF8",
+				Command: "hostname", RejectLimit: 0, RejectLimitType: "", ErrTableName: "", ErrTableSchema: "", Encoding: "UTF8",
 				Writable: false, URIs: nil}
 
 			structmatcher.ExpectStructsToMatchExcluding(&extTable, &result, "Oid")
@@ -64,7 +64,7 @@ SEGMENT REJECT LIMIT 10 PERCENT
 
 			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: "file://tmp/myfile.txt",
 				ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "delimiter '	' null '\\N' escape '\\'",
-				Options: "", Command: "", RejectLimit: 10, RejectLimitType: "p", ErrTableName: "ext_table", ErrTableSchema: "public", Encoding: "UTF8",
+				Command: "", RejectLimit: 10, RejectLimitType: "p", ErrTableName: "ext_table", ErrTableSchema: "public", Encoding: "UTF8",
 				Writable: false, URIs: []string{"file://tmp/myfile.txt"}}
 
 			structmatcher.ExpectStructsToMatchExcluding(&extTable, &result, "Oid")
@@ -84,7 +84,7 @@ SEGMENT REJECT LIMIT 10 PERCENT
 
 			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: "file://tmp/myfile.txt",
 				ExecLocation: "ALL_SEGMENTS", FormatType: "c", FormatOpts: `delimiter '|' null '' escape ''' quote ''' force not null i`,
-				Options: "", Command: "", RejectLimit: 10, RejectLimitType: "p", ErrTableName: "ext_table", ErrTableSchema: "public", Encoding: "UTF8",
+				Command: "", RejectLimit: 10, RejectLimitType: "p", ErrTableName: "ext_table", ErrTableSchema: "public", Encoding: "UTF8",
 				Writable: false, URIs: []string{"file://tmp/myfile.txt"}}
 
 			structmatcher.ExpectStructsToMatchExcluding(&extTable, &result, "Oid")
@@ -103,31 +103,12 @@ SEGMENT REJECT LIMIT 10 PERCENT
 			result := results[oid]
 
 			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: "file://tmp/myfile.txt",
-				ExecLocation: "ALL_SEGMENTS", FormatType: "b", FormatOpts: `formatter 'fixedwidth_out' i '20' `,
-				Options: "", Command: "", RejectLimit: 10, RejectLimitType: "p", ErrTableName: "ext_table", ErrTableSchema: "public", Encoding: "UTF8",
+				ExecLocation: "ALL_SEGMENTS", FormatType: "b", FormatOpts: "formatter 'fixedwidth_out' i '20' ",
+				Command: "", RejectLimit: 10, RejectLimitType: "p", ErrTableName: "ext_table", ErrTableSchema: "public", Encoding: "UTF8",
 				Writable: false, URIs: []string{"file://tmp/myfile.txt"}}
-
-			structmatcher.ExpectStructsToMatchExcluding(&extTable, &result, "Oid")
-		})
-		It("returns a slice for a complex external table definition with options", func() {
-			testutils.SkipIfBefore5(connectionPool)
-			testhelper.AssertQueryRuns(connectionPool, `CREATE READABLE EXTERNAL TABLE public.ext_table(i int)
-LOCATION ('file://tmp/myfile.txt')
-FORMAT 'TEXT'
-OPTIONS (foo 'bar')
-LOG ERRORS
-SEGMENT REJECT LIMIT 10 PERCENT
-`)
-			defer testhelper.AssertQueryRuns(connectionPool, "DROP EXTERNAL TABLE public.ext_table")
-			oid := testutils.OidFromObjectName(connectionPool, "public", "ext_table", backup.TYPE_RELATION)
-
-			results := backup.GetExternalTableDefinitions(connectionPool)
-			result := results[oid]
-
-			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: "file://tmp/myfile.txt",
-				ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "delimiter '	' null '\\N' escape '\\'",
-				Options: "foo 'bar'", Command: "", RejectLimit: 10, RejectLimitType: "p", ErrTableName: "ext_table", ErrTableSchema: "public", Encoding: "UTF8",
-				Writable: false, URIs: []string{"file://tmp/myfile.txt"}}
+			if connectionPool.Version.AtLeast("7") {
+				extTable.FormatOpts = "formatter 'fixedwidth_out'i '20' "
+			}
 
 			structmatcher.ExpectStructsToMatchExcluding(&extTable, &result, "Oid")
 		})

--- a/integration/predata_relations_create_test.go
+++ b/integration/predata_relations_create_test.go
@@ -25,7 +25,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			partitionPartFalseExpectation = "false"
 		)
 		BeforeEach(func() {
-			extTableEmpty = backup.ExternalTableDefinition{Oid: 0, Type: -2, Protocol: -2, Location: "", ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "", Options: "", Command: "", RejectLimit: 0, RejectLimitType: "", ErrTableName: "", ErrTableSchema: "", Encoding: "UTF-8", Writable: false, URIs: nil}
+			extTableEmpty = backup.ExternalTableDefinition{Oid: 0, Type: -2, Protocol: -2, Location: "", ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "", Command: "", RejectLimit: 0, RejectLimitType: "", ErrTableName: "", ErrTableSchema: "", Encoding: "UTF-8", Writable: false, URIs: nil}
 			testTable = backup.Table{
 				Relation:        backup.Relation{Schema: "public", Name: "testtable"},
 				TableDefinition: backup.TableDefinition{DistPolicy: "DISTRIBUTED RANDOMLY", ExtTableDef: extTableEmpty, Inherits: []string{}},
@@ -318,7 +318,7 @@ SET SUBPARTITION TEMPLATE ` + `
 	})
 	Describe("PrintPostCreateTableStatements", func() {
 		var (
-			extTableEmpty = backup.ExternalTableDefinition{Oid: 0, Type: -2, Protocol: -2, Location: "", ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "", Options: "", Command: "", RejectLimit: 0, RejectLimitType: "", ErrTableName: "", ErrTableSchema: "", Encoding: "UTF-8", Writable: false, URIs: nil}
+			extTableEmpty = backup.ExternalTableDefinition{Oid: 0, Type: -2, Protocol: -2, Location: "", ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "", Command: "", RejectLimit: 0, RejectLimitType: "", ErrTableName: "", ErrTableSchema: "", Encoding: "UTF-8", Writable: false, URIs: nil}
 			tableRow      = backup.ColumnDefinition{Oid: 0, Num: 1, Name: "i", NotNull: false, HasDefault: false, Type: "integer", Encoding: "", StatTarget: -1, StorageType: "", DefaultVal: "", Comment: ""}
 			testTable     backup.Table
 			tableMetadata backup.ObjectMetadata


### PR DESCRIPTION
After a changes to external tables in GPDB, it was discovered that the
options attribute on external tables was an undocumented feature. Since
it is undocumented it should be safe to remove. This commit also fixes
some formatting changes to format options attribute that was the result
of commits that changed how external table format options were stored.

GPDB reference commits:
https://github.com/greenplum-db/gpdb/commit/e4b499aa4a16df49241abc9dd70acec5589f1323
https://github.com/greenplum-db/gpdb/commit/eddd3a6e08e81c19b4588a3718cf1cb7197cfaf9

Authored-by: Kevin Yeap <kyeap@pivotal.io>