### PR TITLE
Fix e2e test relating to error tables

### DIFF
--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -794,7 +794,8 @@ var _ = Describe("backup and restore end to end tests", func() {
 				"--backup-dir", backupDir)
 			gprestore(gprestorePath, restoreHelperPath, timestamp,
 				"--redirect-db", "restoredb",
-				"--backup-dir", backupDir)
+				"--backup-dir", backupDir,
+				"--on-error-continue")
 			files, err := path.Glob(path.Join(backupDir, "*-1/backups/*", timestamp, "_error_tables*"))
 			Expect(err).ToNot(HaveOccurred())
 			Expect(files).To(HaveLen(0))


### PR DESCRIPTION
The test asserts that no error table files are generated when
gprestore --on-error-continue is run successfully... however the
gprestore call in the test does not have the --on-error-continue
flag. Fix the test by adding the --on-error-continue to the gprestore
call.