### PR TITLE
Enforce incremental restore to require --data-only

### DIFF
--- a/restore/validate.go
+++ b/restore/validate.go
@@ -271,4 +271,7 @@ func ValidateFlagCombinations(flags *pflag.FlagSet) {
 		!flags.Changed(options.DATA_ONLY) {
 		gplog.Fatal(errors.Errorf("Cannot use --truncate-table without --include-table or --include-table-file and without --data-only"), "")
 	}
+	if flags.Changed(options.INCREMENTAL) && !flags.Changed(options.DATA_ONLY) {
+		gplog.Fatal(errors.Errorf("Cannot use --incremental without --data-only"), "")
+	}
 }


### PR DESCRIPTION
Incremental restore only restores data incrementally and doesn't restore
any metadata (predata/postdata). Validation check has been added to
enforce restore with --incremental to only work with --data-only.

Identifying the missing relations/schemas is now a separate function `verifyIncrementalState` outside of `restorePreData`