### PR TITLE
Always disable gp_autostats_mode and add gprestore --run-analyze flag

### DIFF
--- a/options/flag.go
+++ b/options/flag.go
@@ -41,6 +41,7 @@ const (
 	CREATE_DB             = "create-db"
 	ON_ERROR_CONTINUE     = "on-error-continue"
 	REDIRECT_DB           = "redirect-db"
+	RUN_ANALYZE           = "run-analyze"
 	TIMESTAMP             = "timestamp"
 	WITH_GLOBALS          = "with-globals"
 	REDIRECT_SCHEMA       = "redirect-schema"
@@ -107,6 +108,7 @@ func SetRestoreFlagDefaults(flagSet *pflag.FlagSet) {
 	flagSet.Bool(VERBOSE, false, "Print verbose log messages")
 	flagSet.Bool(WITH_STATS, false, "Restore query plan statistics")
 	flagSet.Bool(LEAF_PARTITION_DATA, false, "For partition tables, create one data file per leaf partition instead of one data file for the whole table")
+	flagSet.Bool(RUN_ANALYZE, false, "Run ANALYZE on restored tables")
 	_ = flagSet.MarkHidden(LEAF_PARTITION_DATA)
 }
 

--- a/restore/data.go
+++ b/restore/data.go
@@ -125,16 +125,7 @@ func restoreDataFromTimestamp(fpInfo filepath.FilePathInfo, dataEntries []toc.Ma
 		workerPool.Add(1)
 		go func(whichConn int) {
 			defer workerPool.Done()
-			if MustGetFlagBool(options.WITH_STATS) && backupConfig.WithStatistics {
-				disableAutoStatsForSession := toc.StatementWithType{
-					Schema:          "",
-					Name:            "",
-					ObjectType:      "SESSION",
-					ReferenceObject: "",
-					Statement:       "SET gp_autostats_mode='none';",
-				}
-				gucStatements = append(gucStatements, disableAutoStatsForSession)
-			}
+
 			setGUCsForConnection(gucStatements, whichConn)
 			for entry := range tasks {
 				if wasTerminated {

--- a/restore/validate.go
+++ b/restore/validate.go
@@ -274,4 +274,5 @@ func ValidateFlagCombinations(flags *pflag.FlagSet) {
 	if flags.Changed(options.INCREMENTAL) && !flags.Changed(options.DATA_ONLY) {
 		gplog.Fatal(errors.Errorf("Cannot use --incremental without --data-only"), "")
 	}
+	options.CheckExclusiveFlags(flags, options.RUN_ANALYZE, options.WITH_STATS)
 }

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -106,6 +106,10 @@ SET default_with_oids = off;
 	}
 	setupQuery += SetMaxCsvLineLengthQuery(connectionPool)
 
+	// Always disable gp_autostats_mode to prevent automatic ANALYZE
+	// during COPY FROM SEGMENT. ANALYZE should be run separately.
+	setupQuery += "SET gp_autostats_mode = 'none';\n"
+
 	for i := 0; i < connectionPool.NumConns; i++ {
 		connectionPool.MustExec(setupQuery, i)
 	}


### PR DESCRIPTION
commit 9a42b36d96e85db3d85840653888a9a40ef06a90

    Introduce --run-analyze flag for gprestore

    In prior gprestore versions, ANALYZE was being inadvertently run at
    the end of each COPY FROM SEGMENT command due to
    gp_autostats_mode... but that has been fully disabled in a recent
    commit. The --run-analyze flag for gprestore will allow the user to
    ANALYZE on all restored tables instead of doing it manually. This
    makes sense since gprestore already has the list of restored tables
    ready to use.

    The way --run-analyze is implemented is somewhat equivalent to how
    gprestore was doing it before but now in its own separate
    transaction. An ANALYZE command is run against all tables that have
    had a COPY FROM SEGMENT command executed on it. There can definitely
    be optimizations here for partition tables involving disabling
    optimizer_analyze_enable_merge_of_leaf_stats GUC and manually merging
    leaf partition stats to the root partition ourselves... but this
    implementation is good enough for now as a simple first pass.

commit 439eda06cbd19a689c849f08fce4190c00aa99d6

    Always disable gp_autostats_mode during data restore

    For the longest time, gprestore was initially designed to not run
    ANALYZE after finishing the restore. This is why there was never a
    flag for the user to run ANALYZE. However, ANALYZE was unintentionally
    being automatically run during each COPY FROM SEGMENT call because of
    gp_autostats_mode. The gp_autostats_mode default value `on_no_stats`
    made it so an ANALYZE would be run on the table when initial data is
    inserted... which is exactly what most gprestore runs will do (create
    new table and load data into it).

    This lead to some unfortunate side effects:
    1. COPY FROM SEGMENT data restore calls take a bit longer.
    2. Rare OOM scenarios when restoring data on large partition tables.

    To prevent the above side effects, we now always disable
    gp_autostats_mode during data restores. A new gprestore flag to run
    ANALYZE after all data restores have finished can be introduced later.