### PR TITLE
Update filepath function ParseSegPrefix to allow error handling

### DIFF
--- a/filepath/filepath.go
+++ b/filepath/filepath.go
@@ -189,22 +189,22 @@ func GetSegPrefix(connectionPool *dbconn.DBConn) string {
 	return segPrefix
 }
 
-func ParseSegPrefix(backupDir string, timestamp string) string {
+func ParseSegPrefix(backupDir string, timestamp string) (string, error) {
 	segPrefix := ""
 	if len(backupDir) > 0 {
 		backupDirForMaster, err := operating.System.Glob(fmt.Sprintf("%s/*-1/backups", backupDir))
 		if err != nil || len(backupDirForMaster) == 0 {
-			gplog.Fatal(err, "Master backup directory in %s missing or inaccessible", backupDir)
+			return "", fmt.Errorf("Master backup directory in %s missing or inaccessible", backupDir)
 		}
 		if len(backupDirForMaster) != 1 {
-			gplog.Fatal(err, "Multiple master backup directories in %s", backupDir)
+			return "", fmt.Errorf("Multiple master backup directories in %s", backupDir)
 		}
 		backupDirForTimestamp, err := operating.System.Glob(fmt.Sprintf("%s/*/%s", backupDirForMaster[0], timestamp))
 		if err != nil || len(backupDirForTimestamp) == 0 {
-			gplog.Fatal(err, "Timestamp directory %s inside backup directory %s is missing or inaccessible", timestamp, backupDir)
+			return "", fmt.Errorf("Timestamp directory %s inside backup directory %s is missing or inaccessible", timestamp, backupDir)
 		}
 		indexOfBackupsSubstr := strings.LastIndex(backupDirForTimestamp[0], "-1/backups/")
 		_, segPrefix = path.Split(backupDirForTimestamp[0][:indexOfBackupsSubstr])
 	}
-	return segPrefix
+	return segPrefix, nil
 }

--- a/filepath/filepath_test.go
+++ b/filepath/filepath_test.go
@@ -133,23 +133,26 @@ var _ = Describe("filepath tests", func() {
 			operating.System.Glob = func(pattern string) (matches []string, err error) {
 				return []string{"/tmp/foo/gpseg-1/backups/datestamp1/timestamp1"}, nil
 			}
-
-			Expect(ParseSegPrefix("/tmp/foo", "timestamp1")).To(Equal("gpseg"))
+			res, err := ParseSegPrefix("/tmp/foo", "timestamp1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal("gpseg"))
 		})
 		It("returns empty string if backup directory is empty", func() {
-			Expect(ParseSegPrefix("", "timestamp1")).To(Equal(""))
+			res, err := ParseSegPrefix("", "timestamp1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(res).To(Equal(""))
 		})
 		It("panics if master backup directory does not exist", func() {
 			operating.System.Glob = func(pattern string) (matches []string, err error) { return []string{}, nil }
-			defer testhelper.ShouldPanicWithMessage("Master backup directory in /tmp/foo missing or inaccessible")
-			Expect(ParseSegPrefix("/tmp/foo", "timestamp1")).To(Equal("gpseg"))
+			_, err := ParseSegPrefix("/tmp/foo", "timestamp1")
+			Expect(err.Error()).To(Equal("Master backup directory in /tmp/foo missing or inaccessible"))
 		})
 		It("panics if there is an error accessing master backup directory", func() {
 			operating.System.Glob = func(pattern string) (matches []string, err error) {
 				return []string{""}, os.ErrPermission
 			}
-			defer testhelper.ShouldPanicWithMessage("Master backup directory in /tmp/foo missing or inaccessible")
-			Expect(ParseSegPrefix("/tmp/foo", "timestamp1")).To(Equal("gpseg"))
+			_, err := ParseSegPrefix("/tmp/foo", "timestamp1")
+			Expect(err.Error()).To(Equal("Master backup directory in /tmp/foo missing or inaccessible"))
 		})
 		It("panics if multiple master backup directories", func() {
 			operating.System.Glob = func(pattern string) (matches []string, err error) {
@@ -159,8 +162,8 @@ var _ = Describe("filepath tests", func() {
 					return []string{}, nil
 				}
 			}
-			defer testhelper.ShouldPanicWithMessage("Multiple master backup directories in /tmp/foo")
-			Expect(ParseSegPrefix("/tmp/foo", "timestamp1")).To(Equal("gpseg"))
+			_, err := ParseSegPrefix("/tmp/foo", "timestamp1")
+			Expect(err.Error()).To(Equal("Multiple master backup directories in /tmp/foo"))
 		})
 		It("panics if timestamp does not exist in master backup directory", func() {
 			operating.System.Glob = func(pattern string) (matches []string, err error) {
@@ -170,8 +173,8 @@ var _ = Describe("filepath tests", func() {
 					return []string{}, nil
 				}
 			}
-			defer testhelper.ShouldPanicWithMessage("Timestamp directory timestamp1 inside backup directory /tmp/foo is missing or inaccessible")
-			Expect(ParseSegPrefix("/tmp/foo", "timestamp1")).To(Equal("gpseg"))
+			_, err := ParseSegPrefix("/tmp/foo", "timestamp1")
+			Expect(err.Error()).To(Equal("Timestamp directory timestamp1 inside backup directory /tmp/foo is missing or inaccessible"))
 		})
 		Describe("IsValidTimestamp", func() {
 			It("allows a valid timestamp", func() {

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -59,6 +59,7 @@ func DoSetup() {
 
 	CreateConnectionPool("postgres")
 
+	var segPrefix string
 	var err error
 	opts, err = options.NewOptions(cmdFlags)
 	gplog.FatalOnError(err)
@@ -68,7 +69,8 @@ func DoSetup() {
 
 	segConfig := cluster.MustGetSegmentConfiguration(connectionPool)
 	globalCluster = cluster.NewCluster(segConfig)
-	segPrefix := filepath.ParseSegPrefix(MustGetFlagString(options.BACKUP_DIR), backupTimestamp)
+	segPrefix, err = filepath.ParseSegPrefix(MustGetFlagString(options.BACKUP_DIR), backupTimestamp)
+	gplog.FatalOnError(err)
 	globalFPInfo = filepath.NewFilePathInfo(globalCluster, MustGetFlagString(options.BACKUP_DIR), backupTimestamp, segPrefix)
 
 	// Get restore metadata from plugin

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -288,7 +288,8 @@ func ExecuteRestoreMetadataStatements(statements []toc.StatementWithType, object
 func GetBackupFPInfoListFromRestorePlan() []filepath.FilePathInfo {
 	fpInfoList := make([]filepath.FilePathInfo, 0)
 	for _, entry := range backupConfig.RestorePlan {
-		segPrefix := filepath.ParseSegPrefix(MustGetFlagString(options.BACKUP_DIR), entry.Timestamp)
+		segPrefix, err := filepath.ParseSegPrefix(MustGetFlagString(options.BACKUP_DIR), entry.Timestamp)
+		gplog.FatalOnError(err)
 
 		fpInfo := filepath.NewFilePathInfo(globalCluster, MustGetFlagString(options.BACKUP_DIR), entry.Timestamp, segPrefix)
 		fpInfoList = append(fpInfoList, fpInfo)
@@ -298,7 +299,8 @@ func GetBackupFPInfoListFromRestorePlan() []filepath.FilePathInfo {
 }
 
 func GetBackupFPInfoForTimestamp(timestamp string) filepath.FilePathInfo {
-	segPrefix := filepath.ParseSegPrefix(MustGetFlagString(options.BACKUP_DIR), timestamp)
+	segPrefix, err := filepath.ParseSegPrefix(MustGetFlagString(options.BACKUP_DIR), timestamp)
+	gplog.FatalOnError(err)
 	fpInfo := filepath.NewFilePathInfo(globalCluster, MustGetFlagString(options.BACKUP_DIR), timestamp, segPrefix)
 	return fpInfo
 }
@@ -374,6 +376,6 @@ func GetExistingSchemas() ([]string, error) {
 
 func TruncateTable(tableFQN string, whichConn int) error {
 	gplog.Verbose("Truncating table %s prior to restoring data", tableFQN)
-	_, err := connectionPool.Exec(`TRUNCATE ` + tableFQN, whichConn)
+	_, err := connectionPool.Exec(`TRUNCATE `+tableFQN, whichConn)
 	return err
 }


### PR DESCRIPTION
Previously, when an error was encountered when parsing a backup's
segment prefix, the program would panic. ParseSegPrefix now returns
an error and the caller of the function is responsible for handling any
errors encountered. This allows for greater flexibiliy in how a program
should react in the event of an error instead of panicking everytime.