### PR TITLE
Filter out system extensions in extension queries

### DIFF
--- a/backup/predata_functions.go
+++ b/backup/predata_functions.go
@@ -238,6 +238,9 @@ func PrintCreateLanguageStatements(metadataFile *utils.FileWithByteCount, toc *t
 	for _, procLang := range procLangs {
 		start := metadataFile.ByteCount
 		metadataFile.MustPrintf("\n\nCREATE ")
+		if connectionPool.Version.AtLeast("6") {
+			metadataFile.MustPrintf("OR REPLACE ")
+		}
 		if procLang.PlTrusted {
 			metadataFile.MustPrintf("TRUSTED ")
 		}

--- a/backup/queries_functions.go
+++ b/backup/queries_functions.go
@@ -719,12 +719,13 @@ func (e Extension) FQN() string {
 func GetExtensions(connectionPool *dbconn.DBConn) []Extension {
 	results := make([]Extension, 0)
 
-	query := `
+	query := fmt.Sprintf(`
 	SELECT e.oid,
 		quote_ident(extname) AS name,
 		quote_ident(n.nspname) AS schema
 	FROM pg_extension e
-		JOIN pg_namespace n ON e.extnamespace = n.oid`
+		JOIN pg_namespace n ON e.extnamespace = n.oid
+	WHERE e.oid >= %d`, FIRST_NORMAL_OBJECT_ID)
 	err := connectionPool.Select(&results, query)
 	gplog.FatalOnError(err)
 	return results

--- a/ci/templates/gpbackup-tpl.yml
+++ b/ci/templates/gpbackup-tpl.yml
@@ -470,14 +470,6 @@ resources:
     uri: https://github.com/greenplum-db/gpdb
     branch: master
 
-- name: bin_gpdb_master_centos6
-  type: gcs
-  icon: google
-  source:
-    bucket: ((gcs-bucket))
-    json_key: ((concourse-gcs-resources-service-account-key))
-    regexp: server/published/master/server-rc-(.*)-rhel6_x86_64((rc-build-type-gcs)).tar.gz
-
 - name: bin_gpdb_master_centos7
   type: gcs
   icon: google
@@ -1178,11 +1170,8 @@ jobs:
 - name: master
   plan:
   - in_parallel:
-    - get: centos6-image
     - get: centos7-image
     - get: gpbackup
-    - get: bin_gpdb_master_centos6
-      trigger: true
     - get: bin_gpdb_master_centos7
     - get: gpdb_src
       resource: gpdb_master_src
@@ -1191,21 +1180,13 @@ jobs:
     - get: gppkgs
       trigger: true
       passed: [build_gppkgs]
-  - in_parallel:
-    - task: run-tests-locally-centos6
-      image: centos6-image
-      file: gpbackup/ci/tasks/test-on-local-cluster.yml
-      params:
-        REQUIRES_DUMMY_SEC: true
-      input_mapping:
-        bin_gpdb: bin_gpdb_master_centos6
-    - task: run-tests-locally-centos7
-      image: centos7-image
-      file: gpbackup/ci/tasks/test-on-local-cluster.yml
-      params:
-        REQUIRES_DUMMY_SEC: true
-      input_mapping:
-        bin_gpdb: bin_gpdb_master_centos7
+  - task: run-tests-locally-centos7
+    image: centos7-image
+    file: gpbackup/ci/tasks/test-on-local-cluster.yml
+    params:
+      REQUIRES_DUMMY_SEC: true
+    input_mapping:
+      bin_gpdb: bin_gpdb_master_centos7
   on_failure:
     *slack_alert
 {% endif %}

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -72,9 +72,6 @@ var _ = BeforeSuite(func() {
 		testhelper.AssertQueryRuns(connectionPool, "SET allow_system_table_mods = 'DML'")
 		testutils.SetupTestFilespace(connectionPool, testCluster)
 	} else {
-		// Drop plpgsql extension to not interfere in extension tests
-		testhelper.AssertQueryRuns(connectionPool, "DROP EXTENSION plpgsql CASCADE")
-		testhelper.AssertQueryRuns(connectionPool, "CREATE LANGUAGE plpgsql")
 		testhelper.AssertQueryRuns(connectionPool, "SET allow_system_table_mods = true")
 
 		remoteOutput := testCluster.GenerateAndExecuteCommand("Creating filespace test directories on all hosts", func(contentID int) string {


### PR DESCRIPTION
As part of the removal of pg_exttable in GPDB master, the external table's
execution logic was moved into an external table fdw extension. A few of
Gpbackup's integration tests broke because it was not filtering out
system extensions.

GPDB reference commit:
https://github.com/greenplum-db/gpdb/commit/d86f32e5bead35167dc4ea0e2053becfc2ed6b00