### PR TITLE
Modified backup directory error check/message

### DIFF
--- a/filepath/filepath.go
+++ b/filepath/filepath.go
@@ -192,9 +192,16 @@ func GetSegPrefix(connectionPool *dbconn.DBConn) string {
 func ParseSegPrefix(backupDir string, timestamp string) string {
 	segPrefix := ""
 	if len(backupDir) > 0 {
-		backupDirForTimestamp, err := operating.System.Glob(fmt.Sprintf("%s/*-1/backups/*/%s", backupDir, timestamp))
-		if err != nil || len(backupDirForTimestamp) == 0 {
+		backupDirForMaster, err := operating.System.Glob(fmt.Sprintf("%s/*-1/backups", backupDir))
+		if err != nil || len(backupDirForMaster) == 0 {
 			gplog.Fatal(err, "Master backup directory in %s missing or inaccessible", backupDir)
+		}
+		if len(backupDirForMaster) != 1 {
+			gplog.Fatal(err, "Multiple master backup directories in %s", backupDir)
+		}
+		backupDirForTimestamp, err := operating.System.Glob(fmt.Sprintf("%s/*/%s", backupDirForMaster[0], timestamp))
+		if err != nil || len(backupDirForTimestamp) == 0 {
+			gplog.Fatal(err, "Master backup directory for timestamp %s in %s is missing or inaccessible", timestamp, backupDir)
 		}
 		indexOfBackupsSubstr := strings.LastIndex(backupDirForTimestamp[0], "-1/backups/")
 		_, segPrefix = path.Split(backupDirForTimestamp[0][:indexOfBackupsSubstr])

--- a/filepath/filepath_test.go
+++ b/filepath/filepath_test.go
@@ -151,6 +151,28 @@ var _ = Describe("filepath tests", func() {
 			defer testhelper.ShouldPanicWithMessage("Master backup directory in /tmp/foo missing or inaccessible")
 			Expect(ParseSegPrefix("/tmp/foo", "timestamp1")).To(Equal("gpseg"))
 		})
+		It("panics if multiple master backup directories", func() {
+			operating.System.Glob = func(pattern string) (matches []string, err error) {
+				if pattern == "/tmp/foo/*-1/backups" {
+					return []string{"/tmp/foo/foo-1/backups", "/tmp/foo/foo-1/backups"}, nil
+				} else {
+					return []string{}, nil
+				}
+			}
+			defer testhelper.ShouldPanicWithMessage("Multiple master backup directories in /tmp/foo")
+			Expect(ParseSegPrefix("/tmp/foo", "timestamp1")).To(Equal("gpseg"))
+		})
+		It("panics if timestamp does not exist in master backup directory", func() {
+			operating.System.Glob = func(pattern string) (matches []string, err error) {
+				if pattern == "/tmp/foo/*-1/backups" {
+					return []string{"/tmp/foo/gpseg-1/backups"}, nil
+				} else {
+					return []string{}, nil
+				}
+			}
+			defer testhelper.ShouldPanicWithMessage("Master backup directory for timestamp timestamp1 in /tmp/foo is missing or inaccessible")
+			Expect(ParseSegPrefix("/tmp/foo", "timestamp1")).To(Equal("gpseg"))
+		})
 		Describe("IsValidTimestamp", func() {
 			It("allows a valid timestamp", func() {
 				timestamp := "20170101010101"


### PR DESCRIPTION
We first check if the master backup directory exists prior to checking
for the existence of the timestamp directory