### PR TITLE
gprestore application name to include timestamp

### DIFF
--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -9,6 +9,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
@@ -349,8 +350,21 @@ func GetAllViews(connectionPool *dbconn.DBConn) []View {
 	return verifiedResults
 }
 
+// This function is responsible for getting the necessary access share locks
+// for the target relations. Each worker thread will have its own set of
+// access share locks in parallel.
 func LockTables(connectionPool *dbconn.DBConn, tables []Relation) {
 	gplog.Info("Acquiring ACCESS SHARE locks on tables")
+	var workerPool sync.WaitGroup
+	for connNum := 0; connNum < connectionPool.NumConns; connNum++ {
+		workerPool.Add(1)
+		go LockTablesWithConnection(connectionPool, tables, connNum, &workerPool)
+	}
+	workerPool.Wait()
+}
+
+func LockTablesWithConnection(connectionPool *dbconn.DBConn, tables []Relation, whichConn int, wg *sync.WaitGroup) {
+	defer wg.Done()
 
 	progressBar := utils.NewProgressBar(len(tables), "Locks acquired: ", utils.PB_VERBOSE)
 	progressBar.Start()
@@ -364,7 +378,7 @@ func LockTables(connectionPool *dbconn.DBConn, tables []Relation) {
 	// AccessExclusiveLock on the table.  In the case gpbackup is interrupted,
 	// cancelBlockedQueries() will cancel these queries during cleanup.
 	for i, currentBatch := range tableBatches {
-		connectionPool.MustExec(fmt.Sprintf("LOCK TABLE %s IN ACCESS SHARE MODE", currentBatch))
+		connectionPool.MustExec(fmt.Sprintf("LOCK TABLE %s IN ACCESS SHARE MODE", currentBatch), whichConn)
 
 		if i == len(tableBatches)-1 && lastBatchSize > 0 {
 			currentBatchSize = lastBatchSize

--- a/integration/queries_locktables_test.go
+++ b/integration/queries_locktables_test.go
@@ -1,0 +1,49 @@
+package integration
+
+import (
+	"github.com/greenplum-db/gp-common-go-libs/dbconn"
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/greenplum-db/gp-common-go-libs/testhelper"
+	"github.com/greenplum-db/gpbackup/backup"
+	"github.com/spf13/cobra"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Queries ", func() {
+	Describe("BackupJobsLockTables", func() {
+		var jobsConnectionPool *dbconn.DBConn
+		BeforeEach(func() {
+			gplog.SetVerbosity(gplog.LOGERROR) // turn off progress bar in the lock-table routine
+			var rootCmd = &cobra.Command{}
+			backup.DoInit(rootCmd) // initialize the ObjectCount
+			jobsConnectionPool = dbconn.NewDBConnFromEnvironment("testdb")
+		})
+		AfterEach(func() {
+			if jobsConnectionPool != nil {
+				jobsConnectionPool.Close()
+			}
+		})
+		It("grab as many access share locks as connections", func() {
+			jobsConnectionPool.MustConnect(3)
+			for connNum := 0; connNum < jobsConnectionPool.NumConns; connNum++ {
+				jobsConnectionPool.MustBegin(connNum)
+			}
+			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.backup_jobs_locktables(i int);")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.backup_jobs_locktables;")
+
+			tableRelations := []backup.Relation {backup.Relation{0, 0, "public", "backup_jobs_locktables"}}
+			backup.LockTables(jobsConnectionPool, tableRelations)
+
+			checkLockQuery := `SELECT count(*) FROM pg_locks l, pg_class c, pg_namespace n WHERE l.relation = c.oid AND n.oid = c.relnamespace AND n.nspname = 'public' AND c.relname = 'backup_jobs_locktables' AND l.granted = 't'`
+			var lockCount int
+			_ = connectionPool.Get(&lockCount, checkLockQuery)
+			Expect(lockCount).To(Equal(3))
+
+			for connNum := 0; connNum < jobsConnectionPool.NumConns; connNum++ {
+				jobsConnectionPool.MustCommit(connNum)
+			}
+		})
+	})
+})

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -54,7 +54,8 @@ func DoSetup() {
 
 	utils.CheckGpexpandRunning(utils.RestorePreventedByGpexpandMessage)
 	restoreStartTime = history.CurrentTimestamp()
-	gplog.Info("Restore Key = %s", MustGetFlagString(options.TIMESTAMP))
+	backupTimestamp := MustGetFlagString(options.TIMESTAMP)
+	gplog.Info("Restore Key = %s", backupTimestamp)
 
 	CreateConnectionPool("postgres")
 
@@ -67,8 +68,8 @@ func DoSetup() {
 
 	segConfig := cluster.MustGetSegmentConfiguration(connectionPool)
 	globalCluster = cluster.NewCluster(segConfig)
-	segPrefix := filepath.ParseSegPrefix(MustGetFlagString(options.BACKUP_DIR), MustGetFlagString(options.TIMESTAMP))
-	globalFPInfo = filepath.NewFilePathInfo(globalCluster, MustGetFlagString(options.BACKUP_DIR), MustGetFlagString(options.TIMESTAMP), segPrefix)
+	segPrefix := filepath.ParseSegPrefix(MustGetFlagString(options.BACKUP_DIR), backupTimestamp)
+	globalFPInfo = filepath.NewFilePathInfo(globalCluster, MustGetFlagString(options.BACKUP_DIR), backupTimestamp, segPrefix)
 
 	// Get restore metadata from plugin
 	if MustGetFlagString(options.PLUGIN_CONFIG) != "" {
@@ -99,7 +100,7 @@ func DoSetup() {
 	if connectionPool != nil {
 		connectionPool.Close()
 	}
-	InitializeConnectionPool(unquotedRestoreDatabase)
+	InitializeConnectionPool(backupTimestamp, restoreStartTime, unquotedRestoreDatabase)
 
 	/*
 	 * We don't need to validate anything if we're creating the database; we

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -67,10 +67,10 @@ func CreateConnectionPool(unquotedDBName string) {
 	utils.ValidateGPDBVersionCompatibility(connectionPool)
 }
 
-func InitializeConnectionPool(unquotedDBName string) {
+func InitializeConnectionPool(backupTimestamp string, restoreTimestamp string, unquotedDBName string) {
 	CreateConnectionPool(unquotedDBName)
-	setupQuery := `
-SET application_name TO 'gprestore';
+	setupQuery := fmt.Sprintf("SET application_name TO 'gprestore_%s_%s';", backupTimestamp, restoreTimestamp)
+	setupQuery += `
 SET search_path TO pg_catalog;
 SET gp_default_storage_options='';
 SET statement_timeout = 0;


### PR DESCRIPTION
    `gprestore` application name has been modified to include both the backup
    time stamp and restore time stamp. This way concurrent `gprestore`
    sessions can be identified separately and we also stay consistent with
    how the `gprestore` report file naming convention