### PR TITLE
Fix integration tests for GPDB 7

### DIFF
--- a/backup/queries_acl.go
+++ b/backup/queries_acl.go
@@ -84,9 +84,9 @@ func InitializeMetadataParams(connectionPool *dbconn.DBConn) {
 	TYPE_FOREIGNSERVER = MetadataQueryParams{ObjectType: "SERVER", NameField: "srvname", ACLField: "srvacl", OwnerField: "srvowner", CatalogTable: "pg_foreign_server"}
 	TYPE_FUNCTION = MetadataQueryParams{ObjectType: "FUNCTION", NameField: "proname", SchemaField: "pronamespace", ACLField: "proacl", OwnerField: "proowner", CatalogTable: "pg_proc"}
 	if connectionPool.Version.AtLeast("7") {
-		TYPE_AGGREGATE.FilterClause = "prokind <> 'a'"
+		TYPE_FUNCTION.FilterClause = "prokind <> 'a'"
 	} else {
-		TYPE_AGGREGATE.FilterClause = "proisagg = 'f'"
+		TYPE_FUNCTION.FilterClause = "proisagg = 'f'"
 	}
 	TYPE_INDEX = MetadataQueryParams{ObjectType: "INDEX", NameField: "relname", OidField: "indexrelid", OidTable: "pg_class", CommentTable: "pg_class", CatalogTable: "pg_index"}
 	TYPE_PROCLANGUAGE = MetadataQueryParams{ObjectType: "LANGUAGE", NameField: "lanname", ACLField: "lanacl", CatalogTable: "pg_language"}

--- a/backup/queries_externals.go
+++ b/backup/queries_externals.go
@@ -161,7 +161,8 @@ func (pi PartitionInfo) GetMetadataEntry() (string, toc.MetadataEntry) {
 }
 
 func GetExternalPartitionInfo(connectionPool *dbconn.DBConn) ([]PartitionInfo, map[uint32]PartitionInfo) {
-	// TODO: fix for gpdb7 partitioning
+	// For GPDB 7+, external partitions will have their own ATTACH PARTITION DDL command
+	// instead of a complicated EXCHANGE PARTITION command.
 	if connectionPool.Version.AtLeast("7") {
 		return []PartitionInfo{}, make(map[uint32]PartitionInfo, 0)
 	}

--- a/backup/queries_globals.go
+++ b/backup/queries_globals.go
@@ -507,7 +507,7 @@ func (rm RoleMember) GetMetadataEntry() (string, toc.MetadataEntry) {
 }
 
 func GetRoleMembers(connectionPool *dbconn.DBConn) []RoleMember {
-	query := `
+	query := fmt.Sprintf(`
 	SELECT quote_ident(pg_get_userbyid(pga.roleid)) AS role,
 		quote_ident(pg_get_userbyid(pga.member)) AS member,
 		CASE
@@ -516,7 +516,8 @@ func GetRoleMembers(connectionPool *dbconn.DBConn) []RoleMember {
 		END AS grantor,
 		admin_option AS isadmin
 	FROM pg_auth_members pga
-	ORDER BY roleid, member`
+	WHERE roleid >= %d
+	ORDER BY roleid, member`, FIRST_NORMAL_OBJECT_ID)
 
 	results := make([]RoleMember, 0)
 	err := connectionPool.Select(&results, query)

--- a/backup/queries_incremental.go
+++ b/backup/queries_incremental.go
@@ -49,7 +49,7 @@ func getAOSegTableFQNs(connectionPool *dbconn.DBConn) map[string]string {
 						FROM pg_class c
 							JOIN pg_namespace n ON c.relnamespace = n.oid
 							JOIN pg_am a ON c.relam = a.oid
-						WHERE a.amname in ('ao_row', 'ao_col')
+						WHERE a.amname in ('ao_row', 'ao_column')
 							AND %s
 					) aotables ON pg_ao.relid = aotables.oid
 			) seg ON aoseg_c.oid = seg.segrelid`, relationAndSchemaFilterClause())
@@ -119,7 +119,7 @@ func getLastDDLTimestamps(connectionPool *dbconn.DBConn) map[string]string {
 				FROM pg_class c
 					JOIN pg_namespace n ON c.relnamespace = n.oid
 					JOIN pg_am a ON c.relam = a.oid
-				WHERE a.amname in ('ao_row', 'ao_col')
+				WHERE a.amname in ('ao_row', 'ao_column')
 					AND %s
 			) aotables
 		JOIN ( SELECT lo.objid,

--- a/backup/queries_table_defs.go
+++ b/backup/queries_table_defs.go
@@ -376,12 +376,18 @@ func GetTableReplicaIdentity(connectionPool *dbconn.DBConn) map[uint32]string {
 	if connectionPool.Version.Before("6") {
 		return make(map[uint32]string)
 	}
+
+	relkindFilter := "'r', 'm'"
+	if connectionPool.Version.AtLeast("7") {
+		relkindFilter = "'r', 'm', 'p'"
+	}
+
 	query := fmt.Sprintf(`
 	SELECT oid,
 		relreplident AS value
 	FROM pg_class
-	WHERE relkind IN ('r', 'm')
-		AND oid >= %d`, FIRST_NORMAL_OBJECT_ID)
+	WHERE relkind IN (%s)
+		AND oid >= %d`, relkindFilter, FIRST_NORMAL_OBJECT_ID)
 	return selectAsOidToStringMap(connectionPool, query)
 }
 

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -548,7 +548,7 @@ func backupDependentObjects(metadataFile *utils.FileWithByteCount, tables []Tabl
 	PrintIdentityColumns(metadataFile, globalTOC, sequences)
 	PrintAlterSequenceStatements(metadataFile, globalTOC, sequences)
 	extPartInfo, partInfoMap := GetExternalPartitionInfo(connectionPool)
-	if len(extPartInfo) > 0 {
+	if connectionPool.Version.Before("7") && len(extPartInfo) > 0 {
 		gplog.Verbose("Writing EXCHANGE PARTITION statements to metadata file")
 		PrintExchangeExternalPartitionStatements(metadataFile, globalTOC, extPartInfo, partInfoMap, tables)
 	}

--- a/integration/incremental_queries_test.go
+++ b/integration/incremental_queries_test.go
@@ -58,8 +58,14 @@ var _ = Describe("backup integration tests", func() {
 			It("should have a last DDL timestamp", func() {
 				Expect(aoIncrementalMetadata[aoTableFQN].LastDDLTimestamp).To(Not(BeEmpty()))
 				Expect(aoIncrementalMetadata[aoCOTableFQN].LastDDLTimestamp).To(Not(BeEmpty()))
-				Expect(aoIncrementalMetadata[aoPartParentTableFQN].LastDDLTimestamp).To(Not(BeEmpty()))
 				Expect(aoIncrementalMetadata[aoPartChildTableFQN].LastDDLTimestamp).To(Not(BeEmpty()))
+
+				// For GPDB 7+, the root partition is not included.
+				// TODO: Should the root be included?
+				if connectionPool.Version.Before("7") {
+					Expect(aoIncrementalMetadata[aoPartParentTableFQN].LastDDLTimestamp).To(Not(BeEmpty()))
+				}
+
 			})
 		})
 		Context("AO, AO_CO and AO partition tables have DML changes", func() {
@@ -97,8 +103,13 @@ var _ = Describe("backup integration tests", func() {
 				It("should have a last DDL timestamp", func() {
 					Expect(aoIncrementalMetadata[aoTableFQN].LastDDLTimestamp).To(Not(BeEmpty()))
 					Expect(aoIncrementalMetadata[aoCOTableFQN].LastDDLTimestamp).To(Not(BeEmpty()))
-					Expect(aoIncrementalMetadata[aoPartParentTableFQN].LastDDLTimestamp).To(Not(BeEmpty()))
 					Expect(aoIncrementalMetadata[aoPartChildTableFQN].LastDDLTimestamp).To(Not(BeEmpty()))
+
+					// For GPDB 7+, the root partition is not included.
+					// TODO: Should the root be included?
+					if connectionPool.Version.Before("7") {
+						Expect(aoIncrementalMetadata[aoPartParentTableFQN].LastDDLTimestamp).To(Not(BeEmpty()))
+					}
 				})
 			})
 			Context("After a delete operation", func() {
@@ -134,8 +145,13 @@ var _ = Describe("backup integration tests", func() {
 				It("should have a last DDL timestamp", func() {
 					Expect(aoIncrementalMetadata[aoTableFQN].LastDDLTimestamp).To(Not(BeEmpty()))
 					Expect(aoIncrementalMetadata[aoCOTableFQN].LastDDLTimestamp).To(Not(BeEmpty()))
-					Expect(aoIncrementalMetadata[aoPartParentTableFQN].LastDDLTimestamp).To(Not(BeEmpty()))
 					Expect(aoIncrementalMetadata[aoPartChildTableFQN].LastDDLTimestamp).To(Not(BeEmpty()))
+
+					// For GPDB 7+, the root partition is not included.
+					// TODO: Should the root be included?
+					if connectionPool.Version.Before("7") {
+						Expect(aoIncrementalMetadata[aoPartParentTableFQN].LastDDLTimestamp).To(Not(BeEmpty()))
+					}
 				})
 			})
 		})

--- a/integration/metadata_globals_queries_test.go
+++ b/integration/metadata_globals_queries_test.go
@@ -1,6 +1,8 @@
 package integration
 
 import (
+	"fmt"
+
 	"github.com/greenplum-db/gp-common-go-libs/structmatcher"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup/backup"
@@ -23,27 +25,27 @@ var _ = Describe("backup integration tests", func() {
 	})
 	Describe("GetDatabaseGUCs", func() {
 		It("returns a slice of values for database level GUCs", func() {
-			testhelper.AssertQueryRuns(connectionPool, "ALTER DATABASE testdb SET default_with_oids TO true")
-			defer testhelper.AssertQueryRuns(connectionPool, "ALTER DATABASE testdb RESET default_with_oids")
+			testhelper.AssertQueryRuns(connectionPool, "ALTER DATABASE testdb SET enable_nestloop TO true")
+			defer testhelper.AssertQueryRuns(connectionPool, "ALTER DATABASE testdb RESET enable_nestloop")
 			testhelper.AssertQueryRuns(connectionPool, "ALTER DATABASE testdb SET search_path TO public,pg_catalog")
 			defer testhelper.AssertQueryRuns(connectionPool, "ALTER DATABASE testdb RESET search_path")
 			testhelper.AssertQueryRuns(connectionPool, "ALTER DATABASE testdb SET lc_time TO 'C'")
 			defer testhelper.AssertQueryRuns(connectionPool, "ALTER DATABASE testdb RESET lc_time")
 			results := backup.GetDatabaseGUCs(connectionPool)
 			Expect(results).To(HaveLen(3))
-			Expect(results[0]).To(Equal(`SET default_with_oids TO 'true'`))
+			Expect(results[0]).To(Equal(`SET enable_nestloop TO 'true'`))
 			Expect(results[1]).To(Equal("SET search_path TO public, pg_catalog"))
 			Expect(results[2]).To(Equal(`SET lc_time TO 'C'`))
 		})
 		It("only gets GUCs that are non role specific", func() {
 			testutils.SkipIfBefore6(connectionPool)
-			testhelper.AssertQueryRuns(connectionPool, "ALTER ROLE testrole IN DATABASE testdb SET default_with_oids TO false")
-			defer testhelper.AssertQueryRuns(connectionPool, "ALTER ROLE testrole IN DATABASE testdb RESET default_with_oids")
-			testhelper.AssertQueryRuns(connectionPool, "ALTER DATABASE testdb SET default_with_oids TO true")
-			defer testhelper.AssertQueryRuns(connectionPool, "ALTER DATABASE testdb RESET default_with_oids")
+			testhelper.AssertQueryRuns(connectionPool, "ALTER ROLE testrole IN DATABASE testdb SET enable_nestloop TO true")
+			defer testhelper.AssertQueryRuns(connectionPool, "ALTER ROLE testrole IN DATABASE testdb RESET enable_nestloop")
+			testhelper.AssertQueryRuns(connectionPool, "ALTER DATABASE testdb SET enable_nestloop TO false")
+			defer testhelper.AssertQueryRuns(connectionPool, "ALTER DATABASE testdb RESET enable_nestloop")
 			results := backup.GetDatabaseGUCs(connectionPool)
 			Expect(results).To(HaveLen(1))
-			Expect(results[0]).To(Equal(`SET default_with_oids TO 'true'`))
+			Expect(results[0]).To(Equal(`SET enable_nestloop TO 'false'`))
 		})
 	})
 	Describe("GetDefaultDatabaseEncodingInfo", func() {
@@ -500,7 +502,12 @@ CREATEEXTTABLE (protocol='gphdfs', type='writable')`
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP ROLE role1")
 			testhelper.AssertQueryRuns(connectionPool, "ALTER ROLE role1 SET search_path TO public")
 			testhelper.AssertQueryRuns(connectionPool, "ALTER ROLE role1 SET client_min_messages TO 'info'")
-			testhelper.AssertQueryRuns(connectionPool, "ALTER ROLE role1 SET gp_default_storage_options TO 'appendonly=true, compresslevel=6, orientation=row, compresstype=none'")
+
+			defaultStorageOptionsString := "appendonly=true, compresslevel=6, orientation=row, compresstype=none"
+			if connectionPool.Version.AtLeast("7") {
+				defaultStorageOptionsString = "compresslevel=6, compresstype=none"
+			}
+			testhelper.AssertQueryRuns(connectionPool, fmt.Sprintf("ALTER ROLE role1 SET gp_default_storage_options TO '%s'", defaultStorageOptionsString))
 
 			results := backup.GetRoleGUCs(connectionPool)
 			roleConfig := results["role1"]
@@ -508,7 +515,7 @@ CREATEEXTTABLE (protocol='gphdfs', type='writable')`
 			Expect(roleConfig).To(HaveLen(3))
 			expectedRoleConfig := []backup.RoleGUC{
 				{RoleName: "role1", Config: `SET client_min_messages TO 'info'`},
-				{RoleName: "role1", Config: `SET gp_default_storage_options TO 'appendonly=true, compresslevel=6, orientation=row, compresstype=none'`},
+				{RoleName: "role1", Config: fmt.Sprintf(`SET gp_default_storage_options TO '%s'`, defaultStorageOptionsString)},
 				{RoleName: "role1", Config: `SET search_path TO public`}}
 
 			Expect(roleConfig).To(ConsistOf(expectedRoleConfig))

--- a/integration/postdata_create_test.go
+++ b/integration/postdata_create_test.go
@@ -170,7 +170,11 @@ var _ = Describe("backup integration create statement tests", func() {
 			triggerMetadataMap = backup.MetadataMap{}
 		})
 		It("creates a basic trigger", func() {
-			triggers := []backup.TriggerDefinition{{Oid: 0, Name: "sync_testtable", OwningSchema: "public", OwningTable: "testtable", Def: sql.NullString{String: `CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON public.testtable FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`, Valid: true}}}
+			triggerDef := `CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON public.testtable FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`
+			if connectionPool.Version.AtLeast("7") {
+				triggerDef = `CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON public.testtable FOR EACH ROW EXECUTE FUNCTION "RI_FKey_check_ins"()`
+			}
+			triggers := []backup.TriggerDefinition{{Oid: 0, Name: "sync_testtable", OwningSchema: "public", OwningTable: "testtable", Def: sql.NullString{String: triggerDef, Valid: true}}}
 			backup.PrintCreateTriggerStatements(backupfile, tocfile, triggers, triggerMetadataMap)
 
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.testtable(i int)")
@@ -183,7 +187,11 @@ var _ = Describe("backup integration create statement tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&resultTriggers[0], &triggers[0], "Oid")
 		})
 		It("creates a trigger with a comment", func() {
-			triggers := []backup.TriggerDefinition{{Oid: 1, Name: "sync_testtable", OwningSchema: "public", OwningTable: "testtable", Def: sql.NullString{String: `CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON public.testtable FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`, Valid: true}}}
+			triggerDef := `CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON public.testtable FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`
+			if connectionPool.Version.AtLeast("7") {
+				triggerDef = `CREATE TRIGGER sync_testtable AFTER INSERT OR DELETE OR UPDATE ON public.testtable FOR EACH ROW EXECUTE FUNCTION "RI_FKey_check_ins"()`
+			}
+			triggers := []backup.TriggerDefinition{{Oid: 1, Name: "sync_testtable", OwningSchema: "public", OwningTable: "testtable", Def: sql.NullString{String: triggerDef, Valid: true}}}
 			triggerMetadataMap = testutils.DefaultMetadataMap("RULE", false, false, true, false)
 			triggerMetadata := triggerMetadataMap[triggers[0].GetUniqueID()]
 			backup.PrintCreateTriggerStatements(backupfile, tocfile, triggers, triggerMetadataMap)

--- a/integration/postdata_queries_test.go
+++ b/integration/postdata_queries_test.go
@@ -88,6 +88,12 @@ var _ = Describe("backup integration tests", func() {
 			structmatcher.ExpectStructsToMatchExcluding(&index2, &userIndex[1], "Oid")
 		})
 		It("returns a slice of indexes for only partition parent tables", func() {
+			// In GPDB 7+, all partitions will have their own CREATE INDEX statement
+			// followed by an ALTER INDEX ATTACH PARTITION statement
+			if connectionPool.Version.AtLeast("7") {
+				Skip("Test is not applicable to GPDB 7+")
+			}
+
 			testhelper.AssertQueryRuns(connectionPool, `CREATE TABLE public.part (id int, date date, amt decimal(10,2)) DISTRIBUTED BY (id)
 PARTITION BY RANGE (date)
       (PARTITION Jan08 START (date '2008-01-01') INCLUSIVE ,
@@ -271,17 +277,24 @@ PARTITION BY RANGE (date)
 			Expect(results).To(BeEmpty())
 		})
 		It("returns a slice of multiple triggers", func() {
+			triggerString1 := `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`
+			triggerString2 := `CREATE TRIGGER sync_trigger_table2 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table2 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`
+			if connectionPool.Version.AtLeast("7") {
+				triggerString1 = `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table1 FOR EACH ROW EXECUTE FUNCTION "RI_FKey_check_ins"()`
+				triggerString2 = `CREATE TRIGGER sync_trigger_table2 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table2 FOR EACH ROW EXECUTE FUNCTION "RI_FKey_check_ins"()`
+
+			}
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.trigger_table1(i int)")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.trigger_table1")
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.trigger_table2(j int)")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.trigger_table2")
-			testhelper.AssertQueryRuns(connectionPool, `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`)
+			testhelper.AssertQueryRuns(connectionPool, triggerString1)
+			testhelper.AssertQueryRuns(connectionPool, triggerString2)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TRIGGER sync_trigger_table1 ON public.trigger_table1")
-			testhelper.AssertQueryRuns(connectionPool, `CREATE TRIGGER sync_trigger_table2 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table2 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TRIGGER sync_trigger_table2 ON public.trigger_table2")
 
-			trigger1 := backup.TriggerDefinition{Oid: 0, Name: "sync_trigger_table1", OwningSchema: "public", OwningTable: "trigger_table1", Def: sql.NullString{String: `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`, Valid: true}}
-			trigger2 := backup.TriggerDefinition{Oid: 1, Name: "sync_trigger_table2", OwningSchema: "public", OwningTable: "trigger_table2", Def: sql.NullString{String: `CREATE TRIGGER sync_trigger_table2 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table2 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`, Valid: true}}
+			trigger1 := backup.TriggerDefinition{Oid: 0, Name: "sync_trigger_table1", OwningSchema: "public", OwningTable: "trigger_table1", Def: sql.NullString{String: triggerString1, Valid: true}}
+			trigger2 := backup.TriggerDefinition{Oid: 1, Name: "sync_trigger_table2", OwningSchema: "public", OwningTable: "trigger_table2", Def: sql.NullString{String: triggerString2, Valid: true}}
 
 			results := backup.GetTriggers(connectionPool)
 
@@ -301,19 +314,25 @@ PARTITION BY RANGE (date)
 			Expect(results).To(BeEmpty())
 		})
 		It("returns a slice of triggers for a specific schema", func() {
+			triggerString1 := `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`
+			triggerString2 := `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON testschema.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`
+			if connectionPool.Version.AtLeast("7") {
+				triggerString1 = `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table1 FOR EACH ROW EXECUTE FUNCTION "RI_FKey_check_ins"()`
+				triggerString2 = `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON testschema.trigger_table1 FOR EACH ROW EXECUTE FUNCTION "RI_FKey_check_ins"()`
+			}
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.trigger_table1(i int)")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.trigger_table1")
-			testhelper.AssertQueryRuns(connectionPool, `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`)
+			testhelper.AssertQueryRuns(connectionPool, triggerString1)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TRIGGER sync_trigger_table1 ON public.trigger_table1")
 			testhelper.AssertQueryRuns(connectionPool, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE testschema.trigger_table1(i int)")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE testschema.trigger_table1")
-			testhelper.AssertQueryRuns(connectionPool, `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON testschema.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`)
+			testhelper.AssertQueryRuns(connectionPool, triggerString2)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TRIGGER sync_trigger_table1 ON testschema.trigger_table1")
 			_ = backupCmdFlags.Set(options.INCLUDE_SCHEMA, "testschema")
 
-			trigger1 := backup.TriggerDefinition{Oid: 0, Name: "sync_trigger_table1", OwningSchema: "testschema", OwningTable: "trigger_table1", Def: sql.NullString{String: `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON testschema.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`, Valid: true}}
+			trigger1 := backup.TriggerDefinition{Oid: 0, Name: "sync_trigger_table1", OwningSchema: "testschema", OwningTable: "trigger_table1", Def: sql.NullString{String: triggerString2, Valid: true}}
 
 			results := backup.GetTriggers(connectionPool)
 
@@ -321,19 +340,25 @@ PARTITION BY RANGE (date)
 			structmatcher.ExpectStructsToMatchExcluding(&trigger1, &results[0], "Oid")
 		})
 		It("returns a slice of triggers belonging to filtered tables", func() {
+			triggerString1 := `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`
+			triggerString2 := `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON testschema.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`
+			if connectionPool.Version.AtLeast("7") {
+				triggerString1 = `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table1 FOR EACH ROW EXECUTE FUNCTION "RI_FKey_check_ins"()`
+				triggerString2 = `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON testschema.trigger_table1 FOR EACH ROW EXECUTE FUNCTION "RI_FKey_check_ins"()`
+			}
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.trigger_table1(i int)")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.trigger_table1")
-			testhelper.AssertQueryRuns(connectionPool, `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON public.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`)
+			testhelper.AssertQueryRuns(connectionPool, triggerString1)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TRIGGER sync_trigger_table1 ON public.trigger_table1")
 			testhelper.AssertQueryRuns(connectionPool, "CREATE SCHEMA testschema")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE testschema.trigger_table1(i int)")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE testschema.trigger_table1")
-			testhelper.AssertQueryRuns(connectionPool, `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON testschema.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`)
+			testhelper.AssertQueryRuns(connectionPool, triggerString2)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TRIGGER sync_trigger_table1 ON testschema.trigger_table1")
 			_ = backupCmdFlags.Set(options.INCLUDE_RELATION, "testschema.trigger_table1")
 
-			trigger1 := backup.TriggerDefinition{Oid: 0, Name: "sync_trigger_table1", OwningSchema: "testschema", OwningTable: "trigger_table1", Def: sql.NullString{String: `CREATE TRIGGER sync_trigger_table1 AFTER INSERT OR DELETE OR UPDATE ON testschema.trigger_table1 FOR EACH STATEMENT EXECUTE PROCEDURE "RI_FKey_check_ins"()`, Valid: true}}
+			trigger1 := backup.TriggerDefinition{Oid: 0, Name: "sync_trigger_table1", OwningSchema: "testschema", OwningTable: "trigger_table1", Def: sql.NullString{String: triggerString2, Valid: true}}
 
 			results := backup.GetTriggers(connectionPool)
 

--- a/integration/predata_externals_queries_test.go
+++ b/integration/predata_externals_queries_test.go
@@ -1,6 +1,8 @@
 package integration
 
 import (
+	"database/sql"
+
 	"github.com/greenplum-db/gp-common-go-libs/structmatcher"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup/backup"
@@ -24,7 +26,7 @@ FORMAT 'TEXT'`)
 			results := backup.GetExternalTableDefinitions(connectionPool)
 			result := results[oid]
 
-			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: "file://tmp/myfile.txt",
+			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: sql.NullString{String: "file://tmp/myfile.txt", Valid: true},
 				ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "delimiter '	' null '\\N' escape '\\'",
 				Command: "", RejectLimit: 0, RejectLimitType: "", ErrTableName: "", ErrTableSchema: "", Encoding: "UTF8",
 				Writable: false, URIs: []string{"file://tmp/myfile.txt"}}
@@ -42,10 +44,14 @@ FORMAT 'TEXT'`)
 			results := backup.GetExternalTableDefinitions(connectionPool)
 			result := results[oid]
 
-			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: "",
+			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: sql.NullString{String: "", Valid: true},
 				ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "delimiter '	' null '\\N' escape '\\'",
 				Command: "hostname", RejectLimit: 0, RejectLimitType: "", ErrTableName: "", ErrTableSchema: "", Encoding: "UTF8",
 				Writable: false, URIs: nil}
+			if connectionPool.Version.AtLeast("7") {
+				// The query for GPDB 7+ will have a NULL value instead of ""
+				extTable.Location.Valid = false
+			}
 
 			structmatcher.ExpectStructsToMatchExcluding(&extTable, &result, "Oid")
 		})
@@ -62,7 +68,7 @@ SEGMENT REJECT LIMIT 10 PERCENT
 			results := backup.GetExternalTableDefinitions(connectionPool)
 			result := results[oid]
 
-			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: "file://tmp/myfile.txt",
+			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: sql.NullString{String: "file://tmp/myfile.txt", Valid: true},
 				ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "delimiter '	' null '\\N' escape '\\'",
 				Command: "", RejectLimit: 10, RejectLimitType: "p", LogErrors: true, Encoding: "UTF8",
 				Writable: false, URIs: []string{"file://tmp/myfile.txt"}}
@@ -82,7 +88,7 @@ SEGMENT REJECT LIMIT 10 PERCENT
 			results := backup.GetExternalTableDefinitions(connectionPool)
 			result := results[oid]
 
-			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: "file://tmp/myfile.txt",
+			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: sql.NullString{String: "file://tmp/myfile.txt", Valid: true},
 				ExecLocation: "ALL_SEGMENTS", FormatType: "c", FormatOpts: `delimiter '|' null '' escape ''' quote ''' force not null i`,
 				Command: "", RejectLimit: 10, RejectLimitType: "p", LogErrors: true, Encoding: "UTF8",
 				Writable: false, URIs: []string{"file://tmp/myfile.txt"}}
@@ -102,7 +108,7 @@ SEGMENT REJECT LIMIT 10 PERCENT
 			results := backup.GetExternalTableDefinitions(connectionPool)
 			result := results[oid]
 
-			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: "file://tmp/myfile.txt",
+			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: sql.NullString{String: "file://tmp/myfile.txt", Valid: true},
 				ExecLocation: "ALL_SEGMENTS", FormatType: "b", FormatOpts: "formatter 'fixedwidth_out' i '20' ",
 				Command: "", RejectLimit: 10, RejectLimitType: "p", LogErrors: true, Encoding: "UTF8",
 				Writable: false, URIs: []string{"file://tmp/myfile.txt"}}
@@ -128,7 +134,7 @@ LOG ERRORS SEGMENT REJECT LIMIT 10 PERCENT`)
 			results := backup.GetExternalTableDefinitions(connectionPool)
 			result := results[oid]
 
-			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: "file://tmp/myfile.txt",
+			extTable := backup.ExternalTableDefinition{Oid: 0, Type: 0, Protocol: 0, Location: sql.NullString{String: "file://tmp/myfile.txt", Valid: true},
 				ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "delimiter '%' null '' escape 'OFF'",
 				Command: "", RejectLimit: 10, RejectLimitType: "p", LogErrors: true, Encoding: "UTF8",
 				Writable: false, URIs: []string{"file://tmp/myfile.txt"}}
@@ -157,6 +163,12 @@ LOG ERRORS SEGMENT REJECT LIMIT 10 PERCENT`)
 		})
 	})
 	Describe("GetExternalPartitionInfo", func() {
+		BeforeEach(func() {
+			// For GPDB 7+, external partitions will have their own ATTACH PARTITION DDL commands.
+			if connectionPool.Version.AtLeast("7") {
+				Skip("Test is not applicable to GPDB 7+")
+			}
+		})
 		AfterEach(func() {
 			testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.part_tbl")
 			testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.part_tbl_ext_part_")

--- a/integration/predata_functions_create_test.go
+++ b/integration/predata_functions_create_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"database/sql"
+	"fmt"
 
 	"github.com/greenplum-db/gp-common-go-libs/structmatcher"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
@@ -95,6 +96,10 @@ var _ = Describe("backup integration create statement tests", func() {
 					Volatility: "v", IsStrict: false, IsSecurityDefiner: false, Config: "", Cost: 100, NumRows: 0, DataAccess: "c",
 					Language: "sql", ExecLocation: "a",
 				}
+				if connectionPool.Version.AtLeast("7") {
+					addFunction.PlannerSupport = "-"
+					addFunction.Kind = "f"
+				}
 
 				metadata := testutils.DefaultMetadata("FUNCTION", true, true, true, includeSecurityLabels)
 				backup.PrintCreateFunctionStatement(backupfile, tocfile, addFunction, metadata)
@@ -117,6 +122,10 @@ var _ = Describe("backup integration create statement tests", func() {
 					Volatility: "s", IsStrict: true, IsSecurityDefiner: true, Config: "SET search_path TO 'pg_temp'", Cost: 200,
 					NumRows: 200, DataAccess: "m", Language: "sql", ExecLocation: "a",
 				}
+				if connectionPool.Version.AtLeast("7") {
+					appendFunction.PlannerSupport = "-"
+					appendFunction.Kind = "f"
+				}
 
 				backup.PrintCreateFunctionStatement(backupfile, tocfile, appendFunction, funcMetadata)
 
@@ -137,6 +146,10 @@ var _ = Describe("backup integration create statement tests", func() {
 					ResultType: sql.NullString{String: "TABLE(f1 integer, f2 text)", Valid: true},
 					Volatility: "v", IsStrict: false, IsSecurityDefiner: false, Config: "", Cost: 100, NumRows: 1000, DataAccess: "c",
 					Language: "sql", ExecLocation: "a",
+				}
+				if connectionPool.Version.AtLeast("7") {
+					dupFunction.PlannerSupport = "-"
+					dupFunction.Kind = "f"
 				}
 
 				backup.PrintCreateFunctionStatement(backupfile, tocfile, dupFunction, funcMetadata)
@@ -162,7 +175,13 @@ var _ = Describe("backup integration create statement tests", func() {
 					IdentArgs: sql.NullString{String: "integer, integer", Valid: true},
 					ResultType: sql.NullString{String: "integer", Valid: true},
 					Volatility: "v", IsStrict: false, IsSecurityDefiner: false, Config: "", Cost: 100, NumRows: 0, DataAccess: "c",
-					Language: "sql", IsWindow: true, ExecLocation: "m",
+					Language: "sql", ExecLocation: "m",
+				}
+				if connectionPool.Version.AtLeast("7") {
+					windowFunction.PlannerSupport = "-"
+					windowFunction.Kind = "w"
+				} else {
+					windowFunction.IsWindow = true
 				}
 
 				backup.PrintCreateFunctionStatement(backupfile, tocfile, windowFunction, funcMetadata)
@@ -184,6 +203,10 @@ var _ = Describe("backup integration create statement tests", func() {
 					Volatility: "v", IsStrict: false, IsSecurityDefiner: false, Config: "", Cost: 100, NumRows: 0, DataAccess: "c",
 					Language: "sql", IsWindow: false, ExecLocation: "s",
 				}
+				if connectionPool.Version.AtLeast("7") {
+					segmentFunction.PlannerSupport = "-"
+					segmentFunction.Kind = "f"
+				}
 
 				backup.PrintCreateFunctionStatement(backupfile, tocfile, segmentFunction, funcMetadata)
 
@@ -203,6 +226,10 @@ var _ = Describe("backup integration create statement tests", func() {
 					ResultType: sql.NullString{String: "integer", Valid: true},
 					Volatility: "v", IsStrict: false, IsLeakProof: true, IsSecurityDefiner: false, Config: "", Cost: 100, NumRows: 0, DataAccess: "c",
 					Language: "sql", IsWindow: false, ExecLocation: "a",
+				}
+				if connectionPool.Version.AtLeast("7") {
+					leakProofFunction.PlannerSupport = "-"
+					leakProofFunction.Kind = "f"
 				}
 
 				backup.PrintCreateFunctionStatement(backupfile, tocfile, leakProofFunction, funcMetadata)
@@ -473,9 +500,14 @@ var _ = Describe("backup integration create statement tests", func() {
 	})
 	Describe("PrintCreateLanguageStatements", func() {
 		It("creates procedural languages", func() {
+			plpythonString := "plpython"
+			if connectionPool.Version.AtLeast("7") {
+				plpythonString = "plpython3"
+			}
+
 			funcInfoMap := map[uint32]backup.FunctionInfo{
-				1: {QualifiedName: "pg_catalog.plpython_call_handler", Arguments: sql.NullString{String: "", Valid: true}, IsInternal: true},
-				2: {QualifiedName: "pg_catalog.plpython_inline_handler", Arguments: sql.NullString{String: "internal", Valid: true}, IsInternal: true},
+				1: {QualifiedName: fmt.Sprintf("pg_catalog.%s_call_handler", plpythonString), Arguments: sql.NullString{String: "", Valid: true}, IsInternal: true},
+				2: {QualifiedName: fmt.Sprintf("pg_catalog.%s_inline_handler", plpythonString), Arguments: sql.NullString{String: "internal", Valid: true}, IsInternal: true},
 			}
 			langOwner := ""
 			var langMetadata backup.ObjectMetadata
@@ -486,7 +518,7 @@ var _ = Describe("backup integration create statement tests", func() {
 				langOwner = "testrole"
 				langMetadata = testutils.DefaultMetadata("LANGUAGE", false, true, true, includeSecurityLabels)
 			}
-			plpythonInfo := backup.ProceduralLanguage{Oid: 1, Name: "plpythonu", Owner: langOwner, IsPl: true, PlTrusted: false, Handler: 1, Inline: 2}
+			plpythonInfo := backup.ProceduralLanguage{Oid: 1, Name: fmt.Sprintf("%su", plpythonString), Owner: langOwner, IsPl: true, PlTrusted: false, Handler: 1, Inline: 2}
 
 			langMetadataMap := map[backup.UniqueID]backup.ObjectMetadata{plpythonInfo.GetUniqueID(): langMetadata}
 			if connectionPool.Version.Before("5") {
@@ -497,12 +529,12 @@ var _ = Describe("backup integration create statement tests", func() {
 			backup.PrintCreateLanguageStatements(backupfile, tocfile, procLangs, funcInfoMap, langMetadataMap)
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
-			defer testhelper.AssertQueryRuns(connectionPool, "DROP LANGUAGE plpythonu")
+			defer testhelper.AssertQueryRuns(connectionPool, fmt.Sprintf("DROP LANGUAGE %su", plpythonString))
 
 			resultProcLangs := backup.GetProceduralLanguages(connectionPool)
 			resultMetadataMap := backup.GetMetadataForObjectType(connectionPool, backup.TYPE_PROCLANGUAGE)
 
-			plpythonInfo.Oid = testutils.OidFromObjectName(connectionPool, "", "plpythonu", backup.TYPE_PROCLANGUAGE)
+			plpythonInfo.Oid = testutils.OidFromObjectName(connectionPool, "", fmt.Sprintf("%su", plpythonString), backup.TYPE_PROCLANGUAGE)
 			Expect(resultProcLangs).To(HaveLen(1))
 			resultMetadata := resultMetadataMap[plpythonInfo.GetUniqueID()]
 			structmatcher.ExpectStructsToMatchIncluding(&plpythonInfo, &resultProcLangs[0], "Name", "IsPl", "PlTrusted")

--- a/integration/predata_functions_queries_test.go
+++ b/integration/predata_functions_queries_test.go
@@ -2,6 +2,7 @@ package integration
 
 import (
 	"database/sql"
+	"fmt"
 
 	"github.com/greenplum-db/gp-common-go-libs/structmatcher"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
@@ -739,18 +740,23 @@ LANGUAGE SQL`)
 	})
 	Describe("GetProceduralLanguages", func() {
 		It("returns a slice of procedural languages", func() {
-			testhelper.AssertQueryRuns(connectionPool, "CREATE LANGUAGE plpythonu")
-			defer testhelper.AssertQueryRuns(connectionPool, "DROP LANGUAGE plpythonu")
+			plpythonString := "plpython"
+			if connectionPool.Version.AtLeast("7") {
+				plpythonString = "plpython3"
+			}
 
-			pythonHandlerOid := testutils.OidFromObjectName(connectionPool, "pg_catalog", "plpython_call_handler", backup.TYPE_FUNCTION)
+			testhelper.AssertQueryRuns(connectionPool, fmt.Sprintf("CREATE LANGUAGE %su", plpythonString))
+			defer testhelper.AssertQueryRuns(connectionPool, fmt.Sprintf("DROP LANGUAGE %su", plpythonString))
 
-			expectedPlpythonInfo := backup.ProceduralLanguage{Oid: 1, Name: "plpythonu", Owner: "testrole", IsPl: true, PlTrusted: false, Handler: pythonHandlerOid, Inline: 0, Validator: 0}
+			pythonHandlerOid := testutils.OidFromObjectName(connectionPool, "pg_catalog", fmt.Sprintf("%s_call_handler", plpythonString), backup.TYPE_FUNCTION)
+
+			expectedPlpythonInfo := backup.ProceduralLanguage{Oid: 1, Name: fmt.Sprintf("%su", plpythonString), Owner: "testrole", IsPl: true, PlTrusted: false, Handler: pythonHandlerOid, Inline: 0, Validator: 0}
 			if connectionPool.Version.AtLeast("5") {
-				pythonInlineOid := testutils.OidFromObjectName(connectionPool, "pg_catalog", "plpython_inline_handler", backup.TYPE_FUNCTION)
+				pythonInlineOid := testutils.OidFromObjectName(connectionPool, "pg_catalog", fmt.Sprintf("%s_inline_handler", plpythonString), backup.TYPE_FUNCTION)
 				expectedPlpythonInfo.Inline = pythonInlineOid
 			}
 			if connectionPool.Version.AtLeast("6") {
-				expectedPlpythonInfo.Validator = testutils.OidFromObjectName(connectionPool, "pg_catalog", "plpython_validator", backup.TYPE_FUNCTION)
+				expectedPlpythonInfo.Validator = testutils.OidFromObjectName(connectionPool, "pg_catalog", fmt.Sprintf("%s_validator", plpythonString), backup.TYPE_FUNCTION)
 			}
 
 			resultProcLangs := backup.GetProceduralLanguages(connectionPool)

--- a/integration/predata_relations_create_test.go
+++ b/integration/predata_relations_create_test.go
@@ -25,7 +25,7 @@ var _ = Describe("backup integration create statement tests", func() {
 			partitionPartFalseExpectation = "false"
 		)
 		BeforeEach(func() {
-			extTableEmpty = backup.ExternalTableDefinition{Oid: 0, Type: -2, Protocol: -2, Location: "", ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "", Command: "", RejectLimit: 0, RejectLimitType: "", ErrTableName: "", ErrTableSchema: "", Encoding: "UTF-8", Writable: false, URIs: nil}
+			extTableEmpty = backup.ExternalTableDefinition{Oid: 0, Type: -2, Protocol: -2, Location: sql.NullString{String: "", Valid: true}, ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "", Command: "", RejectLimit: 0, RejectLimitType: "", ErrTableName: "", ErrTableSchema: "", Encoding: "UTF-8", Writable: false, URIs: nil}
 			testTable = backup.Table{
 				Relation:        backup.Relation{Schema: "public", Name: "testtable"},
 				TableDefinition: backup.TableDefinition{DistPolicy: "DISTRIBUTED RANDOMLY", ExtTableDef: extTableEmpty, Inherits: []string{}},
@@ -100,6 +100,10 @@ var _ = Describe("backup integration create statement tests", func() {
 			rowOne := backup.ColumnDefinition{Oid: 0, Num: 1, Name: "i", NotNull: false, HasDefault: false, Type: "integer", Encoding: "compresstype=zlib,blocksize=32768,compresslevel=1", StatTarget: -1, StorageType: "", DefaultVal: "", Comment: ""}
 			rowTwo := backup.ColumnDefinition{Oid: 0, Num: 2, Name: "j", NotNull: false, HasDefault: false, Type: "character varying(20)", Encoding: "compresstype=zlib,blocksize=32768,compresslevel=1", StatTarget: -1, StorageType: "", DefaultVal: "", Comment: ""}
 			testTable.StorageOpts = "appendonly=true, orientation=column, fillfactor=42, compresstype=zlib, blocksize=32768, compresslevel=1"
+			if connectionPool.Version.AtLeast("7") {
+				// Apparently, fillfactor is not backwards compatible with GPDB 7
+				testTable.StorageOpts = "appendonly=true, orientation=column, compresstype=zlib, blocksize=32768, compresslevel=1"
+			}
 			testTable.ColumnDefs = []backup.ColumnDefinition{rowOne, rowTwo}
 
 			backup.PrintRegularTableCreateStatement(backupfile, tocfile, testTable)
@@ -107,6 +111,11 @@ var _ = Describe("backup integration create statement tests", func() {
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 			testTable.Oid = testutils.OidFromObjectName(connectionPool, "public", "testtable", backup.TYPE_RELATION)
 			resultTable := backup.ConstructDefinitionsForTables(connectionPool, []backup.Relation{testTable.Relation})[0]
+			if connectionPool.Version.AtLeast("7") {
+				// For GPDB 7+, the storage options no longer store the appendonly and orientation field
+				testTable.StorageOpts = "compresstype=zlib, blocksize=32768, compresslevel=1"
+				testTable.TableDefinition.AccessMethodName = "ao_column"
+			}
 			structmatcher.ExpectStructsToMatchExcluding(testTable.TableDefinition, resultTable.TableDefinition, "ColumnDefs.Oid", "ExtTableDef")
 		})
 		It("creates a basic GPDB 7+ append-optimized table", func() {
@@ -123,12 +132,17 @@ var _ = Describe("backup integration create statement tests", func() {
 		It("creates a one-level partition table", func() {
 			rowOne := backup.ColumnDefinition{Oid: 0, Num: 1, Name: "region", NotNull: false, HasDefault: false, Type: "text", Encoding: "", StatTarget: -1, StorageType: "", DefaultVal: "", Comment: ""}
 			rowTwo := backup.ColumnDefinition{Oid: 0, Num: 2, Name: "gender", NotNull: false, HasDefault: false, Type: "text", Encoding: "", StatTarget: -1, StorageType: "", DefaultVal: "", Comment: ""}
-			testTable.PartDef = fmt.Sprintf(`PARTITION BY LIST(gender) `+`
+
+			if connectionPool.Version.Before("7") {
+				testTable.PartDef = fmt.Sprintf(`PARTITION BY LIST(gender) `+`
           (
           PARTITION girls VALUES('F') WITH (tablename='public.rank_1_prt_girls', appendonly=%[1]s ), `+`
           PARTITION boys VALUES('M') WITH (tablename='public.rank_1_prt_boys', appendonly=%[1]s ), `+`
           DEFAULT PARTITION other  WITH (tablename='public.rank_1_prt_other', appendonly=%[1]s )
           )`, partitionPartFalseExpectation)
+			} else {
+				testTable.PartitionKeyDef = "LIST (gender)"
+			}
 
 			testTable.ColumnDefs = []backup.ColumnDefinition{rowOne, rowTwo}
 			testTable.PartitionLevelInfo.Level = "p"
@@ -146,10 +160,8 @@ var _ = Describe("backup integration create statement tests", func() {
 			 * The spacing is very specific here and is output from the postgres function
 			 * The only difference between the below statements is spacing
 			 */
-			subpartitionDef := ""
-			partTemplateDef := ""
 			if connectionPool.Version.Before("6") {
-				subpartitionDef = `PARTITION BY LIST(gender)
+				testTable.PartDef = `PARTITION BY LIST(gender)
           SUBPARTITION BY LIST(region) ` + `
           (
           PARTITION girls VALUES('F') WITH (tablename='public.rank_1_prt_girls', appendonly=false ) ` + `
@@ -174,7 +186,7 @@ var _ = Describe("backup integration create statement tests", func() {
                   DEFAULT SUBPARTITION other_regions  WITH (tablename='public.rank_1_prt_other_2_prt_other_regions', appendonly=false )
                   )
           )`
-				partTemplateDef = `ALTER TABLE public.testtable ` + `
+				testTable.PartTemplateDef = `ALTER TABLE public.testtable ` + `
 SET SUBPARTITION TEMPLATE  ` + `
           (
           SUBPARTITION usa VALUES('usa') WITH (tablename='testtable'), ` + `
@@ -183,8 +195,8 @@ SET SUBPARTITION TEMPLATE  ` + `
           DEFAULT SUBPARTITION other_regions  WITH (tablename='testtable')
           )
 `
-			} else {
-				subpartitionDef = fmt.Sprintf(`PARTITION BY LIST(gender)
+			} else if connectionPool.Version.Is("6") {
+				testTable.PartDef = fmt.Sprintf(`PARTITION BY LIST(gender)
           SUBPARTITION BY LIST(region) `+`
           (
           PARTITION girls VALUES('F') WITH (tablename='public.rank_1_prt_girls', appendonly=%[1]s )`+`
@@ -209,7 +221,7 @@ SET SUBPARTITION TEMPLATE  ` + `
                   DEFAULT SUBPARTITION other_regions  WITH (tablename='public.rank_1_prt_other_2_prt_other_regions', appendonly=%[1]s )
                   )
           )`, partitionPartFalseExpectation)
-				partTemplateDef = `ALTER TABLE public.testtable ` + `
+				testTable.PartTemplateDef = `ALTER TABLE public.testtable ` + `
 SET SUBPARTITION TEMPLATE ` + `
           (
           SUBPARTITION usa VALUES('usa') WITH (tablename='testtable'), ` + `
@@ -218,11 +230,13 @@ SET SUBPARTITION TEMPLATE ` + `
           DEFAULT SUBPARTITION other_regions  WITH (tablename='testtable')
           )
 `
+			} else {
+				testTable.PartitionKeyDef = "LIST (gender)"
 			}
+
+
 			rowOne := backup.ColumnDefinition{Oid: 0, Num: 1, Name: "region", NotNull: false, HasDefault: false, Type: "text", Encoding: "", StatTarget: -1, StorageType: "", DefaultVal: "", Comment: ""}
 			rowTwo := backup.ColumnDefinition{Oid: 0, Num: 2, Name: "gender", NotNull: false, HasDefault: false, Type: "text", Encoding: "", StatTarget: -1, StorageType: "", DefaultVal: "", Comment: ""}
-			testTable.PartDef = subpartitionDef
-			testTable.PartTemplateDef = partTemplateDef
 			testTable.ColumnDefs = []backup.ColumnDefinition{rowOne, rowTwo}
 			testTable.PartitionLevelInfo.Level = "p"
 
@@ -236,14 +250,16 @@ SET SUBPARTITION TEMPLATE ` + `
 
 		})
 		It("creates a GPDB 7+ root table", func() {
+			testutils.SkipIfBefore7(connectionPool)
+
 			testTable.PartitionKeyDef = "RANGE (b)"
-			rowOne := backup.ColumnDefinition{Oid: 0, Num: 1, Name: "a", NotNull: false, HasDefault: false, Type: "int", Encoding: "", StatTarget: -1, StorageType: "", DefaultVal: "", Comment: ""}
-			rowTwo := backup.ColumnDefinition{Oid: 0, Num: 2, Name: "b", NotNull: false, HasDefault: false, Type: "int", Encoding: "", StatTarget: -1, StorageType: "", DefaultVal: "", Comment: ""}
+			rowOne := backup.ColumnDefinition{Oid: 0, Num: 1, Name: "a", NotNull: false, HasDefault: false, Type: "integer", Encoding: "", StatTarget: -1, StorageType: "", DefaultVal: "", Comment: ""}
+			rowTwo := backup.ColumnDefinition{Oid: 0, Num: 2, Name: "b", NotNull: false, HasDefault: false, Type: "integer", Encoding: "", StatTarget: -1, StorageType: "", DefaultVal: "", Comment: ""}
 			testTable.ColumnDefs = []backup.ColumnDefinition{rowOne, rowTwo}
+			testTable.PartitionLevelInfo.Level = "p"
 
 			backup.PrintRegularTableCreateStatement(backupfile, tocfile, testTable)
 
-			fmt.Println(buffer.String())
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 
 			testTable.PartitionLevelInfo.Oid = testutils.OidFromObjectName(connectionPool, "public", "testtable", backup.TYPE_RELATION)
@@ -345,7 +361,7 @@ SET SUBPARTITION TEMPLATE ` + `
 	})
 	Describe("PrintPostCreateTableStatements", func() {
 		var (
-			extTableEmpty = backup.ExternalTableDefinition{Oid: 0, Type: -2, Protocol: -2, Location: "", ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "", Command: "", RejectLimit: 0, RejectLimitType: "", ErrTableName: "", ErrTableSchema: "", Encoding: "UTF-8", Writable: false, URIs: nil}
+			extTableEmpty = backup.ExternalTableDefinition{Oid: 0, Type: -2, Protocol: -2, Location: sql.NullString{String: "", Valid: true}, ExecLocation: "ALL_SEGMENTS", FormatType: "t", FormatOpts: "", Command: "", RejectLimit: 0, RejectLimitType: "", ErrTableName: "", ErrTableSchema: "", Encoding: "UTF-8", Writable: false, URIs: nil}
 			tableRow      = backup.ColumnDefinition{Oid: 0, Num: 1, Name: "i", NotNull: false, HasDefault: false, Type: "integer", Encoding: "", StatTarget: -1, StorageType: "", DefaultVal: "", Comment: ""}
 			testTable     backup.Table
 			tableMetadata backup.ObjectMetadata
@@ -445,7 +461,7 @@ SET SUBPARTITION TEMPLATE ` + `
 					DistPolicy:  "DISTRIBUTED BY (i)",
 					ColumnDefs:  []backup.ColumnDefinition{tableRow},
 					ExtTableDef: extTableEmpty,
-					Inherits:    []string{},
+					Inherits:    []string{"public.testroottable"},
 					AttachPartitionInfo: backup.AttachPartitionInfo{
 						Relname: "public.testchildtable",
 						Parent:  "public.testroottable",
@@ -650,6 +666,10 @@ SET SUBPARTITION TEMPLATE ` + `
 			sequence.OwningColumn = "public.sequence_table.a"
 
 			sequence.Definition = backup.SequenceDefinition{LastVal: 1, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 1, StartVal: startValue}
+			if connectionPool.Version.AtLeast("7") {
+				sequence.Definition.Type = "bigint"
+			}
+
 			backup.PrintCreateSequenceStatements(backupfile, tocfile, []backup.Sequence{sequence}, backup.MetadataMap{})
 			backup.PrintAlterSequenceStatements(backupfile, tocfile, []backup.Sequence{sequence})
 
@@ -667,21 +687,19 @@ SET SUBPARTITION TEMPLATE ` + `
 		})
 		It("skips identity sequences", func() {
 			testutils.SkipIfBefore7(connectionPool)
-			startValue := int64(0)
 			sequenceRel := backup.Relation{SchemaOid: 0, Oid: 1, Schema: "public", Name: "my_sequence"}
 			sequence := backup.Sequence{Relation: sequenceRel}
-			sequence.Definition = backup.SequenceDefinition{LastVal: 1, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 1, StartVal: startValue}
+			sequence.Definition = backup.SequenceDefinition{LastVal: 1, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 1, StartVal: 1, Type: "bigint"}
 
 			identitySequenceRel := backup.Relation{SchemaOid: 0, Oid: 1, Schema: "public", Name: "my_identity_sequence"}
 			identitySequence := backup.Sequence{Relation: identitySequenceRel, IsIdentity: true}
-			identitySequence.Definition = backup.SequenceDefinition{LastVal: 1, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 20, StartVal: startValue}
+			identitySequence.Definition = backup.SequenceDefinition{LastVal: 1, Increment: 1, MaxVal: math.MaxInt64, MinVal: 1, CacheVal: 20, StartVal: 1, Type: "bigint"}
 
 			backup.PrintCreateSequenceStatements(backupfile, tocfile, []backup.Sequence{sequence, identitySequence}, backup.MetadataMap{})
 			backup.PrintAlterSequenceStatements(backupfile, tocfile, []backup.Sequence{sequence, identitySequence})
 
 			testhelper.AssertQueryRuns(connectionPool, buffer.String())
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP SEQUENCE public.my_sequence")
-			defer testhelper.AssertQueryRuns(connectionPool, "DROP SEQUENCE public.my_identity_sequence")
 
 			sequences := backup.GetAllSequences(connectionPool)
 			Expect(sequences).To(HaveLen(1))

--- a/integration/predata_relations_queries_test.go
+++ b/integration/predata_relations_queries_test.go
@@ -52,7 +52,13 @@ PARTITION BY LIST (gender)
 
 				tableRank := backup.Relation{Schema: "public", Name: "rank"}
 
-				Expect(tables).To(HaveLen(1))
+				if connectionPool.Version.Before("7") {
+					Expect(tables).To(HaveLen(1))
+				} else {
+					// For GPDB 7+, the leaf partitions have their own DDL so they need to be obtained as well
+					Expect(tables).To(HaveLen(4))
+				}
+
 				structmatcher.ExpectStructsToMatchExcluding(&tableRank, &tables[0], "SchemaOid", "Oid")
 			})
 			It("returns both parent and leaf partition tables if the leaf-partition-data flag is set and there are no include tables", func() {
@@ -379,7 +385,9 @@ PARTITION BY LIST (gender)
 			if connectionPool.Version.AtLeast("7") {
 				// In GPDB 7+, default cache value is 20
 				seqOneDef.CacheVal = 20
+				seqOneDef.Type = "bigint"
 				seqTwoDef.CacheVal = 20
+				seqTwoDef.Type = "bigint"
 			}
 
 			results := backup.GetAllSequences(connectionPool)

--- a/integration/statistics_queries_test.go
+++ b/integration/statistics_queries_test.go
@@ -59,6 +59,10 @@ var _ = Describe("backup integration tests", func() {
 			expectedStats5K := backup.AttributeStatistic{Oid: tableOid, Schema: "public", Table: "foo", AttName: "k",
 				Type: "bool", Relid: tableOid, AttNumber: 3, Inherit: false, Width: 1, Distinct: -1, Kind1: 2, Kind2: 3, Operator1: 58,
 				Operator2: 58, Numbers2: []string{"-1"}, Values1: []string{"f", "t"}}
+			if connectionPool.Version.AtLeast("7") {
+				expectedStats5J.Collation1 = 100
+				expectedStats5J.Collation2 = 100
+			}
 
 			// The order in which the stavalues1 values is returned is not guaranteed to be deterministic
 			sort.Strings(tableAttStatsI.Values1)


### PR DESCRIPTION
This PR has some small fixes to the gpbackup code relating to previous master_changes commits.

With this PR, the integration tests pass against all versions of GPDB (7devel, 6X, 5X, 4.3.X).

Suggestion is to view each commit individually for review.  The main commit is the last one which touches the integration tests as a single commit.