### PR TITLE
Remove directory check when parsing segment prefix

### DIFF
--- a/filepath/filepath.go
+++ b/filepath/filepath.go
@@ -189,22 +189,23 @@ func GetSegPrefix(connectionPool *dbconn.DBConn) string {
 	return segPrefix
 }
 
-func ParseSegPrefix(backupDir string, timestamp string) (string, error) {
-	segPrefix := ""
-	if len(backupDir) > 0 {
-		backupDirForMaster, err := operating.System.Glob(fmt.Sprintf("%s/*-1/backups", backupDir))
-		if err != nil || len(backupDirForMaster) == 0 {
-			return "", fmt.Errorf("Master backup directory in %s missing or inaccessible", backupDir)
-		}
-		if len(backupDirForMaster) != 1 {
-			return "", fmt.Errorf("Multiple master backup directories in %s", backupDir)
-		}
-		backupDirForTimestamp, err := operating.System.Glob(fmt.Sprintf("%s/*/%s", backupDirForMaster[0], timestamp))
-		if err != nil || len(backupDirForTimestamp) == 0 {
-			return "", fmt.Errorf("Timestamp directory %s inside backup directory %s is missing or inaccessible", timestamp, backupDir)
-		}
-		indexOfBackupsSubstr := strings.LastIndex(backupDirForTimestamp[0], "-1/backups/")
-		_, segPrefix = path.Split(backupDirForTimestamp[0][:indexOfBackupsSubstr])
+func ParseSegPrefix(backupDir string) (string, error) {
+	if backupDir == "" {
+		return "", nil
 	}
+
+	backupDirForMaster, err := operating.System.Glob(fmt.Sprintf("%s/*-1/backups", backupDir))
+	if err != nil {
+		return "", fmt.Errorf("Failure while trying to locate master backup directory in %s. Error: %s", backupDir, err.Error())
+	}
+	if len(backupDirForMaster) == 0 {
+		return "", fmt.Errorf("Master backup directory in %s missing", backupDir)
+	}
+	if len(backupDirForMaster) != 1 {
+		return "", fmt.Errorf("Multiple master backup directories in %s", backupDir)
+	}
+	indexOfBackupsSubstr := strings.LastIndex(backupDirForMaster[0], "-1/backups")
+	_, segPrefix := path.Split(backupDirForMaster[0][:indexOfBackupsSubstr])
+
 	return segPrefix, nil
 }

--- a/filepath/filepath_test.go
+++ b/filepath/filepath_test.go
@@ -131,30 +131,30 @@ var _ = Describe("filepath tests", func() {
 		})
 		It("returns segment prefix from directory path if master backup directory exists", func() {
 			operating.System.Glob = func(pattern string) (matches []string, err error) {
-				return []string{"/tmp/foo/gpseg-1/backups/datestamp1/timestamp1"}, nil
+				return []string{"/tmp/foo/gpseg-1/backups"}, nil
 			}
-			res, err := ParseSegPrefix("/tmp/foo", "timestamp1")
+			res, err := ParseSegPrefix("/tmp/foo")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(Equal("gpseg"))
 		})
 		It("returns empty string if backup directory is empty", func() {
-			res, err := ParseSegPrefix("", "timestamp1")
+			res, err := ParseSegPrefix("")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(Equal(""))
 		})
-		It("panics if master backup directory does not exist", func() {
+		It("returns an error when master backup directory does not exist", func() {
 			operating.System.Glob = func(pattern string) (matches []string, err error) { return []string{}, nil }
-			_, err := ParseSegPrefix("/tmp/foo", "timestamp1")
-			Expect(err.Error()).To(Equal("Master backup directory in /tmp/foo missing or inaccessible"))
+			_, err := ParseSegPrefix("/tmp/foo")
+			Expect(err.Error()).To(Equal("Master backup directory in /tmp/foo missing"))
 		})
-		It("panics if there is an error accessing master backup directory", func() {
+		It("returns an error when there is an error accessing master backup directory", func() {
 			operating.System.Glob = func(pattern string) (matches []string, err error) {
 				return []string{""}, os.ErrPermission
 			}
-			_, err := ParseSegPrefix("/tmp/foo", "timestamp1")
-			Expect(err.Error()).To(Equal("Master backup directory in /tmp/foo missing or inaccessible"))
+			_, err := ParseSegPrefix("/tmp/foo")
+			Expect(err.Error()).To(Equal("Failure while trying to locate master backup directory in /tmp/foo. Error: permission denied"))
 		})
-		It("panics if multiple master backup directories", func() {
+		It("returns an error when multiple master backup directories", func() {
 			operating.System.Glob = func(pattern string) (matches []string, err error) {
 				if pattern == "/tmp/foo/*-1/backups" {
 					return []string{"/tmp/foo/foo-1/backups", "/tmp/foo/foo-1/backups"}, nil
@@ -162,19 +162,8 @@ var _ = Describe("filepath tests", func() {
 					return []string{}, nil
 				}
 			}
-			_, err := ParseSegPrefix("/tmp/foo", "timestamp1")
+			_, err := ParseSegPrefix("/tmp/foo")
 			Expect(err.Error()).To(Equal("Multiple master backup directories in /tmp/foo"))
-		})
-		It("panics if timestamp does not exist in master backup directory", func() {
-			operating.System.Glob = func(pattern string) (matches []string, err error) {
-				if pattern == "/tmp/foo/*-1/backups" {
-					return []string{"/tmp/foo/gpseg-1/backups"}, nil
-				} else {
-					return []string{}, nil
-				}
-			}
-			_, err := ParseSegPrefix("/tmp/foo", "timestamp1")
-			Expect(err.Error()).To(Equal("Timestamp directory timestamp1 inside backup directory /tmp/foo is missing or inaccessible"))
 		})
 		Describe("IsValidTimestamp", func() {
 			It("allows a valid timestamp", func() {

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -72,7 +72,7 @@ func DoSetup() {
 
 	segConfig := cluster.MustGetSegmentConfiguration(connectionPool)
 	globalCluster = cluster.NewCluster(segConfig)
-	segPrefix, err = filepath.ParseSegPrefix(MustGetFlagString(options.BACKUP_DIR), backupTimestamp)
+	segPrefix, err = filepath.ParseSegPrefix(MustGetFlagString(options.BACKUP_DIR))
 	gplog.FatalOnError(err)
 	globalFPInfo = filepath.NewFilePathInfo(globalCluster, MustGetFlagString(options.BACKUP_DIR), backupTimestamp, segPrefix)
 

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -292,7 +292,7 @@ func ExecuteRestoreMetadataStatements(statements []toc.StatementWithType, object
 func GetBackupFPInfoListFromRestorePlan() []filepath.FilePathInfo {
 	fpInfoList := make([]filepath.FilePathInfo, 0)
 	for _, entry := range backupConfig.RestorePlan {
-		segPrefix, err := filepath.ParseSegPrefix(MustGetFlagString(options.BACKUP_DIR), entry.Timestamp)
+		segPrefix, err := filepath.ParseSegPrefix(MustGetFlagString(options.BACKUP_DIR))
 		gplog.FatalOnError(err)
 
 		fpInfo := filepath.NewFilePathInfo(globalCluster, MustGetFlagString(options.BACKUP_DIR), entry.Timestamp, segPrefix)
@@ -303,7 +303,7 @@ func GetBackupFPInfoListFromRestorePlan() []filepath.FilePathInfo {
 }
 
 func GetBackupFPInfoForTimestamp(timestamp string) filepath.FilePathInfo {
-	segPrefix, err := filepath.ParseSegPrefix(MustGetFlagString(options.BACKUP_DIR), timestamp)
+	segPrefix, err := filepath.ParseSegPrefix(MustGetFlagString(options.BACKUP_DIR))
 	gplog.FatalOnError(err)
 	fpInfo := filepath.NewFilePathInfo(globalCluster, MustGetFlagString(options.BACKUP_DIR), timestamp, segPrefix)
 	return fpInfo


### PR DESCRIPTION
The existence of a backup set's directory should not be required to
parse out a cluster's segment directory prefix.