### PR TITLE
Properly handle postdata metadata for parallel postdata restore

### DIFF
--- a/backup/postdata.go
+++ b/backup/postdata.go
@@ -20,7 +20,10 @@ func PrintCreateIndexStatements(metadataFile *utils.FileWithByteCount, toc *toc.
 			metadataFile.MustPrintf("\n\n%s;", index.Def.String)
 			toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 
+			// Start INDEX metadata
 			indexFQN := utils.MakeFQN(index.OwningSchema, index.Name)
+			entry.ReferenceObject = indexFQN
+			entry.ObjectType = "INDEX METADATA"
 			if index.Tablespace != "" {
 				start := metadataFile.ByteCount
 				metadataFile.MustPrintf("\nALTER INDEX %s SET TABLESPACE %s;", indexFQN, index.Tablespace)
@@ -78,6 +81,9 @@ func PrintCreateEventTriggerStatements(metadataFile *utils.FileWithByteCount, to
 		metadataFile.MustPrintf("\nEXECUTE PROCEDURE %s();", eventTrigger.FunctionName)
 		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 
+		// Start EVENT TRIGGER metadata
+		entry.ReferenceObject = eventTrigger.Name
+		entry.ObjectType = "EVENT TRIGGER METADATA"
 		if eventTrigger.Enabled != "O" {
 			var enableOption string
 			switch eventTrigger.Enabled {

--- a/backup/predata_acl.go
+++ b/backup/predata_acl.go
@@ -62,6 +62,19 @@ func PrintStatements(metadataFile *utils.FileWithByteCount, toc *toc.TOC,
 		start := metadataFile.ByteCount
 		metadataFile.MustPrintf("\n\n%s\n", statement)
 		section, entry := obj.GetMetadataEntry()
+
+		/*
+		 * Postdata metadata needs to be specifically marked as such to
+		 * help with gprestore postdata parallel restore (--jobs).
+		 */
+		if section == "postdata" {
+			entry.ObjectType = fmt.Sprintf("%s METADATA", entry.ObjectType)
+			if entry.Schema != "" {
+				entry.ReferenceObject = utils.MakeFQN(entry.Schema, entry.Name)
+			} else {
+				entry.ReferenceObject = entry.Name
+			}
+		}
 		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
 	}
 }

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -1490,4 +1490,62 @@ var _ = Describe("backup and restore end to end tests", func() {
 			"--metadata-only")
 		assertRelationsCreated(restoreConn, 4)
 	})
+	It("runs gprestore with jobs flag and postdata has metadata", func() {
+		if useOldBackupVersion {
+			Skip("This test is not needed for old backup versions")
+		}
+
+		if backupConn.Version.Before("6") {
+			testhelper.AssertQueryRuns(backupConn, "CREATE TABLESPACE test_tablespace FILESPACE test_dir")
+		} else {
+			testhelper.AssertQueryRuns(backupConn, "CREATE TABLESPACE test_tablespace LOCATION '/tmp/test_dir';")
+		}
+		defer testhelper.AssertQueryRuns(backupConn, "DROP TABLESPACE test_tablespace;")
+
+		// Store everything in this test schema for easy test cleanup.
+		testhelper.AssertQueryRuns(backupConn, "CREATE SCHEMA postdata_metadata;")
+		defer testhelper.AssertQueryRuns(backupConn, "DROP SCHEMA postdata_metadata CASCADE;")
+		defer testhelper.AssertQueryRuns(restoreConn, "DROP SCHEMA postdata_metadata CASCADE;")
+
+		// Create a table and indexes. Currently for indexes, there are 4 possible pieces
+		// of metadata: TABLESPACE, CLUSTER, REPLICA IDENTITY, and COMMENT.
+		testhelper.AssertQueryRuns(backupConn, "CREATE TABLE postdata_metadata.foobar (a int NOT NULL);")
+		testhelper.AssertQueryRuns(backupConn, "CREATE INDEX fooidx1 ON postdata_metadata.foobar USING btree(a) TABLESPACE test_tablespace;")
+		testhelper.AssertQueryRuns(backupConn, "CREATE INDEX fooidx2 ON postdata_metadata.foobar USING btree(a) TABLESPACE test_tablespace;")
+		testhelper.AssertQueryRuns(backupConn, "CREATE UNIQUE INDEX fooidx3 ON postdata_metadata.foobar USING btree(a) TABLESPACE test_tablespace;")
+		testhelper.AssertQueryRuns(backupConn, "COMMENT ON INDEX postdata_metadata.fooidx1 IS 'hello';")
+		testhelper.AssertQueryRuns(backupConn, "COMMENT ON INDEX postdata_metadata.fooidx2 IS 'hello';")
+		testhelper.AssertQueryRuns(backupConn, "COMMENT ON INDEX postdata_metadata.fooidx3 IS 'hello';")
+		testhelper.AssertQueryRuns(backupConn, "ALTER TABLE postdata_metadata.foobar CLUSTER ON fooidx3;")
+		if backupConn.Version.AtLeast("6") {
+			testhelper.AssertQueryRuns(backupConn, "ALTER TABLE postdata_metadata.foobar REPLICA IDENTITY USING INDEX fooidx3")
+		}
+
+		// Create a rule. Currently for rules, the only metadata is COMMENT.
+		testhelper.AssertQueryRuns(backupConn, "CREATE RULE postdata_rule AS ON UPDATE TO postdata_metadata.foobar DO SELECT * FROM postdata_metadata.foobar;")
+		testhelper.AssertQueryRuns(backupConn, "COMMENT ON RULE postdata_rule IS 'hello';")
+
+		// Create a trigger. Currently for triggers, the only metadata is COMMENT.
+		testhelper.AssertQueryRuns(backupConn, `CREATE TRIGGER postdata_trigger AFTER INSERT OR DELETE OR UPDATE ON postdata_metadata.foobar FOR EACH STATEMENT EXECUTE PROCEDURE pg_catalog."RI_FKey_check_ins"();`)
+		testhelper.AssertQueryRuns(backupConn, "COMMENT ON TRIGGER postdata_trigger ON postdata_metadata.foobar IS 'hello';")
+
+		// Create an event trigger. Currently for event triggers, there are 2 possible
+		// pieces of metadata: ENABLE and COMMENT.
+		if backupConn.Version.AtLeast("6") {
+			testhelper.AssertQueryRuns(backupConn, "CREATE OR REPLACE FUNCTION postdata_metadata.postdata_eventtrigger_func() RETURNS event_trigger AS $$ BEGIN END $$ LANGUAGE plpgsql;")
+			testhelper.AssertQueryRuns(backupConn, "CREATE EVENT TRIGGER postdata_eventtrigger ON sql_drop EXECUTE PROCEDURE postdata_metadata.postdata_eventtrigger_func();")
+			testhelper.AssertQueryRuns(backupConn, "ALTER EVENT TRIGGER postdata_eventtrigger DISABLE;")
+			testhelper.AssertQueryRuns(backupConn, "COMMENT ON EVENT TRIGGER postdata_eventtrigger IS 'hello'")
+		}
+
+		timestamp := gpbackup(gpbackupPath, backupHelperPath,
+			"--metadata-only")
+		output := gprestore(gprestorePath, restoreHelperPath, timestamp,
+			"--redirect-db", "restoredb", "--jobs", "8", "--verbose")
+
+		// The gprestore parallel postdata restore should have succeeded without a CRITICAL error.
+		stdout := string(output)
+		Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
+		Expect(stdout).To(Not(ContainSubstring("Error encountered when executing statement")))
+	})
 })

--- a/restore/parallel_test.go
+++ b/restore/parallel_test.go
@@ -10,28 +10,37 @@ import (
 
 var _ = Describe("restore/parallel tests", func() {
 	Describe("BatchPostdataStatements", func() {
-		index1 := toc.StatementWithType{ObjectType: "INDEX", ReferenceObject: "public.table1", Statement: `CREATE INDEX testindex ON public.testtable USING btree(i);`}
-		index2 := toc.StatementWithType{ObjectType: "INDEX", ReferenceObject: "public.table2", Statement: `CREATE INDEX testindex ON public.testtable USING btree(i);`}
-		index3 := toc.StatementWithType{ObjectType: "INDEX", ReferenceObject: "public.table3", Statement: `CREATE INDEX testindex ON public.testtable USING btree(i);`}
-		trigger := toc.StatementWithType{ObjectType: "TRIGGER", ReferenceObject: "public.table3", Statement: `CREATE INDEX testindex ON public.testtable USING btree(i);`}
+		index1 := toc.StatementWithType{ObjectType: "INDEX", ReferenceObject: "public.table1", Statement: `CREATE INDEX testindex1 ON public.table1 USING btree(i);`}
+		index2 := toc.StatementWithType{ObjectType: "INDEX", ReferenceObject: "public.table2", Statement: `CREATE INDEX testindex2 ON public.table2 USING btree(i);`}
+		index3 := toc.StatementWithType{ObjectType: "INDEX", ReferenceObject: "public.table3", Statement: `CREATE INDEX testindex3 ON public.table3 USING btree(i);`}
+		index2_comment := toc.StatementWithType{ObjectType: "INDEX METADATA", ReferenceObject: "public.testindex2", Statement: `COMMENT ON INDEX public.testindex2 IS 'hello';`}
+		index2_tablespace := toc.StatementWithType{ObjectType: "INDEX METADATA", ReferenceObject: "public.testindex2", Statement: `ALTER INDEX public.testindex2 SET TABLESPACE footblspc;`}
+		trigger := toc.StatementWithType{ObjectType: "TRIGGER", ReferenceObject: "public.table3", Statement: `CREATE TRIGGER footrigger AFTER INSERT ON table1 FOR EACH STATEMENT EXECUTE PROCEDURE fooproc();`}
+		trigger_comment := toc.StatementWithType{ObjectType: "TRIGGER METADATA", ReferenceObject: "footrigger", Statement: `COMMENT ON TRIGGER footrigger ON table1 IS 'hello'`}
 		It("places all indexes in first batch when all are on different tables", func() {
 			statements := []toc.StatementWithType{index1, index2, index3}
-			firstBatch, secondBatch := restore.BatchPostdataStatements(statements)
+			firstBatch, secondBatch, _ := restore.BatchPostdataStatements(statements)
 			Expect(firstBatch).To(Equal([]toc.StatementWithType{index1, index2, index3}))
 			Expect(secondBatch).To(Equal([]toc.StatementWithType{}))
 		})
 		It("places first index for a table in first batch, and other indexes for that table in second", func() {
 			statements := []toc.StatementWithType{index1, index2, index2, index2, index3, index3}
-			firstBatch, secondBatch := restore.BatchPostdataStatements(statements)
+			firstBatch, secondBatch, _ := restore.BatchPostdataStatements(statements)
 			Expect(firstBatch).To(Equal([]toc.StatementWithType{index1, index2, index3}))
 			Expect(secondBatch).To(Equal([]toc.StatementWithType{index2, index2, index3}))
 		})
 		It("places non-index objects in second batch", func() {
 			statements := []toc.StatementWithType{index1, index1, trigger}
-			firstBatch, secondBatch := restore.BatchPostdataStatements(statements)
+			firstBatch, secondBatch, _ := restore.BatchPostdataStatements(statements)
 			Expect(firstBatch).To(Equal([]toc.StatementWithType{index1}))
 			Expect(secondBatch).To(Equal([]toc.StatementWithType{index1, trigger}))
 		})
-
+		It("places postdata metadata in third batch", func() {
+			statements := []toc.StatementWithType{index1, index2, index3, index2_comment, index2_tablespace, trigger, trigger_comment}
+			firstBatch, secondBatch, thirdBatch := restore.BatchPostdataStatements(statements)
+			Expect(firstBatch).To(Equal([]toc.StatementWithType{index1, index2, index3}))
+			Expect(secondBatch).To(Equal([]toc.StatementWithType{trigger}))
+			Expect(thirdBatch).To(Equal([]toc.StatementWithType{index2_comment, index2_tablespace, trigger_comment}))
+		})
 	})
 })

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -396,11 +396,12 @@ func restorePostdata(metadataFilename string) {
 
 	statements := GetRestoreMetadataStatementsFiltered("postdata", metadataFilename, []string{}, []string{}, filters)
 	editStatementsRedirectSchema(statements, opts.RedirectSchema)
-	firstBatch, secondBatch := BatchPostdataStatements(statements)
+	firstBatch, secondBatch, thirdBatch := BatchPostdataStatements(statements)
 	progressBar := utils.NewProgressBar(len(statements), "Post-data objects restored: ", utils.PB_VERBOSE)
 	progressBar.Start()
 	ExecuteRestoreMetadataStatements(firstBatch, "", progressBar, utils.PB_VERBOSE, connectionPool.NumConns > 1)
 	ExecuteRestoreMetadataStatements(secondBatch, "", progressBar, utils.PB_VERBOSE, connectionPool.NumConns > 1)
+	ExecuteRestoreMetadataStatements(thirdBatch, "", progressBar, utils.PB_VERBOSE, connectionPool.NumConns > 1)
 	progressBar.Finish()
 	if wasTerminated {
 		gplog.Info("Post-data metadata restore incomplete")


### PR DESCRIPTION
Postdata metadata (e.g. ALTER INDEX, ALTER EVENT TRIGGER, COMMENT ON)
was not being handled for parallel postdata restore. There was no
dependency information stored in the backup TOC file and gprestore had
no logic to handle postdata object dependencies. This would result in
"does not exist" errors when the postdata metadata SQL statements were
being executed before their dependent postdata objects were finished
being created.

To fix this issue, we now specifically identify postdata metadata in
the backup TOC file during gpbackup. When gprestore with --jobs flag
is specified, the postdata metadata is filtered into a third batch of
SQL statements which are executed after the postdata objects are
created in the second batch postdata execution.

Reported by user cobolbaby:
https://github.com/greenplum-db/gpbackup/issues/494