### PR TITLE
Fix end_to_end tests for GPDB 7

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -471,6 +471,9 @@ func cancelBlockedQueries(timestamp string) {
 		select {
 		case <-tickerCheckCanceled.C:
 			blockedQueryCount := fmt.Sprintf("SELECT count(*) from pg_stat_activity WHERE application_name='gpbackup_%s' AND waiting='t' AND  waiting_reason='lock';", timestamp)
+			if conn.Version.AtLeast("7") {
+				blockedQueryCount = fmt.Sprintf("SELECT count(*) from pg_stat_activity WHERE application_name='gpbackup_%s' AND wait_event_type='Lock';", timestamp)
+			}
 			count = dbconn.MustSelectString(conn, blockedQueryCount)
 			if count == "0" {
 				return

--- a/backup/dependencies.go
+++ b/backup/dependencies.go
@@ -27,7 +27,7 @@ func AddProtocolDependenciesForGPDB4(depMap DependencyMap, tables []Table, proto
 	}
 	for _, table := range tables {
 		extTableDef := table.ExtTableDef
-		if extTableDef.Location.Valid {
+		if extTableDef.Location.Valid && extTableDef.Location.String != "" {
 			protocolName := extTableDef.Location.String[0:strings.Index(extTableDef.Location.String, "://")]
 			if protocolEntry, ok := protocolMap[protocolName]; ok {
 				tableEntry := table.GetUniqueID()

--- a/backup/predata_externals.go
+++ b/backup/predata_externals.go
@@ -76,7 +76,8 @@ func DetermineExternalTableCharacteristics(extTableDef ExternalTableDefinition) 
 	isWritable := extTableDef.Writable
 	var tableType int
 	tableProtocol := -1
-	if !extTableDef.Location.Valid { // EXTERNAL WEB tables may have EXECUTE instead of LOCATION
+	if !extTableDef.Location.Valid ||
+		extTableDef.Location.String == "" { // EXTERNAL WEB tables may have EXECUTE instead of LOCATION
 		tableProtocol = HTTP
 		if isWritable {
 			tableType = WRITABLE_WEB

--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -38,25 +38,59 @@ func SplitTablesByPartitionType(tables []Table, includeList []string) ([]Table, 
 				metadataTables = append(metadataTables, table)
 			}
 			partType := table.PartitionLevelInfo.Level
-			if partType != "l" && partType != "i" {
+			if connectionPool.Version.AtLeast("7") {
+				// In GPDB 7+, we need to dump out the leaf partition DDL along with their
+				// ALTER TABLE ATTACH PARTITION commands to construct the partition table
+				metadataTables = append(metadataTables, table)
+			} else if partType != "l" && partType != "i" {
 				metadataTables = append(metadataTables, table)
 			}
 			if MustGetFlagBool(options.LEAF_PARTITION_DATA) {
 				if partType != "p" && partType != "i" {
 					dataTables = append(dataTables, table)
 				}
+			} else if connectionPool.Version.AtLeast("7") &&
+				table.AttachPartitionInfo != (AttachPartitionInfo{}) {
+				// For GPDB 7+ and without --leaf-partition-data, we must exclude the
+				// leaf partitions from dumping data. The COPY will be called on the
+				// top-most root partition.
+				continue
 			} else if includeSet.MatchesFilter(table.FQN()) {
 				dataTables = append(dataTables, table)
 			}
 		}
 	} else {
+		var excludeList *utils.FilterSet
+		if connectionPool.Version.AtLeast("7") {
+			excludeList = utils.NewExcludeSet(MustGetFlagStringArray(options.EXCLUDE_RELATION))
+		} else {
+			excludeList = utils.NewExcludeSet([]string{})
+		}
+
 		for _, table := range tables {
+			// In GPDB 7+, we need to filter out leaf and intermediate subroot partitions
+			// since the COPY will be called on the top-most root partition. It just so
+			// happens that those particular partition types will always have an
+			// AttachPartitionInfo initialized.
+			if table.AttachPartitionInfo == (AttachPartitionInfo{}) {
+				dataTables = append(dataTables, table)
+			}
+
+			// In GPDB 7+, we need to filter out leaf and intermediate subroot partitions
+			// from being added to the metadata table list if their root partition parent
+			// is in the exclude list. This is to prevent ATTACH PARTITION statements
+			// against nonexistant root partitions from being printed to the metadata file.
+			if connectionPool.Version.AtLeast("7") &&
+				table.AttachPartitionInfo != (AttachPartitionInfo{}) &&
+				!excludeList.MatchesFilter(table.AttachPartitionInfo.Parent) {
+				continue
+			}
+
 			if table.IsExternal && table.PartitionLevelInfo.Level == "l" {
 				table.Name = AppendExtPartSuffix(table.Name)
 			}
 			metadataTables = append(metadataTables, table)
 		}
-		dataTables = tables
 	}
 	return metadataTables, dataTables
 }

--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -241,7 +241,7 @@ func PrintPostCreateTableStatements(metadataFile *utils.FileWithByteCount, toc *
 	attachInfo := table.AttachPartitionInfo
 	if (attachInfo != AttachPartitionInfo{}) {
 		statements = append(statements,
-			fmt.Sprintf("ALTER TABLE ONLY %s ATTACH PARTITION %s %s;", attachInfo.Parent, attachInfo.Relname, attachInfo.Expr))
+			fmt.Sprintf("ALTER TABLE ONLY %s ATTACH PARTITION %s %s;", table.Inherits[0], attachInfo.Relname, attachInfo.Expr))
 	}
 
 	PrintStatements(metadataFile, toc, table, statements)

--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -119,7 +119,7 @@ func PrintRegularTableCreateStatement(metadataFile *utils.FileWithByteCount, toc
 	if table.PartitionKeyDef != "" {
 		metadataFile.MustPrintf("PARTITION BY %s ", table.PartitionKeyDef)
 	}
-	if len(table.Inherits) != 0 {
+	if len(table.Inherits) != 0  && table.AttachPartitionInfo == (AttachPartitionInfo{}) {
 		dependencyList := strings.Join(table.Inherits, ", ")
 		metadataFile.MustPrintf("INHERITS (%s) ", dependencyList)
 	}

--- a/backup/queries_externals.go
+++ b/backup/queries_externals.go
@@ -82,7 +82,7 @@ func GetExternalTableDefinitions(connectionPool *dbconn.DBConn) map[uint32]Exter
 		} else {
 			extTableDef = result
 		}
-		if result.Location.Valid {
+		if result.Location.Valid && result.Location.String != "" {
 			extTableDef.URIs = append(extTableDef.URIs, result.Location.String)
 		}
 		resultMap[result.Oid] = extTableDef

--- a/backup/queries_shared.go
+++ b/backup/queries_shared.go
@@ -109,11 +109,6 @@ func (c Constraint) FQN() string {
 }
 
 func GetConstraints(connectionPool *dbconn.DBConn, includeTables ...Relation) []Constraint {
-	// TODO: fix for gpdb7 partitioning
-	if connectionPool.Version.AtLeast("7") {
-		return []Constraint{}
-	}
-
 	// ConIsLocal should always return true from GetConstraints because we
 	// filter out constraints that are inherited using the INHERITS clause, or
 	// inherited from a parent partition table. This field only accurately
@@ -127,29 +122,56 @@ func GetConstraints(connectionPool *dbconn.DBConn, includeTables ...Relation) []
 		groupByConIsLocal = `con.conislocal,`
 	}
 	// This query is adapted from the queries underlying \d in psql.
-	tableQuery := fmt.Sprintf(`
-	SELECT con.oid,
-		quote_ident(n.nspname) AS schema,
-		quote_ident(conname) AS name,
-		contype,
-		%s
-		pg_get_constraintdef(con.oid, TRUE) AS condef,
-		quote_ident(n.nspname) || '.' || quote_ident(c.relname) AS owningobject,
-		'f' AS isdomainconstraint,
-		CASE
-			WHEN pt.parrelid IS NULL THEN 'f'
-			ELSE 't'
-		END AS ispartitionparent
-	FROM pg_constraint con
-		LEFT JOIN pg_class c ON con.conrelid = c.oid
-		LEFT JOIN pg_partition pt ON con.conrelid = pt.parrelid
-		JOIN pg_namespace n ON n.oid = con.connamespace
-	WHERE %s
-		AND %s
-		AND c.relname IS NOT NULL
-		AND conrelid NOT IN (SELECT parchildrelid FROM pg_partition_rule)
-		AND (conrelid, conname) NOT IN (SELECT i.inhrelid, con.conname FROM pg_inherits i JOIN pg_constraint con ON i.inhrelid = con.conrelid JOIN pg_constraint p ON i.inhparent = p.conrelid WHERE con.conname = p.conname)
-	GROUP BY con.oid, conname, contype, c.relname, n.nspname, %s pt.parrelid`, selectConIsLocal, "%s", ExtensionFilterClause("c"), groupByConIsLocal)
+	tableQuery := ""
+	if connectionPool.Version.Before("7") {
+		tableQuery = fmt.Sprintf(`
+		SELECT con.oid,
+			quote_ident(n.nspname) AS schema,
+			quote_ident(conname) AS name,
+			contype,
+			%s
+			pg_get_constraintdef(con.oid, TRUE) AS condef,
+			quote_ident(n.nspname) || '.' || quote_ident(c.relname) AS owningobject,
+			'f' AS isdomainconstraint,
+			CASE
+				WHEN pt.parrelid IS NULL THEN 'f'
+				ELSE 't'
+			END AS ispartitionparent
+		FROM pg_constraint con
+			LEFT JOIN pg_class c ON con.conrelid = c.oid
+			LEFT JOIN pg_partition pt ON con.conrelid = pt.parrelid
+			JOIN pg_namespace n ON n.oid = con.connamespace
+		WHERE %s
+			AND %s
+			AND c.relname IS NOT NULL
+			AND conrelid NOT IN (SELECT parchildrelid FROM pg_partition_rule)
+			AND (conrelid, conname) NOT IN (SELECT i.inhrelid, con.conname FROM pg_inherits i JOIN pg_constraint con ON i.inhrelid = con.conrelid JOIN pg_constraint p ON i.inhparent = p.conrelid WHERE con.conname = p.conname)
+		GROUP BY con.oid, conname, contype, c.relname, n.nspname, %s pt.parrelid`, selectConIsLocal, "%s", ExtensionFilterClause("c"), groupByConIsLocal)
+	} else {
+		tableQuery = fmt.Sprintf(`
+		SELECT con.oid,
+			quote_ident(n.nspname) AS schema,
+			quote_ident(conname) AS name,
+			contype,
+			%s
+			pg_get_constraintdef(con.oid, TRUE) AS condef,
+			quote_ident(n.nspname) || '.' || quote_ident(c.relname) AS owningobject,
+			'f' AS isdomainconstraint,
+			CASE
+				WHEN pt.partrelid IS NULL THEN 'f'
+				ELSE 't'
+			END AS ispartitionparent
+		FROM pg_constraint con
+			LEFT JOIN pg_class c ON con.conrelid = c.oid
+			LEFT JOIN pg_partitioned_table pt ON con.conrelid = pt.partrelid
+			JOIN pg_namespace n ON n.oid = con.connamespace
+		WHERE %s
+			AND %s
+			AND c.relname IS NOT NULL
+			AND c.relispartition IS FALSE
+			AND (conrelid, conname) NOT IN (SELECT i.inhrelid, con.conname FROM pg_inherits i JOIN pg_constraint con ON i.inhrelid = con.conrelid JOIN pg_constraint p ON i.inhparent = p.conrelid WHERE con.conname = p.conname)
+		GROUP BY con.oid, conname, contype, c.relname, n.nspname, %s pt.partrelid`, selectConIsLocal, "%s", ExtensionFilterClause("c"), groupByConIsLocal)
+	}
 
 	nonTableQuery := fmt.Sprintf(`
 	SELECT con.oid,

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -178,7 +178,7 @@ func assertSchemasExist(conn *dbconn.DBConn, expectedNumSchemas int) {
 }
 
 func assertRelationsCreated(conn *dbconn.DBConn, expectedNumTables int) {
-	countQuery := `SELECT count(*) AS string FROM pg_class c LEFT JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind IN ('S','v','r') AND n.nspname IN ('public', 'schema2');`
+	countQuery := `SELECT count(*) AS string FROM pg_class c LEFT JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind IN ('S','v','r','p') AND n.nspname IN ('public', 'schema2');`
 	actualTableCount := dbconn.MustSelectString(conn, countQuery)
 	if strconv.Itoa(expectedNumTables) != actualTableCount {
 		Fail(fmt.Sprintf("Expected:\n\t%s relations to have been created\nActual:\n\t%s relations were created", strconv.Itoa(expectedNumTables), actualTableCount))
@@ -186,7 +186,7 @@ func assertRelationsCreated(conn *dbconn.DBConn, expectedNumTables int) {
 }
 
 func assertRelationsCreatedInSchema(conn *dbconn.DBConn, schema string, expectedNumTables int) {
-	countQuery := fmt.Sprintf(`SELECT count(*) AS string FROM pg_class c LEFT JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind IN ('S','v','r') AND n.nspname = '%s'`, schema)
+	countQuery := fmt.Sprintf(`SELECT count(*) AS string FROM pg_class c LEFT JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind IN ('S','v','r','p') AND n.nspname = '%s'`, schema)
 	actualTableCount := dbconn.MustSelectString(conn, countQuery)
 	if strconv.Itoa(expectedNumTables) != actualTableCount {
 		Fail(fmt.Sprintf("Expected:\n\t%s relations to have been created\nActual:\n\t%s relations were created", strconv.Itoa(expectedNumTables), actualTableCount))
@@ -194,7 +194,7 @@ func assertRelationsCreatedInSchema(conn *dbconn.DBConn, schema string, expected
 }
 
 func assertRelationsExistForIncremental(conn *dbconn.DBConn, expectedNumTables int) {
-	countQuery := `SELECT count(*) AS string FROM pg_class c LEFT JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind IN ('S','v','r') AND n.nspname IN ('old_schema', 'new_schema');`
+	countQuery := `SELECT count(*) AS string FROM pg_class c LEFT JOIN pg_namespace n ON n.oid = c.relnamespace WHERE c.relkind IN ('S','v','r','p') AND n.nspname IN ('old_schema', 'new_schema');`
 	actualTableCount := dbconn.MustSelectString(conn, countQuery)
 	if strconv.Itoa(expectedNumTables) != actualTableCount {
 		Fail(fmt.Sprintf("Expected:\n\t%s relations to exist in old_schema and new_schema\nActual:\n\t%s relations are present", strconv.Itoa(expectedNumTables), actualTableCount))

--- a/end_to_end/filtered_test.go
+++ b/end_to_end/filtered_test.go
@@ -96,7 +96,15 @@ PARTITION BY LIST (gender)
 				"--redirect-db", "restoredb",
 				"--backup-dir", backupDir)
 
-			assertRelationsCreated(restoreConn, 4)
+			// When running against GPDB 7+, only the root partition and the included leaf partition
+			// will be created due to the new flexible GPDB 7+ partitioning logic. For versions
+			// before GPDB 7, there is only one big DDL for the entire partition table.
+			if backupConn.Version.AtLeast("7") {
+				assertRelationsCreated(restoreConn, 2)
+			} else {
+				assertRelationsCreated(restoreConn, 4)
+			}
+
 			localSchemaTupleCounts := map[string]int{
 				`public.testparent_1_prt_girls`: 1,
 				`public.testparent`:             1,

--- a/end_to_end/incremental_test.go
+++ b/end_to_end/incremental_test.go
@@ -252,7 +252,15 @@ var _ = Describe("End to End incremental tests", func() {
 				gprestore(gprestorePath, restoreHelperPath, incremental1Timestamp,
 					"--redirect-db", "restoredb")
 
-				assertRelationsCreated(restoreConn, TOTAL_RELATIONS-2) // -2 for public.holds and schema2.ao1, excluded partition will be included anyway but it's data - will not
+				if backupConn.Version.Before("7") {
+					// -2 for public.holds and schema2.ao1, excluded partition will be included anyway but it's data - will not
+					assertRelationsCreated(restoreConn, TOTAL_RELATIONS-2)
+				} else {
+					// In GPDB 7+, the sales_1_prt_mar17 partition will not be created.
+					// TODO: Should the leaf partition actually be created when it has
+					// been excluded with the new GPDB partitioning logic?
+					assertRelationsCreated(restoreConn, TOTAL_RELATIONS-3)
+				}
 				assertDataRestored(restoreConn, publicSchemaTupleCountsWithExclude)
 				assertDataRestored(restoreConn, schema2TupleCountsWithExclude)
 			})

--- a/end_to_end/plugin_test.go
+++ b/end_to_end/plugin_test.go
@@ -80,21 +80,35 @@ var _ = Describe("End to End plugin tests", func() {
 			assertArtifactsCleaned(restoreConn, timestamp)
 		})
 		It("runs gpbackup and gprestore on database with all objects", func() {
-			testhelper.AssertQueryRuns(backupConn,
-				"DROP SCHEMA IF EXISTS schema2 CASCADE; DROP SCHEMA public CASCADE; CREATE SCHEMA public; DROP PROCEDURAL LANGUAGE IF EXISTS plpythonu;")
+			schemaResetStatements := "DROP SCHEMA IF EXISTS schema2 CASCADE; DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
+			testhelper.AssertQueryRuns(backupConn, schemaResetStatements)
 			defer testutils.ExecuteSQLFile(backupConn,
 				"resources/test_tables_data.sql")
 			defer testutils.ExecuteSQLFile(backupConn,
 				"resources/test_tables_ddl.sql")
-			defer testhelper.AssertQueryRuns(backupConn,
-				"DROP SCHEMA IF EXISTS schema2 CASCADE; DROP SCHEMA public CASCADE; CREATE SCHEMA public; DROP PROCEDURAL LANGUAGE IF EXISTS plpythonu;")
-			defer testhelper.AssertQueryRuns(restoreConn,
-				"DROP SCHEMA IF EXISTS schema2 CASCADE; DROP SCHEMA public CASCADE; CREATE SCHEMA public; DROP PROCEDURAL LANGUAGE IF EXISTS plpythonu;")
+			defer testhelper.AssertQueryRuns(backupConn, schemaResetStatements)
+			defer testhelper.AssertQueryRuns(restoreConn, schemaResetStatements)
 			testhelper.AssertQueryRuns(backupConn,
 				"CREATE ROLE testrole SUPERUSER")
 			defer testhelper.AssertQueryRuns(backupConn,
 				"DROP ROLE testrole")
+
+			// In GPDB 7+, we use plpython3u because of default python 3 support.
+			plpythonDropStatement := "DROP PROCEDURAL LANGUAGE IF EXISTS plpythonu;"
+			if backupConn.Version.AtLeast("7") {
+				plpythonDropStatement = "DROP PROCEDURAL LANGUAGE IF EXISTS plpython3u;"
+			}
+			testhelper.AssertQueryRuns(backupConn, plpythonDropStatement)
+			defer testhelper.AssertQueryRuns(backupConn, plpythonDropStatement)
+			defer testhelper.AssertQueryRuns(restoreConn, plpythonDropStatement)
+
 			testutils.ExecuteSQLFile(backupConn, "resources/gpdb4_objects.sql")
+			if backupConn.Version.Before("7") {
+				testutils.ExecuteSQLFile(backupConn, "resources/gpdb4_compatible_objects_before_gpdb7.sql")
+			} else {
+				testutils.ExecuteSQLFile(backupConn, "resources/gpdb4_compatible_objects_after_gpdb7.sql")
+			}
+
 			if backupConn.Version.AtLeast("5") {
 				testutils.ExecuteSQLFile(backupConn, "resources/gpdb5_objects.sql")
 			}

--- a/end_to_end/resources/gpdb4_compatible_objects_after_gpdb7.sql
+++ b/end_to_end/resources/gpdb4_compatible_objects_after_gpdb7.sql
@@ -1,0 +1,23 @@
+CREATE PROCEDURAL LANGUAGE plpython3u;
+
+
+CREATE TABLE part_with_ext (
+    id integer,
+    year integer,
+    qtr integer,
+    day integer,
+    region text
+) DISTRIBUTED BY (id) PARTITION BY RANGE(year)
+          (
+          PARTITION yr_2 START (2011) END (2012) EVERY (1) WITH (tablename='sales_1_prt_yr_2', appendonly=false ),
+          PARTITION yr_3 START (2012) END (2013) EVERY (1) WITH (tablename='sales_1_prt_yr_3', appendonly=false ),
+          PARTITION yr_4 START (2013) END (2014) EVERY (1) WITH (tablename='sales_1_prt_yr_4', appendonly=false )
+          );
+-- TODO: Fix dependency issues with external leaf partitions for GPDB 7
+--ALTER TABLE part_with_ext ATTACH PARTITION sales_1_prt_yr_1_external_partition__ FOR VALUES FROM ('2010') TO ('2011');
+
+
+CREATE TRIGGER sync_trigger_table1
+    AFTER INSERT ON trigger_table1
+    FOR EACH ROW
+    EXECUTE PROCEDURE "RI_FKey_check_ins"();

--- a/end_to_end/resources/gpdb4_compatible_objects_before_gpdb7.sql
+++ b/end_to_end/resources/gpdb4_compatible_objects_before_gpdb7.sql
@@ -1,0 +1,24 @@
+CREATE PROCEDURAL LANGUAGE plpythonu;
+
+
+CREATE TABLE part_with_ext (
+    id integer,
+    year integer,
+    qtr integer,
+    day integer,
+    region text
+) DISTRIBUTED BY (id) PARTITION BY RANGE(year)
+          (
+          PARTITION yr_1 START (2010) END (2011) EVERY (1) WITH (tablename='sales_1_prt_yr_1', appendonly=false ),
+          PARTITION yr_2 START (2011) END (2012) EVERY (1) WITH (tablename='sales_1_prt_yr_2', appendonly=false ),
+          PARTITION yr_3 START (2012) END (2013) EVERY (1) WITH (tablename='sales_1_prt_yr_3', appendonly=false ),
+          PARTITION yr_4 START (2013) END (2014) EVERY (1) WITH (tablename='sales_1_prt_yr_4', appendonly=false )
+          );
+ALTER TABLE part_with_ext EXCHANGE PARTITION yr_1 WITH TABLE sales_1_prt_yr_1_external_partition__ WITHOUT VALIDATION;
+DROP TABLE sales_1_prt_yr_1_external_partition__;
+
+
+CREATE TRIGGER sync_trigger_table1
+    AFTER INSERT OR DELETE OR UPDATE ON trigger_table1
+    FOR EACH STATEMENT
+    EXECUTE PROCEDURE "RI_FKey_check_ins"();

--- a/end_to_end/resources/gpdb4_objects.sql
+++ b/end_to_end/resources/gpdb4_objects.sql
@@ -11,9 +11,6 @@ SET default_with_oids = false;
 CREATE SCHEMA schema2;
 
 
-CREATE PROCEDURAL LANGUAGE plpythonu;
-
-
 SET search_path = public, pg_catalog;
 
 
@@ -282,23 +279,6 @@ FORMAT 'csv' (delimiter E',' null E'' escape E'"' quote E'"')
 ENCODING 'UTF8';
 
 
-CREATE TABLE part_with_ext (
-    id integer,
-    year integer,
-    qtr integer,
-    day integer,
-    region text
-) DISTRIBUTED BY (id) PARTITION BY RANGE(year)
-          (
-          PARTITION yr_1 START (2010) END (2011) EVERY (1) WITH (tablename='sales_1_prt_yr_1', appendonly=false ),
-          PARTITION yr_2 START (2011) END (2012) EVERY (1) WITH (tablename='sales_1_prt_yr_2', appendonly=false ),
-          PARTITION yr_3 START (2012) END (2013) EVERY (1) WITH (tablename='sales_1_prt_yr_3', appendonly=false ),
-          PARTITION yr_4 START (2013) END (2014) EVERY (1) WITH (tablename='sales_1_prt_yr_4', appendonly=false )
-          );
-ALTER TABLE part_with_ext EXCHANGE PARTITION yr_1 WITH TABLE sales_1_prt_yr_1_external_partition__ WITHOUT VALIDATION;
-DROP TABLE sales_1_prt_yr_1_external_partition__;
-
-
 SET search_path = public, pg_catalog;
 
 
@@ -419,12 +399,6 @@ CREATE INDEX simple_table_idx1 ON foo4 USING btree (n);
 
 
 CREATE RULE double_insert AS ON INSERT TO rule_table1 DO INSERT INTO rule_table1 VALUES (1);
-
-
-CREATE TRIGGER sync_trigger_table1
-    AFTER INSERT OR DELETE OR UPDATE ON trigger_table1
-    FOR EACH STATEMENT
-    EXECUTE PROCEDURE "RI_FKey_check_ins"();
 
 
 ALTER TABLE ONLY reference_table

--- a/end_to_end/special_characters_test.go
+++ b/end_to_end/special_characters_test.go
@@ -69,7 +69,15 @@ PARTITION BY LIST (gender)
 			"--redirect-db", "restoredb",
 			"--backup-dir", backupDir)
 
-		assertRelationsCreated(restoreConn, 4)
+		// When running against GPDB 7+, only the root partition and the included leaf partition
+		// will be created due to the new flexible GPDB 7+ partitioning logic. For versions
+		// before GPDB 7, there is only one big DDL for the entire partition table.
+		if backupConn.Version.AtLeast("7") {
+			assertRelationsCreated(restoreConn, 2)
+		} else {
+			assertRelationsCreated(restoreConn, 4)
+		}
+
 		localSchemaTupleCounts := map[string]int{
 			`public."CAPparent_1_prt_girls"`: 1,
 			`public."CAPparent"`:             1,

--- a/options/options.go
+++ b/options/options.go
@@ -260,11 +260,6 @@ func (o *Options) QuoteIncludeRelations(conn *dbconn.DBConn) error {
 }
 
 func (o Options) getUserTableRelationsWithIncludeFiltering(connectionPool *dbconn.DBConn, includedRelationsQuoted []string) ([]FqnStruct, error) {
-	// TODO: fix for gpdb7 partitioning
-	if connectionPool.Version.AtLeast("7") {
-		return []FqnStruct{}, nil
-	}
-
 	includeOids, err := getOidsFromRelationList(connectionPool, includedRelationsQuoted)
 	if err != nil {
 		return nil, err
@@ -272,28 +267,65 @@ func (o Options) getUserTableRelationsWithIncludeFiltering(connectionPool *dbcon
 
 	oidStr := strings.Join(includeOids, ", ")
 	childPartitionFilter := ""
-	if o.isLeafPartitionData {
-		//Get all leaf partition tables whose parents are in the include list
-		childPartitionFilter = fmt.Sprintf(`
-	OR c.oid IN (
-		SELECT
-			r.parchildrelid
-		FROM pg_partition p
-		JOIN pg_partition_rule r ON p.oid = r.paroid
-		WHERE p.paristemplate = false
-		AND p.parrelid IN (%s))`, oidStr)
+	parentAndExternalPartitionFilter := ""
+	if connectionPool.Version.Before("7") {
+		if o.isLeafPartitionData {
+			//Get all leaf partition tables whose parents are in the include list
+			childPartitionFilter = fmt.Sprintf(`
+		OR c.oid IN (
+			SELECT
+				r.parchildrelid
+			FROM pg_partition p
+			JOIN pg_partition_rule r ON p.oid = r.paroid
+			WHERE p.paristemplate = false
+			AND p.parrelid IN (%s))`, oidStr)
+		} else {
+			//Get only external partition tables whose parents are in the include list
+			childPartitionFilter = fmt.Sprintf(`
+		OR c.oid IN (
+			SELECT
+				r.parchildrelid
+			FROM pg_partition p
+			JOIN pg_partition_rule r ON p.oid = r.paroid
+			JOIN pg_exttable e ON r.parchildrelid = e.reloid
+			WHERE p.paristemplate = false
+			AND e.reloid IS NOT NULL
+			AND p.parrelid IN (%s))`, oidStr)
+		}
+
+		parentAndExternalPartitionFilter = fmt.Sprintf(`
+		-- Get parent partition tables whose children are in the include list
+		OR c.oid IN (
+			SELECT
+				p.parrelid
+			FROM pg_partition p
+			JOIN pg_partition_rule r ON p.oid = r.paroid
+			WHERE p.paristemplate = false
+			AND r.parchildrelid IN (%[1]s)
+		)
+		-- Get external partition tables whose siblings are in the include list
+		OR c.oid IN (
+			SELECT
+				r.parchildrelid
+			FROM pg_partition_rule r
+			JOIN pg_exttable e ON r.parchildrelid = e.reloid
+			WHERE r.paroid IN (
+				SELECT
+					pr.paroid
+				FROM pg_partition_rule pr
+				WHERE pr.parchildrelid IN (%[1]s)
+			)
+		)`, oidStr)
 	} else {
-		//Get only external partition tables whose parents are in the include list
 		childPartitionFilter = fmt.Sprintf(`
-	OR c.oid IN (
-		SELECT
-			r.parchildrelid
-		FROM pg_partition p
-		JOIN pg_partition_rule r ON p.oid = r.paroid
-		JOIN pg_exttable e ON r.parchildrelid = e.reloid
-		WHERE p.paristemplate = false
-		AND e.reloid IS NOT NULL
-		AND p.parrelid IN (%s))`, oidStr)
+		-- Get leaf partitions whose roots are in the include list
+		OR pg_partition_root(c.oid) IN (%s)`, oidStr)
+
+		parentAndExternalPartitionFilter = fmt.Sprintf(`
+		-- Get parent partition tables whose children are in the include list
+		OR c.oid IN (
+			SELECT DISTINCT pg_partition_root(unnest(ARRAY[%s]))::oid
+		)`, oidStr)
 	}
 
 	query := fmt.Sprintf(`
@@ -307,33 +339,12 @@ WHERE %s
 AND (
 	-- Get tables in the include list
 	c.oid IN (%s)
-	-- Get parent partition tables whose children are in the include list
-	OR c.oid IN (
-		SELECT
-			p.parrelid
-		FROM pg_partition p
-		JOIN pg_partition_rule r ON p.oid = r.paroid
-		WHERE p.paristemplate = false
-		AND r.parchildrelid IN (%s)
-	)
-	-- Get external partition tables whose siblings are in the include list
-	OR c.oid IN (
-		SELECT
-			r.parchildrelid
-		FROM pg_partition_rule r
-		JOIN pg_exttable e ON r.parchildrelid = e.reloid
-		WHERE r.paroid IN (
-			SELECT
-				pr.paroid
-			FROM pg_partition_rule pr
-			WHERE pr.parchildrelid IN (%s)
-		)
-	)
+	%s
 	%s
 )
-AND (relkind = 'r' OR relkind = 'f')
+AND relkind IN ('r', 'f', 'p')
 AND %s
-ORDER BY c.oid;`, o.schemaFilterClause("n"), oidStr, oidStr, oidStr, childPartitionFilter, ExtensionFilterClause("c"))
+ORDER BY c.oid;`, o.schemaFilterClause("n"), oidStr, parentAndExternalPartitionFilter, childPartitionFilter, ExtensionFilterClause("c"))
 
 	results := make([]FqnStruct, 0)
 	err = connectionPool.Select(&results, query)

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -334,6 +334,18 @@ func editStatementsRedirectSchema(statements []toc.StatementWithType, redirectSc
 		newSchema := fmt.Sprintf("%s.", redirectSchema)
 		statements[i].Schema = redirectSchema
 		statements[i].Statement = strings.Replace(statement.Statement, oldSchema, newSchema, 1)
+
+		// ALTER TABLE schema.root ATTACH PARTITION schema.leaf needs two schema replacements
+		if connectionPool.Version.AtLeast("7") && statement.ObjectType == "TABLE" && statement.ReferenceObject != "" {
+			alterTableAttachPart := strings.Split(statements[i].Statement, " ATTACH PARTITION ")
+
+			if len(alterTableAttachPart) == 2 {
+				statements[i].Statement = fmt.Sprintf(`%s ATTACH PARTITION %s`,
+					alterTableAttachPart[0],
+					strings.Replace(alterTableAttachPart[1], oldSchema, newSchema, 1))
+			}
+		}
+
 		// only postdata will have a reference object
 		if statement.ReferenceObject != "" {
 			statements[i].ReferenceObject = strings.Replace(statement.ReferenceObject, oldSchema, newSchema, 1)

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -348,7 +348,7 @@ func GetExistingTableFQNs() ([]string, error) {
 	if connectionPool.Version.Before("6") {
 		relkindFilter = "'r', 'S'"
 	} else if connectionPool.Version.Is("6") {
-		relkindFilter = "'r', 'S', f'"
+		relkindFilter = "'r', 'S', 'f'"
 	} else if connectionPool.Version.AtLeast("7") {
 		relkindFilter = "'r', 'S', 'f', 'p'"
 	}


### PR DESCRIPTION
This PR should fix a lot of issues in the code regarding GPDB 7 partition tables which end up fixing a lot of the end_to_end tests.  There are some other code and test fixes as well but the main thing is partitioning.

With this PR, the end_to_end tests pass against all versions of GPDB (7devel, 6X, 5X, 4.3.X).

Suggestion is to view each commit individually for review.