### PR TITLE
Fix timestamp directory error check message

### DIFF
--- a/filepath/filepath.go
+++ b/filepath/filepath.go
@@ -201,7 +201,7 @@ func ParseSegPrefix(backupDir string, timestamp string) string {
 		}
 		backupDirForTimestamp, err := operating.System.Glob(fmt.Sprintf("%s/*/%s", backupDirForMaster[0], timestamp))
 		if err != nil || len(backupDirForTimestamp) == 0 {
-			gplog.Fatal(err, "Master backup directory for timestamp %s in %s is missing or inaccessible", timestamp, backupDir)
+			gplog.Fatal(err, "Timestamp directory %s inside backup directory %s is missing or inaccessible", timestamp, backupDir)
 		}
 		indexOfBackupsSubstr := strings.LastIndex(backupDirForTimestamp[0], "-1/backups/")
 		_, segPrefix = path.Split(backupDirForTimestamp[0][:indexOfBackupsSubstr])

--- a/filepath/filepath_test.go
+++ b/filepath/filepath_test.go
@@ -170,7 +170,7 @@ var _ = Describe("filepath tests", func() {
 					return []string{}, nil
 				}
 			}
-			defer testhelper.ShouldPanicWithMessage("Master backup directory for timestamp timestamp1 in /tmp/foo is missing or inaccessible")
+			defer testhelper.ShouldPanicWithMessage("Timestamp directory timestamp1 inside backup directory /tmp/foo is missing or inaccessible")
 			Expect(ParseSegPrefix("/tmp/foo", "timestamp1")).To(Equal("gpseg"))
 		})
 		Describe("IsValidTimestamp", func() {


### PR DESCRIPTION
The error was referencing the master backup directory which was
already previously checked in the same function. This particular error
message should only reference how the timestamp directory is missing
from the backup directory provided by the user.

gpbackup commit reference:
https://github.com/greenplum-db/gpbackup/commit/985d0943de7f86165724a8b7beb8512c87de015c