### PR TITLE
Planner support

### DIFF
--- a/backup/predata_functions.go
+++ b/backup/predata_functions.go
@@ -88,6 +88,9 @@ func PrintFunctionModifiers(metadataFile *utils.FileWithByteCount, funcDef Funct
 	}
 	if connectionPool.Version.AtLeast("7") {
 		// TODO: TRANSFORM
+		if funcDef.PlannerSupport != "-" {
+			metadataFile.MustPrintf("\nSUPPORT %s", funcDef.PlannerSupport)
+		}
 	}
 	// Default cost is 1 for C and internal functions or 100 for functions in other languages
 	isInternalOrC := funcDef.Language == "c" || funcDef.Language == "internal"

--- a/backup/predata_functions_test.go
+++ b/backup/predata_functions_test.go
@@ -170,6 +170,11 @@ $_$`)
 				testhelper.ExpectRegexp(buffer, "WINDOW")
 			})
 			// TODO: TRANSFORM for stored procedures
+			It("print 'SUPPORT' if PlanerSupport is set", func() {
+				funcDef.PlannerSupport = "my_planner_support"
+				backup.PrintFunctionModifiers(backupfile, funcDef)
+				testhelper.ExpectRegexp(buffer, "SUPPORT my_planner_support")
+			})
 			Context("Execlocation cases", func() {
 				It("Default", func() {
 					funcDef.ExecLocation = "a"

--- a/backup/queries_functions.go
+++ b/backup/queries_functions.go
@@ -37,6 +37,7 @@ type Function struct {
 	DataAccess        string  `db:"prodataaccess"`
 	Language          string
 	Kind              string `db:"prokind"`     // GPDB 7+
+	PlannerSupport    string `db:"prosupport"`  // GPDB 7+
 	IsWindow          bool   `db:"proiswindow"` // before 7
 	ExecLocation      string `db:"proexeclocation"`
 }
@@ -133,6 +134,7 @@ func GetFunctions(connectionPool *dbconn.DBConn) []Function {
 			prorows,
 			prodataaccess,
 			prokind,
+			prosupport,
 			l.lanname AS language
 		FROM pg_proc p
 			JOIN pg_catalog.pg_language l ON p.prolang = l.oid

--- a/integration/predata_functions_queries_test.go
+++ b/integration/predata_functions_queries_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"database/sql"
+
 	"github.com/greenplum-db/gp-common-go-libs/structmatcher"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup/backup"
@@ -14,8 +15,17 @@ import (
 
 var _ = Describe("backup integration tests", func() {
 	Describe("GetFunctions", func() {
+		var prokindValue string
+		var plannerSupportValue string
 		BeforeEach(func() {
 			testutils.SkipIfBefore5(connectionPool)
+			if connectionPool.Version.AtLeast("7") {
+				prokindValue = "f"
+				plannerSupportValue = "-"
+			} else {
+				prokindValue = ""
+				plannerSupportValue = ""
+			}
 		})
 		It("returns a slice of functions", func() {
 			testhelper.AssertQueryRuns(connectionPool, `CREATE FUNCTION public.add(integer, integer) RETURNS integer
@@ -38,26 +48,21 @@ MODIFIES SQL DATA
 			testhelper.AssertQueryRuns(connectionPool, "COMMENT ON FUNCTION public.append(integer, integer) IS 'this is a function comment'")
 
 			results := backup.GetFunctions(connectionPool)
-			var prokindValue string
-			if connectionPool.Version.AtLeast("7"){
-				prokindValue = "f"
-			} else {
-				prokindValue = ""
-			}
 
 			addFunction := backup.Function{
 				Schema: "public", Name: "add", Kind: prokindValue, ReturnsSet: false, FunctionBody: "SELECT $1 + $2",
 				BinaryPath: "", Arguments: sql.NullString{String: "integer, integer", Valid: true},
-				IdentArgs: sql.NullString{String: "integer, integer", Valid: true},
+				IdentArgs:  sql.NullString{String: "integer, integer", Valid: true},
 				ResultType: sql.NullString{String: "integer", Valid: true},
-				Volatility: "v", IsStrict: false, IsSecurityDefiner: false, Config: "", Cost: 100, NumRows: 0, DataAccess: "c",
-				Language: "sql", ExecLocation: "a"}
+				Volatility: "v", IsStrict: false, IsSecurityDefiner: false, PlannerSupport: plannerSupportValue, Config: "", Cost: 100, NumRows: 0,
+				DataAccess: "c",
+				Language:   "sql", ExecLocation: "a"}
 			appendFunction := backup.Function{
 				Schema: "public", Name: "append", Kind: prokindValue, ReturnsSet: true, FunctionBody: "SELECT ($1, $2)",
 				BinaryPath: "", Arguments: sql.NullString{String: "integer, integer", Valid: true},
-				IdentArgs: sql.NullString{String: "integer, integer", Valid: true},
+				IdentArgs:  sql.NullString{String: "integer, integer", Valid: true},
 				ResultType: sql.NullString{String: "SETOF record", Valid: true},
-				Volatility: "s", IsStrict: true, IsSecurityDefiner: true, Config: `SET search_path TO 'pg_temp'`, Cost: 200,
+				Volatility: "s", IsStrict: true, IsSecurityDefiner: true, PlannerSupport: plannerSupportValue, Config: `SET search_path TO 'pg_temp'`, Cost: 200,
 				NumRows: 200, DataAccess: "m", Language: "sql", ExecLocation: "a"}
 
 			Expect(results).To(HaveLen(2))
