### PR TITLE
Quote table names for gprestore exclude relation filter

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -259,6 +259,16 @@ func (o *Options) QuoteIncludeRelations(conn *dbconn.DBConn) error {
 	return nil
 }
 
+func (o *Options) QuoteExcludeRelations(conn *dbconn.DBConn) error {
+	var err error
+	o.ExcludedRelations, err = QuoteTableNames(conn, o.GetExcludedTables())
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (o Options) getUserTableRelationsWithIncludeFiltering(connectionPool *dbconn.DBConn, includedRelationsQuoted []string) ([]FqnStruct, error) {
 	includeOids, err := getOidsFromRelationList(connectionPool, includedRelationsQuoted)
 	if err != nil {

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -66,6 +66,9 @@ func DoSetup() {
 	err = opts.QuoteIncludeRelations(connectionPool)
 	gplog.FatalOnError(err)
 
+	err = opts.QuoteExcludeRelations(connectionPool)
+	gplog.FatalOnError(err)
+
 	segConfig := cluster.MustGetSegmentConfiguration(connectionPool)
 	globalCluster = cluster.NewCluster(segConfig)
 	segPrefix := filepath.ParseSegPrefix(MustGetFlagString(options.BACKUP_DIR), backupTimestamp)


### PR DESCRIPTION
When using the exclusion filters with gprestore, we were not properly
quoting the excluded tables (e.g. for table names that have special
characters or are keywords). The tables would bypass the exclusion
filter and get unexpectedly restored. To fix this issue, simply quote
the user-given tables in the exclusion filter similar to how we handle
the inclusion filter.

This was discovered while reviewing
https://github.com/greenplum-db/gpbackup/pull/500. In that PR, github
user tm-drtina only handled the issue for gpbackup.  This commit
handles the issue for gprestore.