### PR TITLE
Move primary key constraints to create table

### DIFF
--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -164,6 +164,9 @@ func printColumnDefinitions(metadataFile *utils.FileWithByteCount, columnDefs []
 		if column.NotNull {
 			line += " NOT NULL"
 		}
+		if column.PrimaryKey {
+			line += " PRIMARY KEY"
+		}
 		if column.Encoding != "" {
 			line += fmt.Sprintf(" ENCODING (%s)", column.Encoding)
 		}

--- a/backup/queries_shared.go
+++ b/backup/queries_shared.go
@@ -137,6 +137,7 @@ func GetConstraints(connectionPool *dbconn.DBConn, includeTables ...Relation) []
 	WHERE %s
 		AND %s
 		AND c.relname IS NOT NULL
+		AND contype != 'p'
 		AND conrelid NOT IN (SELECT parchildrelid FROM pg_partition_rule)
 		AND (conrelid, conname) NOT IN (SELECT i.inhrelid, con.conname FROM pg_inherits i JOIN pg_constraint con ON i.inhrelid = con.conrelid JOIN pg_constraint p ON i.inhparent = p.conrelid WHERE con.conname = p.conname)
 	GROUP BY con.oid, conname, contype, c.relname, n.nspname, %s pt.parrelid`, selectConIsLocal, "%s", ExtensionFilterClause("c"), groupByConIsLocal)


### PR DESCRIPTION
View definition may rely on primary keys to obviate group by statements. gpbackup prints primary key constraints as alter table statements. This ordering may result in invalid SQL and is breaking ICW restores.

Skip primary keys when retrieving and writing constraints. Instead add and populate primary key field to ColumnDefinition struct.