### PR TITLE
Support user-defined functions with EXECUTE ON INITPLAN

### DIFF
--- a/backup/predata_functions.go
+++ b/backup/predata_functions.go
@@ -68,6 +68,8 @@ func PrintFunctionModifiers(metadataFile *utils.FileWithByteCount, funcDef Funct
 		metadataFile.MustPrintf(" EXECUTE ON MASTER")
 	case "s":
 		metadataFile.MustPrintf(" EXECUTE ON ALL SEGMENTS")
+	case "i":
+		metadataFile.MustPrintf(" EXECUTE ON INITPLAN")
 	case "a": // Default case, don't print anything else
 	}
 	if funcDef.IsWindow {

--- a/backup/predata_functions_test.go
+++ b/backup/predata_functions_test.go
@@ -172,6 +172,11 @@ $_$`)
 					backup.PrintFunctionModifiers(backupfile, funcDef)
 					testhelper.ExpectRegexp(buffer, "EXECUTE ON ALL SEGMENTS")
 				})
+				It("print 'i' as EXECUTE ON INITPLAN", func() {
+					funcDef.ExecLocation = "i"
+					backup.PrintFunctionModifiers(backupfile, funcDef)
+					testhelper.ExpectRegexp(buffer, "EXECUTE ON INITPLAN")
+				})
 			})
 			Context("Cost cases", func() {
 				/*


### PR DESCRIPTION
In GPDB6.5, a new function execution location, INITPLAN, was added. The
value of the execute location was being correctly pulled from the
catalog pg_proc (proexeclocation == 'i') and just needed to be printed
out.

gpdb commit reference:
https://github.com/greenplum-db/gpdb/commit/a21ff23b615e5f9a7dd3b02d82fad86175b188ec

Co-authored-by: Kevin Yeap <kyeap@vmware.com>
Co-authored-by: Jimmy Yih <jyih@vmware.com>