### PR TITLE
Remove LogCnt from SequenceDefinition struct

### DIFF
--- a/backup/predata_relations_other_test.go
+++ b/backup/predata_relations_other_test.go
@@ -22,14 +22,14 @@ var _ = Describe("backup/predata_relations tests", func() {
 	})
 	Describe("PrintCreateSequenceStatements", func() {
 		baseSequence := backup.Relation{SchemaOid: 0, Oid: 1, Schema: "public", Name: "seq_name"}
-		seqDefault := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: true}}
-		seqNegIncr := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: -1, MaxVal: -1, MinVal: math.MinInt64, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: true}}
-		seqMaxPos := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: 100, MinVal: 1, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: true}}
-		seqMinPos := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: math.MaxInt64, MinVal: 10, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: true}}
-		seqMaxNeg := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: -1, MaxVal: -10, MinVal: math.MinInt64, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: true}}
-		seqMinNeg := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: -1, MaxVal: -1, MinVal: -100, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: true}}
-		seqCycle := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 5, LogCnt: 42, IsCycled: true, IsCalled: true}}
-		seqStart := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: false}}
+		seqDefault := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 5, IsCycled: false, IsCalled: true}}
+		seqNegIncr := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: -1, MaxVal: -1, MinVal: math.MinInt64, CacheVal: 5,IsCycled: false, IsCalled: true}}
+		seqMaxPos := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: 100, MinVal: 1, CacheVal: 5, IsCycled: false, IsCalled: true}}
+		seqMinPos := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: math.MaxInt64, MinVal: 10, CacheVal: 5, IsCycled: false, IsCalled: true}}
+		seqMaxNeg := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: -1, MaxVal: -10, MinVal: math.MinInt64, CacheVal: 5, IsCycled: false, IsCalled: true}}
+		seqMinNeg := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: -1, MaxVal: -1, MinVal: -100, CacheVal: 5, IsCycled: false, IsCalled: true}}
+		seqCycle := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 5, IsCycled: true, IsCalled: true}}
+		seqStart := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 5, IsCycled: false, IsCalled: false}}
 		emptySequenceMetadataMap := backup.MetadataMap{}
 
 		getSeqDefReplace := func() (string) {
@@ -138,7 +138,7 @@ SELECT pg_catalog.setval('public.seq_name', 7, false);`)
 		})
 		It("escapes a sequence containing single quotes", func() {
 			baseSequenceWithQuote := backup.Relation{SchemaOid: 0, Oid: 1, Schema: "public", Name: "seq_'name"}
-			seqWithQuote := backup.Sequence{Relation: baseSequenceWithQuote, Definition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: true}}
+			seqWithQuote := backup.Sequence{Relation: baseSequenceWithQuote, Definition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 5, IsCycled: false, IsCalled: true}}
 			sequences := []backup.Sequence{seqWithQuote}
 			backup.PrintCreateSequenceStatements(backupfile, tocfile, sequences, emptySequenceMetadataMap)
 			testutils.AssertBufferContents(tocfile.PredataEntries, buffer, fmt.Sprintf(`CREATE SEQUENCE public.seq_'name%s
@@ -244,7 +244,7 @@ GRANT ALL ON shamwow.shazam TO testrole;`}
 	})
 	Describe("PrintAlterSequenceStatements", func() {
 		baseSequence := backup.Relation{Schema: "public", Name: "seq_name"}
-		seqDefault := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 5, LogCnt: 42, IsCycled: false, IsCalled: true}}
+		seqDefault := backup.Sequence{Relation: baseSequence, Definition: backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 5, IsCycled: false, IsCalled: true}}
 		It("prints nothing for a sequence without an owning column", func() {
 			seqDefault.OwningColumn = ""
 			sequences := []backup.Sequence{seqDefault}

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -175,7 +175,6 @@ type SequenceDefinition struct {
 	MaxVal      int64
 	MinVal      int64
 	CacheVal    int64
-	LogCnt      int64
 	IsCycled    bool
 	IsCalled    bool
 	OwningTable string
@@ -245,7 +244,6 @@ func GetSequenceDefinition(connectionPool *dbconn.DBConn, seqName string) Sequen
 		max_value AS maxval,
 		min_value AS minval,
 		cache_value AS cacheval,
-		log_cnt AS logcnt,
 		is_cycled AS iscycled,
 		is_called AS iscalled
 	FROM %s`, startValQuery, seqName)

--- a/integration/predata_relations_create_test.go
+++ b/integration/predata_relations_create_test.go
@@ -506,9 +506,6 @@ SET SUBPARTITION TEMPLATE ` + `
 			}
 			sequence.Definition = backup.SequenceDefinition{LastVal: 1, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 1, StartVal: startValue}
 			backup.PrintCreateSequenceStatements(backupfile, tocfile, []backup.Sequence{sequence}, sequenceMetadataMap)