@@ -76,19 +81,12 @@ AS 'SELECT $1 + $2'
 LANGUAGE SQL`)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP FUNCTION testschema.add(integer, integer)")
 
-			var prokindValue string
-			if connectionPool.Version.AtLeast("7"){
-				prokindValue = "f"
-			} else {
-				prokindValue = ""
-			}
-
 			addFunction := backup.Function{
 				Schema: "testschema", Name: "add", Kind: prokindValue, ReturnsSet: false, FunctionBody: "SELECT $1 + $2",
 				BinaryPath: "", Arguments: sql.NullString{String: "integer, integer", Valid: true},
-				IdentArgs: sql.NullString{String: "integer, integer", Valid: true},
+				IdentArgs:  sql.NullString{String: "integer, integer", Valid: true},
 				ResultType: sql.NullString{String: "integer", Valid: true},
-				Volatility: "v", IsStrict: false, IsSecurityDefiner: false, Config: "", Cost: 100, NumRows: 0, DataAccess: "c",
+				Volatility: "v", IsStrict: false, IsSecurityDefiner: false, PlannerSupport: plannerSupportValue, Config: "", Cost: 100, NumRows: 0, DataAccess: "c",
 				Language: "sql", ExecLocation: "a"}
 			_ = backupCmdFlags.Set(options.INCLUDE_SCHEMA, "testschema")
 			results := backup.GetFunctions(connectionPool)
@@ -105,21 +103,22 @@ LANGUAGE SQL WINDOW`)
 
 			results := backup.GetFunctions(connectionPool)
 			var windowFunction backup.Function
-			if connectionPool.Version.AtLeast("7"){
+			if connectionPool.Version.AtLeast("7") {
 				windowFunction = backup.Function{
 					Schema: "public", Name: "add", ReturnsSet: false, FunctionBody: "SELECT $1 + $2",
 					BinaryPath: "", Arguments: sql.NullString{String: "integer, integer", Valid: true},
-					IdentArgs: sql.NullString{String: "integer, integer", Valid: true},
+					IdentArgs:  sql.NullString{String: "integer, integer", Valid: true},
 					ResultType: sql.NullString{String: "integer", Valid: true},
-					Volatility: "v", IsStrict: false, IsSecurityDefiner: false, Config: "", Cost: 100, NumRows: 0, DataAccess: "c",
+					Volatility: "v", IsStrict: false, IsSecurityDefiner: false, PlannerSupport: plannerSupportValue, Config: "", Cost: 100, NumRows: 0, DataAccess: "c",
 					Language: "sql", Kind: "w", ExecLocation: "a"}
 			} else {
 				windowFunction = backup.Function{
 					Schema: "public", Name: "add", ReturnsSet: false, FunctionBody: "SELECT $1 + $2",
 					BinaryPath: "", Arguments: sql.NullString{String: "integer, integer", Valid: true},
-					IdentArgs: sql.NullString{String: "integer, integer", Valid: true},
+					IdentArgs:  sql.NullString{String: "integer, integer", Valid: true},
 					ResultType: sql.NullString{String: "integer", Valid: true},
-					Volatility: "v", IsStrict: false, IsSecurityDefiner: false, Config: "", Cost: 100, NumRows: 0, DataAccess: "c",
+					Volatility: "v", IsStrict: false, IsSecurityDefiner: false,
+					PlannerSupport: plannerSupportValue, Config: "", Cost: 100, NumRows: 0, DataAccess: "c",
 					Language: "sql", IsWindow: true, ExecLocation: "a"}
 			}
 			Expect(results).To(HaveLen(1))
@@ -141,7 +140,7 @@ EXECUTE ON ALL SEGMENTS;`)
 			results := backup.GetFunctions(connectionPool)
 			var prokindValue string
 			var isWindowValue bool
-			if connectionPool.Version.AtLeast("7"){
+			if connectionPool.Version.AtLeast("7") {
 				prokindValue = "w"
 				isWindowValue = false
 			} else {
@@ -152,16 +151,18 @@ EXECUTE ON ALL SEGMENTS;`)
 			srfOnMasterFunction := backup.Function{
 				Schema: "public", Name: "srf_on_master", Kind: prokindValue, ReturnsSet: false, FunctionBody: "SELECT $1 + $2",
 				BinaryPath: "", Arguments: sql.NullString{String: "integer, integer", Valid: true},
-				IdentArgs: sql.NullString{String: "integer, integer", Valid: true},
+				IdentArgs:  sql.NullString{String: "integer, integer", Valid: true},
 				ResultType: sql.NullString{String: "integer", Valid: true},
-				Volatility: "v", IsStrict: false, IsSecurityDefiner: false, Config: "", Cost: 100, NumRows: 0, DataAccess: "c",
+				Volatility: "v", IsStrict: false, IsSecurityDefiner: false,
+				PlannerSupport: plannerSupportValue, Config: "", Cost: 100, NumRows: 0, DataAccess: "c",
 				Language: "sql", IsWindow: isWindowValue, ExecLocation: "m"}
 			srfOnAllSegmentsFunction := backup.Function{
 				Schema: "public", Name: "srf_on_all_segments", Kind: prokindValue, ReturnsSet: false, FunctionBody: "SELECT $1 + $2",
 				BinaryPath: "", Arguments: sql.NullString{String: "integer, integer", Valid: true},
-				IdentArgs: sql.NullString{String: "integer, integer", Valid: true},
+				IdentArgs:  sql.NullString{String: "integer, integer", Valid: true},
 				ResultType: sql.NullString{String: "integer", Valid: true},
-				Volatility: "v", IsStrict: false, IsSecurityDefiner: false, Config: "", Cost: 100, NumRows: 0, DataAccess: "c",
+				Volatility: "v", IsStrict: false, IsSecurityDefiner: false,
+				PlannerSupport: plannerSupportValue, Config: "", Cost: 100, NumRows: 0, DataAccess: "c",
 				Language: "sql", IsWindow: isWindowValue, ExecLocation: "s"}
 
 			Expect(results).To(HaveLen(2))
