### PR TITLE
Support parallelism in user-defined functions

### DIFF
--- a/backup/predata_functions.go
+++ b/backup/predata_functions.go
@@ -9,8 +9,10 @@ package backup
 import (
 	"fmt"
 
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gpbackup/toc"
 	"github.com/greenplum-db/gpbackup/utils"
+	"github.com/pkg/errors"
 )
 
 func PrintCreateFunctionStatement(metadataFile *utils.FileWithByteCount, toc *toc.TOC, funcDef Function, funcMetadata ObjectMetadata) {
@@ -102,6 +104,17 @@ func PrintFunctionModifiers(metadataFile *utils.FileWithByteCount, funcDef Funct
 	}
 	if funcDef.Config != "" {
 		metadataFile.MustPrintf("\n%s", funcDef.Config)
+	}
+
+	switch funcDef.Parallel {
+	case "u":
+		metadataFile.MustPrintf(" PARALLEL UNSAFE")
+	case "s":
+		metadataFile.MustPrintf(" PARALLEL SAFE")
+	case "r":
+		metadataFile.MustPrintf(" PARALLEL RESTRICTED")
+	default:
+		gplog.Fatal(errors.Errorf("unrecognized proparallel value for function %s", funcDef.FQN()), "")
 	}
 }
 

--- a/backup/predata_functions_test.go
+++ b/backup/predata_functions_test.go
@@ -277,6 +277,29 @@ $_$`)
 				backup.PrintFunctionModifiers(backupfile, funcDef)
 				testhelper.ExpectRegexp(buffer, "SET client_min_messages TO error")
 			})
+			Context("Parallel cases", func() {
+				It("prints 'u' as 'PARALLEL UNSAFE'", func() {
+					funcDef.Parallel = "u"
+					backup.PrintFunctionModifiers(backupfile, funcDef)
+					testhelper.ExpectRegexp(buffer, "PARALLEL UNSAFE")
+				})
+				It("prints 's' as 'PARALLEL SAFE'", func() {
+					funcDef.Parallel = "s"
+					backup.PrintFunctionModifiers(backupfile, funcDef)
+					testhelper.ExpectRegexp(buffer, "PARALLEL SAFE")
+				})
+				It("prints 'r' as 'PARALLEL RESTRICTED'", func() {
+					funcDef.Parallel = "r"
+					backup.PrintFunctionModifiers(backupfile, funcDef)
+					testhelper.ExpectRegexp(buffer, "PARALLEL RESTRICTED")
+				})
+				It("panics is there is an unrecognized parallel value", func() {
+					defer testhelper.ShouldPanicWithMessage("unrecognized proparallel value for function public.func_name")
+					funcDef.Parallel = "unknown_value"
+					backup.PrintFunctionModifiers(backupfile, funcDef)
+				})
+			})
+
 		})
 
 	})

--- a/backup/queries_functions.go
+++ b/backup/queries_functions.go
@@ -40,6 +40,7 @@ type Function struct {
 	PlannerSupport    string `db:"prosupport"`  // GPDB 7+
 	IsWindow          bool   `db:"proiswindow"` // before 7
 	ExecLocation      string `db:"proexeclocation"`
+	Parallel          string `db:"proparallel"` // GPDB 7+
 }
 
 func (f Function) GetMetadataEntry() (string, toc.MetadataEntry) {
@@ -113,7 +114,7 @@ func GetFunctions(connectionPool *dbconn.DBConn) []Function {
 	}
 	var query string
 	if connectionPool.Version.AtLeast("7") {
-		masterAtts = "proexeclocation,proleakproof,"
+		masterAtts = "proexeclocation,proleakproof,proparallel,"
 		query = fmt.Sprintf(`
 		SELECT p.oid,
 			quote_ident(nspname) AS schema,


### PR DESCRIPTION
In GPDB 7+, PostgreSQL can devise query plans which can leverage
multiple CPUs in order to answer queries faster. Support backup of
Parallelism capabilities of user-defined functions.