### PR TITLE
Include failed backups into history file

### DIFF
--- a/backup/incremental.go
+++ b/backup/incremental.go
@@ -1,6 +1,8 @@
 package backup
 
 import (
+	"path"
+
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gp-common-go-libs/iohelper"
 	"github.com/greenplum-db/gpbackup/history"
@@ -8,7 +10,6 @@ import (
 	"github.com/greenplum-db/gpbackup/toc"
 	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/pkg/errors"
-	"path"
 )
 
 func FilterTablesForIncremental(lastBackupTOC, currentTOC *toc.TOC, tables []Table) []Table {
@@ -63,7 +64,7 @@ func GetLatestMatchingBackupTimestamp() string {
 
 func GetLatestMatchingBackupConfig(history *history.History, currentBackupConfig *history.BackupConfig) *history.BackupConfig {
 	for _, backupConfig := range history.BackupConfigs {
-		if matchesIncrementalFlags(&backupConfig, currentBackupConfig) {
+		if matchesIncrementalFlags(&backupConfig, currentBackupConfig) && !backupConfig.Failed() {
 			return &backupConfig
 		}
 	}

--- a/backup/incremental_test.go
+++ b/backup/incremental_test.go
@@ -80,7 +80,7 @@ var _ = Describe("backup/incremental tests", func() {
 
 	Describe("GetLatestMatchingBackupConfig", func() {
 		contents := history.History{BackupConfigs: []history.BackupConfig{
-			{DatabaseName: "test2", Timestamp: "timestamp4"},
+			{DatabaseName: "test2", Timestamp: "timestamp4", Status: history.BackupStatusFailed},
 			{DatabaseName: "test1", Timestamp: "timestamp3"},
 			{DatabaseName: "test2", Timestamp: "timestamp2"},
 			{DatabaseName: "test1", Timestamp: "timestamp1"},
@@ -91,6 +91,13 @@ var _ = Describe("backup/incremental tests", func() {
 			latestBackupHistoryEntry := backup.GetLatestMatchingBackupConfig(&contents, &currentBackupConfig)
 
 			structmatcher.ExpectStructsToMatch(contents.BackupConfigs[1], latestBackupHistoryEntry)
+		})
+		It("Should return the latest matching backup's timestamp that did not fail", func() {
+			currentBackupConfig := history.BackupConfig{DatabaseName: "test2"}
+
+			latestBackupHistoryEntry := backup.GetLatestMatchingBackupConfig(&contents, &currentBackupConfig)
+
+			structmatcher.ExpectStructsToMatch(contents.BackupConfigs[2], latestBackupHistoryEntry)
 		})
 		It("should return nil with no matching Dbname", func() {
 			currentBackupConfig := history.BackupConfig{DatabaseName: "test3"}

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -2,6 +2,9 @@ package backup
 
 import (
 	"fmt"
+	"path"
+	"reflect"
+
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
@@ -11,8 +14,6 @@ import (
 	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/nightlyone/lockfile"
 	"github.com/pkg/errors"
-	"path"
-	"reflect"
 )
 
 /*
@@ -98,6 +99,7 @@ func NewBackupConfig(dbName string, dbVersion string, backupVersion string, plug
 		Timestamp:             timestamp,
 		WithoutGlobals:        MustGetFlagBool(options.WITHOUT_GLOBALS),
 		WithStatistics:        MustGetFlagBool(options.WITH_STATS),
+		Status:                history.BackupStatusFailed,
 	}
 
 	return &backupConfig

--- a/history/history.go
+++ b/history/history.go
@@ -18,6 +18,11 @@ type RestorePlanEntry struct {
 	TableFQNs []string
 }
 
+const (
+	BackupStatusSucceed = "Success"
+	BackupStatusFailed  = "Failure"
+)
+
 type BackupConfig struct {
 	BackupDir             string
 	BackupVersion         string
@@ -45,6 +50,11 @@ type BackupConfig struct {
 	EndTime               string
 	WithoutGlobals        bool
 	WithStatistics        bool
+	Status                string
+}
+
+func (backup *BackupConfig) Failed() bool {
+	return backup.Status == BackupStatusFailed
 }
 
 func ReadConfigFile(filename string) *BackupConfig {
@@ -76,7 +86,6 @@ func NewHistory(filename string) (*History, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	return history, nil
 }
 
@@ -156,7 +165,7 @@ func (history *History) WriteToFileAndMakeReadOnly(filename string) error {
 
 func (history *History) FindBackupConfig(timestamp string) *BackupConfig {
 	for _, backupConfig := range history.BackupConfigs {
-		if backupConfig.Timestamp == timestamp {
+		if backupConfig.Timestamp == timestamp && !backupConfig.Failed() {
 			return &backupConfig
 		}
 	}

--- a/report/report.go
+++ b/report/report.go
@@ -144,12 +144,12 @@ func (report *Report) WriteBackupReportFile(reportFilename string, timestamp str
 	if errMsg != "" {
 		reportInfo = append(reportInfo,
 			LineInfo{},
-			LineInfo{Key: "backup status:", Value: "Failure"},
+			LineInfo{Key: "backup status:", Value: history.BackupStatusFailed},
 			LineInfo{Key: "backup error:", Value: errMsg})
 	} else {
 		reportInfo = append(reportInfo,
 			LineInfo{},
-			LineInfo{Key: "backup status:", Value: "Success"})
+			LineInfo{Key: "backup status:", Value: history.BackupStatusSucceed})
 	}
 	if report.DatabaseSize != "" {
 		reportInfo = append(reportInfo,

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -33,9 +33,9 @@ import (
 )
 
 var (
-	stdout       *Buffer
-	logfile      *Buffer
-	buffer       *Buffer
+	stdout  *Buffer
+	logfile *Buffer
+	buffer  *Buffer
 )
 
 func TestReport(t *testing.T) {
@@ -324,6 +324,7 @@ restore status:      Success but non-fatal errors occurred. See log file .+ for 
 				Plugin:               "/tmp/plugin.sh",
 				Timestamp:            "timestamp1",
 				IncludeTableFiltered: true,
+				Status:               history.BackupStatusFailed,
 			}, backupConfig)
 		})
 	})


### PR DESCRIPTION
 - Previously we only added successful backups in the
   history file. This commit moves WriteBackupHistory
   into deferred DoTeardown() function that executes
   even if there was an error (unless we explicitly
   exited before). 
- It also adds Failed field to reflect the status of backup in the 
  history file and makes restore to ignore backups that failed
  when searching for the backup with specific timestamp
  or latest backup with matching config (for --incremental)
- Validated manually: 
    * if history already has some records without Failed field 
      gpbackup will just treat them as ones that have Failed false
   * on next incremental restore plan will move the record for the table
     updated in failed backup into next successful.

Authored-by: Kate Dontsova <edontsova@pivotal.io>