### PR TITLE
Improve gpbackup_helper signal handling and cleanup

### DIFF
--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -15,7 +15,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+
 	"github.com/blang/semver"
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
@@ -28,6 +29,7 @@ import (
 	"github.com/greenplum-db/gpbackup/testutils"
 	"github.com/greenplum-db/gpbackup/toc"
 	"github.com/greenplum-db/gpbackup/utils"
+	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 
 	. "github.com/onsi/ginkgo"
@@ -296,6 +298,12 @@ func saveHistory(myCluster *cluster.Cluster) {
 	_ = utils.CopyFile(historyFilePath, saveHistoryFilePath)
 }
 
+// Parse backup timestamp from gpbackup log string
+func getBackupTimestamp(output string) string {
+	r := regexp.MustCompile(`Backup Timestamp = (\d{14})`)
+	return r.FindStringSubmatch(output)[1]
+}
+
 func TestEndToEnd(t *testing.T) {
 	format.MaxLength = 0
 	RegisterFailHandler(Fail)
@@ -537,173 +545,448 @@ var _ = Describe("backup and restore end to end tests", func() {
 			Expect(tocStruct.GlobalEntries[0].ObjectType).To(Equal("SESSION GUCS"))
 		})
 	})
-	Describe("SIGINT tests", func() {
-		It("runs gpbackup and sends a SIGINT to ensure cleanup functions successfully", func() {
-			if useOldBackupVersion {
-				Skip("This test is not needed for old backup versions")
-			}
-			args := []string{"--dbname", "testdb",
-				"--backup-dir", backupDir,
-				"--single-data-file",
-				"--verbose"}
-			cmd := exec.Command(gpbackupPath, args...)
-			go func() {
-				/*
-				 * We use a random delay for the sleep in this test (between
-				 * 0.5s and 0.8s) so that gpbackup will be interrupted at a
-				 * different point in the backup process every time to help
-				 * catch timing issues with the cleanup.
-				 */
-				rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-				time.Sleep(time.Duration(rng.Intn(300)+500) * time.Millisecond)
-				_ = cmd.Process.Signal(os.Interrupt)
-			}()
-			output, _ := cmd.CombinedOutput()
-			stdout := string(output)
-
-			Expect(stdout).To(ContainSubstring("Received a termination signal, aborting backup process"))
-			Expect(stdout).To(ContainSubstring("Cleanup complete"))
-			Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
+	Describe("Signal handler tests", func() {
+		BeforeEach(func() {
+			testhelper.AssertQueryRuns(backupConn, "CREATE table bigtable(id int unique); INSERT INTO bigtable SELECT generate_series(1,10000000)")
 		})
-		It("runs gpbackup with copy-queue-size and sends a SIGINT to ensure cleanup functions successfully", func() {
-			if useOldBackupVersion {
-				Skip("This test is not needed for old backup versions")
-			}
-			args := []string{"--dbname", "testdb",
-				"--backup-dir", backupDir,
-				"--single-data-file",
-				"--copy-queue-size", "4",
-				"--verbose"}
-			cmd := exec.Command(gpbackupPath, args...)
-			go func() {
-				/*
-				 * We use a random delay for the sleep in this test (between
-				 * 0.5s and 0.8s) so that gpbackup will be interrupted at a
-				 * different point in the backup process every time to help
-				 * catch timing issues with the cleanup.
-				 */
-				rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-				time.Sleep(time.Duration(rng.Intn(300)+500) * time.Millisecond)
-				_ = cmd.Process.Signal(os.Interrupt)
-			}()
-			output, _ := cmd.CombinedOutput()
-			stdout := string(output)
-
-			Expect(stdout).To(ContainSubstring("Received a termination signal, aborting backup process"))
-			Expect(stdout).To(ContainSubstring("Cleanup complete"))
-			Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
+		AfterEach(func() {
+			testhelper.AssertQueryRuns(backupConn, "DROP TABLE bigtable")
 		})
-		It("runs gprestore and sends a SIGINT to ensure cleanup functions successfully", func() {
-			if useOldBackupVersion {
-				Skip("This test is not needed for old backup versions")
-			}
-			timestamp := gpbackup(gpbackupPath, backupHelperPath,
-				"--backup-dir", backupDir,
-				"--single-data-file")
-			args := []string{
-				"--timestamp", timestamp,
-				"--redirect-db", "restoredb",
-				"--backup-dir", backupDir,
-				"--verbose"}
-			cmd := exec.Command(gprestorePath, args...)
-			go func() {
-				/*
-				 * We use a random delay for the sleep in this test (between
-				 * 0.5s and 0.8s) so that gprestore will be interrupted at a
-				 * different point in the backup process every time to help
-				 * catch timing issues with the cleanup.
-				 */
-				rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-				time.Sleep(time.Duration(rng.Intn(300)+500) * time.Millisecond)
-				_ = cmd.Process.Signal(os.Interrupt)
-			}()
-			output, _ := cmd.CombinedOutput()
-			stdout := string(output)
-
-			Expect(stdout).To(ContainSubstring("Received a termination signal, aborting restore process"))
-			Expect(stdout).To(ContainSubstring("Cleanup complete"))
-			Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
-			assertArtifactsCleaned(restoreConn, timestamp)
-		})
-		It("runs gprestore with copy-queue-size and sends a SIGINT to ensure cleanup functions successfully", func() {
-			if useOldBackupVersion {
-				Skip("This test is not needed for old backup versions")
-			}
-			timestamp := gpbackup(gpbackupPath, backupHelperPath,
-				"--backup-dir", backupDir,
-				"--single-data-file")
-			args := []string{
-				"--timestamp", timestamp,
-				"--redirect-db", "restoredb",
-				"--backup-dir", backupDir,
-				"--verbose",
-				"--copy-queue-size", "4"}
-			cmd := exec.Command(gprestorePath, args...)
-			go func() {
-				/*
-				 * We use a random delay for the sleep in this test (between
-				 * 0.5s and 0.8s) so that gprestore will be interrupted at a
-				 * different point in the backup process every time to help
-				 * catch timing issues with the cleanup.
-				 */
-				rng := rand.New(rand.NewSource(time.Now().UnixNano()))
-				time.Sleep(time.Duration(rng.Intn(300)+500) * time.Millisecond)
-				_ = cmd.Process.Signal(os.Interrupt)
-			}()
-			output, _ := cmd.CombinedOutput()
-			stdout := string(output)
-
-			Expect(stdout).To(ContainSubstring("Received a termination signal, aborting restore process"))
-			Expect(stdout).To(ContainSubstring("Cleanup complete"))
-			Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
-			assertArtifactsCleaned(restoreConn, timestamp)
-		})
-		It("runs gpbackup and sends a SIGINT to ensure blocked LOCK TABLE query is canceled", func() {
-			if useOldBackupVersion {
-				Skip("This test is not needed for old backup versions")
-			}
-
-			// Query to see if gpbackup lock acquire on schema2.foo2 is blocked
-			checkLockQuery := `SELECT count(*) FROM pg_locks l, pg_class c, pg_namespace n WHERE l.relation = c.oid AND n.oid = c.relnamespace AND n.nspname = 'schema2' AND c.relname = 'foo2' AND l.granted = 'f'`
-
-			// Acquire AccessExclusiveLock on schema2.foo2 to prevent gpbackup from acquiring AccessShareLock
-			backupConn.MustExec("BEGIN; LOCK TABLE schema2.foo2 IN ACCESS EXCLUSIVE MODE")
-			args := []string{
-				"--dbname", "testdb",
-				"--backup-dir", backupDir,
-				"--verbose"}
-			cmd := exec.Command(gpbackupPath, args...)
-
-			// Wait up to 5 seconds for gpbackup to block on acquiring AccessShareLock.
-			// Once blocked, we send a SIGINT to cancel gpbackup.
-			var beforeLockCount int
-			go func() {
-				iterations := 50
-				for iterations > 0 {
-					_ = backupConn.Get(&beforeLockCount, checkLockQuery)
-					if beforeLockCount < 1 {
-						time.Sleep(100 * time.Millisecond)
-						iterations--
-					} else {
-						break
-					}
+		Context("SIGINT", func() {
+			It("runs gpbackup and sends a SIGINT to ensure cleanup functions successfully", func() {
+				if useOldBackupVersion {
+					Skip("This test is not needed for old backup versions")
 				}
-				_ = cmd.Process.Signal(os.Interrupt)
-			}()
-			output, _ := cmd.CombinedOutput()
-			Expect(beforeLockCount).To(Equal(1))
-
-			// After gpbackup has been canceled, we should no longer see a blocked SQL
-			// session trying to acquire AccessShareLock on foo2.
-			var afterLockCount int
-			_ = backupConn.Get(&afterLockCount, checkLockQuery)
-			Expect(afterLockCount).To(Equal(0))
-			backupConn.MustExec("ROLLBACK")
-
-			stdout := string(output)
-			Expect(stdout).To(ContainSubstring("Received a termination signal, aborting backup process"))
-			Expect(stdout).To(ContainSubstring("Cleanup complete"))
-			Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
+				args := []string{"--dbname", "testdb",
+					"--backup-dir", backupDir,
+					"--single-data-file",
+					"--verbose"}
+				cmd := exec.Command(gpbackupPath, args...)
+				go func() {
+					/*
+					 * We use a random delay for the sleep in this test (between
+					 * 1.0s and 1.5s) so that gpbackup will be interrupted at a
+					 * different point in the backup process every time to help
+					 * catch timing issues with the cleanup.
+					 */
+					rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+					time.Sleep(time.Duration(rng.Intn(1000)+500) * time.Millisecond)
+					_ = cmd.Process.Signal(unix.SIGINT)
+				}()
+				output, _ := cmd.CombinedOutput()
+				stdout := string(output)
+				assertArtifactsCleaned(backupConn, getBackupTimestamp(stdout))
+				Expect(stdout).To(ContainSubstring("Received an interrupt signal, aborting backup process"))
+				Expect(stdout).To(ContainSubstring("Cleanup complete"))
+				Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
+			})
+			It("runs gpbackup with copy-queue-size and sends a SIGINT to ensure cleanup functions successfully", func() {
+				if useOldBackupVersion {
+					Skip("This test is not needed for old backup versions")
+				}
+				args := []string{"--dbname", "testdb",
+					"--backup-dir", backupDir,
+					"--single-data-file",
+					"--copy-queue-size", "4",
+					"--verbose"}
+				cmd := exec.Command(gpbackupPath, args...)
+				go func() {
+					/*
+					 * We use a random delay for the sleep in this test (between
+					 * 0.5s and 0.8s) so that gpbackup will be interrupted at a
+					 * different point in the backup process every time to help
+					 * catch timing issues with the cleanup.
+					 */
+					rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+					time.Sleep(time.Duration(rng.Intn(300)+500) * time.Millisecond)
+					_ = cmd.Process.Signal(unix.SIGINT)
+				}()
+				output, _ := cmd.CombinedOutput()
+				stdout := string(output)
+				assertArtifactsCleaned(backupConn, getBackupTimestamp(stdout))
+				Expect(stdout).To(ContainSubstring("Received an interrupt signal, aborting backup process"))
+				Expect(stdout).To(ContainSubstring("Cleaning up segment agent processes"))
+				Expect(stdout).To(ContainSubstring("Cleanup complete"))
+				Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
+			})
+			It("runs gpbackup and sends a SIGINT to ensure blocked LOCK TABLE query is canceled", func() {
+				if useOldBackupVersion {
+					Skip("This test is not needed for old backup versions")
+				}
+	
+				// Query to see if gpbackup lock acquire on schema2.foo2 is blocked
+				checkLockQuery := `SELECT count(*) FROM pg_locks l, pg_class c, pg_namespace n WHERE l.relation = c.oid AND n.oid = c.relnamespace AND n.nspname = 'schema2' AND c.relname = 'foo2' AND l.granted = 'f'`
+	
+				// Acquire AccessExclusiveLock on schema2.foo2 to prevent gpbackup from acquiring AccessShareLock
+				backupConn.MustExec("BEGIN; LOCK TABLE schema2.foo2 IN ACCESS EXCLUSIVE MODE")
+				args := []string{
+					"--dbname", "testdb",
+					"--backup-dir", backupDir,
+					"--verbose"}
+				cmd := exec.Command(gpbackupPath, args...)
+	
+				// Wait up to 5 seconds for gpbackup to block on acquiring AccessShareLock.
+				// Once blocked, we send a SIGINT to cancel gpbackup.
+				var beforeLockCount int
+				go func() {
+					iterations := 50
+					for iterations > 0 {
+						_ = backupConn.Get(&beforeLockCount, checkLockQuery)
+						if beforeLockCount < 1 {
+							time.Sleep(100 * time.Millisecond)
+							iterations--
+						} else {
+							break
+						}
+					}
+					_ = cmd.Process.Signal(unix.SIGINT)
+				}()
+				output, _ := cmd.CombinedOutput()
+				Expect(beforeLockCount).To(Equal(1))
+	
+				// After gpbackup has been canceled, we should no longer see a blocked SQL
+				// session trying to acquire AccessShareLock on foo2.
+				var afterLockCount int
+				_ = backupConn.Get(&afterLockCount, checkLockQuery)
+				Expect(afterLockCount).To(Equal(0))
+				backupConn.MustExec("ROLLBACK")
+	
+				stdout := string(output)
+				assertArtifactsCleaned(backupConn, getBackupTimestamp(stdout))
+				Expect(stdout).To(ContainSubstring("Received an interrupt signal, aborting backup process"))
+				Expect(stdout).To(ContainSubstring("Cleanup complete"))
+				Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
+			})
+			It("runs gpbackup with single-data-file and sends a SIGINT to ensure blocked LOCK TABLE query is canceled", func() {
+				if useOldBackupVersion {
+					Skip("This test is not needed for old backup versions")
+				}
+	
+				// Query to see if gpbackup lock acquire on schema2.foo2 is blocked
+				checkLockQuery := `SELECT count(*) FROM pg_locks l, pg_class c, pg_namespace n WHERE l.relation = c.oid AND n.oid = c.relnamespace AND n.nspname = 'schema2' AND c.relname = 'foo2' AND l.granted = 'f'`
+	
+				// Acquire AccessExclusiveLock on schema2.foo2 to prevent gpbackup from acquiring AccessShareLock
+				backupConn.MustExec("BEGIN; LOCK TABLE schema2.foo2 IN ACCESS EXCLUSIVE MODE")
+				args := []string{
+					"--dbname", "testdb",
+					"--backup-dir", backupDir,
+					"--single-data-file",
+					"--verbose"}
+				cmd := exec.Command(gpbackupPath, args...)
+	
+				// Wait up to 5 seconds for gpbackup to block on acquiring AccessShareLock.
+				// Once blocked, we send a SIGINT to cancel gpbackup.
+				var beforeLockCount int
+				go func() {
+					iterations := 50
+					for iterations > 0 {
+						_ = backupConn.Get(&beforeLockCount, checkLockQuery)
+						if beforeLockCount < 1 {
+							time.Sleep(100 * time.Millisecond)
+							iterations--
+						} else {
+							break
+						}
+					}
+					_ = cmd.Process.Signal(unix.SIGINT)
+				}()
+				output, _ := cmd.CombinedOutput()
+				Expect(beforeLockCount).To(Equal(1))
+	
+				// After gpbackup has been canceled, we should no longer see a blocked SQL
+				// session trying to acquire AccessShareLock on foo2.
+				var afterLockCount int
+				_ = backupConn.Get(&afterLockCount, checkLockQuery)
+				Expect(afterLockCount).To(Equal(0))
+				backupConn.MustExec("ROLLBACK")
+	
+				stdout := string(output)
+				assertArtifactsCleaned(backupConn, getBackupTimestamp(stdout))
+				Expect(stdout).To(ContainSubstring("Received an interrupt signal, aborting backup process"))
+				Expect(stdout).To(ContainSubstring("Cleanup complete"))
+				Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
+			})
+			It("runs gprestore and sends a SIGINT to ensure cleanup functions successfully", func() {
+				if useOldBackupVersion {
+					Skip("This test is not needed for old backup versions")
+				}
+				timestamp := gpbackup(gpbackupPath, backupHelperPath,
+					"--backup-dir", backupDir,
+					"--single-data-file")
+				args := []string{
+					"--timestamp", timestamp,
+					"--redirect-db", "restoredb",
+					"--backup-dir", backupDir,
+					"--verbose"}
+				cmd := exec.Command(gprestorePath, args...)
+				go func() {
+					/*
+					 * We use a random delay for the sleep in this test (between
+					 * 1.0s and 1.5s) so that gprestore will be interrupted at a
+					 * different point in the backup process every time to help
+					 * catch timing issues with the cleanup.
+					 */
+					rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+					time.Sleep(time.Duration(rng.Intn(1000)+500) * time.Millisecond)
+					_ = cmd.Process.Signal(unix.SIGINT)
+				}()
+				output, _ := cmd.CombinedOutput()
+				stdout := string(output)
+				Expect(stdout).To(ContainSubstring("Received an interrupt signal, aborting restore process"))
+				Expect(stdout).To(ContainSubstring("Cleaning up segment agent processes"))
+				Expect(stdout).To(ContainSubstring("Cleanup complete"))
+				Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
+				assertArtifactsCleaned(restoreConn, timestamp)
+			})
+			It("runs gprestore with copy-queue-size and sends a SIGINT to ensure cleanup functions successfully", func() {
+				if useOldBackupVersion {
+					Skip("This test is not needed for old backup versions")
+				}
+				timestamp := gpbackup(gpbackupPath, backupHelperPath,
+					"--backup-dir", backupDir,
+					"--single-data-file")
+				args := []string{
+					"--timestamp", timestamp,
+					"--redirect-db", "restoredb",
+					"--backup-dir", backupDir,
+					"--verbose",
+					"--copy-queue-size", "4"}
+				cmd := exec.Command(gprestorePath, args...)
+				go func() {
+					/*
+					 * We use a random delay for the sleep in this test (between
+					 * 1.0s and 1.5s) so that gprestore will be interrupted at a
+					 * different point in the backup process every time to help
+					 * catch timing issues with the cleanup.
+					 */
+					rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+					time.Sleep(time.Duration(rng.Intn(1000)+500) * time.Millisecond)
+					_ = cmd.Process.Signal(unix.SIGINT)
+				}()
+				output, _ := cmd.CombinedOutput()
+				stdout := string(output)
+				Expect(stdout).To(ContainSubstring("Received an interrupt signal, aborting restore process"))
+				Expect(stdout).To(ContainSubstring("Cleanup complete"))
+				Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
+				assertArtifactsCleaned(restoreConn, timestamp)
+			})
+		})
+		Context("SIGTERM", func() {
+			It("runs gpbackup and sends a SIGTERM to ensure cleanup functions successfully", func() {
+				if useOldBackupVersion {
+					Skip("This test is not needed for old backup versions")
+				}
+				args := []string{"--dbname", "testdb",
+					"--backup-dir", backupDir,
+					"--single-data-file",
+					"--verbose"}
+				cmd := exec.Command(gpbackupPath, args...)
+				go func() {
+					/*
+					 * We use a random delay for the sleep in this test (between
+					 * 1.0s and 1.5s) so that gpbackup will be interrupted at a
+					 * different point in the backup process every time to help
+					 * catch timing issues with the cleanup.
+					 */
+					rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+					time.Sleep(time.Duration(rng.Intn(1000)+500) * time.Millisecond)
+					_ = cmd.Process.Signal(unix.SIGTERM)
+				}()
+				output, _ := cmd.CombinedOutput()
+				stdout := string(output)
+				assertArtifactsCleaned(backupConn, getBackupTimestamp(stdout))
+				Expect(stdout).To(ContainSubstring("Received a termination signal, aborting backup process"))
+				Expect(stdout).To(ContainSubstring("Cleanup complete"))
+				Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
+			})
+			It("runs gpbackup and sends a SIGTERM to ensure blocked LOCK TABLE query is canceled", func() {
+				if useOldBackupVersion {
+					Skip("This test is not needed for old backup versions")
+				}
+	
+				// Query to see if gpbackup lock acquire on schema2.foo2 is blocked
+				checkLockQuery := `SELECT count(*) FROM pg_locks l, pg_class c, pg_namespace n WHERE l.relation = c.oid AND n.oid = c.relnamespace AND n.nspname = 'schema2' AND c.relname = 'foo2' AND l.granted = 'f'`
+	
+				// Acquire AccessExclusiveLock on schema2.foo2 to prevent gpbackup from acquiring AccessShareLock
+				backupConn.MustExec("BEGIN; LOCK TABLE schema2.foo2 IN ACCESS EXCLUSIVE MODE")
+				args := []string{
+					"--dbname", "testdb",
+					"--backup-dir", backupDir,
+					"--verbose"}
+				cmd := exec.Command(gpbackupPath, args...)
+	
+				// Wait up to 5 seconds for gpbackup to block on acquiring AccessShareLock.
+				// Once blocked, we send a SIGTERM to cancel gpbackup.
+				var beforeLockCount int
+				go func() {
+					iterations := 50
+					for iterations > 0 {
+						_ = backupConn.Get(&beforeLockCount, checkLockQuery)
+						if beforeLockCount < 1 {
+							time.Sleep(100 * time.Millisecond)
+							iterations--
+						} else {
+							break
+						}
+					}
+					_ = cmd.Process.Signal(unix.SIGTERM)
+				}()
+				output, _ := cmd.CombinedOutput()
+				Expect(beforeLockCount).To(Equal(1))
+	
+				// After gpbackup has been canceled, we should no longer see a blocked SQL
+				// session trying to acquire AccessShareLock on foo2.
+				var afterLockCount int
+				_ = backupConn.Get(&afterLockCount, checkLockQuery)
+				Expect(afterLockCount).To(Equal(0))
+				backupConn.MustExec("ROLLBACK")
+	
+				stdout := string(output)
+				assertArtifactsCleaned(backupConn, getBackupTimestamp(stdout))
+				Expect(stdout).To(ContainSubstring("Received a termination signal, aborting backup process"))
+				Expect(stdout).To(ContainSubstring("Cleanup complete"))
+				Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
+			})
+			It("runs gpbackup with single-data-file and sends a SIGTERM to ensure blocked LOCK TABLE query is canceled", func() {
+				if useOldBackupVersion {
+					Skip("This test is not needed for old backup versions")
+				}
+	
+				// Query to see if gpbackup lock acquire on schema2.foo2 is blocked
+				checkLockQuery := `SELECT count(*) FROM pg_locks l, pg_class c, pg_namespace n WHERE l.relation = c.oid AND n.oid = c.relnamespace AND n.nspname = 'schema2' AND c.relname = 'foo2' AND l.granted = 'f'`
+	
+				// Acquire AccessExclusiveLock on schema2.foo2 to prevent gpbackup from acquiring AccessShareLock
+				backupConn.MustExec("BEGIN; LOCK TABLE schema2.foo2 IN ACCESS EXCLUSIVE MODE")
+				args := []string{
+					"--dbname", "testdb",
+					"--backup-dir", backupDir,
+					"--single-data-file",
+					"--verbose"}
+				cmd := exec.Command(gpbackupPath, args...)
+	
+				// Wait up to 5 seconds for gpbackup to block on acquiring AccessShareLock.
+				// Once blocked, we send a SIGTERM to cancel gpbackup.
+				var beforeLockCount int
+				go func() {
+					iterations := 50
+					for iterations > 0 {
+						_ = backupConn.Get(&beforeLockCount, checkLockQuery)
+						if beforeLockCount < 1 {
+							time.Sleep(100 * time.Millisecond)
+							iterations--
+						} else {
+							break
+						}
+					}
+					_ = cmd.Process.Signal(unix.SIGTERM)
+				}()
+				output, _ := cmd.CombinedOutput()
+				Expect(beforeLockCount).To(Equal(1))
+	
+				// After gpbackup has been canceled, we should no longer see a blocked SQL
+				// session trying to acquire AccessShareLock on foo2.
+				var afterLockCount int
+				_ = backupConn.Get(&afterLockCount, checkLockQuery)
+				Expect(afterLockCount).To(Equal(0))
+				backupConn.MustExec("ROLLBACK")
+	
+				stdout := string(output)
+				assertArtifactsCleaned(backupConn, getBackupTimestamp(stdout))
+				Expect(stdout).To(ContainSubstring("Received a termination signal, aborting backup process"))
+				Expect(stdout).To(ContainSubstring("Cleanup complete"))
+				Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
+			})
+			It("runs gpbackup with copy-queue-size and sends a SIGTERM to ensure cleanup functions successfully", func() {
+				if useOldBackupVersion {
+					Skip("This test is not needed for old backup versions")
+				}
+				args := []string{"--dbname", "testdb",
+					"--backup-dir", backupDir,
+					"--single-data-file",
+					"--copy-queue-size", "4",
+					"--verbose"}
+				cmd := exec.Command(gpbackupPath, args...)
+				go func() {
+					/*
+					 * We use a random delay for the sleep in this test (between
+					 * 1.0s and 1.5s) so that gpbackup will be interrupted at a
+					 * different point in the backup process every time to help
+					 * catch timing issues with the cleanup.
+					 */
+					rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+					time.Sleep(time.Duration(rng.Intn(1000)+500) * time.Millisecond)
+					_ = cmd.Process.Signal(unix.SIGTERM)
+				}()
+				output, _ := cmd.CombinedOutput()
+				stdout := string(output)
+				assertArtifactsCleaned(backupConn, getBackupTimestamp(stdout))
+				Expect(stdout).To(ContainSubstring("Received a termination signal, aborting backup process"))
+				Expect(stdout).To(ContainSubstring("Cleanup complete"))
+				Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
+			})
+			It("runs gprestore and sends a SIGTERM to ensure cleanup functions successfully", func() {
+				if useOldBackupVersion {
+					Skip("This test is not needed for old backup versions")
+				}
+				timestamp := gpbackup(gpbackupPath, backupHelperPath,
+					"--backup-dir", backupDir,
+					"--single-data-file")
+				args := []string{
+					"--timestamp", timestamp,
+					"--redirect-db", "restoredb",
+					"--backup-dir", backupDir,
+					"--verbose"}
+				cmd := exec.Command(gprestorePath, args...)
+				go func() {
+					/*
+					 * We use a random delay for the sleep in this test (between
+					 * 1.0s and 1.5s) so that gprestore will be interrupted at a
+					 * different point in the backup process every time to help
+					 * catch timing issues with the cleanup.
+					 */
+					rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+					time.Sleep(time.Duration(rng.Intn(1000)+500) * time.Millisecond)
+					_ = cmd.Process.Signal(unix.SIGTERM)
+				}()
+				output, _ := cmd.CombinedOutput()
+				stdout := string(output)
+				Expect(stdout).To(ContainSubstring("Received a termination signal, aborting restore process"))
+				Expect(stdout).To(ContainSubstring("Cleanup complete"))
+				Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
+				assertArtifactsCleaned(restoreConn, timestamp)
+			})
+			It("runs gprestore with copy-queue-size and sends a SIGTERM to ensure cleanup functions successfully", func() {
+				if useOldBackupVersion {
+					Skip("This test is not needed for old backup versions")
+				}
+				timestamp := gpbackup(gpbackupPath, backupHelperPath,
+					"--backup-dir", backupDir,
+					"--single-data-file")
+				args := []string{
+					"--timestamp", timestamp,
+					"--redirect-db", "restoredb",
+					"--backup-dir", backupDir,
+					"--verbose",
+					"--copy-queue-size", "4"}
+				cmd := exec.Command(gprestorePath, args...)
+				go func() {
+					/*
+					 * We use a random delay for the sleep in this test (between
+					 * 1.0s and 1.5s) so that gprestore will be interrupted at a
+					 * different point in the backup process every time to help
+					 * catch timing issues with the cleanup.
+					 */
+					rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+					time.Sleep(time.Duration(rng.Intn(1000)+500) * time.Millisecond)
+					_ = cmd.Process.Signal(unix.SIGTERM)
+				}()
+				output, _ := cmd.CombinedOutput()
+				stdout := string(output)
+				Expect(stdout).To(ContainSubstring("Received a termination signal, aborting restore process"))
+				Expect(stdout).To(ContainSubstring("Cleanup complete"))
+				Expect(stdout).To(Not(ContainSubstring("CRITICAL")))
+				assertArtifactsCleaned(restoreConn, timestamp)
+			})
 		})
 	})
 	Describe(`On Error Continue`, func() {

--- a/integration/helper_test.go
+++ b/integration/helper_test.go
@@ -10,11 +10,11 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/greenplum-db/gp-common-go-libs/operating"
 	"github.com/klauspost/compress/zstd"
+	"golang.org/x/sys/unix"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -83,7 +83,7 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 		err = os.MkdirAll(pluginDir, 0777)
 		Expect(err).ToNot(HaveOccurred())
 
-		err = syscall.Mkfifo(fmt.Sprintf("%s_%d", pipeFile, 1), 0777)
+		err = unix.Mkfifo(fmt.Sprintf("%s_%d", pipeFile, 1), 0777)
 		if err != nil {
 			Fail(fmt.Sprintf("%v", err))
 		}
@@ -151,7 +151,7 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 		It("Generates error file when backup agent interrupted", func() {
 			helperCmd := gpbackupHelper(gpbackupHelperPath, "--backup-agent", "--compression-level", "0", "--data-file", dataFileFullPath)
 			waitForPipeCreation()
-			err := helperCmd.Process.Signal(os.Interrupt)
+			err := helperCmd.Process.Signal(unix.SIGINT)
 			Expect(err).ToNot(HaveOccurred())
 			err = helperCmd.Wait()
 			Expect(err).To(HaveOccurred())
@@ -235,7 +235,7 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 			setupRestoreFiles("gzip", false)
 			helperCmd := gpbackupHelper(gpbackupHelperPath, "--restore-agent", "--data-file", dataFileFullPath+".gz")
 			waitForPipeCreation()
-			err := helperCmd.Process.Signal(os.Interrupt)
+			err := helperCmd.Process.Signal(unix.SIGINT)
 			Expect(err).ToNot(HaveOccurred())
 			err = helperCmd.Wait()
 			Expect(err).To(HaveOccurred())

--- a/utils/agent_remote.go
+++ b/utils/agent_remote.go
@@ -188,7 +188,7 @@ func CleanUpSegmentHelperProcesses(c *cluster.Cluster, fpInfo filepath.FilePathI
 		 * as it's possible that all gpbackup_helper processes have finished by
 		 * the time DoCleanup is called.
 		 */
-		return fmt.Sprintf("PIDS=`ps ux | grep \"%s\" | grep -v grep | awk '{print $2}'`; if [[ ! -z \"$PIDS\" ]]; then kill $PIDS; fi", procPattern)
+		return fmt.Sprintf("PIDS=`ps ux | grep \"%s\" | grep -v grep | awk '{print $2}'`; if [[ ! -z \"$PIDS\" ]]; then kill -USR1 $PIDS; fi", procPattern)
 	})
 	c.CheckClusterError(remoteOutput, "Unable to clean up agent processes", func(contentID int) string {
 		return "Unable to clean up agent process"


### PR DESCRIPTION
Improvements:
- Send SIGUSR1 and SIGPIPE handlers to gpbackup_helper.
  - By catching SIGUSR1 in gpbackup_helper, we can differentiate external
    termination signals from ones sent by gpbackup/gprestore.
  - By catching SIGPIPE, we can more quickly diagnose broken pipe errors
- Ensure blocked queries are canceled during single-data-file cleanup to
  avoid potential deadlock.
- If SIGPIPE is caught and on-error-continue is set, do not cleanup and
  exit
- Use unix package over deprecated https://pkg.go.dev/syscall package

Signal handling tests:
- Expand tests exercising signal handlers and cleanup.
- Increase random delay before sending signal to give time
  for helpers to start consistently
- Generate 10 million row table so backup/restore will run long enough
  for signals to be received and cleanup to occur.

Authored-by: Brent Doil <bdoil@vmware.com>