### PR TITLE
Convert CASE unnest() query logic into LEFT JOIN LATERAL for GPDB 7+

### DIFF
--- a/backup/dependencies.go
+++ b/backup/dependencies.go
@@ -27,8 +27,8 @@ func AddProtocolDependenciesForGPDB4(depMap DependencyMap, tables []Table, proto
 	}
 	for _, table := range tables {
 		extTableDef := table.ExtTableDef
-		if extTableDef.Location != "" {
-			protocolName := extTableDef.Location[0:strings.Index(extTableDef.Location, "://")]
+		if extTableDef.Location.Valid {
+			protocolName := extTableDef.Location.String[0:strings.Index(extTableDef.Location.String, "://")]
 			if protocolEntry, ok := protocolMap[protocolName]; ok {
 				tableEntry := table.GetUniqueID()
 				if _, ok := depMap[tableEntry]; !ok {

--- a/backup/predata_externals.go
+++ b/backup/predata_externals.go
@@ -7,6 +7,7 @@ package backup
  */
 
 import (
+	"database/sql"
 	"fmt"
 	"strings"
 
@@ -32,7 +33,7 @@ type ExternalTableDefinition struct {
 	Oid             uint32
 	Type            int
 	Protocol        int
-	Location        string
+	Location        sql.NullString
 	ExecLocation    string
 	FormatType      string
 	FormatOpts      string
@@ -75,7 +76,7 @@ func DetermineExternalTableCharacteristics(extTableDef ExternalTableDefinition) 
 	isWritable := extTableDef.Writable
 	var tableType int
 	tableProtocol := -1
-	if extTableDef.Location == "" { // EXTERNAL WEB tables may have EXECUTE instead of LOCATION
+	if !extTableDef.Location.Valid { // EXTERNAL WEB tables may have EXECUTE instead of LOCATION
 		tableProtocol = HTTP
 		if isWritable {
 			tableType = WRITABLE_WEB
@@ -87,7 +88,7 @@ func DetermineExternalTableCharacteristics(extTableDef ExternalTableDefinition) 
 		 * All data sources must use the same protocol, so we can use Location to determine
 		 * the table's protocol even though it only holds one data source URI.
 		 */
-		isWeb := strings.HasPrefix(extTableDef.Location, "http")
+		isWeb := strings.HasPrefix(extTableDef.Location.String, "http")
 		if isWeb && isWritable {
 			tableType = WRITABLE_WEB
 		} else if isWeb && !isWritable {
@@ -97,7 +98,7 @@ func DetermineExternalTableCharacteristics(extTableDef ExternalTableDefinition) 
 		} else {
 			tableType = READABLE
 		}
-		prefix := extTableDef.Location[0:strings.Index(extTableDef.Location, "://")]
+		prefix := extTableDef.Location.String[0:strings.Index(extTableDef.Location.String, "://")]
 		switch prefix {
 		case "file":
 			tableProtocol = FILE

--- a/backup/queries_acl.go
+++ b/backup/queries_acl.go
@@ -137,11 +137,22 @@ func GetMetadataForObjectType(connectionPool *dbconn.DBConn, params MetadataQuer
 	nameCol := params.NameField
 	aclCols := "''"
 	kindCol := "''"
+	aclLateralJoin := ""
 	if params.ACLField != "" {
-		aclCols = fmt.Sprintf(`CASE
-		WHEN %[1]s IS NULL THEN NULL
-		WHEN array_upper(%[1]s, 1) = 0 THEN %[1]s[0]
-		ELSE unnest(%[1]s) END`, params.ACLField)
+		// Cannot use unnest() in CASE statements anymore in GPDB 7+ so convert
+		// it to a LEFT JOIN LATERAL. We do not use LEFT JOIN LATERAL for GPDB 6
+		// because the CASE unnest() logic is more performant.
+		if connectionPool.Version.AtLeast("7") {
+			aclLateralJoin = fmt.Sprintf(
+				`LEFT JOIN LATERAL unnest(o.%[1]s) ljl_unnest ON o.%[1]s IS NOT NULL AND array_length(o.%[1]s, 1) != 0`, params.ACLField)
+			aclCols = "ljl_unnest"
+		} else {
+			aclCols = fmt.Sprintf(`CASE
+			WHEN %[1]s IS NULL THEN NULL
+			WHEN array_upper(%[1]s, 1) = 0 THEN %[1]s[0]
+			ELSE unnest(%[1]s) END`, params.ACLField)
+		}
+
 		kindCol = fmt.Sprintf(`CASE
 		WHEN %[1]s IS NULL THEN ''
 		WHEN array_upper(%[1]s, 1) = 0 THEN 'Empty'
@@ -196,10 +207,11 @@ func GetMetadataForObjectType(connectionPool *dbconn.DBConn, params MetadataQuer
 		coalesce(description,'') AS comment
 	FROM %s o LEFT JOIN %s d ON (d.objoid = o.oid AND d.classoid = '%s'::regclass%s)
 		%s
+		%s
 	WHERE %s
 	ORDER BY o.oid`,
 		params.ObjectType, tableName, nameCol, kindCol, schemaCol, ownerCol, aclCols, secCols,
-		tableName, descTable, tableName, subidFilter, joinClause, filterClause)
+		tableName, descTable, tableName, subidFilter, joinClause, aclLateralJoin, filterClause)
 	results := make([]MetadataQueryStruct, 0)
 	err := connectionPool.Select(&results, query)
 	gplog.FatalOnError(err)
@@ -299,15 +311,27 @@ func (dp DefaultPrivileges) GetMetadataEntry() (string, toc.MetadataEntry) {
 }
 
 func GetDefaultPrivileges(connectionPool *dbconn.DBConn) []DefaultPrivileges {
-	query := `
+	// Cannot use unnest() in CASE statements anymore in GPDB 7+ so convert
+	// it to a LEFT JOIN LATERAL. We do not use LEFT JOIN LATERAL for GPDB 6
+	// because the CASE unnest() logic is more performant.
+	aclCols := "''"
+	aclLateralJoin := ""
+	if connectionPool.Version.AtLeast("7") {
+		aclLateralJoin =
+			`LEFT JOIN LATERAL unnest(a.defaclacl) ljl_unnest ON a.defaclacl IS NOT NULL AND array_length(a.defaclacl, 1) != 0`
+		aclCols = "ljl_unnest"
+	} else {
+		aclCols = `CASE
+			WHEN a.defaclacl IS NULL THEN NULL
+			WHEN array_upper(a.defaclacl, 1) = 0 THEN a.defaclacl[0]
+			ELSE unnest(a.defaclacl) END`
+	}
+
+	query := fmt.Sprintf(`
 	SELECT a.oid,
 		quote_ident(r.rolname) AS owner,
 		coalesce(quote_ident(n.nspname),'') AS schema,
-		CASE
-			WHEN a.defaclacl IS NULL THEN NULL
-			WHEN array_upper(a.defaclacl, 1) = 0 THEN a.defaclacl[0]
-			ELSE unnest(a.defaclacl)
-		END AS privileges,
+		%s AS privileges,
 		CASE
 			WHEN a.defaclacl IS NULL THEN ''
 			WHEN array_upper(a.defaclacl, 1) = 0 THEN 'Empty'
@@ -317,7 +341,9 @@ func GetDefaultPrivileges(connectionPool *dbconn.DBConn) []DefaultPrivileges {
 	FROM pg_default_acl a
 		JOIN pg_roles r ON r.oid = a.defaclrole
 		LEFT JOIN pg_namespace n ON n.oid = a.defaclnamespace
-	ORDER BY n.nspname, a.defaclobjtype, r.rolname`
+		%s
+	ORDER BY n.nspname, a.defaclobjtype, r.rolname`,
+		aclCols, aclLateralJoin)
 	results := make([]DefaultPrivilegesQueryStruct, 0)
 	err := connectionPool.Select(&results, query)
 	gplog.FatalOnError(err)

--- a/backup/queries_externals.go
+++ b/backup/queries_externals.go
@@ -17,13 +17,21 @@ func GetExternalTableDefinitions(connectionPool *dbconn.DBConn) map[uint32]Exter
 	gplog.Verbose("Retrieving external table information")
 
 	var location string
+	locationJoin := ""
 	if connectionPool.Version.Before("5") {
 		execOptions := "'ALL_SEGMENTS', 'HOST', 'MASTER_ONLY', 'PER_HOST', 'SEGMENT_ID', 'TOTAL_SEGS'"
 		location = fmt.Sprintf(`CASE WHEN split_part(location[1], ':', 1) NOT IN (%s) THEN unnest(location) ELSE '' END AS location,
 		CASE WHEN split_part(location[1], ':', 1) IN (%s) THEN unnest(location) ELSE 'ALL_SEGMENTS' END AS execlocation,`, execOptions, execOptions)
-	} else {
+	} else if connectionPool.Version.Before("7") {
 		location = `CASE WHEN urilocation IS NOT NULL THEN unnest(urilocation) ELSE '' END AS location,
 		array_to_string(execlocation, ',') AS execlocation,`
+	} else if connectionPool.Version.AtLeast("7") {
+		// Cannot use unnest() in CASE statements anymore in GPDB 7+ so convert
+		// it to a LEFT JOIN LATERAL. We do not use LEFT JOIN LATERAL for GPDB 6
+		// because the CASE unnest() logic is more performant.
+		location = `ljl_unnest AS location,
+			array_to_string(execlocation, ',') AS execlocation,`
+		locationJoin = `LEFT JOIN LATERAL unnest(urilocation) ljl_unnest ON urilocation IS NOT NULL`
 	}
 
 	// In GPDB 4.3, users can define an error table with `LOG ERRORS
@@ -60,7 +68,8 @@ func GetExternalTableDefinitions(connectionPool *dbconn.DBConn) map[uint32]Exter
 		pg_encoding_to_char(encoding) AS encoding,
 		writable
 	FROM pg_exttable e
-		%s`, location, errorHandling, errorHandlingJoin)
+		%s
+		%s`, location, errorHandling, errorHandlingJoin, locationJoin)
 
 	results := make([]ExternalTableDefinition, 0)
 	err := connectionPool.Select(&results, query)
@@ -73,8 +82,8 @@ func GetExternalTableDefinitions(connectionPool *dbconn.DBConn) map[uint32]Exter
 		} else {
 			extTableDef = result
 		}
-		if result.Location != "" {
-			extTableDef.URIs = append(extTableDef.URIs, result.Location)
+		if result.Location.Valid {
+			extTableDef.URIs = append(extTableDef.URIs, result.Location.String)
 		}
 		resultMap[result.Oid] = extTableDef
 	}

--- a/backup/queries_incremental.go
+++ b/backup/queries_incremental.go
@@ -119,7 +119,7 @@ func getLastDDLTimestamps(connectionPool *dbconn.DBConn) map[string]string {
 				FROM pg_class c
 					JOIN pg_namespace n ON c.relnamespace = n.oid
 					JOIN pg_am a ON c.relam = a.oid
-				WHERE a.amname in ('ao_row', 'ao_col');
+				WHERE a.amname in ('ao_row', 'ao_col')
 					AND %s
 			) aotables
 		JOIN ( SELECT lo.objid,

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -197,7 +197,7 @@ func GetAllSequences(connectionPool *dbconn.DBConn) []Sequence {
 			coalesce(quote_ident(m.nspname), '') AS owningtableschema,
 			coalesce(quote_ident(t.relname), '') AS owningtable,
 			coalesce(quote_ident(a.attname), '') AS owningcolumn,
-			a.attidentity AS owningcolumnattidentity,
+			coalesce(a.attidentity, '') AS owningcolumnattidentity,
 			CASE
 				WHEN d.deptype IS NULL THEN false
 				ELSE d.deptype = 'i'

--- a/backup/queries_table_defs.go
+++ b/backup/queries_table_defs.go
@@ -252,12 +252,24 @@ func GetColumnDefinitions(connectionPool *dbconn.DBConn) map[uint32][]ColumnDefi
 	ORDER BY a.attrelid, a.attnum`, relationAndSchemaFilterClause(), partitionRuleExcludeClause)
 
 	if connectionPool.Version.AtLeast("6") {
-		selectClause += `,
-		CASE
-			WHEN a.attacl IS NULL THEN NULL
-			WHEN array_upper(a.attacl, 1) = 0 THEN a.attacl[0]
-			ELSE UNNEST(a.attacl)
-		END AS privileges,
+		// Cannot use unnest() in CASE statements anymore in GPDB 7+ so convert
+		// it to a LEFT JOIN LATERAL. We do not use LEFT JOIN LATERAL for GPDB 6
+		// because the CASE unnest() logic is more performant.
+		aclCols := "''"
+		aclLateralJoin := ""
+		if connectionPool.Version.AtLeast("7") {
+			aclLateralJoin =
+				`LEFT JOIN LATERAL unnest(a.attacl) ljl_unnest ON a.attacl IS NOT NULL AND array_length(a.attacl, 1) != 0`
+			aclCols = "ljl_unnest"
+		} else {
+			aclCols = `CASE
+				WHEN a.attacl IS NULL THEN NULL
+				WHEN array_upper(a.attacl, 1) = 0 THEN a.attacl[0]
+				ELSE unnest(a.attacl) END`
+		}
+
+		selectClause += fmt.Sprintf(`,
+		%s AS privileges,
 		CASE
 			WHEN a.attacl IS NULL THEN ''
 			WHEN array_upper(a.attacl, 1) = 0 THEN 'Empty'
@@ -267,12 +279,14 @@ func GetColumnDefinitions(connectionPool *dbconn.DBConn) map[uint32][]ColumnDefi
 		coalesce(array_to_string(ARRAY(SELECT option_name || ' ' || quote_literal(option_value) FROM pg_options_to_table(attfdwoptions) ORDER BY option_name), ', '), '') AS fdwoptions,
 		CASE WHEN a.attcollation <> t.typcollation THEN quote_ident(cn.nspname) || '.' || quote_ident(coll.collname) ELSE '' END AS collation,
 		coalesce(sec.provider,'') AS securitylabelprovider,
-		coalesce(sec.label,'') AS securitylabel`
-		fromClause += `
+		coalesce(sec.label,'') AS securitylabel`, aclCols)
+
+		fromClause += fmt.Sprintf(`
 		LEFT JOIN pg_collation coll ON a.attcollation = coll.oid
 		LEFT JOIN pg_namespace cn ON coll.collnamespace = cn.oid
 		LEFT JOIN pg_seclabel sec ON sec.objoid = a.attrelid AND
-			sec.classoid = 'pg_class'::regclass AND sec.objsubid = a.attnum`
+			sec.classoid = 'pg_class'::regclass AND sec.objsubid = a.attnum
+		%s`, aclLateralJoin)
 	}
 
 	query := fmt.Sprintf(`%s %s %s;`, selectClause, fromClause, whereClause)


### PR DESCRIPTION
In GPDB 7+, set-returning functions are no longer allowed inside CASE
and COALESCE statements. Because of this, we must convert our CASE
unnest() query logic into LEFT JOIN LATERAL when running against GPDB
7+ to conserve gpbackup code logic.

One thing to note is that GPDB 6 also has LATERAL joins available but
we opt not to use it when running against GPDB 6 because the CASE
unnest() query logic is much more performant than the LEFT JOIN
LATERAL alternative (~2x performance regression from my small local
testing but probably less than that in an actual production
environment).

Postgres Reference:
https://github.com/postgres/postgres/commit/0436f6bde8848b7135f19dd7f8548b8c2ae89a34

With this PR, gpbackup should no longer error out against GPDB 7 for catalog differences (when using simple bare minimum flags).