### PR TITLE
Lengthen gprestore SIGINT test window

### DIFF
--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -573,7 +573,6 @@ var _ = Describe("backup and restore end to end tests", func() {
 				"--timestamp", timestamp,
 				"--redirect-db", "restoredb",
 				"--backup-dir", backupDir,
-				"--include-schema", "schema2",
 				"--verbose"}
 			cmd := exec.Command(gprestorePath, args...)
 			go func() {


### PR DESCRIPTION
There have been frequent false failures where the test expects SIGINT
handling but the gprestore call had already finished. As a workaround
fix, lengthen the testing window by removing the unnecessary schema
filter. In the future, we need to reevaluate and/or probably get rid
of the test as randomness should have no place in these test suites.