### PR TITLE
Support for Row level security policies GPDB7+

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -298,6 +298,9 @@ func backupPostdata(metadataFile *utils.FileWithByteCount) {
 			backupEventTriggers(metadataFile)
 		}
 	}
+	if connectionPool.Version.AtLeast("7") {
+		backupRowLevelSecurityPolicies(metadataFile)
+	}
 
 	logCompletionMessage("Post-data metadata backup")
 }

--- a/backup/queries_acl.go
+++ b/backup/queries_acl.go
@@ -65,6 +65,7 @@ var (
 	TYPE_TSTEMPLATE         MetadataQueryParams
 	TYPE_TRIGGER            MetadataQueryParams
 	TYPE_TYPE               MetadataQueryParams
+	TYPE_POLICY             MetadataQueryParams
 )
 
 func InitializeMetadataParams(connectionPool *dbconn.DBConn) {

--- a/backup/queries_postdata.go
+++ b/backup/queries_postdata.go
@@ -348,3 +348,62 @@ func GetEventTriggers(connectionPool *dbconn.DBConn) []EventTrigger {
 	gplog.FatalOnError(err)
 	return results
 }
+
+type RLSPolicy struct {
+	Oid         uint32
+	Name        string
+	Cmd         string
+	Permissive  string
+	Schema      string
+	Table       string
+	Roles       string
+	Qual        string
+	WithCheck   string
+}
+
+func GetPolicies(connectionPool *dbconn.DBConn) []RLSPolicy {
+	query := fmt.Sprintf(`
+	SELECT
+		p.oid as oid,
+		quote_ident(p.polname) as name,
+		p.polcmd as cmd,
+		p.polpermissive as permissive,
+		quote_ident(c.relnamespace::regnamespace::text) as schema,
+		quote_ident(c.relname) as table,
+		CASE
+			WHEN polroles = '{0}' THEN ''
+			ELSE coalesce(pg_catalog.array_to_string(ARRAY(SELECT pg_catalog.quote_ident(rolname) from pg_catalog.pg_roles WHERE oid = ANY(polroles)), ', '), '')
+		END AS roles,
+		coalesce(pg_catalog.pg_get_expr(polqual, polrelid), '') AS qual,
+		coalesce(pg_catalog.pg_get_expr(polwithcheck, polrelid), '') AS withcheck
+	FROM pg_catalog.pg_policy p
+		JOIN pg_catalog.pg_class c ON p.polrelid = c.oid
+	ORDER BY p.polname`)
+
+
+	results := make([]RLSPolicy, 0)
+	err := connectionPool.Select(&results, query)
+	gplog.FatalOnError(err)
+	return results
+}
+
+func (p RLSPolicy) GetMetadataEntry() (string, toc.MetadataEntry) {
+	tableFQN := utils.MakeFQN(p.Schema, p.Table)
+	return "postdata",
+		toc.MetadataEntry{
+			Schema:          p.Schema,
+			Name:            p.Table,
+			ObjectType:      "POLICY",
+			ReferenceObject: tableFQN,
+			StartByte:       0,
+			EndByte:         0,
+		}
+}
+
+func (p RLSPolicy) GetUniqueID() UniqueID {
+	return UniqueID{ClassID: PG_REWRITE_OID, Oid: p.Oid}
+}
+
+func (p RLSPolicy) FQN() string {
+	return p.Name
+}

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -649,6 +649,14 @@ func backupEventTriggers(metadataFile *utils.FileWithByteCount) {
 	PrintCreateEventTriggerStatements(metadataFile, globalTOC, eventTriggers, eventTriggerMetadata)
 }
 
+func backupRowLevelSecurityPolicies(metadataFile *utils.FileWithByteCount) {
+	gplog.Verbose("Writing CREATE POLICY statements to metadata file")
+	policies := GetPolicies(connectionPool)
+	objectCounts["Policies"] = len(policies)
+	ruleMetadata := GetCommentsForObjectType(connectionPool, TYPE_RULE)
+	PrintCreatePolicyStatements(metadataFile, globalTOC, policies, ruleMetadata)
+}
+
 func backupDefaultPrivileges(metadataFile *utils.FileWithByteCount) {
 	gplog.Verbose("Writing ALTER DEFAULT PRIVILEGES statements to metadata file")
 	defaultPrivileges := GetDefaultPrivileges(connectionPool)

--- a/integration/postdata_queries_test.go
+++ b/integration/postdata_queries_test.go
@@ -423,4 +423,53 @@ AS $$ BEGIN RAISE EXCEPTION 'exception'; END; $$;`)
 
 		})
 	})
+	Describe("GetPolicies", func() {
+		BeforeEach(func() {
+			testutils.SkipIfBefore7(connectionPool)
+		})
+		It("returns no results when no policies exists", func() {
+			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.policy_table(user_name text)")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.policy_table")
+			results := backup.GetPolicies(connectionPool)
+			Expect(results).To(BeEmpty())
+		})
+		It("returns a slice of multiple policies", func() {
+			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.users(user_name text)")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.users")
+			testhelper.AssertQueryRuns(connectionPool, "CREATE POLICY policy1_user_sel ON public.users FOR SELECT USING (true)")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP POLICY policy1_user_sel on public.users")
+			testhelper.AssertQueryRuns(connectionPool, "CREATE POLICY policy2_user_mod ON public.users USING (user_name = current_user)")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP POLICY policy2_user_mod on public.users")
+
+			results := backup.GetPolicies(connectionPool)
+
+			Expect(results).To(HaveLen(2))
+			policy1 := backup.RLSPolicy{Oid: 1, Name: "policy1_user_sel", Cmd: "r", Permissive: "true", Schema: "public", Table: "users", Qual: "true"}
+			policy2 := backup.RLSPolicy{Oid: 1, Name: "policy2_user_mod", Cmd: "*", Permissive: "true", Schema: "public", Table: "users", Qual: "(user_name = CURRENT_USER)"}
+			structmatcher.ExpectStructsToMatchExcluding(&policy1, &results[0], "Oid")
+			structmatcher.ExpectStructsToMatchExcluding(&policy2, &results[1], "Oid")
+		})
+		It("returns a slice of multiple policies with checks", func() {
+			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.passwd(user_name text, shell text not null)")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.passwd")
+			testhelper.AssertQueryRuns(connectionPool, "CREATE ROLE BOB")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP ROLE BOB")
+			testhelper.AssertQueryRuns(connectionPool, "CREATE POLICY policy1_bob_all ON public.passwd TO bob USING (true) WITH CHECK (true)")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP POLICY policy1_bob_all on public.passwd")
+			testhelper.AssertQueryRuns(connectionPool, "CREATE POLICY policy2_all_view ON public.passwd FOR SELECT USING (true)")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP POLICY policy2_all_view on public.passwd")
+			testhelper.AssertQueryRuns(connectionPool, "CREATE POLICY policy3_user_mod ON public.passwd FOR UPDATE USING (user_name = current_user) WITH CHECK (current_user = user_name AND shell IN ('/bin/bash', '/bin/sh'))")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP POLICY policy3_user_mod on public.passwd")
+
+			results := backup.GetPolicies(connectionPool)
+
+			Expect(results).To(HaveLen(3))
+			policy1 := backup.RLSPolicy{Oid: 1, Name: "policy1_bob_all", Cmd: "*", Permissive: "true", Schema: "public", Table: "passwd", Roles: "bob", Qual: "true",WithCheck:"true"}
+			policy2 := backup.RLSPolicy{Oid: 1, Name: "policy2_all_view", Cmd: "r", Permissive: "true", Schema: "public", Table: "passwd", Roles: "", Qual: "true", WithCheck:""}
+			policy3 := backup.RLSPolicy{Oid: 1, Name: "policy3_user_mod", Cmd: "w", Permissive: "true", Schema: "public", Table: "passwd", Roles: "", Qual: "(user_name = CURRENT_USER)", WithCheck: "((CURRENT_USER = user_name) AND (shell = ANY (ARRAY['/bin/bash'::text, '/bin/sh'::text])))"}
+			structmatcher.ExpectStructsToMatchExcluding(&policy1, &results[0], "Oid")
+			structmatcher.ExpectStructsToMatchExcluding(&policy2, &results[1], "Oid")
+			structmatcher.ExpectStructsToMatchExcluding(&policy3, &results[2], "Oid")
+		})
+	})
 })


### PR DESCRIPTION
In GPDB 7+, row level security policies have been added.

This would require the follwoing statements `ALTER TABLE <tbl_name> ENABLE ROW LEVEL SECURITY;` followed by `CREATE POLICY ...` statements

Postgres Reference:
postgres/postgres@088c833

TODO: Unit tests