### PR TITLE
Set xmloption session GUC to content for GPDB 6+

### DIFF
--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -92,6 +92,7 @@ SET default_with_oids = off;
 		setupQuery += "SET allow_system_table_mods = true;\n"
 		setupQuery += "SET lock_timeout = 0;\n"
 		setupQuery += "SET default_transaction_read_only = off;\n"
+		setupQuery += "SET xmloption = content;\n"
 
 		// If the backup is from a GPDB version less than 6.0,
 		// we need to use legacy hash operators when restoring


### PR DESCRIPTION
This fix makes it so that XML document data can be restored when the
xmloption GUC is set to content. The xmloption GUC can be interchanged
in sessions between content and document, but cannot reliably do so
during restore. Postgres introduced the fix specifically for
dump/restore operations.

reference commits:
https://github.com/greenplum-db/gpdb/commit/78f84fe0f478142c490dcffd5eb46704b0131b9e
https://github.com/postgres/postgres/commit/8ba485422933e0ae48e8c4e1686ea59cfab75111