### PR TITLE
Create GPDB 7+ root partition

### DIFF
--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -114,6 +114,9 @@ func PrintRegularTableCreateStatement(metadataFile *utils.FileWithByteCount, toc
 
 	printColumnDefinitions(metadataFile, table.ColumnDefs, table.TableType)
 	metadataFile.MustPrintf(") ")
+	if table.PartitionKeyDef != "" {
+		metadataFile.MustPrintf("PARTITION BY %s ", table.PartitionKeyDef)
+	}
 	if len(table.Inherits) != 0 {
 		dependencyList := strings.Join(table.Inherits, ", ")
 		metadataFile.MustPrintf("INHERITS (%s) ", dependencyList)

--- a/backup/predata_relations_tables_test.go
+++ b/backup/predata_relations_tables_test.go
@@ -352,6 +352,15 @@ ALTER TABLE ONLY public.tablename ALTER COLUMN i SET (n_distinct=1);`)
 	j character varying(20)
 ) WITH (appendonly=true, orientation=column, fillfactor=42, compresstype=zlib, blocksize=32768, compresslevel=1) DISTRIBUTED BY (i, j);`)
 			})
+			It("is a GPDB 7+ root partition", func() {
+				testutils.SkipIfBefore7(connectionPool)
+				testTable.PartitionKeyDef = "RANGE (b)"
+				backup.PrintRegularTableCreateStatement(backupfile, tocfile, testTable)
+				testutils.AssertBufferContents(tocfile.PredataEntries, buffer, `CREATE TABLE public.tablename (
+	i integer,
+	j character varying(20)
+) PARTITION BY RANGE (b) DISTRIBUTED RANDOMLY;`)
+			})
 		})
 		Context("Table partitioning", func() {
 			col := []backup.ColumnDefinition{rowOne, rowTwo}

--- a/backup/queries_table_defs.go
+++ b/backup/queries_table_defs.go
@@ -73,6 +73,7 @@ type TableDefinition struct {
 	ReplicaIdentity         string
 	PartitionAlteredSchemas []AlteredPartitionRelation
 	AccessMethodName        string
+	PartitionKeyDef         string
 }
 
 /*
@@ -97,6 +98,7 @@ func ConstructDefinitionsForTables(connectionPool *dbconn.DBConn, tableRelations
 	inheritanceMap := GetTableInheritance(connectionPool, tableRelations)
 	replicaIdentityMap := GetTableReplicaIdentity(connectionPool)
 	partitionAlteredSchemaMap := GetPartitionAlteredSchema(connectionPool)
+	partitionKeyDefs := GetPartitionKeyDefs(connectionPool)
 
 	gplog.Verbose("Constructing table definition map")
 	for _, tableRel := range tableRelations {
@@ -118,6 +120,7 @@ func ConstructDefinitionsForTables(connectionPool *dbconn.DBConn, tableRelations
 			ReplicaIdentity:         replicaIdentityMap[oid],
 			PartitionAlteredSchemas: partitionAlteredSchemaMap[oid],
 			AccessMethodName:        accessMethodMap[oid],
+			PartitionKeyDef:         partitionKeyDefs[oid],
 		}
 		if tableDef.Inherits == nil {
 			tableDef.Inherits = []string{}
@@ -527,6 +530,32 @@ func GetTableInheritance(connectionPool *dbconn.DBConn, tables []Relation) map[u
 	gplog.FatalOnError(err)
 	for _, result := range results {
 		resultMap[result.Oid] = append(resultMap[result.Oid], result.ReferencedObject)
+	}
+	return resultMap
+}
+
+// Used to contruct root tables for GPDB 7+, because the root partition must be
+// constructed by itself first.
+func GetPartitionKeyDefs(connectionPool *dbconn.DBConn) map[uint32]string {
+	if connectionPool.Version.Before("7") {
+		return make(map[uint32]string, 0)
+	}
+	query := `
+SELECT
+    partrelid AS oid,
+    pg_get_partkeydef(partrelid) AS keydef
+FROM
+    pg_partitioned_table;`
+
+	var results []struct {
+		Oid    uint32
+		Keydef string
+	}
+	err := connectionPool.Select(&results, query)
+	gplog.FatalOnError(err)
+	resultMap := make(map[uint32]string)
+	for _, result := range results {
+		resultMap[result.Oid] = result.Keydef
 	}
 	return resultMap
 }


### PR DESCRIPTION
In GPDB 7+, we no longer have large DDL commands to create a partition
table. The root partition must be constructed by itself first.
Information for the root partition can be found in the new
pg_partitioned_table catalog table and the partition key available from
using new pg_get_partkeydef() catalog function. Essentially, we just
need to get the partition key definition and attach it to the CREATE
TABLE statement.


The integration test is non function until GetColumnDefinitions() is fixed.