### PR TITLE
Output proper gprestore --on-error-continue step completion messages

### DIFF
--- a/restore/data.go
+++ b/restore/data.go
@@ -84,11 +84,11 @@ func CheckRowsRestored(rowsRestored int64, rowsBackedUp int64, tableName string)
 }
 
 func restoreDataFromTimestamp(fpInfo filepath.FilePathInfo, dataEntries []toc.MasterDataEntry,
-	gucStatements []toc.StatementWithType, dataProgressBar utils.ProgressBar) {
+	gucStatements []toc.StatementWithType, dataProgressBar utils.ProgressBar) int32 {
 	totalTables := len(dataEntries)
 	if totalTables == 0 {
 		gplog.Verbose("No data to restore for timestamp = %s", fpInfo.Timestamp)
-		return
+		return 0
 	}
 
 	if backupConfig.SingleDataFile {
@@ -102,7 +102,7 @@ func restoreDataFromTimestamp(fpInfo filepath.FilePathInfo, dataEntries []toc.Ma
 		firstOid := fmt.Sprintf("%d", dataEntries[0].Oid)
 		utils.CreateFirstSegmentPipeOnAllHosts(firstOid, globalCluster, fpInfo)
 		if wasTerminated {
-			return
+			return 0
 		}
 		isFilter := false
 		if len(opts.IncludedRelations) > 0 || len(opts.ExcludedRelations) > 0 || len(opts.IncludedSchemas) > 0 || len(opts.ExcludedSchemas) > 0 {
@@ -187,4 +187,6 @@ func restoreDataFromTimestamp(fpInfo filepath.FilePathInfo, dataEntries []toc.Ma
 		fmt.Println("")
 		gplog.Error("Encountered %d error(s) during table data restore; see log file %s for a list of table errors.", numErrors, gplog.GetLogFilePath())
 	}
+
+	return numErrors
 }

--- a/restore/parallel.go
+++ b/restore/parallel.go
@@ -50,7 +50,7 @@ func executeStatementsForConn(statements chan toc.StatementWithType, fatalErr *e
  * This function creates a worker pool of N goroutines to be able to execute up
  * to N statements in parallel.
  */
-func ExecuteStatements(statements []toc.StatementWithType, progressBar utils.ProgressBar, executeInParallel bool, whichConn ...int) {
+func ExecuteStatements(statements []toc.StatementWithType, progressBar utils.ProgressBar, executeInParallel bool, whichConn ...int) int32 {
 	var workerPool sync.WaitGroup
 	var fatalErr error
 	var numErrors int32
@@ -81,13 +81,17 @@ func ExecuteStatements(statements []toc.StatementWithType, progressBar utils.Pro
 		fmt.Println("")
 		gplog.Error("Encountered %d errors during metadata restore; see log file %s for a list of failed statements.", numErrors, gplog.GetLogFilePath())
 	}
+
+	return numErrors
 }
 
-func ExecuteStatementsAndCreateProgressBar(statements []toc.StatementWithType, objectsTitle string, showProgressBar int, executeInParallel bool, whichConn ...int) {
+func ExecuteStatementsAndCreateProgressBar(statements []toc.StatementWithType, objectsTitle string, showProgressBar int, executeInParallel bool, whichConn ...int) int32 {
 	progressBar := utils.NewProgressBar(len(statements), fmt.Sprintf("%s restored: ", objectsTitle), showProgressBar)
 	progressBar.Start()
-	ExecuteStatements(statements, progressBar, executeInParallel, whichConn...)
+	numErrors := ExecuteStatements(statements, progressBar, executeInParallel, whichConn...)
 	progressBar.Finish()
+
+	return numErrors
 }
 
 /*

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -277,12 +277,15 @@ func GetRestoreMetadataStatementsFiltered(section string, filename string, inclu
 	return statements
 }
 
-func ExecuteRestoreMetadataStatements(statements []toc.StatementWithType, objectsTitle string, progressBar utils.ProgressBar, showProgressBar int, executeInParallel bool) {
+func ExecuteRestoreMetadataStatements(statements []toc.StatementWithType, objectsTitle string, progressBar utils.ProgressBar, showProgressBar int, executeInParallel bool) int32 {
+	var numErrors int32
 	if progressBar == nil {
-		ExecuteStatementsAndCreateProgressBar(statements, objectsTitle, showProgressBar, executeInParallel)
+		numErrors = ExecuteStatementsAndCreateProgressBar(statements, objectsTitle, showProgressBar, executeInParallel)
 	} else {
-		ExecuteStatements(statements, progressBar, executeInParallel)
+		numErrors = ExecuteStatements(statements, progressBar, executeInParallel)
 	}
+
+	return numErrors
 }
 
 func GetBackupFPInfoListFromRestorePlan() []filepath.FilePathInfo {


### PR DESCRIPTION
When gprestore --on-error-continue fails at a particular step
(e.g. pre-data metadata restore, data restore, post-data metadata
restore, etc.), we output the step is simply complete. Instead, we
should output that the step completed with failures.

Example gprestore --on-error-continue pre-data metadata restore failure:
Before: "Pre-data metadata restore complete"
After: "Pre-data metadata restore completed with failures"