### PR TITLE
Support different compression types. Implement `zstd` compression support

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -72,7 +72,7 @@ func DoSetup() {
 	}
 	globalTOC = &toc.TOC{}
 	globalTOC.InitializeMetadataEntryMap()
-	utils.InitializePipeThroughParameters(!MustGetFlagBool(options.NO_COMPRESSION), MustGetFlagInt(options.COMPRESSION_LEVEL))
+	utils.InitializePipeThroughParameters(!MustGetFlagBool(options.NO_COMPRESSION), MustGetFlagString(options.COMPRESSION_TYPE), MustGetFlagInt(options.COMPRESSION_LEVEL))
 	getQuotedRoleNames(connectionPool)
 
 	pluginConfigFlag := MustGetFlagString(options.PLUGIN_CONFIG)
@@ -268,7 +268,7 @@ func backupData(tables []Table) {
 		}
 		utils.WriteOidListToSegments(oidList, globalCluster, globalFPInfo)
 		utils.CreateFirstSegmentPipeOnAllHosts(oidList[0], globalCluster, globalFPInfo)
-		compressStr := fmt.Sprintf(" --compression-level %d", MustGetFlagInt(options.COMPRESSION_LEVEL))
+		compressStr := fmt.Sprintf(" --compression-level %d --compression-type %s", MustGetFlagInt(options.COMPRESSION_LEVEL), MustGetFlagString(options.COMPRESSION_TYPE))
 		if MustGetFlagBool(options.NO_COMPRESSION) {
 			compressStr = " --compression-level 0"
 		}

