### PR TITLE
Replace gpbackup scp usage with rsync

### DIFF
--- a/utils/agent_remote.go
+++ b/utils/agent_remote.go
@@ -56,13 +56,13 @@ func WriteOidListToSegments(oidList []string, c *cluster.Cluster, fpInfo filepat
 		hostname := c.GetHostForContent(contentID)
 		dest := fpInfo.GetSegmentHelperFilePath(contentID, "oid")
 
-		return fmt.Sprintf(`scp %s %s:%s`, sourceFile, hostname, dest)
+		return fmt.Sprintf(`rsync -e ssh %s %s:%s`, sourceFile, hostname, dest)
 	}
-	remoteOutput := c.GenerateAndExecuteCommand("Scp oid file to segments", cluster.ON_LOCAL|cluster.ON_SEGMENTS, generateScpCmd)
+	remoteOutput := c.GenerateAndExecuteCommand("rsync oid file to segments", cluster.ON_LOCAL|cluster.ON_SEGMENTS, generateScpCmd)
 
-	errMsg := "Failed to scp oid file"
+	errMsg := "Failed to rsync oid file"
 	errFunc := func(contentID int) string {
-		return "Failed to run scp"
+		return "Failed to run rsync"
 	}
 	c.CheckClusterError(remoteOutput, errMsg, errFunc, false)
 }

