### PR TITLE
Gprestore --redirect-schema works with --metadata-only

### DIFF
--- a/end_to_end/incremental_test.go
+++ b/end_to_end/incremental_test.go
@@ -478,7 +478,7 @@ EOF1`, backupDir)
 				output, err := cmd.CombinedOutput()
 				Expect(err).To(HaveOccurred())
 				Expect(string(output)).To(ContainSubstring(
-					"The following flags may not be specified together: truncate-table, metadata-only, incremental, redirect-schema"))
+					"The following flags may not be specified together: truncate-table, metadata-only, incremental"))
 			})
 		})
 		Context("No DDL no partitioning", func() {

--- a/restore/validate.go
+++ b/restore/validate.go
@@ -259,6 +259,8 @@ func ValidateFlagCombinations(flags *pflag.FlagSet) {
 
 	options.CheckExclusiveFlags(flags, options.METADATA_ONLY, options.DATA_ONLY)
 	options.CheckExclusiveFlags(flags, options.PLUGIN_CONFIG, options.BACKUP_DIR)
+	options.CheckExclusiveFlags(flags, options.TRUNCATE_TABLE, options.METADATA_ONLY, options.INCREMENTAL)
+	options.CheckExclusiveFlags(flags, options.TRUNCATE_TABLE, options.REDIRECT_SCHEMA)
 
 	if flags.Changed(options.REDIRECT_SCHEMA) {
 		// Redirect schema not compatible with any exclude flags and include schema flags
@@ -272,8 +274,6 @@ func ValidateFlagCombinations(flags *pflag.FlagSet) {
 			gplog.Fatal(errors.Errorf("Cannot use --redirect-schema without --include-table or --include-table-file"), "")
 		}
 	}
-	options.CheckExclusiveFlags(flags,
-		options.TRUNCATE_TABLE, options.METADATA_ONLY, options.INCREMENTAL, options.REDIRECT_SCHEMA)
 	if flags.Changed(options.TRUNCATE_TABLE) &&
 		!(flags.Changed(options.INCLUDE_RELATION) || flags.Changed(options.INCLUDE_RELATION_FILE)) &&
 		!flags.Changed(options.DATA_ONLY) {


### PR DESCRIPTION
 - Validation has been changed to make --redirect-schema
   and --metadata-only flags working together for gprestore.

Authored-by: Kate Dontsova <edontsova@pivotal.io>