### PR TITLE
Backup worker threads to take accessshare locks

### DIFF
--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -9,6 +9,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
@@ -349,8 +350,21 @@ func GetAllViews(connectionPool *dbconn.DBConn) []View {
 	return verifiedResults
 }
 
+// This function is responsible for getting the necessary access share locks
+// for the target relations. Each worker thread will have its own set of
+// access share locks in parallel.
 func LockTables(connectionPool *dbconn.DBConn, tables []Relation) {
 	gplog.Info("Acquiring ACCESS SHARE locks on tables")
+	var workerPool sync.WaitGroup
+	for connNum := 0; connNum < connectionPool.NumConns; connNum++ {
+		workerPool.Add(1)
+		go LockTablesWithConnection(connectionPool, tables, connNum, &workerPool)
+	}
+	workerPool.Wait()
+}
+
+func LockTablesWithConnection(connectionPool *dbconn.DBConn, tables []Relation, whichConn int, wg *sync.WaitGroup) {
+	defer wg.Done()
 
 	progressBar := utils.NewProgressBar(len(tables), "Locks acquired: ", utils.PB_VERBOSE)
 	progressBar.Start()
@@ -364,7 +378,7 @@ func LockTables(connectionPool *dbconn.DBConn, tables []Relation) {
 	// AccessExclusiveLock on the table.  In the case gpbackup is interrupted,
 	// cancelBlockedQueries() will cancel these queries during cleanup.
 	for i, currentBatch := range tableBatches {
-		connectionPool.MustExec(fmt.Sprintf("LOCK TABLE %s IN ACCESS SHARE MODE", currentBatch))
+		connectionPool.MustExec(fmt.Sprintf("LOCK TABLE %s IN ACCESS SHARE MODE", currentBatch), whichConn)
 
 		if i == len(tableBatches)-1 && lastBatchSize > 0 {
 			currentBatchSize = lastBatchSize

--- a/integration/queries_locktables_test.go
+++ b/integration/queries_locktables_test.go
@@ -1,0 +1,49 @@
+package integration
+
+import (
+	"github.com/greenplum-db/gp-common-go-libs/dbconn"
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/greenplum-db/gp-common-go-libs/testhelper"
+	"github.com/greenplum-db/gpbackup/backup"
+	"github.com/spf13/cobra"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Queries ", func() {
+	Describe("BackupJobsLockTables", func() {
+		var jobsConnectionPool *dbconn.DBConn
+		BeforeEach(func() {
+			gplog.SetVerbosity(gplog.LOGERROR) // turn off progress bar in the lock-table routine
+			var rootCmd = &cobra.Command{}
+			backup.DoInit(rootCmd) // initialize the ObjectCount
+			jobsConnectionPool = dbconn.NewDBConnFromEnvironment("testdb")
+		})
+		AfterEach(func() {
+			if jobsConnectionPool != nil {
+				jobsConnectionPool.Close()
+			}
+		})
+		It("grab as many access share locks as connections", func() {
+			jobsConnectionPool.MustConnect(3)
+			for connNum := 0; connNum < jobsConnectionPool.NumConns; connNum++ {
+				jobsConnectionPool.MustBegin(connNum)
+			}
+			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.backup_jobs_locktables(i int);")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.backup_jobs_locktables;")
+
+			tableRelations := []backup.Relation {backup.Relation{0, 0, "public", "backup_jobs_locktables"}}
+			backup.LockTables(jobsConnectionPool, tableRelations)
+
+			checkLockQuery := `SELECT count(*) FROM pg_locks l, pg_class c, pg_namespace n WHERE l.relation = c.oid AND n.oid = c.relnamespace AND n.nspname = 'public' AND c.relname = 'backup_jobs_locktables' AND l.granted = 't'`
+			var lockCount int
+			_ = connectionPool.Get(&lockCount, checkLockQuery)
+			Expect(lockCount).To(Equal(3))
+
+			for connNum := 0; connNum < jobsConnectionPool.NumConns; connNum++ {
+				jobsConnectionPool.MustCommit(connNum)
+			}
+		})
+	})
+})


### PR DESCRIPTION
Each jobs worker thread now gets its own set of AccessShareLocks on the target relations.
This would guarantee each COPY command to not get blocked by other concurrent requests that required AccessExclusiveLock.