### PR TITLE
Improve performance for querying external table metadata

### DIFF
--- a/backup/predata_externals_test.go
+++ b/backup/predata_externals_test.go
@@ -238,6 +238,10 @@ FORMAT 'TEXT'
 ENCODING 'UTF-8'`)
 			})
 			It("prints a CREATE block for a table using error logging with an error table", func() {
+				// Error tables were removed in GPDB 5
+				if connectionPool.Version.AtLeast("5") {
+					Skip("Test does not apply for GPDB versions after 5")
+				}
 				extTableDef.ErrTableName = "error_table"
 				extTableDef.ErrTableSchema = "error_table_schema"
 				backup.PrintExternalTableStatements(backupfile, tableName, extTableDef)
@@ -249,8 +253,7 @@ ENCODING 'UTF-8'
 LOG ERRORS INTO error_table_schema.error_table`)
 			})
 			It("prints a CREATE block for a table using error logging without an error table", func() {
-				extTableDef.ErrTableName = "tablename"
-				extTableDef.ErrTableSchema = "public"
+				extTableDef.LogErrors = true
 				backup.PrintExternalTableStatements(backupfile, tableName, extTableDef)
 				testhelper.ExpectRegexp(buffer, `LOCATION (
 	'file://host:port/path/file'
@@ -282,8 +285,7 @@ ENCODING 'UTF-8'
 SEGMENT REJECT LIMIT 2 PERCENT`)
 			})
 			It("prints a CREATE block for a table with error logging and a row-based reject limit", func() {
-				extTableDef.ErrTableName = "tablename"
-				extTableDef.ErrTableSchema = "public"
+				extTableDef.LogErrors = true
 				extTableDef.RejectLimit = 2
 				extTableDef.RejectLimitType = "r"
 				backup.PrintExternalTableStatements(backupfile, tableName, extTableDef)

--- a/integration/predata_externals_create_test.go
+++ b/integration/predata_externals_create_test.go
@@ -42,8 +42,7 @@ var _ = Describe("backup integration create statement tests", func() {
 		It("creates a READABLE EXTERNAL table", func() {
 			extTable.Type = backup.READABLE
 			extTable.Writable = false
-			extTable.ErrTableName = "testtable"
-			extTable.ErrTableSchema = "public"
+			extTable.LogErrors = true
 			extTable.RejectLimit = 2
 			extTable.RejectLimitType = "r"
 			testTable.ExtTableDef = extTable

--- a/integration/predata_externals_queries_test.go
+++ b/integration/predata_externals_queries_test.go
@@ -64,7 +64,7 @@ SEGMENT REJECT LIMIT 10 PERCENT
 
 			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: "file://tmp/myfile.txt",
 				ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "delimiter '	' null '\\N' escape '\\'",
-				Command: "", RejectLimit: 10, RejectLimitType: "p", ErrTableName: "ext_table", ErrTableSchema: "public", Encoding: "UTF8",
+				Command: "", RejectLimit: 10, RejectLimitType: "p", LogErrors: true, Encoding: "UTF8",
 				Writable: false, URIs: []string{"file://tmp/myfile.txt"}}
 
 			structmatcher.ExpectStructsToMatchExcluding(&extTable, &result, "Oid")
@@ -84,7 +84,7 @@ SEGMENT REJECT LIMIT 10 PERCENT
 
 			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: "file://tmp/myfile.txt",
 				ExecLocation: "ALL_SEGMENTS", FormatType: "c", FormatOpts: `delimiter '|' null '' escape ''' quote ''' force not null i`,
-				Command: "", RejectLimit: 10, RejectLimitType: "p", ErrTableName: "ext_table", ErrTableSchema: "public", Encoding: "UTF8",
+				Command: "", RejectLimit: 10, RejectLimitType: "p", LogErrors: true, Encoding: "UTF8",
 				Writable: false, URIs: []string{"file://tmp/myfile.txt"}}
 
 			structmatcher.ExpectStructsToMatchExcluding(&extTable, &result, "Oid")
@@ -104,7 +104,7 @@ SEGMENT REJECT LIMIT 10 PERCENT
 
 			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: "file://tmp/myfile.txt",
 				ExecLocation: "ALL_SEGMENTS", FormatType: "b", FormatOpts: "formatter 'fixedwidth_out' i '20' ",
-				Command: "", RejectLimit: 10, RejectLimitType: "p", ErrTableName: "ext_table", ErrTableSchema: "public", Encoding: "UTF8",
+				Command: "", RejectLimit: 10, RejectLimitType: "p", LogErrors: true, Encoding: "UTF8",
 				Writable: false, URIs: []string{"file://tmp/myfile.txt"}}
 			if connectionPool.Version.AtLeast("7") {
 				extTable.FormatOpts = "formatter 'fixedwidth_out'i '20'"
@@ -130,7 +130,7 @@ LOG ERRORS SEGMENT REJECT LIMIT 10 PERCENT`)
 
 			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: "file://tmp/myfile.txt",
 				ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "delimiter '%' null '' escape 'OFF'",
-				Command: "", RejectLimit: 10, RejectLimitType: "p", ErrTableName: "ext_table", ErrTableSchema: "public", Encoding: "UTF8",
+				Command: "", RejectLimit: 10, RejectLimitType: "p", LogErrors: true, Encoding: "UTF8",
 				Writable: false, URIs: []string{"file://tmp/myfile.txt"}}
 
 			structmatcher.ExpectStructsToMatchExcluding(&extTable, &result, "Oid")


### PR DESCRIPTION
The query used for gathering external table metadata had poor
performance when there were external tables with error logging enabled
(i.e. LOG ERRORS option for CREATE EXTERNAL TABLE). This was because a
sequential scan on pg_namespace would happen for every row to get the
schema and table name of the error table. Worst of all, the schema and
table name of the error table was only usable for GPDB 4.3 and had no
use for GPDB 5+ since error tables were removed.

To fix this all these issues, we have done the following:
1. Introduce new LogErrors parameter to ExternalTableDefinition
   struct. This is used when running against all GPDB versions to
   designate that LOG ERRORS needs to be printed to the metadata SQL
   file.
2. When running against GPDB 5+, we no longer try to gather schema and
   table name for a nonexistant error table.
3. When running against GPDB 4.3, we have replaced the pg_namespace
   subquery with a LEFT JOIN on pg_namespace instead. We also only
   gather error table schema and table name when pg_exttable.reloid is
   not equal to its respective pg_exttable.fmterrtbl.

With this change, the query performance for external table metadata
should improve significantly when there are external tables with error
logging enabled.