### PR TITLE
Support parallelism for user defined aggregates

### DIFF
--- a/backup/predata_functions_test.go
+++ b/backup/predata_functions_test.go
@@ -531,6 +531,16 @@ $_$`)
 				"SECURITY LABEL FOR dummy ON AGGREGATE public.agg_name(*) IS 'unclassified';"}
 			testutils.AssertBufferContents(tocfile.PredataEntries, buffer, expectedStatements...)
 		})
+		It("prints an aggregate definition with parallel safe modifier", func() {
+			aggDefinition.Parallel = "s"
+			backup.PrintCreateAggregateStatement(backupfile, tocfile, aggDefinition, funcInfoMap, emptyMetadata)
+			testutils.ExpectEntry(tocfile.PredataEntries, 0, "public", "", "agg_name(integer, integer)", "AGGREGATE")
+			testutils.AssertBufferContents(tocfile.PredataEntries, buffer, `CREATE AGGREGATE public.agg_name(integer, integer) (
+	SFUNC = public.mysfunc,
+	STYPE = integer,
+	PARALLEL = SAFE
+);`)
+		})
 	})
 	Describe("PrintCreateCastStatement", func() {
 		emptyMetadata := backup.ObjectMetadata{}

--- a/backup/queries_functions.go
+++ b/backup/queries_functions.go
@@ -406,6 +406,7 @@ type Aggregate struct {
 	MFinalFuncExtra            bool
 	MInitialValue              string
 	MInitValIsNull             bool
+	Parallel                   string // GPDB 7+
 }
 
 func (a Aggregate) GetMetadataEntry() (string, toc.MetadataEntry) {
@@ -490,6 +491,7 @@ func GetAggregates(connectionPool *dbconn.DBConn) []Aggregate {
 	SELECT p.oid,
 		quote_ident(n.nspname) AS schema,
 		p.proname AS name,
+		p.proparallel as parallel,
 		pg_catalog.pg_get_function_arguments(p.oid) AS arguments,
 		pg_catalog.pg_get_function_identity_arguments(p.oid) AS identargs,
 		a.aggtransfn::regproc::oid,


### PR DESCRIPTION
 In GPDB 7+, PostgreSQL can support parallelism for user defined
 aggregates to leverage multiple cores for faster execution.

Postgres Reference:
postgres/postgres@b4e0f18