### PR TITLE
Run analyze against root partitions on GPDB 4.3

### DIFF
--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -998,14 +998,6 @@ var _ = Describe("backup and restore end to end tests", func() {
 			Expect(actualStatisticCount).To(Equal("3"))
 		})
 		It("runs gpbackup with --leaf-partition-data and gprestore with --run-analyze", func() {
-			// TODO: In GPDB 4.3, leaf partition statistics
-			// are not automatically merged up to the root
-			// partition when all leaf partitions have been
-			// analyzed. The gprestore --run-analyze feature
-			// needs to be updated to always run ANALYZE on
-			// the root partition in GPDB 4.3.
-			testutils.SkipIfBefore5(backupConn)
-
 			timestamp := gpbackup(gpbackupPath, backupHelperPath,
 				"--include-table", "public.sales", "--leaf-partition-data")
 			gprestore(gprestorePath, restoreHelperPath, timestamp,

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -440,11 +440,46 @@ func runAnalyze(filteredDataEntries map[string][]toc.MasterDataEntry) {
 			analyzeCommand := fmt.Sprintf("ANALYZE %s", tableFQN)
 
 			newAnalyzeStatement := toc.StatementWithType{
-				Schema: tableSchema,
-				Name: entry.Name,
+				Schema:    tableSchema,
+				Name:      entry.Name,
 				Statement: analyzeCommand,
 			}
 			analyzeStatements = append(analyzeStatements, newAnalyzeStatement)
+		}
+	}
+
+	// Only GPDB 5+ has leaf partition stats merged up to the root
+	// automatically. Against GPDB 4.3, we must extract the root partitions
+	// from the leaf partition info and run ANALYZE ROOTPARTITION on the root
+	// partitions. These particular ANALYZE ROOTPARTITION statements should run
+	// last so add them to the end of the analyzeStatements list.
+	if connectionPool.Version.Is("4") {
+		// Create root partition set
+		partitionRootSet := map[toc.StatementWithType]struct{}{}
+		for _, dataEntries := range filteredDataEntries {
+			for _, entry := range dataEntries {
+				if entry.PartitionRoot != "" {
+					tableSchema := entry.Schema
+					if opts.RedirectSchema != "" {
+						tableSchema = opts.RedirectSchema
+					}
+					rootFQN := utils.MakeFQN(tableSchema, entry.PartitionRoot)
+					analyzeCommand := fmt.Sprintf("ANALYZE ROOTPARTITION %s", rootFQN)
+					rootStatement := toc.StatementWithType{
+						Schema:    tableSchema,
+						Name:      entry.PartitionRoot,
+						Statement: analyzeCommand,
+					}
+
+					if _, ok := partitionRootSet[rootStatement]; !ok {
+						partitionRootSet[rootStatement] = struct{}{}
+					}
+				}
+			}
+		}
+
+		for rootAnalyzeStatement, _ := range partitionRootSet {
+			analyzeStatements = append(analyzeStatements, rootAnalyzeStatement)
 		}
 	}
 


### PR DESCRIPTION
Bug fix for --run-analyze on GPDB 4.3. During analyze, GPDB 5+ has leaf
partition stats merged up to the root automatically. Against GPDB 4.3,
we must extract the root partitions from the leaf partition info and run
ANALYZE only on the root partitions.

Authored-by: Kevin Yeap <kyeap@vmware.com>