### PR TITLE
Local s3-plugin testing using Minio

### DIFF
--- a/plugins/generate_minio_config.sh
+++ b/plugins/generate_minio_config.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+cat <<MINIO_CONFIG > /tmp/minio_config.yaml
+executablepath: $(which gpbackup_s3_plugin)
+options:
+  endpoint: http://localhost:9000/
+  aws_access_key_id: minioadmin
+  aws_secret_access_key: minioadmin
+  bucket: gpbackup-s3-test
+  folder: test/backup
+MINIO_CONFIG


### PR DESCRIPTION
Minio is an s3 compliant object store. A Minio server can be setup
locally and used to test our s3 plugin. This make local testing of our
s3 plugin possible and easy without going through the trouble of needing
to setup Amazon S3 just for a testing endpoint. Created a new makefile
rule to setup a Minio server using docker, run our plugin_test against
the s3 plugin, and tear it down.