### PR TITLE
Fix uncaught error in scale tests

### DIFF
--- a/ci/scripts/scale-tests.bash
+++ b/ci/scripts/scale-tests.bash
@@ -15,6 +15,11 @@ cat <<SCRIPT > /tmp/run_tests.bash
 
 source env.sh
 
+# Double the vmem protect limit default on the master segment to
+# prevent query cancels on large table creations (e.g. scale_db1.sql)
+gpconfig -c gp_vmem_protect_limit -v 16384 --masteronly
+gpstop -air
+
 # only install if not installed already
 is_installed_output=\$(source env.sh; gppkg -q gpbackup*gp*.gppkg)
 set +e


### PR DESCRIPTION
In our scale tests, there are failures outputted when running the
scale_db1.sql file. The large hdb."order" partition table is not able
to be created because the default vmem protect limit is reached and
the query gets canceled. Simply double the vmem protect limit default
on the master segment to allow the master segment to process the large
CREATE TABLE statement.