### PR TITLE
Tests for indexes/constraints with INCLUDE clause

### DIFF
--- a/integration/postdata_queries_test.go
+++ b/integration/postdata_queries_test.go
@@ -216,6 +216,19 @@ PARTITION BY RANGE (date)
 			structmatcher.ExpectStructsToMatchExcluding(&index1, &results[1])
 		})
 
+		It("returns a slice for an index with non-key columns included", func() {
+			testutils.SkipIfBefore7(connectionPool)
+			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.table_with_index (a int, b int, c int, d int) DISTRIBUTED BY (a);")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.table_with_index")
+			testhelper.AssertQueryRuns(connectionPool, "CREATE UNIQUE INDEX table_with_index_idx ON public.table_with_index USING btree (a, b) INCLUDE (c, d);")
+
+			expectedIndex := backup.IndexDefinition{Oid: 0, Name: "table_with_index_idx", OwningSchema: "public", OwningTable: "table_with_index", Def: sql.NullString{String: "CREATE UNIQUE INDEX table_with_index_idx ON public.table_with_index USING btree (a, b) INCLUDE (c, d)", Valid: true}, IsClustered: false}
+
+			results := backup.GetIndexes(connectionPool)
+
+			Expect(results).To(HaveLen(1))
+			structmatcher.ExpectStructsToMatchExcluding(&expectedIndex, &results[0], "Oid")
+		})
 	})
 	Describe("GetRules", func() {
 		var (


### PR DESCRIPTION
- In GPDB 7+, we are able to non-key columns to
  a PRIMARY KEY or UNIQUE index/constraint. This
  should supposedly work in current gpbackup code
  where UNIQUE is covered by pg_get_indexdef()
  and PRIMARY KEY is covered by pg_get_constraintdef().
  This commit adds an integration test to make sure
  we have coverage.