### PR TITLE
Restore flag validation fixes

### DIFF
--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -1354,4 +1354,14 @@ var _ = Describe("backup and restore end to end tests", func() {
 
 		assertArtifactsCleaned(restoreConn, timestamp)
 	})
+	It("runs gprestore with --include-schema and --exclude-table flag", func() {
+		timestamp := gpbackup(gpbackupPath, backupHelperPath,
+			"--metadata-only")
+		gprestore(gprestorePath, restoreHelperPath, timestamp,
+			"--redirect-db", "restoredb",
+			"--include-schema", "schema2",
+			"--exclude-table", "schema2.returns",
+			"--metadata-only")
+		assertRelationsCreated(restoreConn, 4)
+	})
 })


### PR DESCRIPTION
- Support for `include-schema` to work along with `exclude-table` during `gpresotre`. This fixes a regression caused by commit 35e8262

- Refactored redirect flag checks and separated truncate flag checks from it.