### PR TITLE
Do not hold locks on gp_segment_configuration during backup

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -61,9 +61,14 @@ func DoSetup() {
 	err = opts.ExpandIncludesForPartitions(connectionPool, cmdFlags)
 	gplog.FatalOnError(err)
 
-	segConfig := cluster.MustGetSegmentConfiguration(connectionPool)
+	clusterConfigConn := dbconn.NewDBConnFromEnvironment(MustGetFlagString(options.DBNAME))
+	clusterConfigConn.MustConnect(1)
+
+	segConfig := cluster.MustGetSegmentConfiguration(clusterConfigConn)
 	globalCluster = cluster.NewCluster(segConfig)
-	segPrefix := filepath.GetSegPrefix(connectionPool)
+	segPrefix := filepath.GetSegPrefix(clusterConfigConn)
+	clusterConfigConn.Close()
+
 	globalFPInfo = filepath.NewFilePathInfo(globalCluster, MustGetFlagString(options.BACKUP_DIR), timestamp, segPrefix)
 	if MustGetFlagBool(options.METADATA_ONLY) {
 		_, err = globalCluster.ExecuteLocalCommand(fmt.Sprintf("mkdir -p %s", globalFPInfo.GetDirForContent(-1)))


### PR DESCRIPTION
Previously, locks were being held on gp_segment_configuration during the
entire backup process because the query was run against the connection pool,
which holds a transaction open for each connection. This would cause other applications
that queried the table to block until gpbackup was finished.

Instead, use a new connection to query gp_segment_configuration.

Authored-by: Brent Doil <bdoil@vmware.com>