### PR TITLE
Dump user-defined access methods

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -231,6 +231,7 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Table, tableO
 		retrieveOperatorObjects(&objects, metadataMap)
 		retrieveAggregates(&objects, metadataMap)
 		retrieveCasts(&objects, metadataMap)
+		backupAccessMethods(metadataFile)
 	}
 
 	retrieveViews(&objects)

--- a/backup/predata_shared.go
+++ b/backup/predata_shared.go
@@ -7,8 +7,10 @@ package backup
  */
 
 import (
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gpbackup/toc"
 	"github.com/greenplum-db/gpbackup/utils"
+	"github.com/pkg/errors"
 )
 
 /*
@@ -61,5 +63,24 @@ func PrintCreateSchemaStatements(metadataFile *utils.FileWithByteCount, toc *toc
 		section, entry := schema.GetMetadataEntry()
 		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 		PrintObjectMetadata(metadataFile, toc, schemaMetadata[schema.GetUniqueID()], schema, "")
+	}
+}
+
+func PrintAccessMethodStatements(metadataFile *utils.FileWithByteCount, toc *toc.TOC, accessMethods []AccessMethod, accessMethodMetadata MetadataMap) {
+	for _, method := range accessMethods {
+		start := metadataFile.ByteCount
+		methodTypeStr := ""
+		switch method.Type {
+		case "t":
+			methodTypeStr = "TABLE"
+		case "i":
+			methodTypeStr = "INDEX"
+		default:
+			gplog.Fatal(errors.Errorf("Invalid access method type: expected 't' or 'i', got '%s'\n", method.Type), "")
+		}
+		metadataFile.MustPrintf("\n\nCREATE ACCESS METHOD %s TYPE %s HANDLER %s;", method.Name, methodTypeStr, method.Handler)
+		section, entry := method.GetMetadataEntry()
+		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
+		PrintObjectMetadata(metadataFile, toc, accessMethodMetadata[method.GetUniqueID()], method, "")
 	}
 }

--- a/backup/predata_shared_test.go
+++ b/backup/predata_shared_test.go
@@ -171,4 +171,14 @@ GRANT ALL ON SCHEMA schemaname TO testrole;`,
 			testutils.AssertBufferContents(tocfile.PredataEntries, buffer, expectedStatements...)
 		})
 	})
+	Describe("PrintAccessMethodStatements", func() {
+		It("can print a user defined access rights", func() {
+			accessMethods := []backup.AccessMethod{{Oid: 1, Name: "my_access_method", Handler: "my_access_handler", Type: "t"}}
+			emptyMetadataMap := backup.MetadataMap{}
+
+			backup.PrintAccessMethodStatements(backupfile, tocfile, accessMethods, emptyMetadataMap)
+			testutils.ExpectEntry(tocfile.PredataEntries, 0, "", "", "my_access_method", "ACCESS METHOD")
+			testutils.AssertBufferContents(tocfile.PredataEntries, buffer, "CREATE ACCESS METHOD my_access_method TYPE TABLE HANDLER my_access_handler;")
+		})
+	})
 })

--- a/backup/queries_acl.go
+++ b/backup/queries_acl.go
@@ -34,6 +34,7 @@ type MetadataQueryParams struct {
 }
 
 var (
+	TYPE_ACCESS_METHOD      MetadataQueryParams
 	TYPE_AGGREGATE          MetadataQueryParams
 	TYPE_CAST               MetadataQueryParams
 	TYPE_COLLATION          MetadataQueryParams
@@ -67,6 +68,7 @@ var (
 )
 
 func InitializeMetadataParams(connectionPool *dbconn.DBConn) {
+	TYPE_ACCESS_METHOD = MetadataQueryParams{ObjectType: "ACCESS METHOD", NameField: "amname", OidField: "oid", CatalogTable: "pg_am"}
 	TYPE_AGGREGATE = MetadataQueryParams{ObjectType: "AGGREGATE", NameField: "proname", SchemaField: "pronamespace", ACLField: "proacl", OwnerField: "proowner", CatalogTable: "pg_proc"}
 	if connectionPool.Version.AtLeast("7") {
 		TYPE_AGGREGATE.FilterClause = "prokind = 'a'"

--- a/backup/queries_shared.go
+++ b/backup/queries_shared.go
@@ -288,3 +288,45 @@ func ExtensionFilterClause(namespace string) string {
 
 	return fmt.Sprintf("%s NOT IN (select objid from pg_depend where deptype = 'e')", oidStr)
 }
+
+type AccessMethod struct {
+	Oid     uint32
+	Name    string
+	Handler string
+	Type    string
+}
+
+func (a AccessMethod) GetMetadataEntry() (string, toc.MetadataEntry) {
+	return "predata",
+		toc.MetadataEntry{
+			Name:            a.Name,
+			ObjectType:      "ACCESS METHOD",
+			ReferenceObject: "",
+			StartByte:       0,
+			EndByte:         0,
+		}
+}
+
+func (a AccessMethod) FQN() string {
+	return a.Name
+}
+
+func (a AccessMethod) GetUniqueID() UniqueID {
+	return UniqueID{ClassID: PG_TYPE_OID, Oid: a.Oid}
+}
+
+func GetAccessMethods(connectionPool *dbconn.DBConn) []AccessMethod {
+	results := make([]AccessMethod, 0)
+	query := fmt.Sprintf(`
+	SELECT oid,
+       quote_ident(amname) AS name,
+       amhandler::pg_catalog.regproc AS handler,
+       amtype AS type
+	FROM pg_am
+	WHERE oid > %d
+	ORDER BY oid;`, FIRST_NORMAL_OBJECT_ID)
+
+	err := connectionPool.Select(&results, query)
+	gplog.FatalOnError(err)
+	return results
+}

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -497,6 +497,17 @@ func backupEnumTypes(metadataFile *utils.FileWithByteCount, typeMetadata Metadat
 	PrintCreateEnumTypeStatements(metadataFile, globalTOC, enums, typeMetadata)
 }
 
+func backupAccessMethods(metadataFile *utils.FileWithByteCount) {
+	if connectionPool.Version.Before("7") {
+		return
+	}
+	gplog.Verbose("Writing CREATE ACCESS METHOD statements to metadata file")
+	accessMethods := GetAccessMethods(connectionPool)
+	objectCounts["Access Methods"] = len(accessMethods)
+	accessMethodsMetadata := GetMetadataForObjectType(connectionPool, TYPE_ACCESS_METHOD)
+	PrintAccessMethodStatements(metadataFile, globalTOC, accessMethods, accessMethodsMetadata)
+}
+
 func createBackupSet(objSlice []Sortable) (backupSet map[UniqueID]bool) {
 	backupSet = make(map[UniqueID]bool)
 	for _, obj := range objSlice {

--- a/integration/predata_shared_create_test.go
+++ b/integration/predata_shared_create_test.go
@@ -175,6 +175,23 @@ PARTITION BY RANGE (year)
 			structmatcher.ExpectStructsToMatchExcluding(&partitionCheckConstraint, &resultConstraints[0], "Oid")
 		})
 	})
+	Describe("PrintAccessMethodStatement", func() {
+		It("creates user defined access method for tables and indexes", func() {
+			accessMethodTable := backup.AccessMethod{Oid: 1, Name: "test_tableam_table", Handler: "heap_tableam_handler", Type: "t"}
+			accessMethodIndex := backup.AccessMethod{Oid: 2, Name: "test_tableam_index", Handler: "gisthandler", Type: "i"}
+			accessMethods := []backup.AccessMethod{accessMethodTable, accessMethodIndex}
+			backup.PrintAccessMethodStatements(backupfile, tocfile, accessMethods, backup.MetadataMap{})
+
+			testhelper.AssertQueryRuns(connectionPool, buffer.String())
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP ACCESS METHOD test_tableam_table;")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP ACCESS METHOD test_tableam_index;")
+
+			resultAccessMethods := backup.GetAccessMethods(connectionPool)
+			Expect(resultAccessMethods).To(HaveLen(2))
+			structmatcher.ExpectStructsToMatchExcluding(&resultAccessMethods[0], &accessMethodTable, "Oid")
+			structmatcher.ExpectStructsToMatchExcluding(&resultAccessMethods[1], &accessMethodIndex, "Oid")
+		})
+	})
 	Describe("GUC-printing functions", func() {
 		gucs := backup.SessionGUCs{ClientEncoding: "UTF8"}
 		Describe("PrintSessionGUCs", func() {

--- a/integration/predata_shared_queries_test.go
+++ b/integration/predata_shared_queries_test.go
@@ -339,4 +339,23 @@ PARTITION BY RANGE (date)
 			})
 		})
 	})
+	Describe("GetAccessMethods", func() {
+		It("returns information for user defined access methods", func() {
+			testhelper.AssertQueryRuns(connectionPool, "CREATE ACCESS METHOD test_tableam_table TYPE TABLE HANDLER heap_tableam_handler;")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP ACCESS METHOD test_tableam_table;")
+
+			testhelper.AssertQueryRuns(connectionPool, "CREATE ACCESS METHOD test_tableam_index TYPE INDEX HANDLER gisthandler;")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP ACCESS METHOD test_tableam_index;")
+
+			accessMethods := backup.GetAccessMethods(connectionPool)
+
+			accessMethodTable := backup.AccessMethod{Oid: 1, Name: "test_tableam_table", Handler: "heap_tableam_handler", Type: "t"}
+			accessMethodIndex := backup.AccessMethod{Oid: 2, Name: "test_tableam_index", Handler: "gisthandler", Type: "i"}
+
+			Expect(accessMethods).To(HaveLen(2))
+			structmatcher.ExpectStructsToMatchExcluding(&accessMethodTable, &accessMethods[0], "Oid")
+			structmatcher.ExpectStructsToMatchExcluding(&accessMethodIndex, &accessMethods[1], "Oid")
+
+		})
+	})
 })


### PR DESCRIPTION
 - In GPDB 7+, users are now able to create their own access methods.
   To support this we have to create the same structures and
   functionality we are doing for other objects: new struct
   based on pg_am catalog table, GetAccessMethods() with the
   query to get get them and PrintAccessMethodStatements()
   method to dump them in predata.