### PR TITLE
Dump the integer type of a sequence relation

### DIFF
--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -254,6 +254,18 @@ func PrintCreateSequenceStatements(metadataFile *utils.FileWithByteCount,
 		start := metadataFile.ByteCount
 		definition := sequence.Definition
 		metadataFile.MustPrintln("\n\nCREATE SEQUENCE", sequence.FQN())
+		if connectionPool.Version.AtLeast("7") {
+			if definition.Type != "bigint"{
+				metadataFile.MustPrintln("\tAS", definition.Type)
+			}
+			if definition.Type == "smallint" {
+				maxVal = int64(math.MaxInt16)
+				minVal = int64(math.MinInt16)
+			} else if definition.Type == "integer" {
+				maxVal = int64(math.MaxInt32)
+				minVal = int64(math.MinInt32)
+			}
+		}
 		if connectionPool.Version.AtLeast("6") {
 			metadataFile.MustPrintln("\tSTART WITH", definition.StartVal)
 		} else if !definition.IsCalled {

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -172,6 +172,7 @@ func (s Sequence) GetMetadataEntry() (string, toc.MetadataEntry) {
 
 type SequenceDefinition struct {
 	LastVal     int64
+	Type        string
 	StartVal    int64
 	Increment   int64
 	MaxVal      int64
@@ -268,6 +269,7 @@ func GetSequenceDefinition(connectionPool *dbconn.DBConn, seqName string) Sequen
 		query = fmt.Sprintf(`
 		SELECT s.seqstart AS startval,
 			r.last_value AS lastval,
+			pg_catalog.format_type(s.seqtypid, NULL) AS type,
 			s.seqincrement AS increment,
 			s.seqmax AS maxval,
 			s.seqmin AS minval,

--- a/integration/predata_relations_create_test.go
+++ b/integration/predata_relations_create_test.go
@@ -520,18 +520,24 @@ SET SUBPARTITION TEMPLATE ` + `
 			sequenceRel         backup.Relation
 			sequence            backup.Sequence
 			sequenceMetadataMap backup.MetadataMap
+			dataType            string
 		)
 		BeforeEach(func() {
 			sequenceRel = backup.Relation{SchemaOid: 0, Oid: 1, Schema: "public", Name: "my_sequence"}
 			sequence = backup.Sequence{Relation: sequenceRel}
 			sequenceMetadataMap = backup.MetadataMap{}
+
+			dataType = ""
+			if connectionPool.Version.AtLeast("7") {
+				dataType = "bigint"
+			}
 		})
 		It("creates a basic sequence", func() {
 			startValue := int64(0)
 			if connectionPool.Version.AtLeast("6") {
 				startValue = 1
 			}
-			sequence.Definition = backup.SequenceDefinition{LastVal: 1, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 1, StartVal: startValue}
+			sequence.Definition = backup.SequenceDefinition{LastVal: 1, Type: dataType, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 1, StartVal: startValue}
 			backup.PrintCreateSequenceStatements(backupfile, tocfile, []backup.Sequence{sequence}, sequenceMetadataMap)
 			if connectionPool.Version.Before("5") {
 				sequence.Definition.LogCnt = 1 // In GPDB 4.3, sequence log count is one-indexed
@@ -551,7 +557,7 @@ SET SUBPARTITION TEMPLATE ` + `
 			if connectionPool.Version.AtLeast("6") {
 				startValue = 105
 			}
-			sequence.Definition = backup.SequenceDefinition{LastVal: 105, Increment: 5, MaxVal: 1000, MinVal: 20, CacheVal: 1, LogCnt: 0, IsCycled: false, IsCalled: true, StartVal: startValue}
+			sequence.Definition = backup.SequenceDefinition{LastVal: 105, Type: dataType, Increment: 5, MaxVal: 1000, MinVal: 20, CacheVal: 1, LogCnt: 0, IsCycled: false, IsCalled: true, StartVal: startValue}
 			backup.PrintCreateSequenceStatements(backupfile, tocfile, []backup.Sequence{sequence}, sequenceMetadataMap)
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
@@ -568,7 +574,7 @@ SET SUBPARTITION TEMPLATE ` + `
 			if connectionPool.Version.AtLeast("6") {
 				startValue = 1
 			}
-			sequence.Definition = backup.SequenceDefinition{LastVal: 1, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 1, StartVal: startValue}
+			sequence.Definition = backup.SequenceDefinition{LastVal: 1, Type: dataType, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 1, StartVal: startValue}
 			sequenceMetadata := testutils.DefaultMetadata("SEQUENCE", true, true, true, includeSecurityLabels)
 			sequenceMetadataMap[backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: 1}] = sequenceMetadata
 			backup.PrintCreateSequenceStatements(backupfile, tocfile, []backup.Sequence{sequence}, sequenceMetadataMap)
@@ -592,17 +598,16 @@ SET SUBPARTITION TEMPLATE ` + `
 		It("doesn't create identity sequences", func() {
 			testutils.SkipIfBefore7(connectionPool)
 			startValue := int64(0)
-			sequence.Definition = backup.SequenceDefinition{LastVal: 1, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 1, StartVal: startValue}
+			sequence.Definition = backup.SequenceDefinition{LastVal: 1, Type: dataType, MinVal: math.MinInt64, MaxVal: math.MaxInt64, Increment: 1, CacheVal: 1, StartVal: startValue}
 
 			identitySequenceRel := backup.Relation{SchemaOid: 0, Oid: 1, Schema: "public", Name: "my_identity_sequence"}
 			identitySequence := backup.Sequence{Relation: identitySequenceRel, IsIdentity: true}
-			identitySequence.Definition = backup.SequenceDefinition{LastVal: 1, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 20, StartVal: startValue}
+			identitySequence.Definition = backup.SequenceDefinition{LastVal: 1, Type: dataType, MinVal: math.MinInt64, MaxVal: math.MaxInt64, Increment: 1, CacheVal: 20, StartVal: startValue}
 
 			backup.PrintCreateSequenceStatements(backupfile, tocfile, []backup.Sequence{sequence, identitySequence}, sequenceMetadataMap)
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP SEQUENCE public.my_sequence")
-			defer testhelper.AssertQueryRuns(connectionPool, "DROP SEQUENCE public.my_identity_sequence")
 
 			resultSequences := backup.GetAllSequences(connectionPool)
 

--- a/integration/predata_relations_queries_test.go
+++ b/integration/predata_relations_queries_test.go
@@ -251,13 +251,22 @@ PARTITION BY LIST (gender)
 		})
 	})
 	Describe("GetSequenceDefinition", func() {
+		var dataType string
+
+		BeforeEach(func() {
+			dataType = ""
+			if connectionPool.Version.AtLeast("7") {
+				dataType = "bigint"
+			}
+		})
+
 		It("returns sequence information for sequence with default values", func() {
 			testhelper.AssertQueryRuns(connectionPool, "CREATE SEQUENCE public.my_sequence")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP SEQUENCE public.my_sequence")
 
 			resultSequenceDef := backup.GetSequenceDefinition(connectionPool, "public.my_sequence")
 
-			expectedSequence := backup.SequenceDefinition{LastVal: 1, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 1}
+			expectedSequence := backup.SequenceDefinition{LastVal: 1, Type: dataType, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 1}
 			if connectionPool.Version.Before("5") {
 				expectedSequence.LogCnt = 1 // In GPDB 4.3, sequence log count is one-indexed
 			}
@@ -282,7 +291,7 @@ PARTITION BY LIST (gender)
 
 			resultSequenceDef := backup.GetSequenceDefinition(connectionPool, "public.my_sequence")
 
-			expectedSequence := backup.SequenceDefinition{LastVal: 105, Increment: 5, MaxVal: 1000, MinVal: 20, CacheVal: 1, IsCycled: false, IsCalled: true}
+			expectedSequence := backup.SequenceDefinition{LastVal: 105, Type: dataType, Increment: 5, MaxVal: 1000, MinVal: 20, CacheVal: 1, IsCycled: false, IsCalled: true}
 			if connectionPool.Version.Before("5") {
 				expectedSequence.LogCnt = 32 // In GPDB 4.3, sequence log count is one-indexed
 			} else {


### PR DESCRIPTION
 - In GPDB 7+, you can change the integer type of a sequence
   relation from bigint to smallint or integer by specifying
   CREATE SEQUENCE AS <integer type>. We must dump the
   AS <integer type> clause if the sequence is of type
   smallint or integer.

Authored-by: Kate Dontsova <edontsova@pivotal.io>