--- a/backup/validate.go
+++ b/backup/validate.go
@@ -99,6 +99,7 @@ func validateFlagCombinations(flags *pflag.FlagSet) {
 	options.CheckExclusiveFlags(flags, options.EXCLUDE_SCHEMA, options.EXCLUDE_SCHEMA_FILE, options.EXCLUDE_RELATION, options.INCLUDE_RELATION, options.EXCLUDE_RELATION_FILE, options.INCLUDE_RELATION_FILE)
 	options.CheckExclusiveFlags(flags, options.JOBS, options.METADATA_ONLY, options.SINGLE_DATA_FILE)
 	options.CheckExclusiveFlags(flags, options.METADATA_ONLY, options.LEAF_PARTITION_DATA)
+	options.CheckExclusiveFlags(flags, options.NO_COMPRESSION, options.COMPRESSION_TYPE)
 	options.CheckExclusiveFlags(flags, options.NO_COMPRESSION, options.COMPRESSION_LEVEL)
 	options.CheckExclusiveFlags(flags, options.PLUGIN_CONFIG, options.BACKUP_DIR)
 	if MustGetFlagString(options.FROM_TIMESTAMP) != "" && !MustGetFlagBool(options.INCREMENTAL) {
@@ -114,7 +115,7 @@ func validateFlagValues() {
 	gplog.FatalOnError(err)
 	err = utils.ValidateFullPath(MustGetFlagString(options.PLUGIN_CONFIG))
 	gplog.FatalOnError(err)
-	err = utils.ValidateCompressionLevel(MustGetFlagInt(options.COMPRESSION_LEVEL))
+	err = utils.ValidateCompressionTypeAndLevel(MustGetFlagString(options.COMPRESSION_TYPE), MustGetFlagInt(options.COMPRESSION_LEVEL))
 	gplog.FatalOnError(err)
 	if MustGetFlagString(options.FROM_TIMESTAMP) != "" && !filepath.IsValidTimestamp(MustGetFlagString(options.FROM_TIMESTAMP)) {
 		gplog.Fatal(errors.Errorf("Timestamp %s is invalid.  Timestamps must be in the format YYYYMMDDHHMMSS.",

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -80,6 +80,7 @@ func NewBackupConfig(dbName string, dbVersion string, backupVersion string, plug
 		BackupDir:             MustGetFlagString(options.BACKUP_DIR),
 		BackupVersion:         backupVersion,
 		Compressed:            !MustGetFlagBool(options.NO_COMPRESSION),
+		CompressionType:       MustGetFlagString(options.COMPRESSION_TYPE),
 		DatabaseName:          dbName,
 		DatabaseVersion:       dbVersion,
 		DataOnly:              MustGetFlagBool(options.DATA_ONLY),

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/greenplum-db/gp-common-go-libs v1.0.5-0.20201005232358-ee3f0135881b
 	github.com/jackc/pgconn v1.7.0
 	github.com/jmoiron/sqlx v0.0.0-20180614180643-0dae4fefe7c0
+	github.com/klauspost/compress v1.13.1
 	github.com/lib/pq v1.3.0
 	github.com/mattn/go-runewidth v0.0.8 // indirect
 	github.com/nightlyone/lockfile v0.0.0-20200124072040-edb130adc195

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,8 @@ github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:W
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
+github.com/golang/snappy v0.0.3 h1:fHPg5GQYlCeLIPB9BZqMVR5nR9A+IM5zcgeTdjMYmLA=
+github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
@@ -108,6 +110,8 @@ github.com/jackc/puddle v1.1.2/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dv
 github.com/jmoiron/sqlx v0.0.0-20180614180643-0dae4fefe7c0 h1:5B0uxl2lzNRVkJVg+uGHxWtRt4C0Wjc6kJKo5XYx8xE=
 github.com/jmoiron/sqlx v0.0.0-20180614180643-0dae4fefe7c0/go.mod h1:IiEW3SEiiErVyFdH8NTuWjSifiEQKUoyK3LNqr2kCHU=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.13.1 h1:wXr2uRxZTJXHLly6qhJabee5JqIhTRoLBhDOA74hDEQ=
+github.com/klauspost/compress v1.13.1/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=

--- a/helper/backup_helper.go
+++ b/helper/backup_helper.go
@@ -137,6 +137,10 @@ func getBackupPipeWriter() (pipe BackupPipeWriterCloser, writeCmd *exec.Cmd, err
 		pipe, err = NewGZipBackupPipeWriterCloser(writeHandle, *compressionLevel)
 		return
 	}
+	if *compressionType == "zstd" {
+		pipe, err = NewZSTDBackupPipeWriterCloser(writeHandle, *compressionLevel)
+		return
+	}
 
 	writeHandle.Close()
 	return nil, nil, fmt.Errorf("unknown compression type '%s' (compression level %d)", *compressionType, *compressionLevel)

--- a/helper/backup_helper_pipes.go
+++ b/helper/backup_helper_pipes.go
@@ -1,0 +1,60 @@
+package helper
+
+import (
+	"bufio"
+	"compress/gzip"
+	"io"
+)
+
+type BackupPipeWriterCloser interface {
+	io.Writer
+	io.Closer
+}
+
+type CommonBackupPipeWriterCloser struct {
+	writeHandle io.WriteCloser
+	bufIoWriter *bufio.Writer
+	finalWriter io.Writer
+}
+
+func (cPipe CommonBackupPipeWriterCloser) Write(p []byte) (n int, err error) {
+	return cPipe.finalWriter.Write(p)
+}
+
+// Never returns error, suppressing them instead
+func (cPipe CommonBackupPipeWriterCloser) Close() error {
+	_ = cPipe.bufIoWriter.Flush()
+	_ = cPipe.writeHandle.Close()
+	return nil
+}
+
+func NewCommonBackupPipeWriterCloser(writeHandle io.WriteCloser) (cPipe CommonBackupPipeWriterCloser) {
+	cPipe.writeHandle = writeHandle
+	cPipe.bufIoWriter = bufio.NewWriter(cPipe.writeHandle)
+	cPipe.finalWriter = cPipe.bufIoWriter
+	return
+}
+
+type GZipBackupPipeWriterCloser struct {
+	cPipe      CommonBackupPipeWriterCloser
+	gzipWriter *gzip.Writer
+}
+
+func (gzPipe GZipBackupPipeWriterCloser) Write(p []byte) (n int, err error) {
+	return gzPipe.gzipWriter.Write(p)
+}
+
+// Returns errors from underlying common writer only
+func (gzPipe GZipBackupPipeWriterCloser) Close() error {
+	_ = gzPipe.gzipWriter.Close()
+	return gzPipe.cPipe.Close()
+}
+
+func NewGZipBackupPipeWriterCloser(writeHandle io.WriteCloser, compressLevel int) (gzPipe GZipBackupPipeWriterCloser, err error) {
+	gzPipe.cPipe = NewCommonBackupPipeWriterCloser(writeHandle)
+	gzPipe.gzipWriter, err = gzip.NewWriterLevel(gzPipe.cPipe.bufIoWriter, compressLevel)
+	if err != nil {
+		gzPipe.cPipe.Close()
+	}
+	return
+}

--- a/helper/backup_helper_pipes.go
+++ b/helper/backup_helper_pipes.go
@@ -78,7 +78,7 @@ func (zstdPipe ZSTDBackupPipeWriterCloser) Close() error {
 
 func NewZSTDBackupPipeWriterCloser(writeHandle io.WriteCloser, compressLevel int) (zstdPipe ZSTDBackupPipeWriterCloser, err error) {
 	zstdPipe.cPipe = NewCommonBackupPipeWriterCloser(writeHandle)
-	zstdPipe.zstdEncoder, err = zstd.NewWriter(zstdPipe.cPipe.bufIoWriter, zstd.WithEncoderLevel(zstd.EncoderLevel(compressLevel)))
+	zstdPipe.zstdEncoder, err = zstd.NewWriter(zstdPipe.cPipe.bufIoWriter, zstd.WithEncoderLevel(zstd.EncoderLevelFromZstd(compressLevel)))
 	if err != nil {
 		zstdPipe.cPipe.Close()
 	}

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -44,6 +44,7 @@ var (
 var (
 	backupAgent      *bool
 	compressionLevel *int
+	compressionType  *string
 	content          *int
 	dataFile         *string
 	oidFile          *string
@@ -100,7 +101,8 @@ func InitializeGlobals() {
 
 	backupAgent = flag.Bool("backup-agent", false, "Use gpbackup_helper as an agent for backup")
 	content = flag.Int("content", -2, "Content ID of the corresponding segment")
-	compressionLevel = flag.Int("compression-level", 0, "The level of compression to use with gzip. O indicates no compression.")
+	compressionLevel = flag.Int("compression-level", 0, "The level of compression. O indicates no compression.")
+	compressionType = flag.String("compression-type", "gzip", "The type of compression. Valid values are 'gzip'")
 	dataFile = flag.String("data-file", "", "Absolute path to the data file")
 	oidFile = flag.String("oid-file", "", "Absolute path to the file containing a list of oids to restore")
 	onErrorContinue = flag.Bool("on-error-continue", false, "Continue restore even when encountering an error")
@@ -165,7 +167,6 @@ func flushAndCloseRestoreWriter() error {
 	}
 	return nil
 }
-
 
 /*
  * Shared helper functions

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -101,8 +101,8 @@ func InitializeGlobals() {
 
 	backupAgent = flag.Bool("backup-agent", false, "Use gpbackup_helper as an agent for backup")
 	content = flag.Int("content", -2, "Content ID of the corresponding segment")
-	compressionLevel = flag.Int("compression-level", 0, "The level of compression. O indicates no compression.")
-	compressionType = flag.String("compression-type", "gzip", "The type of compression. Valid values are 'gzip'")
+	compressionLevel = flag.Int("compression-level", 0, "The level of compression. O indicates no compression. Range of valid values depends on compression type")
+	compressionType = flag.String("compression-type", "gzip", "The type of compression. Valid values are 'gzip', 'zstd'")
 	dataFile = flag.String("data-file", "", "Absolute path to the data file")
 	oidFile = flag.String("oid-file", "", "Absolute path to the file containing a list of oids to restore")
 	onErrorContinue = flag.Bool("on-error-continue", false, "Continue restore even when encountering an error")

--- a/history/history.go
+++ b/history/history.go
@@ -29,6 +29,7 @@ type BackupConfig struct {
 	BackupDir             string
 	BackupVersion         string
 	Compressed            bool
+	CompressionType       string
 	DatabaseName          string
 	DatabaseVersion       string
 	DataOnly              bool

--- a/integration/helper_test.go
+++ b/integration/helper_test.go
@@ -108,7 +108,7 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 		It("runs backup gpbackup_helper with compression", func() {
-			helperCmd := gpbackupHelper(gpbackupHelperPath, "--backup-agent", "--compression-level", "1", "--data-file", dataFileFullPath+".gz")
+			helperCmd := gpbackupHelper(gpbackupHelperPath, "--backup-agent", "--compression-type", "gzip", "--compression-level", "1", "--data-file", dataFileFullPath+".gz")
 			writeToPipes(defaultData)
 			err := helperCmd.Wait()
 			printHelperLogOnError(err)
@@ -124,7 +124,7 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 			assertBackupArtifacts(false, true)
 		})
 		It("runs backup gpbackup_helper with compression with plugin", func() {
-			helperCmd := gpbackupHelper(gpbackupHelperPath, "--backup-agent", "--compression-level", "1", "--data-file", dataFileFullPath+".gz", "--plugin-config", pluginConfigPath)
+			helperCmd := gpbackupHelper(gpbackupHelperPath, "--backup-agent", "--compression-type", "gzip", "--compression-level", "1", "--data-file", dataFileFullPath+".gz", "--plugin-config", pluginConfigPath)
 			writeToPipes(defaultData)
 			err := helperCmd.Wait()
 			printHelperLogOnError(err)

--- a/integration/helper_test.go
+++ b/integration/helper_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/greenplum-db/gp-common-go-libs/operating"
+	"github.com/klauspost/compress/zstd"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -98,7 +99,7 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 			err := helperCmd.Wait()
 			printHelperLogOnError(err)
 			Expect(err).ToNot(HaveOccurred())
-			assertBackupArtifacts(false, false)
+			assertBackupArtifacts(false)
 		})
 		It("runs backup gpbackup_helper with data exceeding pipe buffer size", func() {
 			helperCmd := gpbackupHelper(gpbackupHelperPath, "--backup-agent", "--compression-level", "0", "--data-file", dataFileFullPath)
@@ -107,13 +108,21 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 			printHelperLogOnError(err)
 			Expect(err).ToNot(HaveOccurred())
 		})
-		It("runs backup gpbackup_helper with compression", func() {
+		It("runs backup gpbackup_helper with gzip compression", func() {
 			helperCmd := gpbackupHelper(gpbackupHelperPath, "--backup-agent", "--compression-type", "gzip", "--compression-level", "1", "--data-file", dataFileFullPath+".gz")
 			writeToPipes(defaultData)
 			err := helperCmd.Wait()
 			printHelperLogOnError(err)
 			Expect(err).ToNot(HaveOccurred())
-			assertBackupArtifacts(true, false)
+			assertBackupArtifactsWithCompression("gzip", false)
+		})
+		It("runs backup gpbackup_helper with zstd compression", func() {
+			helperCmd := gpbackupHelper(gpbackupHelperPath, "--backup-agent", "--compression-type", "zstd", "--compression-level", "1", "--data-file", dataFileFullPath+".zst")
+			writeToPipes(defaultData)
+			err := helperCmd.Wait()
+			printHelperLogOnError(err)
+			Expect(err).ToNot(HaveOccurred())
+			assertBackupArtifactsWithCompression("zstd", false)
 		})
 		It("runs backup gpbackup_helper without compression with plugin", func() {
 			helperCmd := gpbackupHelper(gpbackupHelperPath, "--backup-agent", "--compression-level", "0", "--data-file", dataFileFullPath, "--plugin-config", pluginConfigPath)
@@ -121,15 +130,23 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 			err := helperCmd.Wait()
 			printHelperLogOnError(err)
 			Expect(err).ToNot(HaveOccurred())
-			assertBackupArtifacts(false, true)
+			assertBackupArtifacts(true)
 		})
-		It("runs backup gpbackup_helper with compression with plugin", func() {
+		It("runs backup gpbackup_helper with gzip compression with plugin", func() {
 			helperCmd := gpbackupHelper(gpbackupHelperPath, "--backup-agent", "--compression-type", "gzip", "--compression-level", "1", "--data-file", dataFileFullPath+".gz", "--plugin-config", pluginConfigPath)
 			writeToPipes(defaultData)
 			err := helperCmd.Wait()
 			printHelperLogOnError(err)
 			Expect(err).ToNot(HaveOccurred())
-			assertBackupArtifacts(true, true)
+			assertBackupArtifactsWithCompression("gzip", true)
+		})
+		It("runs backup gpbackup_helper with zstd compression with plugin", func() {
+			helperCmd := gpbackupHelper(gpbackupHelperPath, "--backup-agent", "--compression-type", "zstd", "--compression-level", "1", "--data-file", dataFileFullPath+".zst", "--plugin-config", pluginConfigPath)
+			writeToPipes(defaultData)
+			err := helperCmd.Wait()
+			printHelperLogOnError(err)
+			Expect(err).ToNot(HaveOccurred())
+			assertBackupArtifactsWithCompression("zstd", true)
 		})
 		It("Generates error file when backup agent interrupted", func() {
 			helperCmd := gpbackupHelper(gpbackupHelperPath, "--backup-agent", "--compression-level", "0", "--data-file", dataFileFullPath)
@@ -143,7 +160,7 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 	})
 	Context("restore tests", func() {
 		It("runs restore gpbackup_helper without compression", func() {
-			setupRestoreFiles(false, false)
+			setupRestoreFiles("", false)
 			helperCmd := gpbackupHelper(gpbackupHelperPath, "--restore-agent", "--data-file", dataFileFullPath)
 			for _, i := range []int{1, 3} {
 				contents, _ := ioutil.ReadFile(fmt.Sprintf("%s_%d", pipeFile, i))
@@ -154,8 +171,8 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			assertNoErrors()
 		})
-		It("runs restore gpbackup_helper with compression", func() {
-			setupRestoreFiles(true, false)
+		It("runs restore gpbackup_helper with gzip compression", func() {
+			setupRestoreFiles("gzip", false)
 			helperCmd := gpbackupHelper(gpbackupHelperPath, "--restore-agent", "--data-file", dataFileFullPath+".gz")
 			for _, i := range []int{1, 3} {
 				contents, _ := ioutil.ReadFile(fmt.Sprintf("%s_%d", pipeFile, i))
@@ -166,8 +183,20 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			assertNoErrors()
 		})
+		It("runs restore gpbackup_helper with zstd compression", func() {
+			setupRestoreFiles("zstd", false)
+			helperCmd := gpbackupHelper(gpbackupHelperPath, "--restore-agent", "--data-file", dataFileFullPath+".zst")
+			for _, i := range []int{1, 3} {
+				contents, _ := ioutil.ReadFile(fmt.Sprintf("%s_%d", pipeFile, i))
+				Expect(string(contents)).To(Equal("here is some data\n"))
+			}
+			err := helperCmd.Wait()
+			printHelperLogOnError(err)
+			Expect(err).ToNot(HaveOccurred())
+			assertNoErrors()
+		})
 		It("runs restore gpbackup_helper without compression with plugin", func() {
-			setupRestoreFiles(false, true)
+			setupRestoreFiles("", true)
 			helperCmd := gpbackupHelper(gpbackupHelperPath, "--restore-agent", "--data-file", dataFileFullPath, "--plugin-config", pluginConfigPath)
 			for _, i := range []int{1, 3} {
 				contents, _ := ioutil.ReadFile(fmt.Sprintf("%s_%d", pipeFile, i))
@@ -178,8 +207,8 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			assertNoErrors()
 		})
-		It("runs restore gpbackup_helper with compression with plugin", func() {
-			setupRestoreFiles(true, true)
+		It("runs restore gpbackup_helper with gzip compression with plugin", func() {
+			setupRestoreFiles("gzip", true)
 			helperCmd := gpbackupHelper(gpbackupHelperPath, "--restore-agent", "--data-file", dataFileFullPath+".gz", "--plugin-config", pluginConfigPath)
 			for _, i := range []int{1, 3} {
 				contents, _ := ioutil.ReadFile(fmt.Sprintf("%s_%d", pipeFile, i))
@@ -190,8 +219,20 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			assertNoErrors()
 		})
+		It("runs restore gpbackup_helper with zstd compression with plugin", func() {
+			setupRestoreFiles("zstd", true)
+			helperCmd := gpbackupHelper(gpbackupHelperPath, "--restore-agent", "--data-file", dataFileFullPath+".zst", "--plugin-config", pluginConfigPath)
+			for _, i := range []int{1, 3} {
+				contents, _ := ioutil.ReadFile(fmt.Sprintf("%s_%d", pipeFile, i))
+				Expect(string(contents)).To(Equal("here is some data\n"))
+			}
+			err := helperCmd.Wait()
+			printHelperLogOnError(err)
+			Expect(err).ToNot(HaveOccurred())
+			assertNoErrors()
+		})
 		It("Generates error file when restore agent interrupted", func() {
-			setupRestoreFiles(true, false)
+			setupRestoreFiles("gzip", false)
 			helperCmd := gpbackupHelper(gpbackupHelperPath, "--restore-agent", "--data-file", dataFileFullPath+".gz")
 			waitForPipeCreation()
 			err := helperCmd.Process.Signal(os.Interrupt)
@@ -270,20 +311,27 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 	})
 })
 
-func setupRestoreFiles(withCompression bool, withPlugin bool) {
+func setupRestoreFiles(compressionType string, withPlugin bool) {
 	dataFile := dataFileFullPath
 	if withPlugin {
 		dataFile = pluginBackupPath
 	}
+
 	f, _ := os.Create(oidFile)
 	_, _ = f.WriteString("1\n3\n")
-	if withCompression {
+
+	if compressionType == "gzip" {
 		f, _ := os.Create(dataFile + ".gz")
+		defer f.Close()
 		gzipf := gzip.NewWriter(f)
-		defer func() {
-			_ = gzipf.Close()
-		}()
+		defer gzipf.Close()
 		_, _ = gzipf.Write([]byte(expectedData))
+	} else if compressionType == "zstd" {
+		f, _ := os.Create(dataFile + ".zst")
+		defer f.Close()
+		zstdf, _ := zstd.NewWriter(f)
+		defer zstdf.Close()
+		_, _ = zstdf.Write([]byte(expectedData))
 	} else {
 		f, _ := os.Create(dataFile)
 		_, _ = f.WriteString(expectedData)
@@ -306,28 +354,58 @@ func assertErrorsHandled() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(pipes).To(BeEmpty())
 }
-func assertBackupArtifacts(withCompression bool, withPlugin bool) {
+
+func assertBackupArtifacts(withPlugin bool) {
 	var contents []byte
 	var err error
 	dataFile := dataFileFullPath
 	if withPlugin {
 		dataFile = pluginBackupPath
 	}
-	if withCompression {
-		contents, err = ioutil.ReadFile(dataFile + ".gz")
-		Expect(err).ToNot(HaveOccurred())
-		r, _ := gzip.NewReader(bytes.NewReader(contents))
-		contents, _ = ioutil.ReadAll(r)
-
-	} else {
-		contents, err = ioutil.ReadFile(dataFile)
-		Expect(err).ToNot(HaveOccurred())
-	}
+	contents, err = ioutil.ReadFile(dataFile)
+	Expect(err).ToNot(HaveOccurred())
 	Expect(string(contents)).To(Equal(expectedData))
 
 	contents, err = ioutil.ReadFile(tocFile)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(string(contents)).To(Equal(expectedTOC))
+	assertNoErrors()
+}
+
+func assertBackupArtifactsWithCompression(compressionType string, withPlugin bool) {
+	var contents []byte
+	var err error
+
+	dataFile := dataFileFullPath
+	if withPlugin {
+		dataFile = pluginBackupPath
+	}
+
+	if compressionType == "gzip" {
+		contents, err = ioutil.ReadFile(dataFile + ".gz")
+	} else if compressionType == "zstd" {
+		contents, err = ioutil.ReadFile(dataFile + ".zst")
+	} else {
+		Fail("unknown compression type " + compressionType)
+	}
+	Expect(err).ToNot(HaveOccurred())
+
+	if compressionType == "gzip" {
+		r, _ := gzip.NewReader(bytes.NewReader(contents))
+		contents, _ = ioutil.ReadAll(r)
+		Expect(string(contents)).To(Equal(expectedData))
+	} else if compressionType == "zstd" {
+		r, _ := zstd.NewReader(bytes.NewReader(contents))
+		contents, _ = ioutil.ReadAll(r)
+		Expect(string(contents)).To(Equal(expectedData))
+	} else {
+		Fail("unknown compression type " + compressionType)
+	}
+
+	contents, err = ioutil.ReadFile(tocFile)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(string(contents)).To(Equal(expectedTOC))
+
 	assertNoErrors()
 }
 

--- a/integration/helper_test.go
+++ b/integration/helper_test.go
@@ -393,14 +393,13 @@ func assertBackupArtifactsWithCompression(compressionType string, withPlugin boo
 	if compressionType == "gzip" {
 		r, _ := gzip.NewReader(bytes.NewReader(contents))
 		contents, _ = ioutil.ReadAll(r)
-		Expect(string(contents)).To(Equal(expectedData))
 	} else if compressionType == "zstd" {
 		r, _ := zstd.NewReader(bytes.NewReader(contents))
 		contents, _ = ioutil.ReadAll(r)
-		Expect(string(contents)).To(Equal(expectedData))
 	} else {
 		Fail("unknown compression type " + compressionType)
 	}
+	Expect(string(contents)).To(Equal(expectedData))
 
 	contents, err = ioutil.ReadFile(tocFile)
 	Expect(err).ToNot(HaveOccurred())

--- a/options/flag.go
+++ b/options/flag.go
@@ -52,8 +52,8 @@ const (
 
 func SetBackupFlagDefaults(flagSet *pflag.FlagSet) {
 	flagSet.String(BACKUP_DIR, "", "The absolute path of the directory to which all backup files will be written")
-	flagSet.String(COMPRESSION_TYPE, "gzip", "Type of compression to use during data backup. Valid values are: 'gzip'")
-	flagSet.Int(COMPRESSION_LEVEL, 1, "Level of compression to use during data backup. Valid values are between 1 and 9.")
+	flagSet.String(COMPRESSION_TYPE, "gzip", "Type of compression to use during data backup. Valid values are 'gzip', 'zstd'")
+	flagSet.Int(COMPRESSION_LEVEL, 1, "Level of compression to use during data backup. Range of valid values depends on compression type")
 	flagSet.Bool(DATA_ONLY, false, "Only back up data, do not back up metadata")
 	flagSet.String(DBNAME, "", "The database to be backed up")
 	flagSet.Bool(DEBUG, false, "Print verbose and debug log messages")

--- a/options/flag.go
+++ b/options/flag.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	BACKUP_DIR            = "backup-dir"
+	COMPRESSION_TYPE      = "compression-type"
 	COMPRESSION_LEVEL     = "compression-level"
 	DATA_ONLY             = "data-only"
 	DBNAME                = "dbname"
@@ -51,6 +52,7 @@ const (
 
 func SetBackupFlagDefaults(flagSet *pflag.FlagSet) {
 	flagSet.String(BACKUP_DIR, "", "The absolute path of the directory to which all backup files will be written")
+	flagSet.String(COMPRESSION_TYPE, "gzip", "Type of compression to use during data backup. Valid values are: 'gzip'")
 	flagSet.Int(COMPRESSION_LEVEL, 1, "Level of compression to use during data backup. Valid values are between 1 and 9.")
 	flagSet.Bool(DATA_ONLY, false, "Only back up data, do not back up metadata")
 	flagSet.String(DBNAME, "", "The database to be backed up")

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -295,10 +295,10 @@ restore status:      Success but non-fatal errors occurred. See log file .+ for 
 	})
 	Describe("SetBackupParamFromFlags", func() {
 		AfterEach(func() {
-			utils.InitializePipeThroughParameters(false, 0)
+			utils.InitializePipeThroughParameters(false, "", 0)
 		})
 		It("configures the Report struct correctly", func() {
-			utils.InitializePipeThroughParameters(true, 0)
+			utils.InitializePipeThroughParameters(true, "gzip", 0)
 			backupCmdFlags := pflag.NewFlagSet("gpbackup", pflag.ExitOnError)
 			backup.SetCmdFlags(backupCmdFlags)
 			err := backupCmdFlags.Set(options.INCLUDE_RELATION, "public.foobar")
@@ -315,6 +315,7 @@ restore status:      Success but non-fatal errors occurred. See log file .+ for 
 			structmatcher.ExpectStructsToMatch(history.BackupConfig{
 				BackupVersion:        "0.1.0",
 				Compressed:           true,
+				CompressionType:      "gzip",
 				DatabaseName:         "testdb",
 				DatabaseVersion:      "5.0.0 build test",
 				IncludeSchemas:       []string{},

--- a/restore/data_test.go
+++ b/restore/data_test.go
@@ -21,11 +21,20 @@ var _ = Describe("restore/data tests", func() {
 			backup.SetPluginConfig(nil)
 			_ = cmdFlags.Set(options.PLUGIN_CONFIG, "")
 		})
-		It("will restore a table from its own file with compression", func() {
+		It("will restore a table from its own file with gzip compression", func() {
 			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "gzip", OutputCommand: "gzip -c -1", InputCommand: "gzip -d -c", Extension: ".gz"})
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.gz | gzip -d -c' WITH CSV DELIMITER ',' ON SEGMENT;")
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.gz"
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
+
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("will restore a table from its own file with zstd compression", func() {
+			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "zstd", OutputCommand: "zstd --compress -1 -c", InputCommand: "zstd --decompress -c", Extension: ".zst"})
+			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.zst | zstd --decompress -c' WITH CSV DELIMITER ',' ON SEGMENT;")
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.zst"
 			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
 
 			Expect(err).ShouldNot(HaveOccurred())
@@ -46,7 +55,7 @@ var _ = Describe("restore/data tests", func() {
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
-		It("will restore a table from its own file with compression using a plugin", func() {
+		It("will restore a table from its own file with gzip compression using a plugin", func() {
 			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "gzip", OutputCommand: "gzip -c -1", InputCommand: "gzip -d -c", Extension: ".gz"})
 			_ = cmdFlags.Set(options.PLUGIN_CONFIG, "/tmp/plugin_config")
 			pluginConfig := utils.PluginConfig{ExecutablePath: "/tmp/fake-plugin.sh", ConfigPath: "/tmp/plugin_config"}
@@ -55,6 +64,19 @@ var _ = Describe("restore/data tests", func() {
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz"
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
+
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("will restore a table from its own file with zstd compression using a plugin", func() {
+			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "zstd", OutputCommand: "zstd --compress -1 -c", InputCommand: "zstd --decompress -c", Extension: ".zst"})
+			_ = cmdFlags.Set(options.PLUGIN_CONFIG, "/tmp/plugin_config")
+			pluginConfig := utils.PluginConfig{ExecutablePath: "/tmp/fake-plugin.sh", ConfigPath: "/tmp/plugin_config"}
+			restore.SetPluginConfig(&pluginConfig)
+			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM '/tmp/fake-plugin.sh restore_data /tmp/plugin_config <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.zst | zstd --decompress -c' WITH CSV DELIMITER ',' ON SEGMENT;")
+			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
+
+			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.zst"
 			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
 
 			Expect(err).ShouldNot(HaveOccurred())

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -135,7 +135,7 @@ func SetMaxCsvLineLengthQuery(connectionPool *dbconn.DBConn) string {
 
 func InitializeBackupConfig() {
 	backupConfig = history.ReadConfigFile(globalFPInfo.GetConfigFilePath())
-	utils.InitializePipeThroughParameters(backupConfig.Compressed, 0)
+	utils.InitializePipeThroughParameters(backupConfig.Compressed, backupConfig.CompressionType, 0)
 	report.EnsureBackupVersionCompatibility(backupConfig.BackupVersion, version)
 	report.EnsureDatabaseVersionCompatibility(backupConfig.DatabaseVersion, connectionPool.Version)
 }

--- a/utils/compression.go
+++ b/utils/compression.go
@@ -13,11 +13,20 @@ type PipeThroughProgram struct {
 	Extension     string
 }
 
-func InitializePipeThroughParameters(compress bool, compressionLevel int) {
-	if compress {
-		pipeThroughProgram = PipeThroughProgram{Name: "gzip", OutputCommand: fmt.Sprintf("gzip -c -%d", compressionLevel), InputCommand: "gzip -d -c", Extension: ".gz"}
-	} else {
+func InitializePipeThroughParameters(compress bool, compressionType string, compressionLevel int) {
+	if !compress {
 		pipeThroughProgram = PipeThroughProgram{Name: "cat", OutputCommand: "cat -", InputCommand: "cat -", Extension: ""}
+		return
+	}
+
+	// backward compatibility for inputs without compressionType
+	if compressionType == "" {
+		compressionType = "gzip"
+	}
+
+	if compressionType == "gzip" {
+		pipeThroughProgram = PipeThroughProgram{Name: "gzip", OutputCommand: fmt.Sprintf("gzip -c -%d", compressionLevel), InputCommand: "gzip -d -c", Extension: ".gz"}
+		return
 	}
 }
 

--- a/utils/compression.go
+++ b/utils/compression.go
@@ -28,6 +28,11 @@ func InitializePipeThroughParameters(compress bool, compressionType string, comp
 		pipeThroughProgram = PipeThroughProgram{Name: "gzip", OutputCommand: fmt.Sprintf("gzip -c -%d", compressionLevel), InputCommand: "gzip -d -c", Extension: ".gz"}
 		return
 	}
+
+	if compressionType == "zstd" {
+		pipeThroughProgram = PipeThroughProgram{Name: "zstd", OutputCommand: fmt.Sprintf("zstd --compress -%d -c", compressionLevel), InputCommand: "zstd --decompress -c", Extension: ".zst"}
+		return
+	}
 }
 
 func GetPipeThroughProgram() PipeThroughProgram {

--- a/utils/compression_test.go
+++ b/utils/compression_test.go
@@ -43,7 +43,7 @@ var _ = Describe("utils/compression tests", func() {
 			resultProgram := utils.GetPipeThroughProgram()
 			structmatcher.ExpectStructsToMatch(&expectedProgram, &resultProgram)
 		})
-		It("initializes to use gzip when passed compression and a level", func() {
+		It("initializes to use gzip when passed compression type gzip and a level", func() {
 			originalProgram := utils.GetPipeThroughProgram()
 			defer utils.SetPipeThroughProgram(originalProgram)
 			expectedProgram := utils.PipeThroughProgram{
@@ -53,6 +53,19 @@ var _ = Describe("utils/compression tests", func() {
 				Extension:     ".gz",
 			}
 			utils.InitializePipeThroughParameters(true, "gzip", 7)
+			resultProgram := utils.GetPipeThroughProgram()
+			structmatcher.ExpectStructsToMatch(&expectedProgram, &resultProgram)
+		})
+		It("initializes to use zstd when passed compression type zstd and a level", func() {
+			originalProgram := utils.GetPipeThroughProgram()
+			defer utils.SetPipeThroughProgram(originalProgram)
+			expectedProgram := utils.PipeThroughProgram{
+				Name:          "zstd",
+				OutputCommand: "zstd --compress -7 -c",
+				InputCommand:  "zstd --decompress -c",
+				Extension:     ".zst",
+			}
+			utils.InitializePipeThroughParameters(true, "zstd", 7)
 			resultProgram := utils.GetPipeThroughProgram()
 			structmatcher.ExpectStructsToMatch(&expectedProgram, &resultProgram)
 		})

--- a/utils/compression_test.go
+++ b/utils/compression_test.go
@@ -39,7 +39,7 @@ var _ = Describe("utils/compression tests", func() {
 				InputCommand:  "cat -",
 				Extension:     "",
 			}
-			utils.InitializePipeThroughParameters(false, 3)
+			utils.InitializePipeThroughParameters(false, "", 3)
 			resultProgram := utils.GetPipeThroughProgram()
 			structmatcher.ExpectStructsToMatch(&expectedProgram, &resultProgram)
 		})
@@ -52,7 +52,7 @@ var _ = Describe("utils/compression tests", func() {
 				InputCommand:  "gzip -d -c",
 				Extension:     ".gz",
 			}
-			utils.InitializePipeThroughParameters(true, 7)
+			utils.InitializePipeThroughParameters(true, "gzip", 7)
 			resultProgram := utils.GetPipeThroughProgram()
 			structmatcher.ExpectStructsToMatch(&expectedProgram, &resultProgram)
 		})

--- a/utils/util.go
+++ b/utils/util.go
@@ -112,9 +112,11 @@ func ValidateFullPath(path string) error {
 func ValidateCompressionTypeAndLevel(compressionType string, compressionLevel int) error {
 	minAllowedCompressionLevels := map[string]int{
 		"gzip": 1,
+		"zstd": 1,
 	}
 	maxAllowedCompressionLevels := map[string]int{
 		"gzip": 9,
+		"zstd": 19,
 	}
 
 	if maxAllowedLevel, ok := maxAllowedCompressionLevels[compressionType]; ok {

--- a/utils/util.go
+++ b/utils/util.go
@@ -43,11 +43,11 @@ func RemoveFileIfExists(filename string) error {
 }
 
 func OpenFileForWrite(filename string) (*os.File, error) {
-	return os.OpenFile(filename, os.O_CREATE | os.O_TRUNC | os.O_WRONLY, 0644)
+	return os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 }
 
 func WriteToFileAndMakeReadOnly(filename string, contents []byte) error {
-	file, err := os.OpenFile(filename, os.O_CREATE | os.O_TRUNC | os.O_WRONLY, 0644)
+	file, err := os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
 	if err != nil {
 		return err
 	}
@@ -109,10 +109,24 @@ func ValidateFullPath(path string) error {
 	return nil
 }
 
-func ValidateCompressionLevel(compressionLevel int) error {
-	if compressionLevel < 1 || compressionLevel > 9 {
-		return errors.Errorf("Compression level must be between 1 and 9")
+func ValidateCompressionTypeAndLevel(compressionType string, compressionLevel int) error {
+	minAllowedCompressionLevels := map[string]int{
+		"gzip": 1,
 	}
+	maxAllowedCompressionLevels := map[string]int{
+		"gzip": 9,
+	}
+
+	if maxAllowedLevel, ok := maxAllowedCompressionLevels[compressionType]; ok {
+		minAllowedLevel := minAllowedCompressionLevels[compressionType]
+
+		if compressionLevel < minAllowedLevel || compressionLevel > maxAllowedLevel {
+			return fmt.Errorf("compression type '%s' only allows compression levels between %d and %d, but the provided level is %d", compressionType, minAllowedLevel, maxAllowedLevel, compressionLevel)
+		}
+	} else {
+		return fmt.Errorf("unknown compression type '%s'", compressionType)
+	}
+
 	return nil
 }
 

--- a/utils/util.go
+++ b/utils/util.go
@@ -109,21 +109,21 @@ func ValidateFullPath(path string) error {
 	return nil
 }
 
+// A description of compression levels for some compression type
+type CompressionLevelsDescription struct {
+	Min int
+	Max int
+}
+
 func ValidateCompressionTypeAndLevel(compressionType string, compressionLevel int) error {
-	minAllowedCompressionLevels := map[string]int{
-		"gzip": 1,
-		"zstd": 1,
-	}
-	maxAllowedCompressionLevels := map[string]int{
-		"gzip": 9,
-		"zstd": 19,
+	compressionLevelsForType := map[string]CompressionLevelsDescription{
+		"gzip": {Min: 1, Max: 9},
+		"zstd": {Min: 1, Max: 19},
 	}
 
-	if maxAllowedLevel, ok := maxAllowedCompressionLevels[compressionType]; ok {
-		minAllowedLevel := minAllowedCompressionLevels[compressionType]
-
-		if compressionLevel < minAllowedLevel || compressionLevel > maxAllowedLevel {
-			return fmt.Errorf("compression type '%s' only allows compression levels between %d and %d, but the provided level is %d", compressionType, minAllowedLevel, maxAllowedLevel, compressionLevel)
+	if levelsDescription, ok := compressionLevelsForType[compressionType]; ok {
+		if compressionLevel < levelsDescription.Min || compressionLevel > levelsDescription.Max {
+			return fmt.Errorf("compression type '%s' only allows compression levels between %d and %d, but the provided level is %d", compressionType, levelsDescription.Min, levelsDescription.Max, compressionLevel)
 		}
 	} else {
 		return fmt.Errorf("unknown compression type '%s'", compressionType)

--- a/utils/util_test.go
+++ b/utils/util_test.go
@@ -140,6 +140,24 @@ var _ = Describe("utils/util tests", func() {
 			err := utils.ValidateCompressionTypeAndLevel(compressType, compressLevel)
 			Expect(err).To(MatchError("unknown compression type ''"))
 		})
+		It("validates a compression type 'zstd' and a level between 1 and 19", func() {
+			compressType := "zstd"
+			compressLevel := 11
+			err := utils.ValidateCompressionTypeAndLevel(compressType, compressLevel)
+			Expect(err).To(Not(HaveOccurred()))
+		})
+		It("panics if given a compression type 'zstd' and a compression level < 1", func() {
+			compressType := "zstd"
+			compressLevel := 0
+			err := utils.ValidateCompressionTypeAndLevel(compressType, compressLevel)
+			Expect(err).To(MatchError("compression type 'zstd' only allows compression levels between 1 and 19, but the provided level is 0"))
+		})
+		It("panics if given a compression type 'gzip' and a compression level > 19", func() {
+			compressType := "zstd"
+			compressLevel := 20
+			err := utils.ValidateCompressionTypeAndLevel(compressType, compressLevel)
+			Expect(err).To(MatchError("compression type 'zstd' only allows compression levels between 1 and 19, but the provided level is 20"))
+		})
 	})
 	Describe("UnquoteIdent", func() {
 		It("returns unchanged ident when passed a single char", func() {

--- a/utils/util_test.go
+++ b/utils/util_test.go
@@ -103,21 +103,42 @@ var _ = Describe("utils/util tests", func() {
 			utils.ValidateGPDBVersionCompatibility(connectionPool)
 		})
 	})
-	Describe("ValidateCompressionLevel", func() {
-		It("validates a compression level between 1 and 9", func() {
+	Describe("ValidateCompressionTypeAndLevel", func() {
+		It("validates a compression type 'gzip' and a level between 1 and 9", func() {
+			compressType := "gzip"
 			compressLevel := 5
-			err := utils.ValidateCompressionLevel(compressLevel)
+			err := utils.ValidateCompressionTypeAndLevel(compressType, compressLevel)
 			Expect(err).To(Not(HaveOccurred()))
 		})
-		It("panics if given a compression level < 1", func() {
+		It("panics if given a compression type 'gzip' and a compression level < 1", func() {
+			compressType := "gzip"
 			compressLevel := 0
-			err := utils.ValidateCompressionLevel(compressLevel)
-			Expect(err).To(MatchError("Compression level must be between 1 and 9"))
+			err := utils.ValidateCompressionTypeAndLevel(compressType, compressLevel)
+			Expect(err).To(MatchError("compression type 'gzip' only allows compression levels between 1 and 9, but the provided level is 0"))
 		})
-		It("panics if given a compression level > 9", func() {
+		It("panics if given a compression type 'gzip' and a compression level > 9", func() {
+			compressType := "gzip"
 			compressLevel := 11
-			err := utils.ValidateCompressionLevel(compressLevel)
-			Expect(err).To(MatchError("Compression level must be between 1 and 9"))
+			err := utils.ValidateCompressionTypeAndLevel(compressType, compressLevel)
+			Expect(err).To(MatchError("compression type 'gzip' only allows compression levels between 1 and 9, but the provided level is 11"))
+		})
+		It("panics if given a compression type 'invalid' and a compression level > 0", func() {
+			compressType := "invalid"
+			compressLevel := 1
+			err := utils.ValidateCompressionTypeAndLevel(compressType, compressLevel)
+			Expect(err).To(MatchError("unknown compression type 'invalid'"))
+		})
+		It("panics if given a compression type 'invalid' and a compression level < 0", func() {
+			compressType := "invalid"
+			compressLevel := -1
+			err := utils.ValidateCompressionTypeAndLevel(compressType, compressLevel)
+			Expect(err).To(MatchError("unknown compression type 'invalid'"))
+		})
+		It("panics if given a compression type '' and a compression level > 0", func() {
+			compressType := ""
+			compressLevel := 1
+			err := utils.ValidateCompressionTypeAndLevel(compressType, compressLevel)
+			Expect(err).To(MatchError("unknown compression type ''"))
 		})
 	})
 	Describe("UnquoteIdent", func() {


### PR DESCRIPTION
1. Add a command-line option to set compression type. To disable compression, `--no-compression` or `--compression-level 0` are to be set (this is the [current](https://github.com/greenplum-db/gpbackup/tree/1a3169a615ab9137e519722a770a6c44ce7ba711) behaviour). The `--compression-type` option is optional, and `gzip` is its default value; as a result, the existing behaviour of `gpbackup` is preserved without any changes to external scripts that call it.
2. In `helper` module, `backup_helper_pipes.go` is introduced. It defines wrappers for buffer writers encapsulating various compression types (initially "no compression" and "gzip"). This allows to drop (somewhat) complex `Writer` close algorithm in `backup_helper.go`.
3. On top of the above changes, implement new compression type `zstd`. https://pkg.go.dev/github.com/klauspost/compress/zstd is used in `backup_helper` to provide this kind of compression, as well as `zstd` command-line utility in other locations.

Tests in various modules are updated accordingly. Where applicable, new test cases are added for `zstd` compression.

Closes #394 .