### PR TITLE
Fix gprestore --truncate-table performance bottleneck when using --jobs

### DIFF
--- a/restore/data.go
+++ b/restore/data.go
@@ -148,7 +148,7 @@ func restoreDataFromTimestamp(fpInfo filepath.FilePathInfo, dataEntries []toc.Ma
 				// Truncate table before restore, if needed
 				var err error
 				if MustGetFlagBool(options.INCREMENTAL) || MustGetFlagBool(options.TRUNCATE_TABLE) {
-					err = TruncateTable(tableName)
+					err = TruncateTable(tableName, whichConn)
 				}
 				if err == nil {
 					err = restoreSingleTableData(&fpInfo, entry, tableName, whichConn)

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -368,8 +368,8 @@ func GetExistingSchemas() ([]string, error) {
 	return existingSchemas, err
 }
 
-func TruncateTable(tableFQN string) error {
+func TruncateTable(tableFQN string, whichConn int) error {
 	gplog.Verbose("Truncating table %s prior to restoring data", tableFQN)
-	_, err := connectionPool.Exec(`TRUNCATE ` + tableFQN)
+	_, err := connectionPool.Exec(`TRUNCATE ` + tableFQN, whichConn)
 	return err
 }


### PR DESCRIPTION
When using --truncate-table and --jobs together for gprestore, the
workers were all using the same database connection to execute the
TRUNCATE statements. This causes an unintentional performance
bottleneck since each worker would be waiting on that single database
connection to execute TRUNCATE. Also, that single database connection
is dedicated to its own worker so you could have an extreme bottleneck
scenario as such:
1. Worker A is running COPY FROM SEGMENT on database connection 1
2. Workers B and C are trying to run TRUNCATE on database connection 1
3. Workers B and C are queued until Worker A finishes its COPY FROM
   SEGMENT
4. Workers B and C have their own COPY FROM SEGMENT commands waiting
   on their TRUNCATE commands to finish before running on their
   dedicated database connections 2 and 3

Fix the issue by attaching connection id to the TRUNCATE statements
when executing.