### PR TITLE
Integration tests fix for Photon OS

### DIFF
--- a/integration/metadata_globals_create_test.go
+++ b/integration/metadata_globals_create_test.go
@@ -54,7 +54,8 @@ var _ = Describe("backup integration create statement tests", func() {
 			if connectionPool.Version.Before("6") {
 				db = backup.Database{Oid: 1, Name: "create_test_db", Tablespace: "pg_default", Encoding: "UTF8", Collate: "", CType: ""}
 			} else {
-				db = backup.Database{Oid: 1, Name: "create_test_db", Tablespace: "pg_default", Encoding: "UTF8", Collate: "en_US.utf-8", CType: "en_US.utf-8"}
+				locale := testutils.DefaultLocale()
+				db = backup.Database{Oid: 1, Name: "create_test_db", Tablespace: "pg_default", Encoding: "UTF8", Collate: locale, CType: locale}
 			}
 
 			backup.PrintCreateDatabaseStatement(backupfile, tocfile, emptyDB, db, emptyMetadataMap)

--- a/integration/metadata_globals_queries_test.go
+++ b/integration/metadata_globals_queries_test.go
@@ -1,6 +1,7 @@
 package integration
 
 import (
+	"fmt"
 	"github.com/greenplum-db/gp-common-go-libs/structmatcher"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup/backup"
@@ -57,8 +58,8 @@ var _ = Describe("backup integration tests", func() {
 				 * These values are slightly different between mac and linux
 				 * so we use a regexp to match them
 				 */
-				Expect(result.Collate).To(MatchRegexp("en_US.utf-?8"))
-				Expect(result.CType).To(MatchRegexp("en_US.utf-?8"))
+				Expect(result.Collate).To(MatchRegexp("(?i)en_US.utf-?8"))
+				Expect(result.CType).To(MatchRegexp("(?i)en_US.utf-?8"))
 			}
 		})
 	})
@@ -75,8 +76,9 @@ var _ = Describe("backup integration tests", func() {
 				testhelper.AssertQueryRuns(connectionPool, "CREATE DATABASE create_test_db ENCODING 'UTF8' TEMPLATE template0")
 				expectedDB = backup.Database{Oid: 1, Name: "create_test_db", Tablespace: "pg_default", Encoding: "UTF8", Collate: "", CType: ""}
 			} else {
-				testhelper.AssertQueryRuns(connectionPool, "CREATE DATABASE create_test_db ENCODING 'UTF8' LC_COLLATE 'en_US.utf-8' LC_CTYPE 'en_US.utf-8' TEMPLATE template0")
-				expectedDB = backup.Database{Oid: 1, Name: "create_test_db", Tablespace: "pg_default", Encoding: "UTF8", Collate: "en_US.utf-8", CType: "en_US.utf-8"}
+				locale := testutils.DefaultLocale()
+				testhelper.AssertQueryRuns(connectionPool, fmt.Sprintf("CREATE DATABASE create_test_db ENCODING 'UTF8' LC_COLLATE '%s' LC_CTYPE '%s' TEMPLATE template0", locale, locale))
+				expectedDB = backup.Database{Oid: 1, Name: "create_test_db", Tablespace: "pg_default", Encoding: "UTF8", Collate: locale, CType: locale}
 			}
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP DATABASE create_test_db")
 

--- a/testutils/functions.go
+++ b/testutils/functions.go
@@ -308,6 +308,14 @@ func DefaultACLWithGrantWithout(grantee string, objType string, revoke ...string
 	return defaultACL
 }
 
+func DefaultLocale() string {
+	defaultLocale, err := exec.Command("bash", "-c", "locale -a | grep -i en_US.utf.*8 | head -1").CombinedOutput()
+	if err != nil {
+		Fail(fmt.Sprintf("Error to find utf8 locale: %s\n", err))
+	}
+	return strings.TrimSpace(string(defaultLocale))
+}
+
 /*
  * Wrapper functions around gomega operators for ease of use in tests
  */


### PR DESCRIPTION
 -Photon OS has a known issue of having
  default locale available is "en_US.UTF-8".
  However some our integration tests assume
  that it's en_US.utf-8. This commet makes
  regexpr assumptions for collation and ctype
  case insensitive and introduces a function
  that is trying to find utf8 locale for
  current environment.