@@ -186,19 +187,14 @@ MODIFIES SQL DATA
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP FUNCTION public.append(integer, integer)")
 
 			results := backup.GetFunctions(connectionPool)
-			var prokindValue string
-			if connectionPool.Version.AtLeast("7"){
-				prokindValue = "f"
-			} else {
-				prokindValue = ""
-			}
 
 			appendFunction := backup.Function{
 				Schema: "public", Name: "append", Kind: prokindValue, ReturnsSet: true, FunctionBody: "SELECT ($1, $2)",
 				BinaryPath: "", Arguments: sql.NullString{String: "integer, integer", Valid: true},
-				IdentArgs: sql.NullString{String: "integer, integer", Valid: true},
+				IdentArgs:  sql.NullString{String: "integer, integer", Valid: true},
 				ResultType: sql.NullString{String: "SETOF record", Valid: true},
-				Volatility: "s", IsStrict: true, IsLeakProof: true, IsSecurityDefiner: true, Config: `SET search_path TO 'pg_temp'`, Cost: 200,
+				Volatility: "s", IsStrict: true, IsLeakProof: true, IsSecurityDefiner: true,
+				PlannerSupport: plannerSupportValue, Config: `SET search_path TO 'pg_temp'`, Cost: 200,
 				NumRows: 200, DataAccess: "m", Language: "sql", ExecLocation: "a"}
 
 			Expect(results).To(HaveLen(1))
@@ -228,12 +224,6 @@ MODIFIES SQL DATA
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP FUNCTION public.myfunc(integer)")
 
 			results := backup.GetFunctions(connectionPool)
-			var prokindValue string
-			if connectionPool.Version.AtLeast("7"){
-				prokindValue = "f"
-			} else {
-				prokindValue = ""
-			}
 			appendFunction := backup.Function{
 				Schema: "public", Name: "myfunc", Kind: prokindValue, ReturnsSet: false, FunctionBody: `
 	begin
@@ -242,9 +232,10 @@ MODIFIES SQL DATA
 		return current_setting('work_mem');
 	end `,
 				BinaryPath: "", Arguments: sql.NullString{String: "integer", Valid: true},
-				IdentArgs: sql.NullString{String: "integer", Valid: true},
+				IdentArgs:  sql.NullString{String: "integer", Valid: true},
 				ResultType: sql.NullString{String: "text", Valid: true},
-				Volatility: "v", IsStrict: false, IsLeakProof: false, IsSecurityDefiner: false, Config: "SET work_mem TO '1MB'", Cost: 100,
+				Volatility: "v", IsStrict: false, IsLeakProof: false, IsSecurityDefiner: false,
+				PlannerSupport: plannerSupportValue, Config: "SET work_mem TO '1MB'", Cost: 100,
 				NumRows: 0, DataAccess: "n", Language: "plpgsql", ExecLocation: "a"}
 			Expect(results).To(HaveLen(1))
 			structmatcher.ExpectStructsToMatchExcluding(&results[0], &appendFunction, "Oid")
