### PR TITLE
Transform

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -223,6 +223,7 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Table, tableO
 
 		if len(MustGetFlagStringArray(options.INCLUDE_SCHEMA)) == 0 {
 			backupProceduralLanguages(metadataFile, functions, funcInfoMap, metadataMap)
+			backupTransforms(metadataFile, funcInfoMap)
 			retrieveFDWObjects(&objects, metadataMap)
 		}
 

--- a/backup/dependencies.go
+++ b/backup/dependencies.go
@@ -56,6 +56,7 @@ var (
 	PG_FOREIGN_SERVER_OID       uint32 = 1417
 	PG_INDEX_OID                uint32 = 2610
 	PG_LANGUAGE_OID             uint32 = 2612
+	PG_TRANSFORM_OID            uint32 = 3576
 	PG_NAMESPACE_OID            uint32 = 2615
 	PG_OPCLASS_OID              uint32 = 2616
 	PG_OPERATOR_OID             uint32 = 2617

--- a/backup/predata_functions.go
+++ b/backup/predata_functions.go
@@ -367,6 +367,40 @@ func PrintCreateLanguageStatements(metadataFile *utils.FileWithByteCount, toc *t
 	}
 }
 
+func PrintCreateTransformStatements(metadataFile *utils.FileWithByteCount, toc *toc.TOC, transforms []Transform, transformMetadata MetadataMap, funcInfoMap map[uint32]FunctionInfo) {
+	for _, transform := range transforms {
+		fromSQLFunc, fromSQLIsDefined := funcInfoMap[transform.FromSQLFunc]
+		toSQLFunc, toSQLIsDefined := funcInfoMap[transform.ToSQLFunc]
+		TypeFQN := fmt.Sprintf("%s.%s", transform.TypeNamespace, transform.TypeName)
+
+		if !fromSQLIsDefined && !toSQLIsDefined {
+			gplog.Warn(fmt.Sprintf("Skipping invalid transform object for type %s and language %s; At least one of FROM and TO functions should be specified.", TypeFQN, transform.LanguageName))
+			continue
+		}
+		start := metadataFile.ByteCount
+		statement := fmt.Sprintf("\n\nCREATE TRANSFORM FOR %s LANGUAGE %s (", TypeFQN, transform.LanguageName)
+		if fromSQLIsDefined {
+			statement += fmt.Sprintf("FROM SQL WITH FUNCTION %s", fromSQLFunc.FQN())
+		} else {
+			gplog.Warn(fmt.Sprintf("No FROM function found for transform object with type %s and language %s\n", TypeFQN, transform.LanguageName))
+		}
+
+		if toSQLIsDefined {
+			if fromSQLIsDefined {
+				statement += ", "
+			}
+			statement += fmt.Sprintf("TO SQL WITH FUNCTION %s", toSQLFunc.FQN())
+		} else {
+			gplog.Warn(fmt.Sprintf("No TO function found for transform object with type %s and language %s\n", TypeFQN, transform.LanguageName))
+		}
+		statement += ");"
+		metadataFile.MustPrintf(statement)
+		section, entry := transform.GetMetadataEntry()
+		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
+		PrintObjectMetadata(metadataFile, toc, transformMetadata[transform.GetUniqueID()], transform, "")
+	}
+}
+
 func PrintCreateConversionStatements(metadataFile *utils.FileWithByteCount, toc *toc.TOC, conversions []Conversion, conversionMetadata MetadataMap) {
 	for _, conversion := range conversions {
 		start := metadataFile.ByteCount

--- a/backup/predata_functions_test.go
+++ b/backup/predata_functions_test.go
@@ -850,6 +850,36 @@ GRANT ALL ON LANGUAGE plperl TO testrole;`,
 			testutils.AssertBufferContents(tocfile.PredataEntries, buffer, expectedStatements...)
 		})
 	})
+	Describe("PrintCreateTransformStatements", func() {
+		funcInfoMap := map[uint32]backup.FunctionInfo{
+			1: {QualifiedName: "somenamespace.from_sql_f", IdentArgs: sql.NullString{String: "internal", Valid: true}},
+			2: {QualifiedName: "somenamespace.to_sql_f", IdentArgs: sql.NullString{String: "internal", Valid: true}},
+		}
+
+		DescribeTable("prints transform statements with at least one transform function", func(fromSql uint32, toSql uint32, expected string) {
+			testutils.SkipIfBefore7(connectionPool)
+			transform := backup.Transform{Oid: 1, TypeNamespace: "mynamespace", TypeName: "mytype", LanguageName: "somelang", FromSQLFunc: fromSql, ToSQLFunc: toSql}
+			transforms := []backup.Transform{transform}
+			transMetadataMap := testutils.DefaultMetadataMap("TRANSFORM", false, false, true, false)
+			backup.PrintCreateTransformStatements(backupfile, tocfile, transforms, transMetadataMap, funcInfoMap)
+			expectedStatements := []string{fmt.Sprintf(`CREATE TRANSFORM FOR mynamespace.mytype LANGUAGE somelang %s;`, expected)}
+			testutils.AssertBufferContents(tocfile.PredataEntries, buffer, expectedStatements...)
+		},
+			Entry("both functions are specified", uint32(1), uint32(2), "(FROM SQL WITH FUNCTION somenamespace.from_sql_f(internal), TO SQL WITH FUNCTION somenamespace.to_sql_f(internal))"),
+			Entry("only fromSQL function is specified", uint32(1), uint32(0), "(FROM SQL WITH FUNCTION somenamespace.from_sql_f(internal))"),
+			Entry("only toSql function is specified", uint32(0), uint32(2), "(TO SQL WITH FUNCTION somenamespace.to_sql_f(internal))"),
+		)
+		It("prints a warning if there are no transform functions specified", func() {
+			testutils.SkipIfBefore7(connectionPool)
+			_, _, logfile = testhelper.SetupTestLogger()
+			transform := backup.Transform{Oid: 1, TypeNamespace: "mynamespace", TypeName: "mycustomtype", LanguageName: "someproclanguage", FromSQLFunc: 0, ToSQLFunc: 0}
+			transforms := []backup.Transform{transform}
+			transMetadataMap := testutils.DefaultMetadataMap("TRANSFORM", false, false, true, false)
+			backup.PrintCreateTransformStatements(backupfile, tocfile, transforms, transMetadataMap, funcInfoMap)
+			testhelper.ExpectRegexp(logfile, "[WARNING]:-Skipping invalid transform object for type mynamespace.mycustomtype and language someproclanguage; At least one of FROM and TO functions should be specified")
+		})
+	})
+
 	Describe("PrintCreateConversionStatements", func() {
 		var (
 			convOne     backup.Conversion

--- a/backup/queries_acl.go
+++ b/backup/queries_acl.go
@@ -48,6 +48,7 @@ var (
 	TYPE_FUNCTION           MetadataQueryParams
 	TYPE_INDEX              MetadataQueryParams
 	TYPE_PROCLANGUAGE       MetadataQueryParams
+	TYPE_TRANSFORM          MetadataQueryParams
 	TYPE_OPERATOR           MetadataQueryParams
 	TYPE_OPERATORCLASS      MetadataQueryParams
 	TYPE_OPERATORFAMILY     MetadataQueryParams
@@ -111,6 +112,7 @@ func InitializeMetadataParams(connectionPool *dbconn.DBConn) {
 	TYPE_SCHEMA = MetadataQueryParams{ObjectType: "SCHEMA", NameField: "nspname", ACLField: "nspacl", OwnerField: "nspowner", CatalogTable: "pg_namespace"}
 	TYPE_STATISTIC_EXT = MetadataQueryParams{ObjectType: "STATISTIC_EXT", NameField: "stxname", OwnerField: "stxowner", CatalogTable: "pg_statistic_ext"}
 	TYPE_TABLESPACE = MetadataQueryParams{ObjectType: "TABLESPACE", NameField: "spcname", ACLField: "spcacl", OwnerField: "spcowner", CatalogTable: "pg_tablespace", Shared: true}
+	TYPE_TRANSFORM = MetadataQueryParams{ObjectType: "TRANSFORM", CatalogTable: "pg_transform"}
 	TYPE_TSCONFIGURATION = MetadataQueryParams{ObjectType: "TEXT SEARCH CONFIGURATION", NameField: "cfgname", OidField: "oid", SchemaField: "cfgnamespace", OwnerField: "cfgowner", CatalogTable: "pg_ts_config"}
 	TYPE_TSDICTIONARY = MetadataQueryParams{ObjectType: "TEXT SEARCH DICTIONARY", NameField: "dictname", OidField: "oid", SchemaField: "dictnamespace", OwnerField: "dictowner", CatalogTable: "pg_ts_dict"}
 	TYPE_TSPARSER = MetadataQueryParams{ObjectType: "TEXT SEARCH PARSER", NameField: "prsname", OidField: "oid", SchemaField: "prsnamespace", CatalogTable: "pg_ts_parser"}
@@ -139,7 +141,10 @@ func GetMetadataForObjectType(connectionPool *dbconn.DBConn, params MetadataQuer
 	gplog.Verbose("Getting object type metadata from " + params.CatalogTable)
 
 	tableName := params.CatalogTable
-	nameCol := params.NameField
+	nameCol := "''"
+	if params.NameField != "" {
+		nameCol = params.NameField
+	}
 	aclCols := "''"
 	kindCol := "''"
 	aclLateralJoin := ""
@@ -203,7 +208,7 @@ func GetMetadataForObjectType(connectionPool *dbconn.DBConn, params MetadataQuer
 		'%s' AS objecttype,
 		'%s'::regclass::oid AS classid,
 		o.oid,
-		quote_ident(%s) AS name,
+		coalesce(quote_ident(%s),'') AS name,
 		%s AS kind,
 		coalesce(quote_ident(%s),'') AS schema,
 		%s AS owner,

--- a/backup/queries_functions.go
+++ b/backup/queries_functions.go
@@ -887,6 +887,54 @@ func GetProceduralLanguages(connectionPool *dbconn.DBConn) []ProceduralLanguage 
 	return results
 }
 
+type Transform struct {
+	Oid           uint32
+	TypeNamespace string `db:"typnamespace"`
+	TypeName      string `db:"typname"`
+	LanguageName  string `db:"lanname"`
+	FromSQLFunc   uint32 `db:"trffromsql"`
+	ToSQLFunc     uint32 `db:"trftosql"`
+}
+
+func (trf Transform) GetMetadataEntry() (string, toc.MetadataEntry) {
+	return "predata",
+		toc.MetadataEntry{
+			Schema:          "",
+			Name:            "",
+			ObjectType:      "TRANSFORM",
+			ReferenceObject: "",
+			StartByte:       0,
+			EndByte:         0,
+		}
+}
+
+func (trf Transform) GetUniqueID() UniqueID {
+	return UniqueID{ClassID: PG_TRANSFORM_OID, Oid: trf.Oid}
+}
+
+func (trf Transform) FQN() string {
+	return fmt.Sprintf("FOR %s.%s LANGUAGE %s", trf.TypeNamespace, trf.TypeName, trf.LanguageName)
+}
+
+func GetTransforms(connectionPool *dbconn.DBConn) []Transform {
+	results := make([]Transform, 0)
+	query := fmt.Sprintf(`
+	SELECT trf.oid,
+		quote_ident(ns.nspname) AS typnamespace,
+		quote_ident(tp.typname) AS typname,
+		l.lanname,
+		trf.trffromsql::oid,
+		trf.trftosql::oid
+	FROM pg_transform trf
+		JOIN pg_type tp ON trf.trftype=tp.oid
+		JOIN pg_namespace ns ON tp.typnamespace = ns.oid
+		JOIN pg_language l ON trf.trflang=l.oid;`)
+
+	err := connectionPool.Select(&results, query)
+	gplog.FatalOnError(err)
+	return results
+}
+
 type Conversion struct {
 	Oid                uint32
 	Schema             string

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -489,6 +489,17 @@ func backupProceduralLanguages(metadataFile *utils.FileWithByteCount,
 	PrintCreateLanguageStatements(metadataFile, globalTOC, procLangs, funcInfoMap, procLangMetadata)
 }
 
+func backupTransforms(metadataFile *utils.FileWithByteCount, funcInfoMap map[uint32]FunctionInfo) {
+	if connectionPool.Version.Before("7") {
+		return
+	}
+	gplog.Verbose("Writing CREATE TRANSFORM statements to metadata file")
+	transforms := GetTransforms(connectionPool)
+	objectCounts["Transforms"] = len(transforms)
+	transformMetadata := GetMetadataForObjectType(connectionPool, TYPE_TRANSFORM)
+	PrintCreateTransformStatements(metadataFile, globalTOC, transforms, transformMetadata, funcInfoMap)
+}
+
 func backupShellTypes(metadataFile *utils.FileWithByteCount, shellTypes []ShellType, baseTypes []BaseType, rangeTypes []RangeType) {
 	gplog.Verbose("Writing CREATE TYPE statements for shell types to metadata file")
 	PrintCreateShellTypeStatements(metadataFile, globalTOC, shellTypes, baseTypes, rangeTypes)

--- a/integration/predata_functions_queries_test.go
+++ b/integration/predata_functions_queries_test.go
@@ -851,6 +851,25 @@ LANGUAGE SQL`)
 			structmatcher.ExpectStructsToMatchExcluding(&expectedConversion, &resultConversions[0], "Oid")
 		})
 	})
