### PR TITLE
Log AccessExclusiveLock held on relation when worker cannot obtain AccessShareLock

### DIFF
--- a/backup/data.go
+++ b/backup/data.go
@@ -183,9 +183,8 @@ func backupDataForAllTablesCopyQueue(tables []Table) []map[uint32]int64 {
 						// the following WARN message is nicely outputted.
 						fmt.Printf("\n")
 					}
-					gplog.Warn("Worker %d could not acquire AccessShareLock for table %s. Terminating worker and deferring table to main worker thread.",
-						whichConn, table.FQN())
-
+					// Log locks held on the table
+					logTableLocks(table, whichConn)
 					oidMap.Store(table.Oid, Deferred)
 					// Rollback transaction since it's in an aborted state
 					connectionPool.MustRollback(whichConn)
@@ -322,9 +321,8 @@ func backupDataForAllTables(tables []Table) []map[uint32]int64 {
 							// the following WARN message is nicely outputted.
 							fmt.Printf("\n")
 						}
-						gplog.Warn("Worker %d could not acquire AccessShareLock for table %s. Terminating worker and deferring table to main worker thread.",
-							whichConn, table.FQN())
-
+						// Log locks held on the table
+						logTableLocks(table, whichConn)
 						// Defer table to main worker thread
 						deferredTablesMutex.Lock()
 						deferredTables = append(deferredTables, table)
@@ -412,6 +410,5 @@ func LockTableNoWait(dataTable Table, connNum int) error {
 	if err != nil {
 		return err
 	}
-
 	return nil
 }

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -1656,6 +1656,11 @@ var _ = Describe("backup and restore end to end tests", func() {
 
 			unexpectedCopyString := fmt.Sprintf("[DEBUG]:-Worker %d: COPY ", i)
 			Expect(stdout).ToNot(ContainSubstring(unexpectedCopyString))
+
+			expectedLockString = fmt.Sprintf(`Locks held on table %s`, dataTables[i])
+			Expect(stdout).To(ContainSubstring(expectedLockString))
+
+			Expect(stdout).To(ContainSubstring(`"Mode":"AccessExclusiveLock"`))
 		}
 
 		// Only the main worker thread, worker 0, will run COPY on all the test tables


### PR DESCRIPTION
In case we aren't able to grab an AccessShareLock on the table being backed up, we terminate the worker thread and its corresponding connection and let the main worker thread (Worker 0) handle them. This can happen when there is another session with an AccessExclusiveLock on the same table being handled by the worker thread.

When this occurs, log the AccessExclusiveLock being held on the table.

```
[WARNING]:-Worker 1 could not acquire AccessShareLock for table public.foo. 
Terminating worker and deferring table to main worker thread.
[WARNING]:-Locks held on table public.foo: [{"Oid":70037,"Database":"testdb","Relation":"public.foo",
"Mode":"AccessExclusiveLock","Application":"","Granted":"false","User":"bdoil","Pid":"2080006"}]
```

Authored-by: Brent Doil <bdoil@vmware.com>