-			if connectionPool.Version.Before("5") {
-				sequence.Definition.LogCnt = 1 // In GPDB 4.3, sequence log count is one-indexed
-			}
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP SEQUENCE public.my_sequence")
@@ -524,7 +521,7 @@ SET SUBPARTITION TEMPLATE ` + `
 			if connectionPool.Version.AtLeast("6") {
 				startValue = 105
 			}
-			sequence.Definition = backup.SequenceDefinition{LastVal: 105, Increment: 5, MaxVal: 1000, MinVal: 20, CacheVal: 1, LogCnt: 0, IsCycled: false, IsCalled: true, StartVal: startValue}
+			sequence.Definition = backup.SequenceDefinition{LastVal: 105, Increment: 5, MaxVal: 1000, MinVal: 20, CacheVal: 1, IsCycled: false, IsCalled: true, StartVal: startValue}
 			backup.PrintCreateSequenceStatements(backupfile, tocfile, []backup.Sequence{sequence}, sequenceMetadataMap)
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
@@ -545,9 +542,6 @@ SET SUBPARTITION TEMPLATE ` + `
 			sequenceMetadata := testutils.DefaultMetadata("SEQUENCE", true, true, true, includeSecurityLabels)
 			sequenceMetadataMap[backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: 1}] = sequenceMetadata
 			backup.PrintCreateSequenceStatements(backupfile, tocfile, []backup.Sequence{sequence}, sequenceMetadataMap)
-			if connectionPool.Version.Before("5") {
-				sequence.Definition.LogCnt = 1 // In GPDB 4.3, sequence log count is one-indexed
-			}
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP SEQUENCE public.my_sequence")

--- a/integration/predata_relations_queries_test.go
+++ b/integration/predata_relations_queries_test.go
@@ -258,9 +258,6 @@ PARTITION BY LIST (gender)
 			resultSequenceDef := backup.GetSequenceDefinition(connectionPool, "public.my_sequence")
 
 			expectedSequence := backup.SequenceDefinition{LastVal: 1, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 1}
-			if connectionPool.Version.Before("5") {
-				expectedSequence.LogCnt = 1 // In GPDB 4.3, sequence log count is one-indexed
-			}
 			if connectionPool.Version.AtLeast("6") {
 				expectedSequence.StartVal = 1
 			}
@@ -283,19 +280,12 @@ PARTITION BY LIST (gender)
 			resultSequenceDef := backup.GetSequenceDefinition(connectionPool, "public.my_sequence")
 
 			expectedSequence := backup.SequenceDefinition{LastVal: 105, Increment: 5, MaxVal: 1000, MinVal: 20, CacheVal: 1, IsCycled: false, IsCalled: true}
-			if connectionPool.Version.Before("5") {
-				expectedSequence.LogCnt = 32 // In GPDB 4.3, sequence log count is one-indexed
-			} else {
-				expectedSequence.LogCnt = 31 // In GPDB 5, sequence log count is zero-indexed
-			}
 			if connectionPool.Version.AtLeast("6") {
 				expectedSequence.StartVal = 100
 			}
 			if connectionPool.Version.AtLeast("7") {
 				// In GPDB 7+, default cache value is 20
 				expectedSequence.CacheVal = 20
-				// log_cnt goes from 0 -> 32 -> 12 due to next cache batch
-				expectedSequence.LogCnt = 12
 				// last_value goes from 100 -> 195 -> 295 due to increment_by and cache_value
 				expectedSequence.LastVal = 295
 			}
@@ -376,10 +366,6 @@ PARTITION BY LIST (gender)
 			seqOneDef := backup.SequenceDefinition{LastVal: 3, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 1, StartVal: startValOne}
 			seqTwoRelation := backup.Relation{Schema: "public", Name: "seq_two"}
 			seqTwoDef := backup.SequenceDefinition{LastVal: 7, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 1, StartVal: startValTwo}
-			if connectionPool.Version.Before("5") {
-				seqOneDef.LogCnt = 1 // In GPDB 4.3, sequence log count is one-indexed
-				seqTwoDef.LogCnt = 1
-			}
 			if connectionPool.Version.AtLeast("7") {
 				// In GPDB 7+, default cache value is 20
 				seqOneDef.CacheVal = 20


### PR DESCRIPTION
Authored-by: Kate Dontsova <edontsova@pivotal.io>

Sequence log count is an ephemeral value that Postgres uses to internally track when to create a new WAL record for the next sequence cache. We never use it in gpbackup.