### PR TITLE
Fix terminate copy

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -429,7 +429,7 @@ func DoCleanup(backupFailed bool) {
 			}
 			if wasTerminated {
 				// It is possible for the COPY command to become orphaned if an agent process is killed
-				utils.TerminateHangingCopySessions(connectionPool, globalFPInfo, "gpbackup")
+				utils.TerminateHangingCopySessions(connectionPool, globalFPInfo, fmt.Sprintf("gpbackup_%s", globalFPInfo.Timestamp))
 			}
 			utils.CleanUpHelperFilesOnAllHosts(globalCluster, globalFPInfo)
 		}

--- a/integration/utils_test.go
+++ b/integration/utils_test.go
@@ -1,0 +1,56 @@
+package integration
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/greenplum-db/gp-common-go-libs/dbconn"
+	"github.com/greenplum-db/gp-common-go-libs/testhelper"
+	fp "github.com/greenplum-db/gpbackup/filepath"
+	"github.com/greenplum-db/gpbackup/testutils"
+	"github.com/greenplum-db/gpbackup/utils"
+
+	"golang.org/x/sys/unix"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("utils integration", func() {
+	It("TerminateHangingCopySessions kills hanging COPY sessions", func() {
+		tempDir, err := ioutil.TempDir("", "temp")
+		Expect(err).To(Not(HaveOccurred()))
+		defer os.Remove(tempDir)
+		testPipe := filepath.Join(tempDir, "test_pipe")
+		conn := testutils.SetupTestDbConn("testdb")
+		defer conn.Close()
+
+		fpInfo := fp.FilePathInfo{
+			PID:       1,
+			Timestamp: "11223344556677",
+		}
+
+		testhelper.AssertQueryRuns(conn, "SET application_name TO 'hangingApplication'")
+		testhelper.AssertQueryRuns(conn, "CREATE TABLE public.foo(i int)")
+		defer testhelper.AssertQueryRuns(conn, "DROP TABLE public.foo")
+		err = unix.Mkfifo(testPipe, 0777)
+		Expect(err).To(Not(HaveOccurred()))
+		defer os.Remove(testPipe)
+		go func() {
+			copyFileName := fpInfo.GetSegmentPipePathForCopyCommand()
+			// COPY will blcok because there is no reader for the testPipe
+			_, _ = conn.Exec(fmt.Sprintf("COPY public.foo TO PROGRAM 'echo %s > /dev/null; cat - > %s' WITH CSV DELIMITER ','", copyFileName, testPipe))
+		}()
+
+		query := `SELECT count(*) FROM pg_stat_activity WHERE application_name = 'hangingApplication'`
+		Eventually(func() string { return dbconn.MustSelectString(connectionPool, query) }, 5*time.Second, 100*time.Millisecond).Should(Equal("1"))
+
+		utils.TerminateHangingCopySessions(connectionPool, fpInfo, "hangingApplication")
+
+		Eventually(func() string { return dbconn.MustSelectString(connectionPool, query) }, 5*time.Second, 100*time.Millisecond).Should(Equal("0"))
+
+	})
+})

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -646,7 +646,7 @@ func DoCleanup(restoreFailed bool) {
 			}
 			utils.CleanUpHelperFilesOnAllHosts(globalCluster, fpInfo)
 			if wasTerminated { // These should all end on their own in a successful restore
-				utils.TerminateHangingCopySessions(connectionPool, fpInfo, "gprestore")
+				utils.TerminateHangingCopySessions(connectionPool, fpInfo, fmt.Sprintf("gprestore_%s_%s", fpInfo.Timestamp, restoreStartTime))
 			}
 		}
 	}


### PR DESCRIPTION
commit 92e049b3814acd26a805e25edc9a470c3c1649d3
    Add test for TerminateHangingCopySessions

commit faf61468e5af61461c4f2922713db083aeb8beaf
    Fix wrong application name being passed to TerminateHangingCopySessions

commit 16b5f6f5b59386333c3b725e492e61af97d0dbc2
    Copy sessions must be terminated before cleaning up gpbackup_helper processes to avoid a potential deadlock