### PR TITLE
Require rsync on system

### DIFF
--- a/ci/tasks/build-go-binaries.yml
+++ b/ci/tasks/build-go-binaries.yml
@@ -3,8 +3,8 @@ platform: linux
 image_resource:
   type: registry-image
   source:
-    repository: gcr.io/data-gpdb-public-images/golang
-    tag: 1.17.6
+    repository: gcr.io/data-gpdb-public-images/gpdb6-centos7-build
+    tag: latest
 
 inputs:
 - name: gpbackup

--- a/utils/agent_remote.go
+++ b/utils/agent_remote.go
@@ -40,6 +40,11 @@ func CreateSegmentPipeOnAllHosts(oid string, c *cluster.Cluster, fpInfo filepath
 }
 
 func WriteOidListToSegments(oidList []string, c *cluster.Cluster, fpInfo filepath.FilePathInfo) {
+	rsync_exists := CommandExists("rsync")
+	if !rsync_exists {
+		gplog.Fatal(errors.New("Failed to find rsync on PATH. Please ensure rsync is installed."), "")
+	}
+
 	localOidFile, err := operating.System.TempFile("", "gpbackup-oids")
 	gplog.FatalOnError(err, "Cannot open temporary file to write oids")
 	defer func() {

--- a/utils/plugin.go
+++ b/utils/plugin.go
@@ -300,6 +300,10 @@ func (plugin *PluginConfig) CopyPluginConfigToAllHosts(c *cluster.Cluster) {
 	// an environmental var, at which time the code to write *specific* config files per segment
 	// can be removed
 	var command string
+	rsync_exists := CommandExists("rsync")
+	if !rsync_exists {
+		gplog.Fatal(errors.New("Failed to find rsync on PATH. Please ensure rsync is installed."), "")
+	}
 	remoteOutput := c.GenerateAndExecuteCommand(
 		"Copying plugin config to all hosts",
 		cluster.ON_LOCAL|cluster.ON_HOSTS|cluster.INCLUDE_MASTER,

--- a/utils/util.go
+++ b/utils/util.go
@@ -8,6 +8,7 @@ package utils
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
 	"regexp"
 	"strings"
@@ -26,6 +27,11 @@ const MINIMUM_GPDB5_VERSION = "5.1.0"
 /*
  * General helper functions
  */
+
+func CommandExists(cmd string) bool {
+	_, err := exec.LookPath(cmd)
+	return err == nil
+}
 
 func FileExists(filename string) bool {
 	_, err := os.Stat(filename)


### PR DESCRIPTION
Add utility function for detecting command on PATH.
Add checks for presence of rsync before its used.

Convert image used for building binaries in CI
Image used to build gpbackup go binaries was missing rsync.
Udpated to use a heavier build image.