### PR TITLE
Backup functions before tables

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -203,12 +203,14 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Table, tableO
 	objects := make([]Sortable, 0)
 	metadataMap := make(MetadataMap)
 
+	if !tableOnly {
+		functions, funcInfoMap = retrieveFunctions(&objects, metadataMap)
+	}
 	objects = append(objects, convertToSortableSlice(tables)...)
 	relationMetadata := GetMetadataForObjectType(connectionPool, TYPE_RELATION)
 	addToMetadataMap(relationMetadata, metadataMap)
 
 	if !tableOnly {
-		functions, funcInfoMap = retrieveFunctions(&objects, metadataMap)
 		protocols = retrieveProtocols(&objects, metadataMap)
 		backupSchemas(metadataFile, createAlteredPartitionSchemaSet(tables))
 		backupExtensions(metadataFile)


### PR DESCRIPTION
 - So that tables that depend on functions could be restored without an error
   Also fix the test for functions and --include-filtering where functions were omitted

Authored-by: Kate Dontsova <edontsova@pivotal.io>