### PR TITLE
Dump persistent error logs for external tables

### DIFF
--- a/backup/predata_externals.go
+++ b/backup/predata_externals.go
@@ -42,6 +42,7 @@ type ExternalTableDefinition struct {
 	ErrTableName    string
 	ErrTableSchema  string
 	LogErrors       bool
+	LogErrPersist   bool
 	Encoding        string
 	Writable        bool
 	URIs            []string
@@ -255,7 +256,11 @@ func GenerateFormatStatement(extTableDef ExternalTableDefinition) string {
 func generateLogErrorStatement(extTableDef ExternalTableDefinition) string {
 	logErrorStatement := ""
 	if extTableDef.LogErrors {
-		logErrorStatement += "\nLOG ERRORS"
+		if extTableDef.LogErrPersist {
+			logErrorStatement += "\nLOG ERRORS PERSISTENTLY"
+		} else {
+			logErrorStatement += "\nLOG ERRORS"
+		}
 	} else if extTableDef.ErrTableName != ""  && extTableDef.ErrTableSchema != "" {
 		errTableFQN := utils.MakeFQN(extTableDef.ErrTableSchema, extTableDef.ErrTableName)
 		logErrorStatement += fmt.Sprintf("\nLOG ERRORS INTO %s", errTableFQN)

--- a/backup/predata_externals_test.go
+++ b/backup/predata_externals_test.go
@@ -262,6 +262,16 @@ FORMAT 'TEXT'
 ENCODING 'UTF-8'
 LOG ERRORS`)
 			})
+			It("prints a LOG ERRORS PERSISTENTLY block for an external table using persistent error logging", func() {
+				// PERSISTENTLY option is specifically for GPDB 5+
+				if connectionPool.Version.AtLeast("5") {
+					Skip("Test does not apply for GPDB versions after 5")
+				}
+				extTableDef.LogErrors = true
+				extTableDef.LogErrPersist = true
+				backup.PrintExternalTableStatements(backupfile, tableName, extTableDef)
+				testhelper.ExpectRegexp(buffer, `LOG ERRORS PERSISTENTLY`)
+			})
 			It("prints a CREATE block for a table with a row-based reject limit", func() {
 				extTableDef.RejectLimit = 2
 				extTableDef.RejectLimitType = "r"

--- a/integration/predata_externals_queries_test.go
+++ b/integration/predata_externals_queries_test.go
@@ -121,7 +121,7 @@ SEGMENT REJECT LIMIT 10 PERCENT
 ) ON ALL
 FORMAT 'text' (delimiter E'%' null E'' escape E'OFF')
 ENCODING 'UTF8'
-LOG ERRORS SEGMENT REJECT LIMIT 10 PERCENT`)
+LOG ERRORS PERSISTENTLY SEGMENT REJECT LIMIT 10 PERCENT`)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP EXTERNAL TABLE public.ext_table")
 			oid := testutils.OidFromObjectName(connectionPool, "public", "ext_table", backup.TYPE_RELATION)
 
@@ -130,7 +130,7 @@ LOG ERRORS SEGMENT REJECT LIMIT 10 PERCENT`)
 
 			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: "file://tmp/myfile.txt",
 				ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "delimiter '%' null '' escape 'OFF'",
-				Command: "", RejectLimit: 10, RejectLimitType: "p", LogErrors: true, Encoding: "UTF8",
+				Command: "", RejectLimit: 10, RejectLimitType: "p", LogErrors: true, LogErrPersist: true, Encoding: "UTF8",
 				Writable: false, URIs: []string{"file://tmp/myfile.txt"}}
 
 			structmatcher.ExpectStructsToMatchExcluding(&extTable, &result, "Oid")


### PR DESCRIPTION
In GPDB 5+, a user can create an external table with the option LOG
ERRORS PERSISTENTLY which persists rejected row error logs into a flat
file so that recreating the table would use the same error log. The
PERSISTENTLY part was missing from the gpbackup metadata dump which
this patch fixes.

Note: There is a hidden OPTIONS syntax for CREATE EXTERNAL TABLE in
GPDB 5+ which stores the PERSISTENTLY flag bit. We only examine the
OPTIONS text array for error_log_persistent=true and ignore any other
options since the OPTIONS syntax is an undocumented (and thus
unsupported) feature. It seems like it was a remnant part of the
gpcloud feature which has since lost developer cycles in favor of the
more supported PXF feature.