### PR TITLE
COPY communicates with helper through non-blocking pipe

### DIFF
--- a/helper/helper.go
+++ b/helper/helper.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"path/filepath"
 
 	"golang.org/x/sys/unix"
 
@@ -86,7 +87,7 @@ func DoHelper() {
 		err = doRestoreAgent()
 	}
 	if err != nil {
-		gplog.Error(fmt.Sprintf("%v: %s", err, debug.Stack()))
+		logError(fmt.Sprintf("%v: %s", err, debug.Stack()))
 		handle, _ := utils.OpenFileForWrite(fmt.Sprintf("%s_error", *pipeFile))
 		_ = handle.Close()
 	}
@@ -196,6 +197,14 @@ func DoCleanup() {
 	err = utils.RemoveFileIfExists(nextPipe)
 	if err != nil {
 		log("Encountered error during cleanup: %v", err)
+	}
+
+	skipFiles, _ := filepath.Glob(fmt.Sprintf("%s_skip_*", *pipeFile))
+	for _, skipFile := range skipFiles {
+		err = utils.RemoveFileIfExists(skipFile)
+		if err != nil {
+			log("Encountered error during cleanup skip files: %v", err)
+		}
 	}
 	log("Cleanup complete")
 }

--- a/restore/data.go
+++ b/restore/data.go
@@ -159,6 +159,10 @@ func restoreDataFromTimestamp(fpInfo filepath.FilePathInfo, dataEntries []toc.Ma
 					if !MustGetFlagBool(options.ON_ERROR_CONTINUE) {
 						dataProgressBar.(*pb.ProgressBar).NotPrint = true
 						return
+					} else {
+						// inform segment helpers to skip this entry
+						gplog.Info(fmt.Sprintf("Error encoutered to restore entry %d (%s)", entry.Oid, tableName))
+						utils.CreateSkipFileOnSegments(fmt.Sprintf("%d", entry.Oid), globalCluster, globalFPInfo)
 					}
 					mutex.Lock()
 					errorTablesData[tableName] = Empty{}

--- a/utils/agent_remote.go
+++ b/utils/agent_remote.go
@@ -219,3 +219,12 @@ func CheckAgentErrorsOnSegments(c *cluster.Cluster, fpInfo filepath.FilePathInfo
 	}
 	return nil
 }
+
+func CreateSkipFileOnSegments(oid string, c *cluster.Cluster, fpInfo filepath.FilePathInfo) {
+	remoteOutput := c.GenerateAndExecuteCommand("Touch skip file", cluster.ON_SEGMENTS, func(contentID int) string {
+		return fmt.Sprintf("touch %s_skip_%s", fpInfo.GetSegmentPipeFilePath(contentID), oid)
+	})
+	c.CheckClusterError(remoteOutput, "Error while touching skip file", func(contentID int) string {
+		return fmt.Sprintf("Could not create skip file %s_skip_%s", fpInfo.GetSegmentPipeFilePath(contentID), oid)
+	})
+}


### PR DESCRIPTION
- When we restore with --single-data-file, we write data from the data file to a pipe, and then
   the COPY command reads from this pipe to load data to the database.
   The way we open pipe is blocking - that means opening it for writing would be blocked until
   the reader opens it. If COPY (reader) fails for whatever reason - gpbackup_helper (writer)
   will be blocked opening the pipe.
   If --on-error-continue is specified - another COPY command will be launched,
   but it would not get a pipe to read from because helpers are blocked on the previous one.

 - To prevent this, when an error occurs and we have --on-error-continue, gprestore will
   create skip_oid file on every segment to inform gpbackup-helpers to also skip the table.
   On segments, gpbackup_helper (writer) will now keep trying to open the pipe in non-blocking mode (syscall.O_NONBLOCK)
   and check if gets back the specific syscall.ENXIO error (meaning that the COPY (reader)
   are not ready to consume from it yet). When getting this error gpbackup_helper will try
   to discover a skip file for the current table to check if we are in the
   "error on restore + --on-error-continue" scenario and skip the pipe for the specific table if needed.