### PR TITLE
Master partition logic    Prevent partition queries from running in gpdb7

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -446,8 +446,10 @@ func cancelBlockedQueries(timestamp string) {
 	// Query for all blocked queries
 	pids := make([]int64, 0)
 	findBlockedQuery := fmt.Sprintf("SELECT procpid from pg_stat_activity WHERE application_name='gpbackup_%s' AND waiting='t' AND waiting_reason='lock';", timestamp)
-	if conn.Version.AtLeast("6") {
+	if conn.Version.Is("6") {
 		findBlockedQuery = fmt.Sprintf("SELECT pid from pg_stat_activity WHERE application_name='gpbackup_%s' AND waiting='t' AND waiting_reason='lock';", timestamp)
+	} else if conn.Version.AtLeast("7") {
+		findBlockedQuery = fmt.Sprintf("SELECT pid from pg_stat_activity WHERE application_name='gpbackup_%s' AND wait_event_type='Lock';", timestamp)
 	}
 	err := conn.Select(&pids, findBlockedQuery)
 	gplog.FatalOnError(err)

--- a/backup/queries_externals.go
+++ b/backup/queries_externals.go
@@ -137,6 +137,11 @@ func (pi PartitionInfo) GetMetadataEntry() (string, toc.MetadataEntry) {
 }
 
 func GetExternalPartitionInfo(connectionPool *dbconn.DBConn) ([]PartitionInfo, map[uint32]PartitionInfo) {
+	// TODO: fix for gpdb7 partitioning
+	if connectionPool.Version.AtLeast("7") {
+		return []PartitionInfo{}, make(map[uint32]PartitionInfo, 0)
+	}
+
 	results := make([]PartitionInfo, 0)
 	query := `
 	SELECT pr1.oid AS partitionruleoid,

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -75,8 +75,9 @@ func (r Relation) GetUniqueID() UniqueID {
  * it is currently much simpler than the include case.
  */
 func getUserTableRelations(connectionPool *dbconn.DBConn) []Relation {
+	// TODO: fix for gpdb7 partitioning
 	childPartitionFilter := ""
-	if !MustGetFlagBool(options.LEAF_PARTITION_DATA) {
+	if !MustGetFlagBool(options.LEAF_PARTITION_DATA) && connectionPool.Version.Before("7") {
 		//Filter out non-external child partitions
 		childPartitionFilter = `
 	AND c.oid NOT IN (

--- a/backup/queries_shared.go
+++ b/backup/queries_shared.go
@@ -109,7 +109,17 @@ func (c Constraint) FQN() string {
 }
 
 func GetConstraints(connectionPool *dbconn.DBConn, includeTables ...Relation) []Constraint {
-	// ConIsLocal should always return true from GetConstraints because we filter out constraints that are inherited using the INHERITS clause, or inherited from a parent partition table. This field only accurately reflects constraints in GPDB6+ because check constraints on parent tables must propogate to children. For GPDB versions 5 or lower, this field will default to false.
+	// TODO: fix for gpdb7 partitioning
+	if connectionPool.Version.AtLeast("7") {
+		return []Constraint{}
+	}
+
+	// ConIsLocal should always return true from GetConstraints because we
+	// filter out constraints that are inherited using the INHERITS clause, or
+	// inherited from a parent partition table. This field only accurately
+	// reflects constraints in GPDB6+ because check constraints on parent
+	// tables must propogate to children. For GPDB versions 5 or lower, this
+	// field will default to false.
 	var selectConIsLocal string
 	var groupByConIsLocal string
 	if connectionPool.Version.AtLeast("6") {

--- a/backup/queries_table_defs.go
+++ b/backup/queries_table_defs.go
@@ -57,20 +57,20 @@ func createAlteredPartitionSchemaSet(tables []Table) map[string]bool {
 }
 
 type TableDefinition struct {
-	DistPolicy         string
-	PartDef            string
-	PartTemplateDef    string
-	StorageOpts        string
-	TablespaceName     string
-	ColumnDefs         []ColumnDefinition
-	IsExternal         bool
-	ExtTableDef        ExternalTableDefinition
-	PartitionLevelInfo PartitionLevelInfo
-	TableType          string
-	IsUnlogged         bool
-	ForeignDef         ForeignTableDefinition
-	Inherits           []string
-	ReplicaIdentity    string
+	DistPolicy              string
+	PartDef                 string
+	PartTemplateDef         string
+	StorageOpts             string
+	TablespaceName          string
+	ColumnDefs              []ColumnDefinition
+	IsExternal              bool
+	ExtTableDef             ExternalTableDefinition
+	PartitionLevelInfo      PartitionLevelInfo
+	TableType               string
+	IsUnlogged              bool
+	ForeignDef              ForeignTableDefinition
+	Inherits                []string
+	ReplicaIdentity         string
 	PartitionAlteredSchemas []AlteredPartitionRelation
 }
 
@@ -100,20 +100,20 @@ func ConstructDefinitionsForTables(connectionPool *dbconn.DBConn, tableRelations
 	for _, tableRel := range tableRelations {
 		oid := tableRel.Oid
 		tableDef := TableDefinition{
-			DistPolicy:         distributionPolicies[oid],
-			PartDef:            partitionDefs[oid],
-			PartTemplateDef:    partTemplateDefs[oid],
-			StorageOpts:        storageOptions[oid],
-			TablespaceName:     tablespaceNames[oid],
-			ColumnDefs:         columnDefs[oid],
-			IsExternal:         extTableDefs[oid].Oid != 0,
-			ExtTableDef:        extTableDefs[oid],
-			PartitionLevelInfo: partTableMap[oid],
-			TableType:          tableTypeMap[oid],
-			IsUnlogged:         unloggedTableMap[oid],
-			ForeignDef:         foreignTableDefs[oid],
-			Inherits:           inheritanceMap[oid],
-			ReplicaIdentity:    replicaIdentityMap[oid],
+			DistPolicy:              distributionPolicies[oid],
+			PartDef:                 partitionDefs[oid],
+			PartTemplateDef:         partTemplateDefs[oid],
+			StorageOpts:             storageOptions[oid],
+			TablespaceName:          tablespaceNames[oid],
+			ColumnDefs:              columnDefs[oid],
+			IsExternal:              extTableDefs[oid].Oid != 0,
+			ExtTableDef:             extTableDefs[oid],
+			PartitionLevelInfo:      partTableMap[oid],
+			TableType:               tableTypeMap[oid],
+			IsUnlogged:              unloggedTableMap[oid],
+			ForeignDef:              foreignTableDefs[oid],
+			Inherits:                inheritanceMap[oid],
+			ReplicaIdentity:         replicaIdentityMap[oid],
 			PartitionAlteredSchemas: partitionAlteredSchemaMap[oid],
 		}
 		if tableDef.Inherits == nil {
@@ -137,6 +137,11 @@ type PartitionLevelInfo struct {
 }
 
 func GetPartitionTableMap(connectionPool *dbconn.DBConn) map[uint32]PartitionLevelInfo {
+	// TODO: fix for gpdb7 partitioning
+	if connectionPool.Version.AtLeast("7") {
+		return make(map[uint32]PartitionLevelInfo)
+	}
+
 	query := `
 	SELECT pc.oid AS oid,
 		'p' AS level,
@@ -220,15 +225,22 @@ func GetColumnDefinitions(connectionPool *dbconn.DBConn) map[uint32][]ColumnDefi
 		LEFT JOIN pg_catalog.pg_type t ON a.atttypid = t.oid
 		LEFT JOIN pg_catalog.pg_attribute_encoding e ON e.attrelid = a.attrelid AND e.attnum = a.attnum
 		LEFT JOIN pg_description d ON d.objoid = a.attrelid AND d.classoid = 'pg_class'::regclass AND d.objsubid = a.attnum`
-	whereClause := `
-	WHERE ` + relationAndSchemaFilterClause() + `
+
+	// TODO: fix for gpdb7 partitioning
+	partitionRuleExcludeClause := ""
+	if connectionPool.Version.Before("7") {
+		partitionRuleExcludeClause = `
 		AND NOT EXISTS (SELECT 1 FROM 
 			(SELECT parchildrelid FROM pg_partition_rule EXCEPT SELECT reloid FROM pg_exttable)
-			par WHERE par.parchildrelid = c.oid)
+			par WHERE par.parchildrelid = c.oid)`
+	}
+	whereClause := fmt.Sprintf(`
+	WHERE %s
+		%s
 		AND c.reltype <> 0
 		AND a.attnum > 0::pg_catalog.int2
 		AND a.attisdropped = 'f'
-	ORDER BY a.attrelid, a.attnum`
+	ORDER BY a.attrelid, a.attnum`, relationAndSchemaFilterClause(), partitionRuleExcludeClause)
 
 	if connectionPool.Version.AtLeast("6") {
 		selectClause += `,
@@ -299,7 +311,7 @@ func GetTableType(connectionPool *dbconn.DBConn) map[uint32]string {
 
 func GetTableReplicaIdentity(connectionPool *dbconn.DBConn) map[uint32]string {
 	if connectionPool.Version.Before("6") {
-		return map[uint32]string{}
+		return make(map[uint32]string)
 	}
 	query := fmt.Sprintf(`
 	SELECT oid,
@@ -311,6 +323,10 @@ func GetTableReplicaIdentity(connectionPool *dbconn.DBConn) map[uint32]string {
 }
 
 func GetPartitionDetails(connectionPool *dbconn.DBConn) (map[uint32]string, map[uint32]string) {
+	if connectionPool.Version.AtLeast("7") {
+		return make(map[uint32]string), make(map[uint32]string)
+	}
+
 	gplog.Info("Getting partition definitions")
 	query := fmt.Sprintf(`
 	SELECT p.parrelid AS oid,
@@ -339,9 +355,9 @@ func GetPartitionDetails(connectionPool *dbconn.DBConn) (map[uint32]string, map[
 }
 
 type AlteredPartitionRelation struct {
-	OldSchema	string
-	NewSchema	string
-	Name		string
+	OldSchema string
+	NewSchema string
+	Name      string
 }
 
 /*
@@ -351,6 +367,10 @@ type AlteredPartitionRelation struct {
  * them.
  */
 func GetPartitionAlteredSchema(connectionPool *dbconn.DBConn) map[uint32][]AlteredPartitionRelation {
+	if connectionPool.Version.AtLeast("7") {
+		return make(map[uint32][]AlteredPartitionRelation)
+	}
+
 	gplog.Info("Getting child partitions with altered schema")
 	query := fmt.Sprintf(`
 	SELECT pgp.parrelid AS oid,
@@ -365,7 +385,7 @@ func GetPartitionAlteredSchema(connectionPool *dbconn.DBConn) map[uint32][]Alter
 		JOIN pg_catalog.pg_namespace pgn2 ON pgc2.relnamespace = pgn2.oid
 	WHERE pgc.relnamespace != pgc2.relnamespace`)
 	var results []struct {
-		Oid	uint32
+		Oid uint32
 		AlteredPartitionRelation
 	}
 	err := connectionPool.Select(&results, query)
@@ -437,6 +457,7 @@ func GetForeignTableDefinitions(connectionPool *dbconn.DBConn) map[uint32]Foreig
 	if connectionPool.Version.Before("6") {
 		return map[uint32]ForeignTableDefinition{}
 	}
+
 	query := fmt.Sprintf(`
 	SELECT ftrelid, fs.srvname AS ftserver,
 		pg_catalog.array_to_string(array(
@@ -482,7 +503,7 @@ func GetTableInheritance(connectionPool *dbconn.DBConn, tables []Relation) map[u
 		JOIN pg_namespace n ON p.relnamespace = n.oid
 	WHERE %s%s
 	ORDER BY i.inhrelid, i.inhseqno`,
-	ExtensionFilterClause("p"), tableFilterStr)
+		ExtensionFilterClause("p"), tableFilterStr)
 
 	results := make([]Dependency, 0)
 	resultMap := make(map[uint32][]string)

--- a/options/options.go
+++ b/options/options.go
@@ -260,6 +260,11 @@ func (o *Options) QuoteIncludeRelations(conn *dbconn.DBConn) error {
 }
 
 func (o Options) getUserTableRelationsWithIncludeFiltering(connectionPool *dbconn.DBConn, includedRelationsQuoted []string) ([]FqnStruct, error) {
+	// TODO: fix for gpdb7 partitioning
+	if connectionPool.Version.AtLeast("7") {
+		return []FqnStruct{}, nil
+	}
+
 	includeOids, err := getOidsFromRelationList(connectionPool, includedRelationsQuoted)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In GPDB 7+, partition tables have been heavily revamped to match the
upstream Postgres implementation. Due to this, many existing gpbackup
partitioning logic will simply error out due to missing catalog
functions, catalog views, and catalog tables. As a first step in
preparation for upgrading the gpbackup to support gpdb7, prevent
any queries that use the following deprecated code.

Catalog functions removed:
pg_get_partition_def
pg_get_partition_template_def

Catalog tables removed:
pg_partitions
pg_partition_columns
pg_partition_templates
pg_partition
pg_partition_rule
pg_partition_encoding