### PR TITLE
Allow --redirect-schema to work with included schemas

### DIFF
--- a/restore/validate.go
+++ b/restore/validate.go
@@ -263,15 +263,15 @@ func ValidateFlagCombinations(flags *pflag.FlagSet) {
 	options.CheckExclusiveFlags(flags, options.TRUNCATE_TABLE, options.REDIRECT_SCHEMA)
 
 	if flags.Changed(options.REDIRECT_SCHEMA) {
-		// Redirect schema not compatible with any exclude flags and include schema flags
+		// Redirect schema not compatible with any exclude flags
 		if flags.Changed(options.EXCLUDE_SCHEMA) || flags.Changed(options.EXCLUDE_SCHEMA_FILE) ||
-			flags.Changed(options.EXCLUDE_RELATION) || flags.Changed(options.EXCLUDE_RELATION_FILE) ||
-			flags.Changed(options.INCLUDE_SCHEMA) || flags.Changed(options.INCLUDE_SCHEMA_FILE) {
-			gplog.Fatal(errors.Errorf("Cannot use --redirect-schema with exclude flags or include schema flags"), "")
+			flags.Changed(options.EXCLUDE_RELATION) || flags.Changed(options.EXCLUDE_RELATION_FILE) {
+			gplog.Fatal(errors.Errorf("Cannot use --redirect-schema with exclude flags"), "")
 		}
-		// Redirect schema requires include relation
-		if !(flags.Changed(options.INCLUDE_RELATION) || flags.Changed(options.INCLUDE_RELATION_FILE)) {
-			gplog.Fatal(errors.Errorf("Cannot use --redirect-schema without --include-table or --include-table-file"), "")
+		// Redirect schema requires an include flag
+		if !(flags.Changed(options.INCLUDE_RELATION) || flags.Changed(options.INCLUDE_RELATION_FILE) ||
+			flags.Changed(options.INCLUDE_SCHEMA) || flags.Changed(options.INCLUDE_SCHEMA_FILE)) {
+			gplog.Fatal(errors.Errorf("Cannot use --redirect-schema without --include-table, --include-table-file, --include-schema, or --include-schema-file"), "")
 		}
 	}
 	if flags.Changed(options.TRUNCATE_TABLE) &&


### PR DESCRIPTION
This commit adds support to run --redirect-schema with either the
--include-schema or --include-schema-file flags. This was a small
oversight when the --redirect-schema feature was introduced.

Note that usage of this feature can result in conflicts if the user is
not careful (e.g. two schemas containing duplicate table names being
redirected into the same schema can cause a conflict). It was decided
not to have any intelligent logic to prevent/warn against these
scenarios but will be documented properly. It will be at the user's
discretion to identify any duplicates before deciding to use this
feature.