### PR TITLE
Quote table names for exclude relation filter.

### DIFF
--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -24,7 +24,10 @@ func relationAndSchemaFilterClause() string {
 	}
 	filterRelationClause = SchemaFilterClause("n")
 	if len(MustGetFlagStringArray(options.EXCLUDE_RELATION)) > 0 {
-		excludeOids := getOidsFromRelationList(connectionPool, MustGetFlagStringArray(options.EXCLUDE_RELATION))
+		quotedExcludeRelations, err := options.QuoteTableNames(connectionPool, MustGetFlagStringArray(options.EXCLUDE_RELATION))
+		gplog.FatalOnError(err)
+
+		excludeOids := getOidsFromRelationList(connectionPool, quotedExcludeRelations)
 		if len(excludeOids) > 0 {
 			filterRelationClause += fmt.Sprintf("\nAND c.oid NOT IN (%s)", strings.Join(excludeOids, ", "))
 		}

--- a/integration/predata_relations_queries_test.go
+++ b/integration/predata_relations_queries_test.go
@@ -121,8 +121,11 @@ PARTITION BY LIST (gender)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP SCHEMA testschema")
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE testschema.foo(i int)")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE testschema.foo")
+			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE testschema.\"user\"(i int)")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE testschema.\"user\"")
 
 			_ = backupCmdFlags.Set(options.EXCLUDE_RELATION, "testschema.foo")
+			_ = backupCmdFlags.Set(options.EXCLUDE_RELATION, "testschema.user")
 			tables := backup.GetIncludedUserTableRelations(connectionPool, []string{})
 
 			tableFoo := backup.Relation{Schema: "public", Name: "foo"}
@@ -139,9 +142,12 @@ PARTITION BY LIST (gender)
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE testschema.foo")
 			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE testschema.bar(i int)")
 			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE testschema.bar")
+			testhelper.AssertQueryRuns(connectionPool, "CREATE TABLE testschema.\"user\"(i int)")
+			defer testhelper.AssertQueryRuns(connectionPool, "DROP TABLE testschema.\"user\"")
 
 			_ = backupCmdFlags.Set(options.INCLUDE_SCHEMA, "testschema")
 			_ = backupCmdFlags.Set(options.EXCLUDE_RELATION, "testschema.foo")
+			_ = backupCmdFlags.Set(options.EXCLUDE_RELATION, "testschema.user")
 			tables := backup.GetIncludedUserTableRelations(connectionPool, []string{})
 
 			tableFoo := backup.Relation{Schema: "testschema", Name: "bar"}


### PR DESCRIPTION
Include relation filter first quotes table names before fetching OIDs from the DB. This step was missing in exclude relation filter, which made exclusion of tables, where table name or schema name was a reserved word, impossible.

Also modified two tests I found that would suffer from this behavior.