### PR TITLE
For functions kind use pg_proc prokind column

### DIFF
--- a/backup/predata_functions.go
+++ b/backup/predata_functions.go
@@ -70,7 +70,7 @@ func PrintFunctionModifiers(metadataFile *utils.FileWithByteCount, funcDef Funct
 		metadataFile.MustPrintf(" EXECUTE ON ALL SEGMENTS")
 	case "a": // Default case, don't print anything else
 	}
-	if funcDef.IsWindow {
+	if funcDef.IsWindow || funcDef.Kind == "w" {
 		metadataFile.MustPrintf(" WINDOW")
 	}
 	if funcDef.IsStrict {

--- a/backup/predata_functions_test.go
+++ b/backup/predata_functions_test.go
@@ -156,6 +156,11 @@ $_$`)
 				backup.PrintFunctionModifiers(backupfile, funcDef)
 				testhelper.ExpectRegexp(buffer, "WINDOW")
 			})
+			It("print 'WINDOW' if Kind is 'w'", func() {
+				funcDef.Kind = "w"
+				backup.PrintFunctionModifiers(backupfile, funcDef)
+				testhelper.ExpectRegexp(buffer, "WINDOW")
+			})
 			Context("Execlocation cases", func() {
 				It("Default", func() {
 					funcDef.ExecLocation = "a"

--- a/backup/queries_acl.go
+++ b/backup/queries_acl.go
@@ -67,7 +67,12 @@ var (
 )
 
 func InitializeMetadataParams(connectionPool *dbconn.DBConn) {
-	TYPE_AGGREGATE = MetadataQueryParams{ObjectType: "AGGREGATE", NameField: "proname", SchemaField: "pronamespace", ACLField: "proacl", OwnerField: "proowner", CatalogTable: "pg_proc", FilterClause: "proisagg = 't'"}
+	TYPE_AGGREGATE = MetadataQueryParams{ObjectType: "AGGREGATE", NameField: "proname", SchemaField: "pronamespace", ACLField: "proacl", OwnerField: "proowner", CatalogTable: "pg_proc"}
+	if connectionPool.Version.AtLeast("7") {
+		TYPE_AGGREGATE.FilterClause = "prokind = 'a'"
+	} else {
+		TYPE_AGGREGATE.FilterClause = "proisagg = 't'"
+	}
 	TYPE_CAST = MetadataQueryParams{ObjectType: "CAST", NameField: "typname", OidField: "oid", OidTable: "pg_type", CatalogTable: "pg_cast"}
 	TYPE_COLLATION = MetadataQueryParams{ObjectType: "COLLATION", NameField: "collname", OidField: "oid", SchemaField: "collnamespace", OwnerField: "collowner", CatalogTable: "pg_collation"}
 	TYPE_CONSTRAINT = MetadataQueryParams{ObjectType: "CONSTRAINT", NameField: "conname", SchemaField: "connamespace", OidField: "oid", CatalogTable: "pg_constraint"}
@@ -77,7 +82,12 @@ func InitializeMetadataParams(connectionPool *dbconn.DBConn) {
 	TYPE_EXTENSION = MetadataQueryParams{ObjectType: "EXTENSION", NameField: "extname", OidField: "oid", CatalogTable: "pg_extension"}
 	TYPE_FOREIGNDATAWRAPPER = MetadataQueryParams{ObjectType: "FOREIGN DATA WRAPPER", NameField: "fdwname", ACLField: "fdwacl", OwnerField: "fdwowner", CatalogTable: "pg_foreign_data_wrapper"}
 	TYPE_FOREIGNSERVER = MetadataQueryParams{ObjectType: "SERVER", NameField: "srvname", ACLField: "srvacl", OwnerField: "srvowner", CatalogTable: "pg_foreign_server"}
-	TYPE_FUNCTION = MetadataQueryParams{ObjectType: "FUNCTION", NameField: "proname", SchemaField: "pronamespace", ACLField: "proacl", OwnerField: "proowner", CatalogTable: "pg_proc", FilterClause: "proisagg = 'f'"}
+	TYPE_FUNCTION = MetadataQueryParams{ObjectType: "FUNCTION", NameField: "proname", SchemaField: "pronamespace", ACLField: "proacl", OwnerField: "proowner", CatalogTable: "pg_proc"}
+	if connectionPool.Version.AtLeast("7") {
+		TYPE_AGGREGATE.FilterClause = "prokind <> 'a'"
+	} else {
+		TYPE_AGGREGATE.FilterClause = "proisagg = 'f'"
+	}
 	TYPE_INDEX = MetadataQueryParams{ObjectType: "INDEX", NameField: "relname", OidField: "indexrelid", OidTable: "pg_class", CommentTable: "pg_class", CatalogTable: "pg_index"}
 	TYPE_PROCLANGUAGE = MetadataQueryParams{ObjectType: "LANGUAGE", NameField: "lanname", ACLField: "lanacl", CatalogTable: "pg_language"}
 	if connectionPool.Version.Before("5") {

--- a/integration/predata_functions_queries_test.go
+++ b/integration/predata_functions_queries_test.go
@@ -92,15 +92,24 @@ LANGUAGE SQL WINDOW`)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP FUNCTION public.add(integer, integer)")
 
 			results := backup.GetFunctions(connectionPool)
-
-			windowFunction := backup.Function{
-				Schema: "public", Name: "add", ReturnsSet: false, FunctionBody: "SELECT $1 + $2",
-				BinaryPath: "", Arguments: sql.NullString{String: "integer, integer", Valid: true},
-				IdentArgs: sql.NullString{String: "integer, integer", Valid: true},
-				ResultType: sql.NullString{String: "integer", Valid: true},
-				Volatility: "v", IsStrict: false, IsSecurityDefiner: false, Config: "", Cost: 100, NumRows: 0, DataAccess: "c",
-				Language: "sql", IsWindow: true, ExecLocation: "a"}
-
+			var windowFunction backup.Function
+			if connectionPool.Version.AtLeast("7"){
+				windowFunction = backup.Function{
+					Schema: "public", Name: "add", ReturnsSet: false, FunctionBody: "SELECT $1 + $2",
+					BinaryPath: "", Arguments: sql.NullString{String: "integer, integer", Valid: true},
+					IdentArgs: sql.NullString{String: "integer, integer", Valid: true},
+					ResultType: sql.NullString{String: "integer", Valid: true},
+					Volatility: "v", IsStrict: false, IsSecurityDefiner: false, Config: "", Cost: 100, NumRows: 0, DataAccess: "c",
+					Language: "sql", Kind: "w", ExecLocation: "a"}
+			} else {
+				windowFunction = backup.Function{
+					Schema: "public", Name: "add", ReturnsSet: false, FunctionBody: "SELECT $1 + $2",
+					BinaryPath: "", Arguments: sql.NullString{String: "integer, integer", Valid: true},
+					IdentArgs: sql.NullString{String: "integer, integer", Valid: true},
+					ResultType: sql.NullString{String: "integer", Valid: true},
+					Volatility: "v", IsStrict: false, IsSecurityDefiner: false, Config: "", Cost: 100, NumRows: 0, DataAccess: "c",
+					Language: "sql", IsWindow: true, ExecLocation: "a"}
+			}
 			Expect(results).To(HaveLen(1))
 			structmatcher.ExpectStructsToMatchExcluding(&results[0], &windowFunction, "Oid")
 		})


### PR DESCRIPTION
 - In GPDB 7+, stored procedures were introduced which
   added another function type to go along regular
   functions, window functions, and aggregate functions.
   This was queried using the proisagg and proiswindow
   columns but they have been removed in favor of the
   new prokind column ('f': function, 'p': procedure,
   'a': aggregate, 'w': window).

Authored-by: Kate Dontsova <edontsova@pivotal.io>