### PR TITLE
ATTACH partition indexes to its parent index

### DIFF
--- a/backup/postdata.go
+++ b/backup/postdata.go
@@ -22,10 +22,14 @@ func PrintCreateIndexStatements(metadataFile *utils.FileWithByteCount, toc *toc.
 			metadataFile.MustPrintf("\n\n%s;", index.Def.String)
 			toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 
-			indexFQN := utils.MakeFQN(index.OwningSchema, index.Name)
 			if index.Tablespace != "" {
 				start := metadataFile.ByteCount
-				metadataFile.MustPrintf("\nALTER INDEX %s SET TABLESPACE %s;", indexFQN, index.Tablespace)
+				metadataFile.MustPrintf("\nALTER INDEX %s SET TABLESPACE %s;", index.FQN(), index.Tablespace)
+				toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
+			}
+			if index.ParentIndexFQN != "" && connectionPool.Version.AtLeast("7") {
+				start := metadataFile.ByteCount
+				metadataFile.MustPrintf("\nALTER INDEX %s ATTACH PARTITION %s;", index.ParentIndexFQN, index.FQN())
 				toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 			}
 			tableFQN := utils.MakeFQN(index.OwningSchema, index.OwningTable)

--- a/backup/queries_postdata.go
+++ b/backup/queries_postdata.go
@@ -51,6 +51,8 @@ type IndexDefinition struct {
 	IsClustered        bool
 	SupportsConstraint bool
 	IsReplicaIdentity  bool
+	ParentIndex        uint32
+	ParentIndexFQN     string
 }
 
 func (i IndexDefinition) GetMetadataEntry() (string, toc.MetadataEntry) {
@@ -80,7 +82,6 @@ func (i IndexDefinition) FQN() string {
  * e.g. comments on implicitly created indexes
  */
 func GetIndexes(connectionPool *dbconn.DBConn) []IndexDefinition {
-
 	var query string
 	if connectionPool.Version.Before("6") {
 		indexNameSet := ConstructImplicitIndexNames(connectionPool)
@@ -112,13 +113,7 @@ func GetIndexes(connectionPool *dbconn.DBConn) []IndexDefinition {
 	ORDER BY name`,
 			implicitIndexStr, relationAndSchemaFilterClause(), ExtensionFilterClause("c"))
 
-	} else {
-		// TODO: fix for gpdb7 partitioning
-		partitionRuleExcludeClause := ""
-		if connectionPool.Version.Before("7") {
-			partitionRuleExcludeClause = "AND NOT EXISTS (SELECT 1 FROM pg_partition_rule r WHERE r.parchildrelid = c.oid)"
-		}
-
+	} else if connectionPool.Version.Is("6") {
 		query = fmt.Sprintf(`
 	SELECT DISTINCT i.indexrelid AS oid,
 		quote_ident(ic.relname) AS name,
@@ -142,29 +137,106 @@ func GetIndexes(connectionPool *dbconn.DBConn) []IndexDefinition {
 		AND i.indisvalid
 		AND i.indisready
 		AND i.indisprimary = 'f'
-		%s
+		AND NOT EXISTS (SELECT 1 FROM pg_partition_rule r WHERE r.parchildrelid = c.oid)
 		AND %s
 	ORDER BY name`,
-			relationAndSchemaFilterClause(), partitionRuleExcludeClause, ExtensionFilterClause("c")) // The index itself does not have a dependency on the extension, but the index's table does
+			relationAndSchemaFilterClause(), ExtensionFilterClause("c")) // The index itself does not have a dependency on the extension, but the index's table does
+
+	} else {
+		query = fmt.Sprintf(`
+		SELECT DISTINCT i.indexrelid AS oid,
+			coalesce(inh.inhparent, '0') AS parentindex,
+			quote_ident(ic.relname) AS name,
+			quote_ident(n.nspname) AS owningschema,
+			quote_ident(c.relname) AS owningtable,
+			coalesce(quote_ident(s.spcname), '') AS tablespace,
+			pg_get_indexdef(i.indexrelid) AS def,
+			i.indisclustered AS isclustered,
+			i.indisreplident AS isreplicaidentity,
+			CASE
+				WHEN conindid > 0 THEN 't'
+				ELSE 'f'
+			END as supportsconstraint
+		FROM pg_index i
+			JOIN pg_class ic ON ic.oid = i.indexrelid
+			JOIN pg_namespace n ON ic.relnamespace = n.oid
+			JOIN pg_class c ON c.oid = i.indrelid
+			LEFT JOIN pg_tablespace s ON ic.reltablespace = s.oid
+			LEFT JOIN pg_constraint con ON i.indexrelid = con.conindid
+			LEFT JOIN pg_catalog.pg_inherits inh ON inh.inhrelid = i.indexrelid
+		WHERE %s
+			AND i.indisvalid
+			AND i.indisready
+			AND i.indisprimary = 'f'
+			AND i.indexrelid >= %d
+			AND %s
+		ORDER BY name`,
+			relationAndSchemaFilterClause(), FIRST_NORMAL_OBJECT_ID, ExtensionFilterClause("c"))
 	}
 
 	resultIndexes := make([]IndexDefinition, 0)
 	err := connectionPool.Select(&resultIndexes, query)
 	gplog.FatalOnError(err)
+
 	// Remove all indexes that have NULL definitions. This can happen
 	// if a concurrent index drop happens before the associated table
 	// lock is acquired earlier during gpbackup execution.
 	verifiedResultIndexes := make([]IndexDefinition, 0)
-	for _, resultIndex := range resultIndexes {
-		if resultIndex.Def.Valid {
-			verifiedResultIndexes = append(verifiedResultIndexes, resultIndex)
+	indexMap := make(map[uint32]IndexDefinition, 0)
+	for _, index := range resultIndexes {
+		if index.Def.Valid {
+			verifiedResultIndexes = append(verifiedResultIndexes, index)
+			if connectionPool.Version.AtLeast("7") {
+				indexMap[index.Oid] = index // hash index for topological sort
+			}
 		} else {
 			gplog.Warn("Index '%s' on table '%s.%s' not backed up, most likely dropped after gpbackup had begun.",
-				resultIndex.Name, resultIndex.OwningSchema, resultIndex.OwningTable)
+				index.Name, index.OwningSchema, index.OwningTable)
 		}
 	}
 
-	return verifiedResultIndexes
+	if connectionPool.Version.Before("7") {
+		return verifiedResultIndexes
+	}
+
+	// Since GPDB 7+ partition indexes can now be ALTERED to attach to a parent
+	// index. Topological sort indexes to ensure parent indexes are printed
+	// before their child indexes.
+	visited := make(map[uint32]struct{})
+	sortedIndexes := make([]IndexDefinition, 0)
+	stack := make([]uint32, 0)
+	var seen struct{}
+	for _, index := range verifiedResultIndexes {
+		currIndex := index
+		// Depth-first search loop. Store visited indexes to a stack
+		for {
+			if _, indexWasVisited := visited[currIndex.Oid]; indexWasVisited {
+				break // exit DFS if a visited index is found.
+			}
+
+			stack = append(stack, currIndex.Oid)
+			visited[currIndex.Oid] = seen
+			if currIndex.ParentIndex == 0 {
+				break // exit DFS if index has no parent.
+			} else {
+				currIndex = indexMap[currIndex.ParentIndex]
+			}
+		}
+
+		// "Pop" indexes found by DFS
+		for i := len(stack) - 1; i >= 0; i-- {
+			indexOid := stack[i]
+			popIndex := indexMap[indexOid]
+			if popIndex.ParentIndex != 0 {
+				// Preprocess parent index FQN for GPDB 7+ partition indexes
+				popIndex.ParentIndexFQN = indexMap[popIndex.ParentIndex].FQN()
+			}
+			sortedIndexes = append(sortedIndexes, popIndex)
+		}
+		stack = stack[:0] // empty slice but keep memory allocation
+	}
+
+	return sortedIndexes
 }
 
 type RuleDefinition struct {

--- a/integration/postdata_create_test.go
+++ b/integration/postdata_create_test.go
@@ -115,6 +115,30 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultIndex := resultIndexes[0]
 			structmatcher.ExpectStructsToMatchExcluding(&resultIndex, &index, "Oid")
 		})
+		It("creates a parition index and attaches it to the parent index", func() {
+			testutils.SkipIfBefore7(connectionPool)
+
+			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.foopart_new (a integer, b integer) PARTITION BY RANGE (b) DISTRIBUTED BY (a)")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.foopart_new")
+			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.foopart_new_p1 (a integer, b integer) DISTRIBUTED BY (a)")
+			testhelper.AssertQueryRuns(connectionPool, "ALTER TABLE ONLY public.foopart_new ATTACH PARTITION public.foopart_new_p1 FOR VALUES FROM (0) TO (1)")
+			testhelper.AssertQueryRuns(connectionPool, "CREATE INDEX fooidx ON ONLY public.foopart_new USING btree (b)")
+
+			partitionIndex := backup.IndexDefinition{Oid: 0, Name: "foopart_new_p1_b_idx", OwningSchema: "public", OwningTable: "foopart_new_p1", Def: sql.NullString{String: "CREATE INDEX foopart_new_p1_b_idx ON public.foopart_new_p1 USING btree (b)", Valid: true}, ParentIndexFQN: "public.fooidx"}
+
+			indexes := []backup.IndexDefinition{partitionIndex}
+			backup.PrintCreateIndexStatements(backupfile, tocfile, indexes, indexMetadataMap)
+
+			testhelper.AssertQueryRuns(connectionPool, buffer.String())
+			partitionIndex.Oid = testutils.OidFromObjectName(connectionPool, "", "foopart_new_p1_b_idx", backup.TYPE_INDEX)
+			partitionIndex.ParentIndex = testutils.OidFromObjectName(connectionPool, "", "fooidx", backup.TYPE_INDEX)
+
+			resultIndexes := backup.GetIndexes(connectionPool)
+			Expect(resultIndexes).To(HaveLen(2))
+			resultIndex := resultIndexes[1]
+
+			structmatcher.ExpectStructsToMatch(&resultIndex, &partitionIndex)
+		})
 	})
 	Describe("PrintCreateRuleStatements", func() {
 		var (

--- a/integration/postdata_queries_test.go
+++ b/integration/postdata_queries_test.go
@@ -193,6 +193,29 @@ PARTITION BY RANGE (date)
 
 			structmatcher.ExpectStructsToMatchExcluding(&index1, &results[0], "Oid")
 		})
+		It("returns a sorted slice of partition indexes ", func() {
+			testutils.SkipIfBefore7(connectionPool)
+			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.foopart_new (a integer, b integer) PARTITION BY RANGE (b) DISTRIBUTED BY (a)")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.foopart_new")
+			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.foopart_new_p1 (a integer, b integer) DISTRIBUTED BY (a); ALTER TABLE ONLY public.foopart_new ATTACH PARTITION public.foopart_new_p1 FOR VALUES FROM (0) TO (1);")
+			testhelper.AssertQueryRuns(connectionPool, "CREATE INDEX fooidx ON ONLY public.foopart_new USING btree (b)")
+			testhelper.AssertQueryRuns(connectionPool, "CREATE INDEX foopart_new_p1_b_idx ON public.foopart_new_p1 USING btree (b)")
+			testhelper.AssertQueryRuns(connectionPool, "ALTER INDEX public.fooidx ATTACH PARTITION public.foopart_new_p1_b_idx;")
+
+			index0 := backup.IndexDefinition{Oid: 0, Name: "fooidx", OwningSchema: "public", OwningTable: "foopart_new", Def: sql.NullString{String: "CREATE INDEX fooidx ON ONLY public.foopart_new USING btree (b)", Valid: true}}
+			index1 := backup.IndexDefinition{Oid: 0, Name: "foopart_new_p1_b_idx", OwningSchema: "public", OwningTable: "foopart_new_p1", Def: sql.NullString{String: "CREATE INDEX foopart_new_p1_b_idx ON public.foopart_new_p1 USING btree (b)", Valid: true}, ParentIndexFQN: "public.fooidx"}
+			index0.Oid = testutils.OidFromObjectName(connectionPool, "", "fooidx", backup.TYPE_INDEX)
+			index1.Oid = testutils.OidFromObjectName(connectionPool, "", "foopart_new_p1_b_idx", backup.TYPE_INDEX)
+			index1.ParentIndex = index0.Oid
+
+			results := backup.GetIndexes(connectionPool)
+
+			Expect(results).To(HaveLen(2))
+
+			structmatcher.ExpectStructsToMatchExcluding(&index0, &results[0])
+			structmatcher.ExpectStructsToMatchExcluding(&index1, &results[1])
+		})
+
 	})
 	Describe("GetRules", func() {
 		var (


### PR DESCRIPTION
In GPDB 7+, partition tables have been heavily changed. Along with the
partition tables themselves, the partition indexes are also now
structured differently. We now must attach partition indexes to parent
partition index. Topological sorting of indexes is done to ensure
that a parent index is printed before its child partition indexes.
