### PR TITLE
Prevent orphaned gpbackup_helper race condition

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -270,7 +270,7 @@ func backupData(tables []Table) {
 		}
 		// Do not pass through the --on-error-continue flag because it does not apply to gpbackup
 		utils.StartGpbackupHelpers(globalCluster, globalFPInfo, "--backup-agent",
-			MustGetFlagString(options.PLUGIN_CONFIG), compressStr, false, false)
+			MustGetFlagString(options.PLUGIN_CONFIG), compressStr, false, false, &wasTerminated)
 	}
 	gplog.Info("Writing data to file")
 	rowsCopiedMaps := backupDataForAllTables(tables)

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -379,6 +379,7 @@ func LockTablesWithConnection(connectionPool *dbconn.DBConn, tables []Relation, 
 		if err != nil {
 			if wasTerminated {
 				gplog.Warn("Interrupt received while acquiring ACCESS SHARE locks on tables")
+				select {} // wait for cleanup thread to exit gpbackup
 			} else {
 				gplog.FatalOnError(err)
 			}

--- a/restore/data.go
+++ b/restore/data.go
@@ -108,7 +108,7 @@ func restoreDataFromTimestamp(fpInfo filepath.FilePathInfo, dataEntries []toc.Ma
 		if len(opts.IncludedRelations) > 0 || len(opts.ExcludedRelations) > 0 || len(opts.IncludedSchemas) > 0 || len(opts.ExcludedSchemas) > 0 {
 			isFilter = true
 		}
-		utils.StartGpbackupHelpers(globalCluster, fpInfo, "--restore-agent", MustGetFlagString(options.PLUGIN_CONFIG), "", MustGetFlagBool(options.ON_ERROR_CONTINUE), isFilter)
+		utils.StartGpbackupHelpers(globalCluster, fpInfo, "--restore-agent", MustGetFlagString(options.PLUGIN_CONFIG), "", MustGetFlagBool(options.ON_ERROR_CONTINUE), isFilter, &wasTerminated)
 	}
 	/*
 	 * We break when an interrupt is received and rely on

--- a/utils/agent_remote_test.go
+++ b/utils/agent_remote_test.go
@@ -125,7 +125,8 @@ var _ = Describe("agent remote", func() {
 	})
 	Describe("StartGpbackupHelpers()", func() {
 		It("Correctly propagates --on-error-continue flag to gpbackup_helper", func() {
-			utils.StartGpbackupHelpers(testCluster, fpInfo, "operation", "/tmp/pluginConfigFile.yml", " compressStr", true, false)
+			wasTerminated := false
+			utils.StartGpbackupHelpers(testCluster, fpInfo, "operation", "/tmp/pluginConfigFile.yml", " compressStr", true, false, &wasTerminated)
 
 			cc := testExecutor.ClusterCommands[0]
 			Expect(cc[1].CommandString).To(ContainSubstring(" --on-error-continue"))


### PR DESCRIPTION
Previously, a well-timed SIGTERM can orphan gpbackup_helpers if cleanup
happens before gpbackup_helpers are started. Now a mutex for starting
and stopping gpbackup_helpers prevents this race condition. Before
gpbackup_helpers are started we now check if a SIGTERM was caught.