### PR TITLE
Fix getTableLocks to not use text || regclass operator

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -540,7 +540,7 @@ func getTableLocks(table Table) []TableLocks {
 		query = fmt.Sprintf(`
 		SELECT c.oid as oid,
 		coalesce(a.datname, '') as database,
-		n.nspname || '.' || l.relation::regclass as relation,
+		n.nspname || '.' || l.relation as relation,
 		l.mode,
 		l.GRANTED as granted,
 		coalesce(a.application_name, '') as application,
@@ -560,7 +560,7 @@ func getTableLocks(table Table) []TableLocks {
 		query = fmt.Sprintf(`
 		SELECT c.oid as oid,
 		coalesce(a.datname, '') as database,
-		n.nspname || '.' || l.relation::regclass relation,
+		n.nspname || '.' || l.relation relation,
 		l.mode,
 		l.GRANTED as granted,
 		coalesce(a.application_name, '') as application,


### PR DESCRIPTION
Resolves ERROR: operator does not exist: text || regclass on GPDB4.3

Authored-by: Brent Doil <bdoil@vmware.com>