### PR TITLE
Minor patches to make gpbackup/gprestore work on Solaris

### DIFF
--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -303,8 +303,8 @@ var _ = BeforeSuite(func() {
 	// This is used to run tests from an older gpbackup version to gprestore latest
 	useOldBackupVersion = os.Getenv("OLD_BACKUP_VERSION") != ""
 	pluginConfigPath =
-		fmt.Sprintf("%s/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin_config.yaml",
-			os.Getenv("HOME"))
+		fmt.Sprintf("%s/src/github.com/greenplum-db/gpbackup/plugins/example_plugin_config.yaml",
+			os.Getenv("GOPATH"))
 	var err error
 	testhelper.SetupTestLogger()
 	_ = exec.Command("dropdb", "testdb").Run()

--- a/end_to_end/incremental_test.go
+++ b/end_to_end/incremental_test.go
@@ -273,7 +273,7 @@ var _ = Describe("End to End incremental tests", func() {
 				if useOldBackupVersion {
 					Skip("This test is only needed for the most recent backup versions")
 				}
-				pluginExecutablePath := fmt.Sprintf("%s/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("HOME"))
+				pluginExecutablePath := fmt.Sprintf("%s/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("GOPATH"))
 				copyPluginToAllHosts(backupConn, pluginExecutablePath)
 			})
 			It("Restores from an incremental backup based on a from-timestamp incremental", func() {
@@ -318,7 +318,7 @@ var _ = Describe("End to End incremental tests", func() {
 				assertArtifactsCleaned(restoreConn, incremental2Timestamp)
 			})
 			It("Runs backup and restore if plugin location changed", func(){
-				pluginExecutablePath := fmt.Sprintf("%s/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("HOME"))
+				pluginExecutablePath := fmt.Sprintf("%s/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("GOPATH"))
 				fullBackupTimestamp := gpbackup(gpbackupPath, backupHelperPath,
 					"--leaf-partition-data",
 					"--plugin-config", pluginConfigPath)

--- a/end_to_end/plugin_test.go
+++ b/end_to_end/plugin_test.go
@@ -169,7 +169,7 @@ var _ = Describe("End to End plugin tests", func() {
 				}
 			})
 			It("runs gpbackup and gprestore with plugin, single-data-file, and no-compression", func() {
-				pluginExecutablePath := fmt.Sprintf("%s/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("HOME"))
+				pluginExecutablePath := fmt.Sprintf("%s/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("GOPATH"))
 				copyPluginToAllHosts(backupConn, pluginExecutablePath)
 
 				timestamp := gpbackup(gpbackupPath, backupHelperPath,
@@ -188,7 +188,7 @@ var _ = Describe("End to End plugin tests", func() {
 				assertArtifactsCleaned(restoreConn, timestamp)
 			})
 			It("runs gpbackup and gprestore with plugin and single-data-file", func() {
-				pluginExecutablePath := fmt.Sprintf("%s/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("HOME"))
+				pluginExecutablePath := fmt.Sprintf("%s/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("GOPATH"))
 				copyPluginToAllHosts(backupConn, pluginExecutablePath)
 
 				timestamp := gpbackup(gpbackupPath, backupHelperPath,
@@ -206,7 +206,7 @@ var _ = Describe("End to End plugin tests", func() {
 				assertArtifactsCleaned(restoreConn, timestamp)
 			})
 			It("runs gpbackup and gprestore with plugin and metadata-only", func() {
-				pluginExecutablePath := fmt.Sprintf("%s/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("HOME"))
+				pluginExecutablePath := fmt.Sprintf("%s/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("GOPATH"))
 				copyPluginToAllHosts(backupConn, pluginExecutablePath)
 
 				timestamp := gpbackup(gpbackupPath, backupHelperPath,
@@ -231,7 +231,7 @@ var _ = Describe("End to End plugin tests", func() {
 			if useOldBackupVersion {
 				Skip("This test is only needed for the most recent backup versions")
 			}
-			pluginExecutablePath := fmt.Sprintf("%s/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("HOME"))
+			pluginExecutablePath := fmt.Sprintf("%s/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("GOPATH"))
 			copyPluginToAllHosts(backupConn, pluginExecutablePath)
 
 			timestamp := gpbackup(gpbackupPath, backupHelperPath,
@@ -253,7 +253,7 @@ var _ = Describe("End to End plugin tests", func() {
 			if useOldBackupVersion {
 				Skip("This test is only needed for the most recent backup versions")
 			}
-			pluginExecutablePath := fmt.Sprintf("%s/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("HOME"))
+			pluginExecutablePath := fmt.Sprintf("%s/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("GOPATH"))
 			copyPluginToAllHosts(backupConn, pluginExecutablePath)
 
 			timestamp := gpbackup(gpbackupPath, backupHelperPath,
@@ -275,7 +275,7 @@ var _ = Describe("End to End plugin tests", func() {
 			if useOldBackupVersion {
 				Skip("This test is only needed for the latest backup version")
 			}
-			pluginsDir := fmt.Sprintf("%s/go/src/github.com/greenplum-db/gpbackup/plugins", os.Getenv("HOME"))
+			pluginsDir := fmt.Sprintf("%s/src/github.com/greenplum-db/gpbackup/plugins", os.Getenv("GOPATH"))
 			copyPluginToAllHosts(backupConn, fmt.Sprintf("%s/example_plugin.bash", pluginsDir))
 			command := exec.Command("bash", "-c", fmt.Sprintf("%s/plugin_test_bench.sh %s/example_plugin.bash %s/example_plugin_config.yaml", pluginsDir, pluginsDir, pluginsDir))
 			mustRunCommand(command)

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/sergi/go-diff v1.1.0
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5
+	golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae
 	golang.org/x/tools v0.0.0-20200214225126-5916a50871fb
 	gopkg.in/cheggaaa/pb.v1 v1.0.28
 	gopkg.in/yaml.v2 v2.2.8

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -14,6 +14,8 @@ import (
 	"sync"
 	"syscall"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gp-common-go-libs/operating"
 	"github.com/greenplum-db/gpbackup/utils"
@@ -126,7 +128,7 @@ func InitializeGlobals() {
  */
 
 func createPipe(pipe string) error {
-	err := syscall.Mkfifo(pipe, 0777)
+	err := unix.Mkfifo(pipe, 0777)
 	return err
 }
 

--- a/integration/helper_test.go
+++ b/integration/helper_test.go
@@ -28,7 +28,7 @@ var (
 	dataFileFullPath = filepath.Join(testDir, "test_data")
 	pluginBackupPath = filepath.Join(pluginDir, "test_data")
 	errorFile        = fmt.Sprintf("%s_error", pipeFile)
-	pluginConfigPath = fmt.Sprintf("%s/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin_config.yaml", os.Getenv("HOME"))
+	pluginConfigPath = fmt.Sprintf("%s/src/github.com/greenplum-db/gpbackup/plugins/example_plugin_config.yaml", os.Getenv("GOPATH"))
 )
 
 const (
@@ -67,7 +67,7 @@ func buildAndInstallBinaries() string {
 		Fail(fmt.Sprintf("%v", err))
 	}
 	_ = os.Chdir("integration")
-	binDir := fmt.Sprintf("%s/go/bin", operating.System.Getenv("HOME"))
+	binDir := fmt.Sprintf("%s/bin", operating.System.Getenv("GOPATH"))
 	return fmt.Sprintf("%s/gpbackup_helper", binDir)
 }
 

--- a/plugins/example_plugin_config.yaml
+++ b/plugins/example_plugin_config.yaml
@@ -1,3 +1,3 @@
-executablepath: $HOME/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash
+executablepath: $GOPATH/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash
 options:
   password: unknown

--- a/restore/wrappers_test.go
+++ b/restore/wrappers_test.go
@@ -290,9 +290,9 @@ withstatistics: false
 			restore.SetVersion("1.11.0+dev.28.g10571fd")
 		})
 		AfterEach(func() {
+			_ = os.Chdir(oldWd)
 			err := os.RemoveAll(tempDir)
 			Expect(err).To(Not(HaveOccurred()))
-			_ = os.Chdir(oldWd)
 			_ = os.Remove(testConfigPath)
 			confDir := filepath.Dir(testConfigPath)
 			confFileName := filepath.Base(testConfigPath)


### PR DESCRIPTION
```
commit f6994ad252d3af6ccfcf2bff9aede1c23110989f
    Update test paths to properly use $GOPATH

    The tests in this patch were all hardcoded to assume $GOPATH was
    $HOME/go. That's not a safe assumption. We should instead use $GOPATH
    to be more OSS developer friendly.

commit 73533befa61517195ffc14ffdc3c6ea763d84600
    Fix wrappers unit test cleanup

    We should move out of the directory before removing it. Some operating
    systems will error out on rmdir if there's an active reference.

commit 6fcafd0b258c085c5f207971ae7e7fd8894137fb
    Use x/sys/unix for Mkfifo call

    The syscall standard library is frozen and does not work for certain
    operating systems (e.g. Solaris). The x/sys/unix library is more up to
    date and has more OS support. Switching libraries for the Mkfifo call
    should be okay as there is no regression found while investigating its
    feasability.
```

Fixes https://github.com/greenplum-db/gpbackup/issues/387 which will help @japinli support gpbackup/gprestore on his Solaris platform.