### PR TITLE
Support GPDB 7 append optimized table DDL

### DIFF
--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -124,6 +124,9 @@ func PrintRegularTableCreateStatement(metadataFile *utils.FileWithByteCount, toc
 			metadataFile.MustPrintf("OPTIONS (%s) ", table.ForeignDef.Options)
 		}
 	}
+	if table.AccessMethodName != "" {
+		metadataFile.MustPrintf("USING %s ", table.AccessMethodName)
+	}
 	if table.StorageOpts != "" {
 		metadataFile.MustPrintf("WITH (%s) ", table.StorageOpts)
 	}

--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -289,9 +289,9 @@ func PrintAlterSequenceStatements(metadataFile *utils.FileWithByteCount,
 			start := metadataFile.ByteCount
 			metadataFile.MustPrintf("\n\nALTER SEQUENCE %s OWNED BY %s;\n", seqFQN, sequence.OwningColumn)
 			entry := toc.MetadataEntry{
-				Schema: sequence.Relation.Schema,
-				Name: sequence.Relation.Name,
-				ObjectType: "SEQUENCE OWNER",
+				Schema:          sequence.Relation.Schema,
+				Name:            sequence.Relation.Name,
+				ObjectType:      "SEQUENCE OWNER",
 				ReferenceObject: sequence.OwningTable,
 			}
 			tocfile.AddMetadataEntry("predata", entry, start, metadataFile.ByteCount)

--- a/backup/queries_table_defs.go
+++ b/backup/queries_table_defs.go
@@ -72,6 +72,7 @@ type TableDefinition struct {
 	Inherits                []string
 	ReplicaIdentity         string
 	PartitionAlteredSchemas []AlteredPartitionRelation
+	AccessMethodName        string
 }
 
 /*
@@ -90,6 +91,7 @@ func ConstructDefinitionsForTables(connectionPool *dbconn.DBConn, tableRelations
 	extTableDefs := GetExternalTableDefinitions(connectionPool)
 	partTableMap := GetPartitionTableMap(connectionPool)
 	tableTypeMap := GetTableType(connectionPool)
+	accessMethodMap := GetTableAccessMethod(connectionPool)
 	unloggedTableMap := GetUnloggedTables(connectionPool)
 	foreignTableDefs := GetForeignTableDefinitions(connectionPool)
 	inheritanceMap := GetTableInheritance(connectionPool, tableRelations)
@@ -115,6 +117,7 @@ func ConstructDefinitionsForTables(connectionPool *dbconn.DBConn, tableRelations
 			Inherits:                inheritanceMap[oid],
 			ReplicaIdentity:         replicaIdentityMap[oid],
 			PartitionAlteredSchemas: partitionAlteredSchemaMap[oid],
+			AccessMethodName:        accessMethodMap[oid],
 		}
 		if tableDef.Inherits == nil {
 			tableDef.Inherits = []string{}
@@ -306,6 +309,19 @@ func GetTableType(connectionPool *dbconn.DBConn) map[uint32]string {
 		return map[uint32]string{}
 	}
 	query := `SELECT oid, reloftype::pg_catalog.regtype AS value FROM pg_class WHERE reloftype != 0`
+	return selectAsOidToStringMap(connectionPool, query)
+}
+
+func GetTableAccessMethod(connectionPool *dbconn.DBConn) map[uint32]string {
+	if connectionPool.Version.Before("7") {
+		return map[uint32]string{}
+	}
+	query := `
+	SELECT c.oid, a.amname AS value
+	FROM pg_class c
+        JOIN pg_am a ON c.relam = a.oid
+	WHERE a.amtype = 't'
+        AND a.amname != 'heap';`
 	return selectAsOidToStringMap(connectionPool, query)
 }
 

--- a/integration/predata_relations_create_test.go
+++ b/integration/predata_relations_create_test.go
@@ -109,6 +109,17 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultTable := backup.ConstructDefinitionsForTables(connectionPool, []backup.Relation{testTable.Relation})[0]
 			structmatcher.ExpectStructsToMatchExcluding(testTable.TableDefinition, resultTable.TableDefinition, "ColumnDefs.Oid", "ExtTableDef")
 		})
+		It("creates a basic GPDB 7+ append-optimized table", func() {
+			testutils.SkipIfBefore7(connectionPool)
+			testTable.TableDefinition.AccessMethodName = "ao_column"
+
+			backup.PrintRegularTableCreateStatement(backupfile, tocfile, testTable)
+
+			testhelper.AssertQueryRuns(connectionPool, buffer.String())
+			testTable.Oid = testutils.OidFromObjectName(connectionPool, "public", "testtable", backup.TYPE_RELATION)
+			resultTable := backup.ConstructDefinitionsForTables(connectionPool, []backup.Relation{testTable.Relation})[0]
+			structmatcher.ExpectStructsToMatchExcluding(testTable.TableDefinition, resultTable.TableDefinition, "ColumnDefs.Oid", "ExtTableDef")
+		})
 		It("creates a one-level partition table", func() {
 			rowOne := backup.ColumnDefinition{Oid: 0, Num: 1, Name: "region", NotNull: false, HasDefault: false, Type: "text", Encoding: "", StatTarget: -1, StorageType: "", DefaultVal: "", Comment: ""}
 			rowTwo := backup.ColumnDefinition{Oid: 0, Num: 2, Name: "gender", NotNull: false, HasDefault: false, Type: "text", Encoding: "", StatTarget: -1, StorageType: "", DefaultVal: "", Comment: ""}


### PR DESCRIPTION
In GPDB 7+, the usual way of creating append optimized tables has been
deprecated. We need to add a GPDB version check and use the new DDL
syntax for append optimized tables.
