### PR TITLE
Modify dumped SQL syntax of CREATE EVENT TRIGGER

### DIFF
--- a/backup/postdata.go
+++ b/backup/postdata.go
@@ -75,7 +75,11 @@ func PrintCreateEventTriggerStatements(metadataFile *utils.FileWithByteCount, to
 		if eventTrigger.EventTags != "" {
 			metadataFile.MustPrintf("\nWHEN TAG IN (%s)", eventTrigger.EventTags)
 		}
-		metadataFile.MustPrintf("\nEXECUTE PROCEDURE %s();", eventTrigger.FunctionName)
+		if connectionPool.Version.AtLeast("7") {
+			metadataFile.MustPrintf("\nEXECUTE FUNCTION %s();", eventTrigger.FunctionName)
+		} else {
+			metadataFile.MustPrintf("\nEXECUTE PROCEDURE %s();", eventTrigger.FunctionName)
+		}
 		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 
 		if eventTrigger.Enabled != "O" {


### PR DESCRIPTION
 - In GPDB 7 the use of the keyword PROCEDURE
   in CREATE EVENT TRIGGER statement is deprecated
   because the referenced function must be a function
   not a procedure. To support this we added version
   check when dump the statement and modified statement
   syntax.