### PR TITLE
Add simple Github Actions CI for build and unit tests

### DIFF
--- a/.github/workflows/build_and_unit_test.yml
+++ b/.github/workflows/build_and_unit_test.yml
@@ -1,0 +1,43 @@
+name: build_and_unit_test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+    types: [ opened, synchronize, reopened, edited, ready_for_review ]
+
+jobs:
+
+  build_and_unit_test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        path: go/src/github.com/greenplum-db/gpbackup
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+
+    - name: Set Environment
+      run: |
+        echo "GOPATH=/home/runner/work/gpbackup/gpbackup/go" >> $GITHUB_ENV
+        echo "/home/runner/work/gpbackup/gpbackup/go/bin" >> $GITHUB_PATH
+
+    - name: Dependencies
+      run: |
+        cd ${GOPATH}/src/github.com/greenplum-db/gpbackup
+        make depend
+
+    - name: Build
+      run: |
+        cd ${GOPATH}/src/github.com/greenplum-db/gpbackup
+        make build
+
+    - name: Unit Test
+      run: |
+        cd ${GOPATH}/src/github.com/greenplum-db/gpbackup
+        make unit_all_gpdb_versions


### PR DESCRIPTION
Github Actions is a free and simple solution for gpbackup's need for
an open community CI to automate very simple sanity checks for
compilation and unit testing. Previously, we would need to manually
validate PRs by pulling them down and doing all the checks (compile,
unit tests, integration tests, and e2e tests)... or put them through a
custom Concourse dev pipeline that is only viewable internally. With
this patch, at least compilation errors or unit test errors will be
flagged immediately so that PR authors can be given faster feedback
instead of waiting on committer feedback.