+	Describe("GetTransforms", func() {
+		BeforeEach(func() {
+			testutils.SkipIfBefore7(connectionPool)
+		})
+		It("returns a slice of transfroms", func() {
+			testhelper.AssertQueryRuns(connectionPool, "CREATE TRANSFORM FOR pg_catalog.int4 LANGUAGE c (FROM SQL WITH FUNCTION numeric_support(internal), TO SQL WITH FUNCTION int4recv(internal));")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP TRANSFORM FOR int4 LANGUAGE c")
+
+			fromSQLFuncOid := testutils.OidFromObjectName(connectionPool, "pg_catalog", "numeric_support", backup.TYPE_FUNCTION)
+			toSQLFuncOid := testutils.OidFromObjectName(connectionPool, "pg_catalog", "int4recv", backup.TYPE_FUNCTION)
+
+			expectedTransforms := backup.Transform{TypeNamespace: "pg_catalog", TypeName: "int4", LanguageName: "c", FromSQLFunc: fromSQLFuncOid, ToSQLFunc: toSQLFuncOid}
+
+			resultTransforms := backup.GetTransforms(connectionPool)
+
+			Expect(resultTransforms).To(HaveLen(1))
+			structmatcher.ExpectStructsToMatchExcluding(&expectedTransforms, &resultTransforms[0], "Oid")
+		})
+	})
 	Describe("GetForeignDataWrappers", func() {
 		BeforeEach(func() {
 			testutils.SkipIfBefore6(connectionPool)


### PR DESCRIPTION
In GPDB 7+, users are able to define a transform to better convert SQL data types to their procedural language counterparts. We need to support this in gpbackup/gprestore.