### PR TITLE
Add session GUC idle_in_transaction_session_timeout to gpbackup connections

### DIFF
--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -73,6 +73,10 @@ func SetSessionGUCs(connNum int) {
 		connectionPool.MustExec("SET INTERVALSTYLE = POSTGRES", connNum)
 		connectionPool.MustExec("SET lock_timeout = 0", connNum)
 	}
+
+	if connectionPool.Version.AtLeast("7") {
+		connectionPool.MustExec("SET idle_in_transaction_session_timeout = 0", connNum)
+	}
 }
 
 func NewBackupConfig(dbName string, dbVersion string, backupVersion string, plugin string, timestamp string, opts options.Options) *history.BackupConfig {


### PR DESCRIPTION
- In GPDB 7+, a new GUC can terminate any session
  with an open transaction that has been idle for
  longer than the specified duration. We need to
  turn this off during gpbackup as a precaution.