### PR TITLE
Update OSL filename and add OSL file to release tarball and gppkg

### DIFF
--- a/ci/scripts/build-os-tars.bash
+++ b/ci/scripts/build-os-tars.bash
@@ -10,12 +10,13 @@ pushd gpbackup_tar
   tar -xzf ../gpbackup-go-components/go_components.tar.gz
   cp ../ddboost_components/*version .
   cp gpbackup_version version
+  cp ../gpbackup-release-license/open_source_license_VMware_Tanzu_Greenplum_Backup_and_Restore*.txt open_source_licenses_VMware_Tanzu_Greenplum_Backup_and_Restore.txt
 
   mkdir -p bin lib
   cp gpbackup gpbackup_helper gprestore gpbackup_s3_plugin gpbackup_manager bin/
   cp ../ddboost_components/gpbackup_ddboost_plugin bin/
   cp ../ddboost_components/libDDBoost.so lib/
-  tar -czvf bin_gpbackup.tar.gz bin/ lib/
+  tar -czvf bin_gpbackup.tar.gz bin/ lib/ open_source_licenses_VMware_Tanzu_Greenplum_Backup_and_Restore.txt
 
   tar -czvf gpbackup-$(cat version).tar.gz bin_gpbackup.tar.gz install_gpdb_component *version
 popd

--- a/ci/scripts/update-metadata.bash
+++ b/ci/scripts/update-metadata.bash
@@ -49,11 +49,11 @@ pushd pivnet_release_cache
   touch ../workspace/v-${TILE_RELEASE_VERSION}
 popd
 
-if test ! -f gpbackup-release-license/open_source_license_pivotal-gpdb-backup-${CURR_MAJOR}.${CURR_MINOR}.*.txt ; then
+if test ! -f gpbackup-release-license/open_source_license_VMware_Tanzu_Greenplum_Backup_and_Restore_${CURR_MAJOR}.${CURR_MINOR}.*.txt ; then
   echo "License file for gpbackup version ${CURR_MAJOR}.${CURR_MINOR}.* does not exist in resource.\n Ensure the OSL is properly uploaded to the GCS bucket prior to pushing to pivnet." 1>&2
   exit 1
 fi
-cp gpbackup-release-license/open_source_license_pivotal-gpdb-backup-*.txt workspace/files-to-upload/
+cp gpbackup-release-license/open_source_license_VMware_Tanzu_Greenplum_Backup_and_Restore_*.txt workspace/files-to-upload/
 
 # NOTE: We must use the Pivnet Release Version because we cannot upload files with the same name in different tile releases
 DDBOOST_PLUGIN_VERSION=$(cat workspace/files-to-upload/ddboost_plugin_version)
@@ -64,7 +64,7 @@ BMAN_VERSION=$(cat workspace/files-to-upload/gpbackup_manager_version)
 sed -i "s/<BMAN_VERSION>/${BMAN_VERSION}/g" workspace/metadata.yml
 sed -i "s/<TILE_RELEASE_VERSION>/${TILE_RELEASE_VERSION}/g" workspace/metadata.yml
 sed -i "s/<GPBAR_VERSION>/${TILE_RELEASE_VERSION}/g" workspace/metadata.yml
-OSL_FILENAME=$(basename -- gpbackup-release-license/open_source_license_pivotal-gpdb-backup-*.txt)
+OSL_FILENAME=$(basename -- gpbackup-release-license/open_source_license_VMware_Tanzu_Greenplum_Backup_and_Restore_*.txt)
 sed -i "s/<OSL_FILENAME>/${OSL_FILENAME}/g" workspace/metadata.yml
 sed -i "s/<RELEASE_TYPE>/${RELEASE_TYPE} Release/g" workspace/metadata.yml
 

--- a/ci/tasks/build-os-tars.yml
+++ b/ci/tasks/build-os-tars.yml
@@ -7,6 +7,7 @@ inputs:
 - name: gpbackup
 - name: gpbackup-go-components
 - name: ddboost_components
+- name: gpbackup-release-license
 
 outputs:
 - name: gpbackup_tar

--- a/ci/templates/gpbackup-tpl.yml
+++ b/ci/templates/gpbackup-tpl.yml
@@ -767,6 +767,7 @@ resources:
     region: ((pivnet_aws_region))
     copy_metadata: true
     sort_by: semver
+{% endif %}
 
 - name: gpbackup-release-license
   type: gcs
@@ -774,8 +775,7 @@ resources:
   source:
     bucket: gpbackup-release-licenses
     json_key: ((gcp_svc_acct_key))
-    regexp: open_source_license_pivotal-gpdb-backup-(.*)-*.txt
-{% endif %}
+    regexp: open_source_license_VMware_Tanzu_Greenplum_Backup_and_Restore_(.*)_.*.txt
 
 jobs:
 - name: build_binaries
@@ -831,6 +831,7 @@ jobs:
       trigger: true
 {% endif %}
     - get: pivnet_release_cache
+    - get: gpbackup-release-license
   - task: gpbackup-tools-versions
     image: centos6-image
     file: gpbackup/ci/tasks/gpbackup-tools-versions.yml

--- a/gppkg/gpbackup_tools.spec.in
+++ b/gppkg/gpbackup_tools.spec.in
@@ -18,10 +18,12 @@ Backup and restore utilities for Greenplum
 
 %install
 mkdir -p $RPM_BUILD_ROOT%{prefix}/bin $RPM_BUILD_ROOT%{prefix}/lib
+cp open_source_licenses_VMware_Tanzu_Greenplum_Backup_and_Restore.txt $RPM_BUILD_ROOT%{prefix}/
 cp bin/gpbackup bin/gprestore bin/gpbackup_helper bin/gpbackup_manager bin/gpbackup_ddboost_plugin bin/gpbackup_s3_plugin $RPM_BUILD_ROOT%{prefix}/bin
 cp lib/libDDBoost.so $RPM_BUILD_ROOT%{prefix}/lib
 
 %files
+%{prefix}/open_source_licenses_VMware_Tanzu_Greenplum_Backup_and_Restore.txt
 %{prefix}/bin/gpbackup
 %{prefix}/bin/gprestore
 %{prefix}/bin/gpbackup_helper


### PR DESCRIPTION
With the switch to VMware, we need to update the OSL filename and add
the OSL file to the actual release tarball and gppkg. The OSL file
will be located in $GPHOME directory as part of installation.