### PR TITLE
fchmod before fsync in WriteToFileAndMakeReadOnly function

### DIFF
--- a/utils/util.go
+++ b/utils/util.go
@@ -57,12 +57,12 @@ func WriteToFileAndMakeReadOnly(filename string, contents []byte) error {
 		return err
 	}
 
-	err = file.Sync()
+	err = file.Chmod(0444)
 	if err != nil {
 		return err
 	}
 
-	err = file.Chmod(0444)
+	err = file.Sync()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
We should always have all file operations before the fsync and fclose
calls. This guarantees the file changes have persisted to disk and to
prevent any funny business on unordered filesystems.

This is supposedly why (in our Concourse plugin_test_bench testing)
the plugin segment TOC file ends up as read-only in extremely rare
cases instead of the 755 permissions we expected it to have after
running BackupSegmentTOCs(). The possible theory there is that the
Overlay filesystem that Concourse containers use ordered the chmod 755
(called with system chmod tool) before the chmod 444 (called with
system fchmod).