### PR TITLE
Query for sequence info using new catalog table

### DIFF
--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -242,6 +242,9 @@ func PrintCreateSequenceStatements(metadataFile *utils.FileWithByteCount,
 	maxVal := int64(math.MaxInt64)
 	minVal := int64(math.MinInt64)
 	for _, sequence := range sequences {
+		if sequence.IsIdentity {
+			continue
+		}
 		start := metadataFile.ByteCount
 		definition := sequence.Definition
 		metadataFile.MustPrintln("\n\nCREATE SEQUENCE", sequence.FQN())
@@ -283,6 +286,9 @@ func PrintAlterSequenceStatements(metadataFile *utils.FileWithByteCount,
 	tocfile *toc.TOC, sequences []Sequence) {
 	gplog.Verbose("Writing ALTER SEQUENCE statements to metadata file")
 	for _, sequence := range sequences {
+		if sequence.IsIdentity {
+			continue
+		}
 		seqFQN := sequence.FQN()
 		// owningColumn is quoted and doesn't need to be quoted again
 		if sequence.OwningColumn != "" {

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -154,6 +154,7 @@ type Sequence struct {
 	OwningTableSchema string
 	OwningTable       string
 	OwningColumn      string
+	IsIdentity        bool
 	Definition        SequenceDefinition
 }
 
@@ -183,27 +184,54 @@ type SequenceDefinition struct {
 }
 
 func GetAllSequences(connectionPool *dbconn.DBConn) []Sequence {
-	query := fmt.Sprintf(`
-	SELECT n.oid AS schemaoid,
-		c.oid AS oid,
-		quote_ident(n.nspname) AS schema,
-		quote_ident(c.relname) AS name,
-        coalesce(d.refobjid::text, '') AS owningtableoid,
-		coalesce(quote_ident(m.nspname), '') AS owningtableschema,
-		coalesce(quote_ident(t.relname), '') AS owningtable,
-		coalesce(quote_ident(a.attname), '') AS owningcolumn
-	FROM pg_class c 
-		JOIN pg_namespace n ON n.oid = c.relnamespace
-		LEFT JOIN pg_depend d ON c.oid = d.objid AND d.deptype = 'a'
-		LEFT JOIN pg_class t ON t.oid = d.refobjid
-		LEFT JOIN pg_namespace m ON m.oid = t.relnamespace
-		LEFT JOIN pg_attribute a ON a.attrelid = d.refobjid AND a.attnum = d.refobjsubid
-	WHERE c.relkind = 'S'
-		AND %s
-		AND %s
-	ORDER BY n.nspname, c.relname`,
+	var query string
+	if connectionPool.Version.AtLeast("7") {
+		query = fmt.Sprintf(`
+		SELECT n.oid AS schemaoid,
+			c.oid AS oid,
+			quote_ident(n.nspname) AS schema,
+			quote_ident(c.relname) AS name,
+			coalesce(d.refobjid::text, '') AS owningtableoid,
+			coalesce(quote_ident(m.nspname), '') AS owningtableschema,
+			coalesce(quote_ident(t.relname), '') AS owningtable,
+			coalesce(quote_ident(a.attname), '') AS owningcolumn,
+			CASE
+				WHEN d.deptype IS NULL THEN false
+				ELSE d.deptype = 'i'
+			END AS isidentity
+		FROM pg_class c
+			JOIN pg_namespace n ON n.oid = c.relnamespace
+			LEFT JOIN pg_depend d ON c.oid = d.objid AND d.deptype in ('a', 'i')
+			LEFT JOIN pg_class t ON t.oid = d.refobjid
+			LEFT JOIN pg_namespace m ON m.oid = t.relnamespace
+			LEFT JOIN pg_attribute a ON a.attrelid = d.refobjid AND a.attnum = d.refobjsubid
+		WHERE c.relkind = 'S'
+			AND %s
+			AND %s
+		ORDER BY n.nspname, c.relname`,
 		relationAndSchemaFilterClause(), ExtensionFilterClause("c"))
-
+	} else {
+		query = fmt.Sprintf(`
+		SELECT n.oid AS schemaoid,
+			c.oid AS oid,
+			quote_ident(n.nspname) AS schema,
+			quote_ident(c.relname) AS name,
+			coalesce(d.refobjid::text, '') AS owningtableoid,
+			coalesce(quote_ident(m.nspname), '') AS owningtableschema,
+			coalesce(quote_ident(t.relname), '') AS owningtable,
+			coalesce(quote_ident(a.attname), '') AS owningcolumn
+		FROM pg_class c
+			JOIN pg_namespace n ON n.oid = c.relnamespace
+			LEFT JOIN pg_depend d ON c.oid = d.objid AND d.deptype = 'a'
+			LEFT JOIN pg_class t ON t.oid = d.refobjid
+			LEFT JOIN pg_namespace m ON m.oid = t.relnamespace
+			LEFT JOIN pg_attribute a ON a.attrelid = d.refobjid AND a.attnum = d.refobjsubid
+		WHERE c.relkind = 'S'
+			AND %s
+			AND %s
+		ORDER BY n.nspname, c.relname`,
+		relationAndSchemaFilterClause(), ExtensionFilterClause("c"))
+	}
 	results := make([]Sequence, 0)
 	err := connectionPool.Select(&results, query)
 	gplog.FatalOnError(err)
@@ -235,21 +263,36 @@ func GetAllSequences(connectionPool *dbconn.DBConn) []Sequence {
 }
 
 func GetSequenceDefinition(connectionPool *dbconn.DBConn, seqName string) SequenceDefinition {
-	startValQuery := ""
-	if connectionPool.Version.AtLeast("6") {
-		startValQuery = "start_value AS startval,"
+	var query string
+	if connectionPool.Version.AtLeast("7") {
+		query = fmt.Sprintf(`
+		SELECT s.seqstart AS startval,
+			r.last_value AS lastval,
+			s.seqincrement AS increment,
+			s.seqmax AS maxval,
+			s.seqmin AS minval,
+			s.seqcache AS cacheval,
+			s.seqcycle AS iscycled,
+			r.is_called AS iscalled
+		FROM %s r
+		JOIN pg_sequence s ON s.seqrelid = '%s'::regclass::oid;`, seqName, seqName)
+	} else {
+		startValQuery := ""
+		if connectionPool.Version.AtLeast("6") {
+			startValQuery = "start_value AS startval,"
+		}
+		query = fmt.Sprintf(`
+		SELECT last_value AS lastval,
+			%s
+			increment_by AS increment,
+			max_value AS maxval,
+			min_value AS minval,
+			cache_value AS cacheval,
+			log_cnt AS logcnt,
+			is_cycled AS iscycled,
+			is_called AS iscalled
+		FROM %s`, startValQuery, seqName)
 	}
-	query := fmt.Sprintf(`
-	SELECT last_value AS lastval,
-		%s
-		increment_by AS increment,
-		max_value AS maxval,
-		min_value AS minval,
-		cache_value AS cacheval,
-		log_cnt AS logcnt,
-		is_cycled AS iscycled,
-		is_called AS iscalled
-	FROM %s`, startValQuery, seqName)
 	result := SequenceDefinition{}
 	err := connectionPool.Get(&result, query)
 	gplog.FatalOnError(err)

--- a/integration/predata_relations_create_test.go
+++ b/integration/predata_relations_create_test.go
@@ -562,6 +562,27 @@ SET SUBPARTITION TEMPLATE ` + `
 			structmatcher.ExpectStructsToMatch(&sequence.Definition, &resultSequences[0].Definition)
 			structmatcher.ExpectStructsToMatch(&sequenceMetadata, &resultMetadata)
 		})
+		It("doesn't create identity sequences", func() {
+			testutils.SkipIfBefore7(connectionPool)
+			startValue := int64(0)
+			sequence.Definition = backup.SequenceDefinition{LastVal: 1, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 1, StartVal: startValue}
+
+			identitySequenceRel := backup.Relation{SchemaOid: 0, Oid: 1, Schema: "public", Name: "my_identity_sequence"}
+			identitySequence := backup.Sequence{Relation: identitySequenceRel, IsIdentity: true}
+			identitySequence.Definition = backup.SequenceDefinition{LastVal: 1, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 20, StartVal: startValue}
+
+			backup.PrintCreateSequenceStatements(backupfile, tocfile, []backup.Sequence{sequence, identitySequence}, sequenceMetadataMap)
+
+			testhelper.AssertQueryRuns(connectionPool, buffer.String())
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP SEQUENCE public.my_sequence")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP SEQUENCE public.my_identity_sequence")
+
+			resultSequences := backup.GetAllSequences(connectionPool)
+
+			Expect(resultSequences).To(HaveLen(1))
+			structmatcher.ExpectStructsToMatchExcluding(&sequenceRel, &resultSequences[0].Relation, "SchemaOid", "Oid")
+			structmatcher.ExpectStructsToMatch(&sequence.Definition, &resultSequences[0].Definition)
+		})
 	})
 	Describe("PrintAlterSequenceStatements", func() {
 		It("creates a sequence owned by a table column", func() {
@@ -587,6 +608,29 @@ SET SUBPARTITION TEMPLATE ` + `
 			Expect(sequences).To(HaveLen(1))
 			Expect(sequences[0].OwningTable).To(Equal("public.sequence_table"))
 			Expect(sequences[0].OwningColumn).To(Equal("public.sequence_table.a"))
+		})
+		It("skips identity sequences", func() {
+			testutils.SkipIfBefore7(connectionPool)
+			startValue := int64(0)
+			sequenceRel := backup.Relation{SchemaOid: 0, Oid: 1, Schema: "public", Name: "my_sequence"}
+			sequence := backup.Sequence{Relation: sequenceRel}
+			sequence.Definition = backup.SequenceDefinition{LastVal: 1, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 1, StartVal: startValue}
+
+			identitySequenceRel := backup.Relation{SchemaOid: 0, Oid: 1, Schema: "public", Name: "my_identity_sequence"}
+			identitySequence := backup.Sequence{Relation: identitySequenceRel, IsIdentity: true}
+			identitySequence.Definition = backup.SequenceDefinition{LastVal: 1, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 20, StartVal: startValue}
+
+			backup.PrintCreateSequenceStatements(backupfile, tocfile, []backup.Sequence{sequence, identitySequence}, backup.MetadataMap{})
+			backup.PrintAlterSequenceStatements(backupfile, tocfile, []backup.Sequence{sequence, identitySequence})
+
+			testhelper.AssertQueryRuns(connectionPool, buffer.String())
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP SEQUENCE public.my_sequence")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP SEQUENCE public.my_identity_sequence")
+
+			sequences := backup.GetAllSequences(connectionPool)
+			Expect(sequences).To(HaveLen(1))
+			structmatcher.ExpectStructsToMatchExcluding(&sequenceRel, &sequences[0].Relation, "SchemaOid", "Oid")
+			structmatcher.ExpectStructsToMatch(&sequence.Definition, &sequences[0].Definition)
 		})
 	})
 })

--- a/integration/predata_relations_queries_test.go
+++ b/integration/predata_relations_queries_test.go
@@ -357,6 +357,7 @@ PARTITION BY LIST (gender)
 		})
 	})
 	Describe("GetAllSequences", func() {
+		// TODO: add test for IsIdentity field for GPDB7
 		It("returns a slice of definitions for all sequences", func() {
 			testhelper.AssertQueryRuns(connectionPool, "CREATE SEQUENCE public.seq_one START 3")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP SEQUENCE public.seq_one")


### PR DESCRIPTION
 - In GPDB 7+, sequence relations have been changed
   to no longer store all metadata in the sequence
   relation itself. Instead, there is now a catalog
   table pg_sequence which contains the majority of
   the metadata that we require.

Authored-by: Kate Dontsova <edontsova@pivotal.io>