### PR TITLE
`make install` should NOT call build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ build_linux :
 		env GOOS=linux GOARCH=amd64 $(GO_BUILD) -tags '$(RESTORE)' -o $(RESTORE) -ldflags "-X $(RESTORE_VERSION_STR)"
 		env GOOS=linux GOARCH=amd64 $(GO_BUILD) -tags '$(HELPER)' -o $(HELPER) -ldflags "-X $(HELPER_VERSION_STR)"
 
-install : build
+install :
 		cp $(BIN_DIR)/$(BACKUP) $(BIN_DIR)/$(RESTORE) $(GPHOME)/bin
 		@psql -X -t -d template1 -c 'select distinct hostname from gp_segment_configuration where content != -1' > /tmp/seg_hosts 2>/dev/null; \
 		if [ $$? -eq 0 ]; then \

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This will also attempt to copy `gpbackup_helper` to the greenplum segments (retr
 
 `make build_linux` and `make build_mac` are for cross compiling between macOS and Linux
 
-`make install_helper` will scp the `gpbackup_helper` binary (used with -single-data-file flag) to all hosts
+`make install` will scp the `gpbackup_helper` binary (used with -single-data-file flag) to all hosts
 
 ## Validation and code quality
 


### PR DESCRIPTION
 - We have three different build Makefile targets
   (build, debug, and build_linux). After building,
   calling the install target will first run the
   build target... which pretty much makes the build
   targets useless if you want to run the install target.


https://dp.ci.gpdb.pivotal.io/teams/main/pipelines/dev:gpbackup_install_remove_build - prod pipeline is green.