### PR TITLE
 Support index statistics for expression columns

### DIFF
--- a/integration/postdata_create_test.go
+++ b/integration/postdata_create_test.go
@@ -139,6 +139,21 @@ var _ = Describe("backup integration create statement tests", func() {
 
 			structmatcher.ExpectStructsToMatch(&resultIndex, &partitionIndex)
 		})
+		It("creates an index with statistics on expression columns", func() {
+			testutils.SkipIfBefore7(connectionPool)
+			indexes := []backup.IndexDefinition{{Oid: 0, Name: "testtable_index", OwningSchema: "public", OwningTable: "testtable", Def: sql.NullString{String: "CREATE INDEX testtable_index ON public.testtable USING btree (i, ((i + 1)), ((j * 2)))", Valid: true}, StatisticsColumns: "2,3", StatisticsValues: "5000,600"}}
+			backup.PrintCreateIndexStatements(backupfile, tocfile, indexes, indexMetadataMap)
+
+			//Create table whose columns we can index
+			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.testtable(i int, j int)")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.testtable")
+
+			testhelper.AssertQueryRuns(connectionPool, buffer.String())
+
+			resultIndexes := backup.GetIndexes(connectionPool)
+			Expect(resultIndexes).To(HaveLen(1))
+			structmatcher.ExpectStructsToMatchExcluding(&resultIndexes[0], &indexes[0], "Oid")
+		})
 	})
 	Describe("PrintCreateRuleStatements", func() {
 		var (

--- a/integration/postdata_queries_test.go
+++ b/integration/postdata_queries_test.go
@@ -229,6 +229,23 @@ PARTITION BY RANGE (date)
 			Expect(results).To(HaveLen(1))
 			structmatcher.ExpectStructsToMatchExcluding(&expectedIndex, &results[0], "Oid")
 		})
+		It("returns a slice of an index with statistics on expression columns", func() {
+			testutils.SkipIfBefore7(connectionPool)
+			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE public.simple_table(i int, j int, k int)")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE public.simple_table")
+			testhelper.AssertQueryRuns(connectionPool, "CREATE INDEX simple_table_idx1 ON public.simple_table(i, (i+100), (j * 8))")
+			testhelper.AssertQueryRuns(connectionPool, "ALTER INDEX public.simple_table_idx1 ALTER COLUMN 2 SET STATISTICS 400")
+			testhelper.AssertQueryRuns(connectionPool, "ALTER INDEX public.simple_table_idx1 ALTER COLUMN 3 SET STATISTICS 500")
+
+			index1 := backup.IndexDefinition{Oid: 0, Name: "simple_table_idx1", OwningSchema: "public", OwningTable: "simple_table", Def: sql.NullString{String: "CREATE INDEX simple_table_idx1 ON public.simple_table USING btree (i, ((i + 100)), ((j * 8)))", Valid: true}, StatisticsColumns: "2,3", StatisticsValues: "400,500"}
+
+			results := backup.GetIndexes(connectionPool)
+
+			Expect(results).To(HaveLen(1))
+			results[0].Oid = testutils.OidFromObjectName(connectionPool, "", "simple_table_idx1", backup.TYPE_INDEX)
+
+			structmatcher.ExpectStructsToMatchExcluding(&index1, &results[0], "Oid")
+		})
 	})
 	Describe("GetRules", func() {
 		var (


### PR DESCRIPTION
In postgres 12 with GPDB7, statistics can be used on index columns that are defined as an expression.
This PR captures extracts the additional catalog properties namely `StatisticsColumns` and `StatisticsValues` and uses it to generate the corresponding `ALTER INDEX` DDL statements to set index statistics

Postgres Reference:
postgres/postgres@e4fca461