### PR TITLE
Queue parallelized COPY commands for gpbackup_helper to consume

### DIFF
--- a/backup/data.go
+++ b/backup/data.go
@@ -5,10 +5,12 @@ package backup
  */
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
@@ -110,6 +112,159 @@ func BackupSingleTableData(table Table, rowsCopiedMap map[uint32]int64, counters
 	return nil
 }
 
+// backupDataForAllTablesCopyQueue does not backup tables in parallel. This is
+// specifically for single-data-file. While tables backed up one at a time, it
+// is possible to save a significant amount of time by queuing up the next
+// table to copy. Worker 0 does not have tables pre-assigned to it. The copy
+// queue uses worker 0 a special deferred worker in the event that the other
+// workers encounter locking issues. Worker 0 already has all locks on the
+// tables so it will not run into locking issues.
+func backupDataForAllTablesCopyQueue(tables []Table) []map[uint32]int64 {
+	var numExtOrForeignTables int64
+	for _, table := range tables {
+		if table.SkipDataBackup() {
+			numExtOrForeignTables++
+		}
+	}
+	counters := BackupProgressCounters{NumRegTables: 0, TotalRegTables: int64(len(tables)) - numExtOrForeignTables}
+	counters.ProgressBar = utils.NewProgressBar(int(counters.TotalRegTables), "Tables backed up: ", utils.PB_INFO)
+	counters.ProgressBar.Start()
+	rowsCopiedMaps := make([]map[uint32]int64, connectionPool.NumConns)
+	/*
+	 * We break when an interrupt is received and rely on
+	 * TerminateHangingCopySessions to kill any COPY statements
+	 * in progress if they don't finish on their own.
+	 */
+	tasks := make(chan Table, len(tables))
+	var oidMap sync.Map
+	var workerPool sync.WaitGroup
+	var copyErr error
+	// Record and track tables in a hashmap of oids and table states (preloaded with value Unknown).
+	// The tables are loaded into the tasks channel for the subsequent goroutines to work on.
+	for _, table := range tables {
+		oidMap.Store(table.Oid, Unknown)
+		tasks <- table
+	}
+	// We incremented numConns by 1 to treat connNum 0 as a special worker
+	rowsCopiedMaps[0] = make(map[uint32]int64)
+	for connNum := 1; connNum < connectionPool.NumConns; connNum++ {
+		rowsCopiedMaps[connNum] = make(map[uint32]int64)
+		workerPool.Add(1)
+		go func(whichConn int) {
+			defer workerPool.Done()
+			for table := range tasks {
+				if wasTerminated || copyErr != nil {
+					counters.ProgressBar.(*pb.ProgressBar).NotPrint = true
+					return
+				}
+
+				if table.SkipDataBackup() {
+					gplog.Verbose("Skipping data backup of table %s because it is either an external or foreign table.", table.FQN())
+					oidMap.Store(table.Oid, Complete)
+					continue
+				}
+				// If a random external SQL command had queued an AccessExclusiveLock acquisition request
+				// against this next table, the --job worker thread would deadlock on the COPY attempt.
+				// To prevent gpbackup from hanging, we attempt to acquire an AccessShareLock on the
+				// relation with the NOWAIT option before we run COPY. If the LOCK TABLE NOWAIT call
+				// fails, we catch the error and defer the table to the main worker thread, worker 0.
+				// Afterwards, we break early and terminate the worker since its transaction is now in an
+				// aborted state. We do not need to do this with the main worker thread because it has
+				// already acquired AccessShareLocks on all tables before the metadata dumping part.
+				err := LockTableNoWait(table, whichConn)
+				if err != nil {
+					if pgErr, ok := err.(*pgconn.PgError); ok && pgErr.Code != PG_LOCK_NOT_AVAILABLE {
+						copyErr = err
+						continue
+					}
+
+					if gplog.GetVerbosity() < gplog.LOGVERBOSE {
+						// Add a newline to interrupt the progress bar so that
+						// the following WARN message is nicely outputted.
+						fmt.Printf("\n")
+					}
+					gplog.Warn("Worker %d could not acquire AccessShareLock for table %s. Terminating worker and deferring table to main worker thread.",
+						whichConn, table.FQN())
+
+					oidMap.Store(table.Oid, Deferred)
+					// Rollback transaction since it's in an aborted state
+					connectionPool.MustRollback(whichConn)
+
+					// Worker no longer has a valid distributed transaction snapshot
+					break
+				}
+
+				err = BackupSingleTableData(table, rowsCopiedMaps[whichConn], &counters, whichConn)
+				if err != nil {
+					copyErr = err
+				}
+				oidMap.Store(table.Oid, Complete)
+			}
+		}(connNum)
+	}
+
+	// Special goroutine to handle deferred tables
+	// Handle all tables deferred by the deadlock detection. This can only be
+	// done with the main worker thread, worker 0, because it has
+	// AccessShareLocks on all the tables already.
+	deferredWorkerDone := make(chan bool)
+	go func() {
+		for _, table := range tables {
+			for {
+				state, _ := oidMap.Load(table.Oid)
+				if state.(int) == Unknown {
+					time.Sleep(time.Millisecond * 50)
+				} else if state.(int) == Deferred {
+					err := BackupSingleTableData(table, rowsCopiedMaps[0], &counters, 0)
+					if err != nil {
+						copyErr = err
+					}
+					oidMap.Store(table.Oid, Complete)
+					break
+				} else if state.(int) == Complete {
+					break
+				} else {
+					gplog.Fatal(errors.New("Encountered unknown table state"), "")
+				}
+			}
+		}
+		deferredWorkerDone <- true
+	}()
+
+	close(tasks)
+	workerPool.Wait()
+
+	// Check if all the workers were terminated. If they did, defer all remaining tables to worker 0
+	allWorkersTerminatedLogged := false
+	for _, table := range tables {
+		state, _ := oidMap.Load(table.Oid)
+		if state == Unknown {
+			if !allWorkersTerminatedLogged {
+				gplog.Warn("All copy queue workers terminated due to lock issues. Falling back to single main worker.")
+				allWorkersTerminatedLogged = true
+			}
+			oidMap.Store(table.Oid, Deferred)
+		}
+	}
+	// Main goroutine waits for deferred worker 0 by waiting on this channel
+	<-deferredWorkerDone
+
+	agentErr := utils.CheckAgentErrorsOnSegments(globalCluster, globalFPInfo)
+
+	if copyErr != nil && agentErr != nil {
+		gplog.Error(agentErr.Error())
+		gplog.Fatal(copyErr, "")
+	} else if copyErr != nil {
+		gplog.Fatal(copyErr, "")
+	} else if agentErr != nil {
+		gplog.Fatal(agentErr, "")
+	}
+
+	counters.ProgressBar.Finish()
+	printDataBackupWarnings(numExtOrForeignTables)
+	return rowsCopiedMaps
+}
+
 func backupDataForAllTables(tables []Table) []map[uint32]int64 {
 	var numExtOrForeignTables int64
 	for _, table := range tables {
@@ -157,8 +312,7 @@ func backupDataForAllTables(tables []Table) []map[uint32]int64 {
 				if whichConn != 0 {
 					err := LockTableNoWait(table, whichConn)
 					if err != nil {
-						// Postgres Error Code 55P03 translates to LOCK_NOT_AVAILABLE
-						if pgErr, ok := err.(*pgconn.PgError); ok && pgErr.Code != "55P03" {
+						if pgErr, ok := err.(*pgconn.PgError); ok && pgErr.Code != PG_LOCK_NOT_AVAILABLE {
 							copyErr = err
 							continue
 						}

--- a/backup/data.go
+++ b/backup/data.go
@@ -85,13 +85,14 @@ func CopyTableOut(connectionPool *dbconn.DBConn, table Table, destinationToWrite
 }
 
 func BackupSingleTableData(table Table, rowsCopiedMap map[uint32]int64, counters *BackupProgressCounters, whichConn int) error {
-	atomic.AddInt64(&counters.NumRegTables, 1)
-	numTables := counters.NumRegTables //We save this so it won't be modified before we log it
+	logMessage := fmt.Sprintf("Worker %d: Writing data for table %s to file", whichConn, table.FQN())
+	// Avoid race condition by incrementing counters in call to sprintf
+	tableCount := fmt.Sprintf(" (table %d of %d)", atomic.AddInt64(&counters.NumRegTables, 1), counters.TotalRegTables)
 	if gplog.GetVerbosity() > gplog.LOGINFO {
 		// No progress bar at this log level, so we note table count here
-		gplog.Verbose("Writing data for table %s to file (table %d of %d)", table.FQN(), numTables, counters.TotalRegTables)
+		gplog.Verbose(logMessage + tableCount)
 	} else {
-		gplog.Verbose("Writing data for table %s to file", table.FQN())
+		gplog.Verbose(logMessage)
 	}
 
 	destinationToWrite := ""

--- a/backup/global_variables.go
+++ b/backup/global_variables.go
@@ -20,6 +20,16 @@ import (
  */
 
 /*
+ Table backup state constants
+*/
+const (
+	Unknown int = iota
+	Deferred
+	Complete
+	PG_LOCK_NOT_AVAILABLE = "55P03"
+)
+
+/*
  * Non-flag variables
  */
 var (
@@ -98,6 +108,10 @@ func SetQuotedRoleNames(quotedRoles map[string]string) {
 }
 
 // Util functions to enable ease of access to global flag values
+
+func FlagChanged(flagName string) bool {
+	return cmdFlags.Changed(flagName)
+}
 
 func MustGetFlagString(flagName string) string {
 	return options.MustGetFlagString(cmdFlags, flagName)

--- a/backup/validate.go
+++ b/backup/validate.go
@@ -102,6 +102,9 @@ func validateFlagCombinations(flags *pflag.FlagSet) {
 	options.CheckExclusiveFlags(flags, options.NO_COMPRESSION, options.COMPRESSION_TYPE)
 	options.CheckExclusiveFlags(flags, options.NO_COMPRESSION, options.COMPRESSION_LEVEL)
 	options.CheckExclusiveFlags(flags, options.PLUGIN_CONFIG, options.BACKUP_DIR)
+	if FlagChanged(options.COPY_QUEUE_SIZE) && !MustGetFlagBool(options.SINGLE_DATA_FILE) {
+		gplog.Fatal(errors.Errorf("--copy-queue-size must be specified with --single-data-file"), "")
+	}
 	if MustGetFlagString(options.FROM_TIMESTAMP) != "" && !MustGetFlagBool(options.INCREMENTAL) {
 		gplog.Fatal(errors.Errorf("--from-timestamp must be specified with --incremental"), "")
 	}
@@ -120,6 +123,10 @@ func validateFlagValues() {
 	if MustGetFlagString(options.FROM_TIMESTAMP) != "" && !filepath.IsValidTimestamp(MustGetFlagString(options.FROM_TIMESTAMP)) {
 		gplog.Fatal(errors.Errorf("Timestamp %s is invalid.  Timestamps must be in the format YYYYMMDDHHMMSS.",
 			MustGetFlagString(options.FROM_TIMESTAMP)), "")
+	}
+	if FlagChanged(options.COPY_QUEUE_SIZE) && MustGetFlagInt(options.COPY_QUEUE_SIZE) < 2 {
+		gplog.Fatal(errors.Errorf("--copy-queue-size %d is invalid. Must be at least 2",
+			MustGetFlagInt(options.COPY_QUEUE_SIZE)), "")
 	}
 }
 

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -3,7 +3,6 @@ package end_to_end_test
 import (
 	"flag"
 	"fmt"
-	"github.com/pkg/errors"
 	"io/ioutil"
 	"math/rand"
 	"os"
@@ -16,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/blang/semver"
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
@@ -563,6 +563,34 @@ var _ = Describe("backup and restore end to end tests", func() {
 			Expect(stdout).To(ContainSubstring("Cleanup complete"))
 			Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
 		})
+		It("runs gpbackup with copy-queue-size and sends a SIGINT to ensure cleanup functions successfully", func() {
+			if useOldBackupVersion {
+				Skip("This test is not needed for old backup versions")
+			}
+			args := []string{"--dbname", "testdb",
+				"--backup-dir", backupDir,
+				"--single-data-file",
+				"--copy-queue-size", "4",
+				"--verbose"}
+			cmd := exec.Command(gpbackupPath, args...)
+			go func() {
+				/*
+				 * We use a random delay for the sleep in this test (between
+				 * 0.5s and 0.8s) so that gpbackup will be interrupted at a
+				 * different point in the backup process every time to help
+				 * catch timing issues with the cleanup.
+				 */
+				rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+				time.Sleep(time.Duration(rng.Intn(300)+500) * time.Millisecond)
+				_ = cmd.Process.Signal(os.Interrupt)
+			}()
+			output, _ := cmd.CombinedOutput()
+			stdout := string(output)
+
+			Expect(stdout).To(ContainSubstring("Received a termination signal, aborting backup process"))
+			Expect(stdout).To(ContainSubstring("Cleanup complete"))
+			Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
+		})
 		It("runs gprestore and sends a SIGINT to ensure cleanup functions successfully", func() {
 			if useOldBackupVersion {
 				Skip("This test is not needed for old backup versions")
@@ -575,6 +603,39 @@ var _ = Describe("backup and restore end to end tests", func() {
 				"--redirect-db", "restoredb",
 				"--backup-dir", backupDir,
 				"--verbose"}
+			cmd := exec.Command(gprestorePath, args...)
+			go func() {
+				/*
+				 * We use a random delay for the sleep in this test (between
+				 * 0.5s and 0.8s) so that gprestore will be interrupted at a
+				 * different point in the backup process every time to help
+				 * catch timing issues with the cleanup.
+				 */
+				rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+				time.Sleep(time.Duration(rng.Intn(300)+500) * time.Millisecond)
+				_ = cmd.Process.Signal(os.Interrupt)
+			}()
+			output, _ := cmd.CombinedOutput()
+			stdout := string(output)
+
+			Expect(stdout).To(ContainSubstring("Received a termination signal, aborting restore process"))
+			Expect(stdout).To(ContainSubstring("Cleanup complete"))
+			Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
+			assertArtifactsCleaned(restoreConn, timestamp)
+		})
+		It("runs gprestore with copy-queue-size and sends a SIGINT to ensure cleanup functions successfully", func() {
+			if useOldBackupVersion {
+				Skip("This test is not needed for old backup versions")
+			}
+			timestamp := gpbackup(gpbackupPath, backupHelperPath,
+				"--backup-dir", backupDir,
+				"--single-data-file")
+			args := []string{
+				"--timestamp", timestamp,
+				"--redirect-db", "restoredb",
+				"--backup-dir", backupDir,
+				"--verbose",
+				"--copy-queue-size", "4"}
 			cmd := exec.Command(gprestorePath, args...)
 			go func() {
 				/*
@@ -1360,7 +1421,6 @@ var _ = Describe("backup and restore end to end tests", func() {
 			"--jobs", "9",
 			"--verbose"}
 		cmd := exec.Command(gpbackupPath, args...)
-
 		// Concurrently wait for gpbackup to block when it requests an AccessShareLock on public.foo. Once
 		// that happens, acquire an AccessExclusiveLock on pg_catalog.pg_trigger to block gpbackup during its
 		// trigger metadata dump. Then release the initial AccessExclusiveLock on public.foo (from the
@@ -1457,6 +1517,137 @@ var _ = Describe("backup and restore end to end tests", func() {
 
 		// No non-main worker should have been able to run COPY due to deadlock detection
 		for i := 1; i < 9; i++ {
+			expectedLockString := fmt.Sprintf("[DEBUG]:-Worker %d: LOCK TABLE ", i)
+			Expect(stdout).To(ContainSubstring(expectedLockString))
+
+			expectedWarnString := fmt.Sprintf("[WARNING]:-Worker %d could not acquire AccessShareLock for table", i)
+			Expect(stdout).To(ContainSubstring(expectedWarnString))
+
+			unexpectedCopyString := fmt.Sprintf("[DEBUG]:-Worker %d: COPY ", i)
+			Expect(stdout).ToNot(ContainSubstring(unexpectedCopyString))
+		}
+
+		// Only the main worker thread, worker 0, will run COPY on all the test tables
+		for _, dataTable := range dataTables {
+			expectedString := fmt.Sprintf(`[DEBUG]:-Worker 0: COPY %s TO PROGRAM `, dataTable)
+			Expect(stdout).To(ContainSubstring(expectedString))
+		}
+
+		Expect(stdout).To(ContainSubstring("Backup completed successfully"))
+	})
+	It("runs gpbackup with copy-queue-size flag and COPY deadlock handling occurs", func() {
+		if useOldBackupVersion {
+			Skip("This test is not needed for old backup versions")
+		}
+		// Acquire AccessExclusiveLock on public.foo to block gpbackup when it attempts
+		// to grab AccessShareLocks before its metadata dump section.
+		backupConn.MustExec("BEGIN; LOCK TABLE public.foo IN ACCESS EXCLUSIVE MODE")
+
+		// Execute gpbackup with --copy-queue-size 2
+		args := []string{
+			"--dbname", "testdb",
+			"--backup-dir", backupDir,
+			"--single-data-file",
+			"--copy-queue-size", "2",
+			"--verbose"}
+		cmd := exec.Command(gpbackupPath, args...)
+
+		// Concurrently wait for gpbackup to block when it requests an AccessShareLock on public.foo. Once
+		// that happens, acquire an AccessExclusiveLock on pg_catalog.pg_trigger to block gpbackup during its
+		// trigger metadata dump. Then release the initial AccessExclusiveLock on public.foo (from the
+		// beginning of the test) to unblock gpbackup and let gpbackup move forward to the trigger metadata dump.
+		anotherConn := testutils.SetupTestDbConn("testdb")
+		defer anotherConn.Close()
+		go func() {
+			// Query to see if gpbackup's AccessShareLock request on public.foo is blocked
+			checkLockQuery := `SELECT count(*) FROM pg_locks l, pg_class c, pg_namespace n WHERE l.relation = c.oid AND n.oid = c.relnamespace AND n.nspname = 'public' AND c.relname = 'foo' AND l.granted = 'f' AND l.mode = 'AccessShareLock'`
+
+			// Wait up to 10 seconds for gpbackup to block
+			var gpbackupBlockedLockCount int
+			iterations := 100
+			for iterations > 0 {
+				_ = anotherConn.Get(&gpbackupBlockedLockCount, checkLockQuery)
+				if gpbackupBlockedLockCount < 1 {
+					time.Sleep(100 * time.Millisecond)
+					iterations--
+				} else {
+					break
+				}
+			}
+
+			// Queue AccessExclusiveLock request on pg_catalog.pg_trigger to block gpbackup
+			// during the trigger metadata dump so that the test can queue a bunch of
+			// AccessExclusiveLock requests against the test tables. Afterwards, release the
+			// AccessExclusiveLock on public.foo to let gpbackup go to the trigger metadata dump.
+			anotherConn.MustExec(`BEGIN; LOCK TABLE pg_catalog.pg_trigger IN ACCESS EXCLUSIVE MODE`)
+			backupConn.MustExec("COMMIT")
+		}()
+
+		// Concurrently wait for gpbackup to block on the trigger metadata dump section. Once we
+		// see gpbackup blocked, request AccessExclusiveLock (to imitate a TRUNCATE or VACUUM
+		// FULL) on all the test tables.
+		dataTables := []string{`public."FOObar"`, "public.foo", "public.holds", "public.sales",
+			"schema2.ao1", "schema2.ao2", "schema2.foo2", "schema2.foo3", "schema2.returns"}
+		for _, dataTable := range dataTables {
+			go func(dataTable string) {
+				accessExclusiveLockConn := testutils.SetupTestDbConn("testdb")
+				defer accessExclusiveLockConn.Close()
+
+				// Query to see if gpbackup's AccessShareLock request on pg_catalog.pg_trigger is blocked
+				checkLockQuery := `SELECT count(*) FROM pg_locks l, pg_class c, pg_namespace n WHERE l.relation = c.oid AND n.oid = c.relnamespace AND n.nspname = 'pg_catalog' AND c.relname = 'pg_trigger' AND l.granted = 'f' AND l.mode = 'AccessShareLock'`
+
+				// Wait up to 10 seconds for gpbackup to block
+				var gpbackupBlockedLockCount int
+				iterations := 100
+				for iterations > 0 {
+					_ = accessExclusiveLockConn.Get(&gpbackupBlockedLockCount, checkLockQuery)
+					if gpbackupBlockedLockCount < 1 {
+						time.Sleep(100 * time.Millisecond)
+						iterations--
+					} else {
+						break
+					}
+				}
+
+				// Queue an AccessExclusiveLock request on a test table which will later
+				// result in a detected deadlock during the gpbackup data dump section.
+				accessExclusiveLockConn.MustExec(fmt.Sprintf(`BEGIN; LOCK TABLE %s IN ACCESS EXCLUSIVE MODE; COMMIT`, dataTable))
+			}(dataTable)
+		}
+
+		// Concurrently wait for all AccessExclusiveLock requests on all 9 test tables to block.
+		// Once that happens, release the AccessExclusiveLock on pg_catalog.pg_trigger to unblock
+		// gpbackup and let gpbackup move forward to the data dump section.
+		var accessExclBlockedLockCount int
+		go func() {
+			// Query to check for ungranted AccessExclusiveLock requests on our test tables
+			checkLockQuery := `SELECT count(*) FROM pg_locks WHERE granted = 'f' AND mode = 'AccessExclusiveLock'`
+
+			// Wait up to 10 seconds
+			iterations := 100
+			for iterations > 0 {
+				_ = backupConn.Get(&accessExclBlockedLockCount, checkLockQuery)
+				if accessExclBlockedLockCount < 9 {
+					time.Sleep(100 * time.Millisecond)
+					iterations--
+				} else {
+					break
+				}
+			}
+
+			// Unblock gpbackup by releasing AccessExclusiveLock on pg_catalog.pg_trigger
+			anotherConn.MustExec("COMMIT")
+		}()
+
+		// gpbackup has finished
+		output, _ := cmd.CombinedOutput()
+		stdout := string(output)
+
+		// Sanity check that 9 deadlock traps were placed during the test
+		Expect(accessExclBlockedLockCount).To(Equal(9))
+		Expect(stdout).To(ContainSubstring("All copy queue workers terminated due to lock issues. Falling back to single main worker."))
+		// No non-main worker should have been able to run COPY due to deadlock detection
+		for i := 1; i < 2; i++ {
 			expectedLockString := fmt.Sprintf("[DEBUG]:-Worker %d: LOCK TABLE ", i)
 			Expect(stdout).To(ContainSubstring(expectedLockString))
 

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -7,13 +7,13 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"runtime/debug"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"syscall"
-	"path/filepath"
 
 	"golang.org/x/sys/unix"
 
@@ -28,14 +28,12 @@ import (
 
 var (
 	CleanupGroup  *sync.WaitGroup
-	currentPipe   string
 	errBuf        bytes.Buffer
-	lastPipe      string
-	nextPipe      string
 	version       string
 	wasTerminated bool
 	writeHandle   *os.File
 	writer        *bufio.Writer
+	pipesMap      map[string]bool
 )
 
 /*
@@ -55,6 +53,7 @@ var (
 	restoreAgent     *bool
 	tocFile          *string
 	isFiltered       *bool
+	copyQueue        *int
 )
 
 func DoHelper() {
@@ -112,18 +111,20 @@ func InitializeGlobals() {
 	restoreAgent = flag.Bool("restore-agent", false, "Use gpbackup_helper as an agent for restore")
 	tocFile = flag.String("toc-file", "", "Absolute path to the table of contents file")
 	isFiltered = flag.Bool("with-filters", false, "Used with table/schema filters")
+	copyQueue = flag.Int("copy-queue-size", 1, "Used to know how many COPIES are being queued up")
 
 	if *onErrorContinue && !*restoreAgent {
 		fmt.Printf("--on-error-continue flag can only be used with --restore-agent flag")
 		os.Exit(1)
 	}
-
 	flag.Parse()
 	if *printVersion {
 		fmt.Printf("gpbackup_helper version %s\n", version)
 		os.Exit(0)
 	}
 	operating.InitializeSystemFunctions()
+
+	pipesMap = make(map[string]bool, 0)
 }
 
 /*
@@ -132,7 +133,30 @@ func InitializeGlobals() {
 
 func createPipe(pipe string) error {
 	err := unix.Mkfifo(pipe, 0777)
-	return err
+	if err != nil {
+		return err
+	}
+
+	pipesMap[pipe] = true
+	return nil
+}
+
+func deletePipe(pipe string) error {
+	err := utils.RemoveFileIfExists(pipe)
+	if err != nil {
+		return err
+	}
+
+	delete(pipesMap, pipe)
+	return nil
+}
+
+// Gpbackup creates the first n pipes. Record these pipes.
+func preloadCreatedPipes(oidList []int, queuedPipeCount int) {
+	for i := 0; i < queuedPipeCount; i++ {
+		pipeName := fmt.Sprintf("%s_%d", *pipeFile, oidList[i])
+		pipesMap[pipeName] = true
+	}
 }
 
 func getOidListFromFile() ([]int, error) {
@@ -187,17 +211,13 @@ func DoCleanup() {
 	if err != nil {
 		log("Encountered error during cleanup: %v", err)
 	}
-	err = utils.RemoveFileIfExists(lastPipe)
-	if err != nil {
-		log("Encountered error during cleanup: %v", err)
-	}
-	err = utils.RemoveFileIfExists(currentPipe)
-	if err != nil {
-		log("Encountered error during cleanup: %v", err)
-	}
-	err = utils.RemoveFileIfExists(nextPipe)
-	if err != nil {
-		log("Encountered error during cleanup: %v", err)
+
+	for pipeName, _ := range pipesMap {
+		log("Removing pipe %s", pipeName)
+		err = deletePipe(pipeName)
+		if err != nil {
+			log("Encountered error removing pipe %s: %v", pipeName, err)
+		}
 	}
 
 	skipFiles, _ := filepath.Glob(fmt.Sprintf("%s_skip_*", *pipeFile))

--- a/options/flag.go
+++ b/options/flag.go
@@ -37,6 +37,7 @@ const (
 	PLUGIN_CONFIG         = "plugin-config"
 	QUIET                 = "quiet"
 	SINGLE_DATA_FILE      = "single-data-file"
+	COPY_QUEUE_SIZE       = "copy-queue-size"
 	VERBOSE               = "verbose"
 	WITH_STATS            = "with-stats"
 	CREATE_DB             = "create-db"
@@ -76,6 +77,7 @@ func SetBackupFlagDefaults(flagSet *pflag.FlagSet) {
 	flagSet.Bool("version", false, "Print version number and exit")
 	flagSet.Bool(QUIET, false, "Suppress non-warning, non-error log messages")
 	flagSet.Bool(SINGLE_DATA_FILE, false, "Back up all data to a single file instead of one per table")
+	flagSet.Int(COPY_QUEUE_SIZE, 1, "number of COPY commands gpbackup should enqueue when backing up using the --single-data-file option")
 	flagSet.Bool(VERBOSE, false, "Print verbose log messages")
 	flagSet.Bool(WITH_STATS, false, "Back up query plan statistics")
 	flagSet.Bool(WITHOUT_GLOBALS, false, "Skip backup of global metadata")
@@ -104,6 +106,7 @@ func SetRestoreFlagDefaults(flagSet *pflag.FlagSet) {
 	flagSet.Bool(QUIET, false, "Suppress non-warning, non-error log messages")
 	flagSet.String(REDIRECT_DB, "", "Restore to the specified database instead of the database that was backed up")
 	flagSet.String(REDIRECT_SCHEMA, "", "Restore to the specified schema instead of the schema that was backed up")
+	flagSet.Int(COPY_QUEUE_SIZE, 1, "Number of COPY commands gprestore should enqueue when restoring a backup taken using the --single-data-file option")
 	flagSet.Bool(WITH_GLOBALS, false, "Restore global metadata")
 	flagSet.String(TIMESTAMP, "", "The timestamp to be restored, in the format YYYYMMDDHHMMSS")
 	flagSet.Bool(TRUNCATE_TABLE, false, "Removes data of the tables getting restored")

--- a/plugins/plugin_test.sh
+++ b/plugins/plugin_test.sh
@@ -486,10 +486,12 @@ test_backup_and_restore_with_plugin() {
     echo "[PASSED] gpbackup and gprestore (using ${flags})"
 }
 
+test_backup_and_restore_with_plugin "--single-data-file --no-compression --copy-queue-size 4" "--copy-queue-size 4"
 test_backup_and_restore_with_plugin "--no-compression --single-data-file"
 test_backup_and_restore_with_plugin "--no-compression"
 test_backup_and_restore_with_plugin "--metadata-only"
 test_backup_and_restore_with_plugin "--no-compression --single-data-file" "restore-filter"
+
 
 # ----------------------------------------------
 # Cleanup test artifacts

--- a/plugins/plugin_test_scale.sh
+++ b/plugins/plugin_test_scale.sh
@@ -142,7 +142,7 @@ if [[ "$plugin" == *gpbackup_s3_plugin ]]; then
 fi
 
 test_backup_and_restore_with_plugin "$plugin_config" "--single-data-file --no-compression" "$restore_filter"
-
+test_backup_and_restore_with_plugin "$plugin_config" "--single-data-file --copy-queue-size 4 --no-compression" "--copy-queue-size 4"
 if [[ "$plugin" == *gpbackup_ddboost_plugin ]]; then
   echo
   echo "DISABLED restore_subset"

--- a/restore/data.go
+++ b/restore/data.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gpbackup/filepath"
@@ -94,13 +95,12 @@ func restoreDataFromTimestamp(fpInfo filepath.FilePathInfo, dataEntries []toc.Ma
 	if backupConfig.SingleDataFile {
 		gplog.Verbose("Initializing pipes and gpbackup_helper on segments for single data file restore")
 		utils.VerifyHelperVersionOnSegments(version, globalCluster)
-		filteredOids := make([]string, totalTables)
+		oidList := make([]string, totalTables)
 		for i, entry := range dataEntries {
-			filteredOids[i] = fmt.Sprintf("%d", entry.Oid)
+			oidList[i] = fmt.Sprintf("%d", entry.Oid)
 		}
-		utils.WriteOidListToSegments(filteredOids, globalCluster, fpInfo)
-		firstOid := fmt.Sprintf("%d", dataEntries[0].Oid)
-		utils.CreateFirstSegmentPipeOnAllHosts(firstOid, globalCluster, fpInfo)
+		utils.WriteOidListToSegments(oidList, globalCluster, fpInfo)
+		initialPipes := CreateInitialSegmentPipes(oidList, globalCluster, connectionPool,fpInfo)
 		if wasTerminated {
 			return 0
 		}
@@ -108,7 +108,7 @@ func restoreDataFromTimestamp(fpInfo filepath.FilePathInfo, dataEntries []toc.Ma
 		if len(opts.IncludedRelations) > 0 || len(opts.ExcludedRelations) > 0 || len(opts.IncludedSchemas) > 0 || len(opts.ExcludedSchemas) > 0 {
 			isFilter = true
 		}
-		utils.StartGpbackupHelpers(globalCluster, fpInfo, "--restore-agent", MustGetFlagString(options.PLUGIN_CONFIG), "", MustGetFlagBool(options.ON_ERROR_CONTINUE), isFilter, &wasTerminated)
+		utils.StartGpbackupHelpers(globalCluster, fpInfo, "--restore-agent", MustGetFlagString(options.PLUGIN_CONFIG), "", MustGetFlagBool(options.ON_ERROR_CONTINUE), isFilter, &wasTerminated, initialPipes)
 	}
 	/*
 	 * We break when an interrupt is received and rely on
@@ -191,4 +191,18 @@ func restoreDataFromTimestamp(fpInfo filepath.FilePathInfo, dataEntries []toc.Ma
 	}
 
 	return numErrors
+}
+
+func CreateInitialSegmentPipes(oidList []string, c *cluster.Cluster, connectionPool *dbconn.DBConn, fpInfo filepath.FilePathInfo) int {
+	// Create min(connections, tables) segment pipes on each host
+	var maxPipes int
+	if connectionPool.NumConns < len(oidList) {
+		maxPipes = connectionPool.NumConns
+	} else {
+		maxPipes = len(oidList)
+	}
+	for i := 0; i < maxPipes; i++ {
+		utils.CreateSegmentPipeOnAllHosts(oidList[i], c, fpInfo)
+	}
+	return maxPipes
 }

--- a/restore/data.go
+++ b/restore/data.go
@@ -144,10 +144,9 @@ func restoreDataFromTimestamp(fpInfo filepath.FilePathInfo, dataEntries []toc.Ma
 				if err == nil {
 					err = restoreSingleTableData(&fpInfo, entry, tableName, whichConn)
 
-					atomic.AddInt64(&tableNum, 1)
 					if gplog.GetVerbosity() > gplog.LOGINFO {
 						// No progress bar at this log level, so we note table count here
-						gplog.Verbose("Restored data to table %s from file (table %d of %d)", tableName, tableNum, totalTables)
+						gplog.Verbose("Restored data to table %s from file (table %d of %d)", tableName, atomic.AddInt64(&tableNum, 1), totalTables)
 					} else {
 						gplog.Verbose("Restored data to table %s from file", tableName)
 					}

--- a/restore/global_variables.go
+++ b/restore/global_variables.go
@@ -94,6 +94,10 @@ func SetTOC(toc *toc.TOC) {
 
 // Util functions to enable ease of access to global flag values
 
+func FlagChanged(flagName string) bool {
+	return cmdFlags.Changed(flagName)
+}
+
 func MustGetFlagString(flagName string) string {
 	return options.MustGetFlagString(cmdFlags, flagName)
 }

--- a/restore/validate.go
+++ b/restore/validate.go
@@ -237,6 +237,9 @@ func ValidateBackupFlagCombinations() {
 	if backupConfig.DataOnly && MustGetFlagBool(options.METADATA_ONLY) {
 		gplog.Fatal(errors.Errorf("Cannot use metadata-only flag when restoring data-only backup"), "")
 	}
+	if !backupConfig.SingleDataFile && FlagChanged(options.COPY_QUEUE_SIZE) {
+		gplog.Fatal(errors.Errorf("The --copy-queue-size flag can only be used if the backup was taken with --single-data-file"), "")
+	}
 	validateBackupFlagPluginCombinations()
 }
 

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -63,7 +63,11 @@ func SetLoggerVerbosity() {
 
 func CreateConnectionPool(unquotedDBName string) {
 	connectionPool = dbconn.NewDBConnFromEnvironment(unquotedDBName)
-	connectionPool.MustConnect(MustGetFlagInt(options.JOBS))
+	if FlagChanged(options.COPY_QUEUE_SIZE) {
+		connectionPool.MustConnect(MustGetFlagInt(options.COPY_QUEUE_SIZE))
+	} else {
+		connectionPool.MustConnect(MustGetFlagInt(options.JOBS))
+	}
 	utils.ValidateGPDBVersionCompatibility(connectionPool)
 }
 

--- a/utils/agent_remote_test.go
+++ b/utils/agent_remote_test.go
@@ -126,10 +126,17 @@ var _ = Describe("agent remote", func() {
 	Describe("StartGpbackupHelpers()", func() {
 		It("Correctly propagates --on-error-continue flag to gpbackup_helper", func() {
 			wasTerminated := false
-			utils.StartGpbackupHelpers(testCluster, fpInfo, "operation", "/tmp/pluginConfigFile.yml", " compressStr", true, false, &wasTerminated)
+			utils.StartGpbackupHelpers(testCluster, fpInfo, "operation", "/tmp/pluginConfigFile.yml", " compressStr", true, false, &wasTerminated, 1)
 
 			cc := testExecutor.ClusterCommands[0]
 			Expect(cc[1].CommandString).To(ContainSubstring(" --on-error-continue"))
+		})
+		It("Correctly propagates --copy-queue-size value to gpbackup_helper", func() {
+			wasTerminated := false
+			utils.StartGpbackupHelpers(testCluster, fpInfo, "operation", "/tmp/pluginConfigFile.yml", " compressStr", false, false, &wasTerminated, 4)
+
+			cc := testExecutor.ClusterCommands[0]
+			Expect(cc[1].CommandString).To(ContainSubstring(" --copy-queue-size 4"))
 		})
 	})
 	Describe("CheckAgentErrorsOnSegments", func() {


### PR DESCRIPTION
To reduce the amount of time gpbackup_helper is spent blocked waiting
for COPY statements to return, gpbackup and gprestore can now queue COPY
commands to speed up --single-data-file backups and restores if the
database has cpu cycles to spare.  If a worker can't get a lock on a
table, the worker is terminated and the table is then processed by
Worker 0. Worker 0 has AccessShare locks for all tables, and acts as a
special goroutine to handle deferred tables.

Added flag --single-data-file-copy-prefetch (Default 1). In order for
this to be used during restore the backup must have been taken with
--single-data-file.

This can improve backup and restore times significantly for databases
that contain a lot of tables with very little data where the majority of
time is spent waiting for gpdb to initiate COPY.