### PR TITLE
Add replicate-backup test for ddboost

### DIFF
--- a/ci/scripts/ddboost-plugin-perf.bash
+++ b/ci/scripts/ddboost-plugin-perf.bash
@@ -11,6 +11,27 @@ set -e
 source env.sh
 
 # important: whitespace of yaml below is critical, do not change it
+cat << CONFIG > \${HOME}/ddboost_config.yaml
+executablepath: \${GPHOME}/bin/gpbackup_ddboost_plugin
+options:
+  hostname: ${DD_SOURCE_HOST}
+  username: ${DD_USER}
+  storage_unit: GPDB
+  directory: gpbackup_tests${GPDB_VERSION}
+  replication: "off"
+  replication_streams: 10
+  pgport: 5432
+  password: ${DD_PW}
+  remote_hostname: ${DD_DEST_HOST}
+  remote_username: ${DD_USER}
+  remote_storage_unit: GPDB
+  remote_directory: gpbackup_tests${GPDB_VERSION}
+  remote_password: ${DD_ENCRYPTED_PW}
+  remote_password_encryption: "on"
+  gpbackup_ddboost_plugin: 66706c6c6e677a6965796f68343365303133336f6c73366b316868326764
+CONFIG
+
+# important: whitespace of yaml below is critical, do not change it
 cat << CONFIG > \${HOME}/ddboost_config_replication.yaml
 executablepath: \${GPHOME}/bin/gpbackup_ddboost_plugin
 options:
@@ -18,13 +39,20 @@ options:
   username: ${DD_USER}
   storage_unit: GPDB
   directory: gpbackup_tests${GPDB_VERSION}
-  replication: off
+  replication: "on"
   pgport: 5432
   password: ${DD_PW}
+  remote_hostname: ${DD_DEST_HOST}
+  remote_username: ${DD_USER}
+  remote_storage_unit: GPDB
+  remote_directory: gpbackup_tests${GPDB_VERSION}
+  remote_password: ${DD_ENCRYPTED_PW}
+  remote_password_encryption: "on"
   gpbackup_ddboost_plugin: 66706c6c6e677a6965796f68343365303133336f6c73366b316868326764
 CONFIG
 
 pushd \${GOPATH}/src/github.com/greenplum-db/gpbackup/plugins
+./plugin_test_scale.sh \${GPHOME}/bin/gpbackup_ddboost_plugin \${HOME}/ddboost_config.yaml
 ./plugin_test_scale.sh \${GPHOME}/bin/gpbackup_ddboost_plugin \${HOME}/ddboost_config_replication.yaml
 popd
 
@@ -33,3 +61,4 @@ SCRIPT
 chmod +x /tmp/run_perf.bash
 scp /tmp/run_perf.bash mdw:
 ssh -t mdw "/home/gpadmin/run_perf.bash"
+ssh -t mdw "source env.sh && dropdb tpchdb"

--- a/ci/scripts/ddboost-plugin-tests.bash
+++ b/ci/scripts/ddboost-plugin-tests.bash
@@ -28,6 +28,28 @@ pushd gpbackup_ddboost_plugin
 make test
 
 # important: whitespace of yaml below is critical, do not change it
+cat << CONFIG > \${HOME}/ddboost_config.yaml
+executablepath: \${GPHOME}/bin/gpbackup_ddboost_plugin
+options:
+  hostname: ${DD_SOURCE_HOST}
+  username: ${DD_USER}
+  storage_unit: GPDB
+  directory: gpbackup_tests${GPDB_VERSION}
+  replication: "off"
+  replication_streams: 10
+  pgport: 5432
+  password: ${DD_ENCRYPTED_PW}
+  password_encryption: "on"
+  remote_hostname: ${DD_DEST_HOST}
+  remote_username: ${DD_USER}
+  remote_storage_unit: GPDB
+  remote_directory: gpbackup_tests${GPDB_VERSION}
+  remote_password: ${DD_ENCRYPTED_PW}
+  remote_password_encryption: "on"
+  gpbackup_ddboost_plugin: 66706c6c6e677a6965796f68343365303133336f6c73366b316868326764
+CONFIG
+
+# important: whitespace of yaml below is critical, do not change it
 cat << CONFIG > \${HOME}/ddboost_config_replication.yaml
 executablepath: \${GPHOME}/bin/gpbackup_ddboost_plugin
 options:
@@ -35,14 +57,14 @@ options:
   username: ${DD_USER}
   storage_unit: GPDB
   directory: gpbackup_tests${GPDB_VERSION}
-  replication: on
+  replication: "on"
   pgport: 5432
+  password: ${DD_ENCRYPTED_PW}
+  password_encryption: "on"
   remote_hostname: ${DD_DEST_HOST}
   remote_username: ${DD_USER}
   remote_storage_unit: GPDB
   remote_directory: gpbackup_tests${GPDB_VERSION}
-  password: ${DD_ENCRYPTED_PW}
-  password_encryption: "on"
   remote_password: ${DD_ENCRYPTED_PW}
   remote_password_encryption: "on"
   gpbackup_ddboost_plugin: 66706c6c6e677a6965796f68343365303133336f6c73366b316868326764
@@ -62,7 +84,9 @@ CONFIG
 
 pushd \${GOPATH}/src/github.com/greenplum-db/gpbackup/plugins
 