--- a/utils/agent_remote_test.go
+++ b/utils/agent_remote_test.go
@@ -47,16 +47,16 @@ var _ = Describe("agent remote", func() {
 	// note: technically the file system is written to during the call `operating.System.TempFile`
 	//			this file is not used throughout the unit tests below, and it is cleaned up with the method: `operating.System.Remove`
 	Describe("WriteOidListToSegments()", func() {
-		It("generates the correct scp commands to copy oid file to segments", func() {
+		It("generates the correct rsync commands to copy oid file to segments", func() {
 			utils.WriteOidListToSegments(oidList, testCluster, fpInfo)
 
 			Expect(testExecutor.NumExecutions).To(Equal(1))
 			cc := testExecutor.ClusterCommands[0]
 			Expect(len(cc)).To(Equal(2))
-			Expect(cc[0].CommandString).To(MatchRegexp("scp .*/gpbackup-oids.* localhost:/data/gpseg0/gpbackup_0_11112233445566_oid_.*"))
-			Expect(cc[1].CommandString).To(MatchRegexp("scp .*/gpbackup-oids.* remotehost1:/data/gpseg1/gpbackup_1_11112233445566_oid_.*"))
+			Expect(cc[0].CommandString).To(MatchRegexp("rsync -e ssh .*/gpbackup-oids.* localhost:/data/gpseg0/gpbackup_0_11112233445566_oid_.*"))
+			Expect(cc[1].CommandString).To(MatchRegexp("rsync -e ssh .*/gpbackup-oids.* remotehost1:/data/gpseg1/gpbackup_1_11112233445566_oid_.*"))
 		})
-		It("panics if any scp commands fail and outputs correct err messages", func() {
+		It("panics if any rsync commands fail and outputs correct err messages", func() {
 			testExecutor.ErrorOnExecNum = 1
 			remoteOutput.NumErrors = 1
 			remoteOutput.Scope = cluster.ON_LOCAL & cluster.ON_SEGMENTS
@@ -65,7 +65,7 @@ var _ = Describe("agent remote", func() {
 				cluster.ShellCommand{Content: 0},
 				cluster.ShellCommand{
 					Content:       1,
-					CommandString: "scp fake_master fake_host",
+					CommandString: "rsync -e ssh fake_master fake_host",
 					Stderr:        "stderr content 1",
 					Error:         errors.New("test error 1"),
 				},
@@ -74,7 +74,7 @@ var _ = Describe("agent remote", func() {
 			Expect(func() { utils.WriteOidListToSegments(oidList, testCluster, fpInfo) }).To(Panic())
 
 			Expect(testExecutor.NumExecutions).To(Equal(1))
-			Expect(string(logfile.Contents())).To(ContainSubstring(`[CRITICAL]:-Failed to scp oid file on 1 segment. See gbytes.Buffer for a complete list of errors.`))
+			Expect(string(logfile.Contents())).To(ContainSubstring(`[CRITICAL]:-Failed to rsync oid file on 1 segment. See gbytes.Buffer for a complete list of errors.`))
 		})
 	})
 	Describe("WriteOidsToFile()", func() {

--- a/utils/plugin.go
+++ b/utils/plugin.go
@@ -305,7 +305,7 @@ func (plugin *PluginConfig) CopyPluginConfigToAllHosts(c *cluster.Cluster) {
 		cluster.ON_LOCAL|cluster.ON_HOSTS|cluster.INCLUDE_MASTER,
 		func(contentIDForSegmentOnHost int) string {
 			hostConfigFile := plugin.createHostPluginConfig(contentIDForSegmentOnHost, c)
-			command = fmt.Sprintf("scp %[1]s %s:%s; rm %[1]s", hostConfigFile,
+			command = fmt.Sprintf("rsync -e ssh %[1]s %s:%s; rm %[1]s", hostConfigFile,
 				c.GetHostForContent(contentIDForSegmentOnHost), plugin.ConfigPath)
 			return command
 		})

--- a/utils/plugin_test.go
+++ b/utils/plugin_test.go
@@ -119,19 +119,19 @@ options:
 			cc := executor.ClusterCommands[0]
 			Expect(len(cc)).To(Equal(3))
 			Expect(cc[0].Content).To(Equal(-1))
-			Expect(cc[0].CommandString).To(MatchRegexp(`scp .*-1 master:\/tmp\/my_plugin_config\.yaml; rm .*-1`))
+			Expect(cc[0].CommandString).To(MatchRegexp(`rsync -e ssh .*-1 master:\/tmp\/my_plugin_config\.yaml; rm .*-1`))
 			Expect(cc[1].Content).To(Equal(0))
-			Expect(cc[1].CommandString).To(MatchRegexp(`scp .*0 segment1:\/tmp\/my_plugin_config\.yaml; rm .*0`))
+			Expect(cc[1].CommandString).To(MatchRegexp(`rsync -e ssh .*0 segment1:\/tmp\/my_plugin_config\.yaml; rm .*0`))
 			Expect(cc[2].Content).To(Equal(1))
-			Expect(cc[2].CommandString).To(MatchRegexp(`scp .*1 segment2:\/tmp\/my_plugin_config\.yaml; rm .*1`))
+			Expect(cc[2].CommandString).To(MatchRegexp(`rsync -e ssh .*1 segment2:\/tmp\/my_plugin_config\.yaml; rm .*1`))
 
-			rgx := regexp.MustCompile(`scp (.*-1) master:\/tmp\/my_plugin_config\.yaml; rm .*-1`)
+			rgx := regexp.MustCompile(`rsync -e ssh (.*-1) master:\/tmp\/my_plugin_config\.yaml; rm .*-1`)
 			rs := rgx.FindStringSubmatch(cc[0].CommandString)
 			masterConfigPath := rs[1]
-			rgx = regexp.MustCompile(`scp (.*0) segment1:\/tmp\/my_plugin_config\.yaml; rm .*0`)
+			rgx = regexp.MustCompile(`rsync -e ssh (.*0) segment1:\/tmp\/my_plugin_config\.yaml; rm .*0`)
 			rs = rgx.FindStringSubmatch(cc[1].CommandString)
 			segmentOneConfigPath := rs[1]
-			rgx = regexp.MustCompile(`scp (.*1) segment2:\/tmp\/my_plugin_config\.yaml; rm .*1`)
+			rgx = regexp.MustCompile(`rsync -e ssh (.*1) segment2:\/tmp\/my_plugin_config\.yaml; rm .*1`)
 			rs = rgx.FindStringSubmatch(cc[2].CommandString)
 			segmentTwoConfigPath := rs[1]
 
@@ -170,13 +170,13 @@ options:
 
 				// check contents
 				cc := executor.ClusterCommands[0]
-				rgx := regexp.MustCompile(`scp (.*-1) master:\/tmp\/my_plugin_config\.yaml; rm .*-1`)
+				rgx := regexp.MustCompile(`rsync -e ssh (.*-1) master:\/tmp\/my_plugin_config\.yaml; rm .*-1`)
 				rs := rgx.FindStringSubmatch(cc[0].CommandString)
 				masterConfigPath := rs[1]
-				rgx = regexp.MustCompile(`scp (.*0) segment1:\/tmp\/my_plugin_config\.yaml; rm .*0`)
+				rgx = regexp.MustCompile(`rsync -e ssh (.*0) segment1:\/tmp\/my_plugin_config\.yaml; rm .*0`)
 				rs = rgx.FindStringSubmatch(cc[1].CommandString)
 				segmentOneConfigPath := rs[1]
-				rgx = regexp.MustCompile(`scp (.*1) segment2:\/tmp\/my_plugin_config\.yaml; rm .*1`)
+				rgx = regexp.MustCompile(`rsync -e ssh (.*1) segment2:\/tmp\/my_plugin_config\.yaml; rm .*1`)
 				rs = rgx.FindStringSubmatch(cc[2].CommandString)
 				segmentTwoConfigPath := rs[1]
 


### PR DESCRIPTION
Replace all exec calls to scp with identical calls to rsync.
Update relevant tests to expect rsync calls.
Use -e ssh flag in rsync calls to guard against old installs using an
insecure protocol.