@@ -267,12 +258,6 @@ MODIFIES SQL DATA
 			defer testhelper.AssertQueryRuns(connectionPool, `DROP SCHEMA "abc""def"`)
 
 			results := backup.GetFunctions(connectionPool)
-			var prokindValue string
-			if connectionPool.Version.AtLeast("7"){
-				prokindValue = "f"
-			} else {
-				prokindValue = ""
-			}
 
 			appendFunction := backup.Function{
 				Schema: "public", Name: "myfunc", Kind: prokindValue, ReturnsSet: false, FunctionBody: `
@@ -282,9 +267,10 @@ MODIFIES SQL DATA
         return current_setting('work_mem');
     end `,
 				BinaryPath: "", Arguments: sql.NullString{String: "integer", Valid: true},
-				IdentArgs: sql.NullString{String: "integer", Valid: true},
+				IdentArgs:  sql.NullString{String: "integer", Valid: true},
 				ResultType: sql.NullString{String: "text", Valid: true},
-				Volatility: "v", IsStrict: false, IsLeakProof: false, IsSecurityDefiner: false, Config: `SET search_path TO '$user', 'public', 'abc"def'`, Cost: 100,
+				Volatility: "v", IsStrict: false, IsLeakProof: false, IsSecurityDefiner: false,
+				PlannerSupport: plannerSupportValue, Config: `SET search_path TO '$user', 'public', 'abc"def'`, Cost: 100,
 				NumRows: 0, DataAccess: "n", Language: "plpgsql", ExecLocation: "a"}
 
 			Expect(results).To(HaveLen(1))
@@ -320,9 +306,10 @@ INSERT INTO public.tbl VALUES (a);
 INSERT INTO public.tbl VALUES (b);
 `,
 				BinaryPath: "", Arguments: sql.NullString{String: "a integer, b integer", Valid: true},
-				IdentArgs: sql.NullString{String: "a integer, b integer", Valid: true},
+				IdentArgs:  sql.NullString{String: "a integer, b integer", Valid: true},
 				ResultType: sql.NullString{String: "", Valid: false},
-				Volatility: "v", IsSecurityDefiner: false, Config: "", Cost: 100, NumRows: 0, DataAccess: "c",
+				Volatility: "v", IsSecurityDefiner: false, PlannerSupport: plannerSupportValue,
+				Config: "", Cost: 100, NumRows: 0, DataAccess: "c",
 				Language: "sql", ExecLocation: "a"}
 			secondProcedure := backup.Function{
 				Schema: "public", Name: "insert_more_data", Kind: "p", ReturnsSet: false, FunctionBody: `
@@ -330,9 +317,10 @@ INSERT INTO public.tbl VALUES (a);
 INSERT INTO public.tbl VALUES (b);
 `,
 				BinaryPath: "", Arguments: sql.NullString{String: "a integer, b integer", Valid: true},
-				IdentArgs: sql.NullString{String: "a integer, b integer", Valid: true},
+				IdentArgs:  sql.NullString{String: "a integer, b integer", Valid: true},
 				ResultType: sql.NullString{String: "", Valid: false},
-				Volatility: "v", IsSecurityDefiner: false, Config: "", Cost: 100, NumRows: 0, DataAccess: "c",
+				Volatility: "v", IsSecurityDefiner: false, PlannerSupport: plannerSupportValue,
+				Config: "", Cost: 100, NumRows: 0, DataAccess: "c",
 				Language: "sql", ExecLocation: "a"}
 
 			Expect(results).To(HaveLen(2))
@@ -442,7 +430,7 @@ SORTOP = ~>~ );`)
 			resultAggregates := backup.GetAggregates(connectionPool)
 			aggregateDef := backup.Aggregate{
 				Schema: "public", Name: "ascii_max", Arguments: sql.NullString{String: "character", Valid: true},
-				IdentArgs: sql.NullString{String: "character", Valid: true},
+				IdentArgs:          sql.NullString{String: "character", Valid: true},
 				TransitionFunction: transitionOid, FinalFunction: 0, SortOperator: "~>~", SortOperatorSchema: "pg_catalog", TransitionDataType: "character",
 				InitialValue: "", InitValIsNull: true, MInitValIsNull: true, IsOrdered: false,
 			}


### PR DESCRIPTION
- In GPDB 7+, user-defined functions can be given extra
   information to help the planner. This is done with new
   SQL syntax SUPPORT <support function> added to the
   CREATE FUNCTION command. We need to make changes in
   Function struct, query to get function info and
   print statement to create function.