### PR TITLE
Support for generated columns

### DIFF
--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -167,7 +167,11 @@ func printColumnDefinitions(metadataFile *utils.FileWithByteCount, columnDefs []
 			line += fmt.Sprintf(" COLLATE %s", column.Collation)
 		}
 		if column.HasDefault {
-			line += fmt.Sprintf(" DEFAULT %s", column.DefaultVal)
+			if column.AttGenerated != ""  {
+				line += fmt.Sprintf(" GENERATED ALWAYS AS %s %s", column.DefaultVal, column.AttGenerated)
+			} else {
+				line += fmt.Sprintf(" DEFAULT %s", column.DefaultVal)
+			}
 		}
 		if column.NotNull {
 			line += " NOT NULL"

--- a/backup/queries_table_defs.go
+++ b/backup/queries_table_defs.go
@@ -199,6 +199,7 @@ type ColumnDefinition struct {
 	Collation             string
 	SecurityLabelProvider string
 	SecurityLabel         string
+	AttGenerated          string
 }
 
 var storageTypeCodes = map[string]string{
@@ -206,6 +207,10 @@ var storageTypeCodes = map[string]string{
 	"m": "MAIN",
 	"p": "PLAIN",
 	"x": "EXTENDED",
+}
+
+var attGeneratedCodes = map[string]string{
+	"s": "STORED",
 }
 
 func GetColumnDefinitions(connectionPool *dbconn.DBConn) map[uint32][]ColumnDefinition {
@@ -261,6 +266,8 @@ func GetColumnDefinitions(connectionPool *dbconn.DBConn) map[uint32][]ColumnDefi
 			aclLateralJoin =
 				`LEFT JOIN LATERAL unnest(a.attacl) ljl_unnest ON a.attacl IS NOT NULL AND array_length(a.attacl, 1) != 0`
 			aclCols = "ljl_unnest"
+			// Generated columns
+			selectClause += `, a.attgenerated`
 		} else {
 			aclCols = `CASE
 				WHEN a.attacl IS NULL THEN NULL
@@ -295,6 +302,9 @@ func GetColumnDefinitions(connectionPool *dbconn.DBConn) map[uint32][]ColumnDefi
 	resultMap := make(map[uint32][]ColumnDefinition)
 	for _, result := range results {
 		result.StorageType = storageTypeCodes[result.StorageType]
+		if connectionPool.Version.AtLeast("7") {
+			result.AttGenerated = attGeneratedCodes[result.AttGenerated]
+		}
 		resultMap[result.Oid] = append(resultMap[result.Oid], result)
 	}
 	return resultMap


### PR DESCRIPTION
In GPDB7+, generated columns are supported which is a special column
that is always computed from other columns. There are
two types of generated columsn - stored and virtual. As of now stored is
the only type supported and this would occupy storage.

Postgres Reference:
postgres/postgres@fc22b66