-./plugin_test_bench.sh \${GPHOME}/bin/gpbackup_ddboost_plugin \${HOME}/ddboost_config_replication.yaml \${HOME}/ddboost_config_replication_restore.yaml
+./plugin_test.sh \${GPHOME}/bin/gpbackup_ddboost_plugin \${HOME}/ddboost_config_replication.yaml \${HOME}/ddboost_config_replication_restore.yaml
+
+./plugin_test.sh \${GPHOME}/bin/gpbackup_ddboost_plugin \${HOME}/ddboost_config.yaml \${HOME}/ddboost_config_replication_restore.yaml
 
 # exercise boostfs, which is mounted at /data/gpdata/dd_dir
 pushd \${GOPATH}/src/github.com/greenplum-db/gpbackup

--- a/ci/scripts/s3-plugin-tests.bash
+++ b/ci/scripts/s3-plugin-tests.bash
@@ -28,7 +28,7 @@ options:
 CONFIG
 
   pushd ~/go/src/github.com/greenplum-db/gpbackup/plugins
-    ./plugin_test_bench.sh \${GPHOME}/bin/gpbackup_s3_plugin \${HOME}/s3_config.yaml
+    ./plugin_test.sh \${GPHOME}/bin/gpbackup_s3_plugin \${HOME}/s3_config.yaml
   popd
 SCRIPT
 

--- a/ci/scripts/setup-perf.bash
+++ b/ci/scripts/setup-perf.bash
@@ -86,6 +86,11 @@ aws s3 cp s3://${BUCKET}/benchmark/tpch/lineitem/${SCALE_FACTOR}/lineitem.tbl /d
 
 # Create tpch dataset
 createdb tpchdb
+
+# install pgcrypto; works for GPDB 5.22+ and 6+
+psql -d postgres -c "CREATE EXTENSION pgcrypto"
+psql -d tpchdb -c "CREATE EXTENSION pgcrypto"
+
 psql -d tpchdb -a -f lineitem.ddl
 gpload -f gpload.yml
 

--- a/end_to_end/plugin_test.go
+++ b/end_to_end/plugin_test.go
@@ -273,13 +273,13 @@ var _ = Describe("End to End plugin tests", func() {
 	})
 
 	Describe("Example Plugin", func() {
-		It("runs example_plugin.bash with plugin_test_bench", func() {
+		It("runs example_plugin.bash with plugin_test", func() {
 			if useOldBackupVersion {
 				Skip("This test is only needed for the latest backup version")
 			}
 			pluginsDir := fmt.Sprintf("%s/src/github.com/greenplum-db/gpbackup/plugins", os.Getenv("GOPATH"))
 			copyPluginToAllHosts(backupConn, fmt.Sprintf("%s/example_plugin.bash", pluginsDir))
-			command := exec.Command("bash", "-c", fmt.Sprintf("%s/plugin_test_bench.sh %s/example_plugin.bash %s/example_plugin_config.yaml", pluginsDir, pluginsDir, pluginsDir))
+			command := exec.Command("bash", "-c", fmt.Sprintf("%s/plugin_test.sh %s/example_plugin.bash %s/example_plugin_config.yaml", pluginsDir, pluginsDir, pluginsDir))
 			mustRunCommand(command)
 
 			_ = os.RemoveAll("/tmp/plugin_dest")

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -371,12 +371,12 @@ options:
 
 ## Verification using the gpbackup plugin API test bench
 
-We provide a test bench to ensure your plugin will work with gpbackup and gprestore. If the test bench succesfully runs your plugin, you can be confident that your plugin will work with the utilities. The test bench is located [here](https://github.com/greenplum-db/gpbackup/blob/master/plugins/plugin_test_bench.sh).
+We provide tests to ensure your plugin will work with gpbackup and gprestore. If the tests succesfully run your plugin, you can be confident that your plugin will work with the utilities. The tests are located [here](https://github.com/greenplum-db/gpbackup/blob/master/plugins/plugin_test.sh).
 
 Run the test bench script using:
 
 ```
-plugin_test_bench.sh [path_to_executable] [plugin_config] [optional_config_for_secondary_destination]
+plugin_test.sh [path_to_executable] [plugin_config] [optional_config_for_secondary_destination]
 ```
 
 This will individually test each command and run a backup and restore using your plugin. This suite will upload small amounts of data to your destination system (<1MB total)

--- a/plugins/plugin_test_scale.sh
+++ b/plugins/plugin_test_scale.sh
@@ -79,6 +79,21 @@ test_backup_and_restore_with_plugin() {
         exit 1
     fi
 
+    # if replication was off during backup, run gpbackup_manager replicate_backup to test replication
+    if [[ "$plugin" == *gpbackup_ddboost_plugin ]] && [[ "$plugin_config" == *ddboost_config.yaml ]]; then
+        echo
+        print_header "GPBACKUP_MANAGER replicate-backup [${timestamp}])"
+        print_time_exec "gpbackup_manager replicate-backup $timestamp --plugin-config $config &> $log_file"
+
+        if [ ! $? -eq 0 ]; then
+            echo "gpbackup_manager replicate-backup failed."
+            echo
+            cat $log_file
+            echo
+            exit 1
+        fi
+    fi
+
     # Run gprestore and check for error. If gprestore failed, call
     # plugin delete_backup to clean up and then exit with error.
     print_header "GPRESTORE $test_db (flags: [${restore_flags}])"
@@ -141,7 +156,6 @@ fi
 # Cleanup test artifacts
 # ----------------------------------------------
 echo "Cleaning up leftover test artifacts"
-dropdb tpchdb
 rm -r $logdir
 
 


### PR DESCRIPTION
 - We have replicate-backup command for ddboost plugin
   and gpbackup_manager, but it was only tested manually.
   This commit adds automated tests for this commad.