### PR TITLE
Make gprestore to inform helpers to skip the table

### DIFF
--- a/restore/data.go
+++ b/restore/data.go
@@ -159,6 +159,10 @@ func restoreDataFromTimestamp(fpInfo filepath.FilePathInfo, dataEntries []toc.Ma
 					if !MustGetFlagBool(options.ON_ERROR_CONTINUE) {
 						dataProgressBar.(*pb.ProgressBar).NotPrint = true
 						return
+					} else {
+						// inform segment helpers to skip this entry
+						gplog.Info(fmt.Sprintf("Error encoutered to restore entry %d (%s)", entry.Oid, tableName))
+						utils.CreateSkipFileOnSegments(fmt.Sprintf("%d", entry.Oid), globalCluster, globalFPInfo)
 					}
 					mutex.Lock()
 					errorTablesData[tableName] = Empty{}


### PR DESCRIPTION
 - When we restore with --single-data-file we have a named
   pipe between data file and COPY. If COPY fails before
   pipe was opened for writing - the attempt to open the pipe
   will be blocked waiting forever for someone to read on the
   other end. If --on-error-continue is specified - another COPY
   command will be launched, but it would not get a pipe to read from
   bacause helpers are blocked on the previous one.

   To prevent this we need some form of communication between gprestore
   and gpbackup_helpers. The solution implemented in this commit
   is when gprestore needs to skip the table because it errored out and
   has --on-error-continue - it creates skip file with oid of the object
   to skip and copies it to all segments. Then on helper side on segment
   we have goroutine that checks for skip file on interval and if this
   happens - we setup an error and go to the next loop if we have
   --on-error-continue instead of waiting forever on the old pipe.

Authored-by: Kate Dontsova <edontsova@pivotal.io>