### PR TITLE
Move Constraints into sorted dependency backup

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -254,12 +254,11 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Table, tableO
 
 	retrieveViews(&objects)
 	sequences := retrieveAndBackupSequences(metadataFile, relationMetadata)
-	constraints, conMetadata := retrieveConstraints()
+	domainConstraints := retrieveConstraints(&objects, metadataMap)
 
-	backupDependentObjects(metadataFile, tables, protocols, metadataMap, constraints, objects, sequences, funcInfoMap, tableOnly)
+	backupDependentObjects(metadataFile, tables, protocols, metadataMap, domainConstraints, objects, sequences, funcInfoMap, tableOnly)
 
 	backupConversions(metadataFile)
-	backupConstraints(metadataFile, constraints, conMetadata)
 
 	logCompletionMessage("Pre-data metadata metadata backup")
 }

--- a/backup/predata_shared.go
+++ b/backup/predata_shared.go
@@ -15,47 +15,19 @@ import (
  * There's no built-in function to generate constraint definitions like there is for other types of
  * metadata, so this function constructs them.
  */
-func PrintConstraintStatements(metadataFile *utils.FileWithByteCount, toc *toc.TOC, constraints []Constraint, conMetadata MetadataMap) {
-	allConstraints := make([]Constraint, 0)
-	allFkConstraints := make([]Constraint, 0)
-	/*
-	 * Because FOREIGN KEY constraints must be backed up after PRIMARY KEY
-	 * constraints, we separate the two types then concatenate the lists,
-	 * so FOREIGN KEY are guaranteed to be printed last.
-	 */
-	for _, constraint := range constraints {
-		if constraint.ConType == "f" {
-			allFkConstraints = append(allFkConstraints, constraint)
-		} else if constraint.ConType == "t" {
-			/*
-			* Trigger constraints are added as triggers in backupPostdata.
-			* We do not need to add them here also.
-			* Further, the ALTER TABLE ADD CONSTRAINT syntax does not support adding triggers
-			 */
-			continue
-		} else {
-			allConstraints = append(allConstraints, constraint)
-		}
-	}
-	constraints = append(allConstraints, allFkConstraints...)
-
+ func PrintConstraintStatement(metadataFile *utils.FileWithByteCount, toc *toc.TOC, constraint Constraint, conMetadata ObjectMetadata) {
 	alterStr := "\n\nALTER %s %s ADD CONSTRAINT %s %s;\n"
-	for _, constraint := range constraints {
-		start := metadataFile.ByteCount
-		if constraint.IsDomainConstraint {
-			continue
-		}
-		// ConIsLocal should always return true from GetConstraints because we filter out constraints that are inherited using the INHERITS clause, or inherited from a parent partition table. This field only accurately reflects constraints in GPDB6+ because check constraints on parent tables must propogate to children. For GPDB versions 5 or lower, this field will default to false.
-		objStr := "TABLE ONLY"
-		if constraint.IsPartitionParent || (constraint.ConType == "c" && constraint.ConIsLocal) {
-			objStr = "TABLE"
-		}
-		metadataFile.MustPrintf(alterStr, objStr, constraint.OwningObject, constraint.Name, constraint.ConDef.String)
-
-		section, entry := constraint.GetMetadataEntry()
-		toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
-		PrintObjectMetadata(metadataFile, toc, conMetadata[constraint.GetUniqueID()], constraint, constraint.OwningObject)
+	start := metadataFile.ByteCount
+	// ConIsLocal should always return true from GetConstraints because we filter out constraints that are inherited using the INHERITS clause, or inherited from a parent partition table. This field only accurately reflects constraints in GPDB6+ because check constraints on parent tables must propogate to children. For GPDB versions 5 or lower, this field will default to false.
+	objStr := "TABLE ONLY"
+	if constraint.IsPartitionParent || (constraint.ConType == "c" && constraint.ConIsLocal) {
+		objStr = "TABLE"
 	}
+	metadataFile.MustPrintf(alterStr, objStr, constraint.OwningObject, constraint.Name, constraint.ConDef.String)
+
+	section, entry := constraint.GetMetadataEntry()
+	toc.AddMetadataEntry(section, entry, start, metadataFile.ByteCount)
+	PrintObjectMetadata(metadataFile, toc, conMetadata, constraint, constraint.OwningObject)
 }
 
 func PrintCreateSchemaStatements(metadataFile *utils.FileWithByteCount, toc *toc.TOC, schemas []Schema, schemaMetadata MetadataMap) {

--- a/backup/predata_shared_test.go
+++ b/backup/predata_shared_test.go
@@ -3,7 +3,6 @@ package backup_test
 import (
 	"database/sql"
 
-	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup/backup"
 	"github.com/greenplum-db/gpbackup/testutils"
 
@@ -14,146 +13,129 @@ var _ = Describe("backup/predata_shared tests", func() {
 	BeforeEach(func() {
 		tocfile, backupfile = testutils.InitializeTestTOC(buffer, "predata")
 	})
-	Describe("PrintConstraintStatements", func() {
+	Describe("PrintConstraintStatement", func() {
 		var (
 			uniqueOne        backup.Constraint
 			uniqueTwo        backup.Constraint
+			uniqueNotValid   backup.Constraint
 			primarySingle    backup.Constraint
 			primaryComposite backup.Constraint
 			foreignOne       backup.Constraint
 			foreignTwo       backup.Constraint
-			trigger          backup.Constraint
-			emptyMetadataMap backup.MetadataMap
+			checkConstraint  backup.Constraint
+
+			objectMetadata    backup.ObjectMetadata
 		)
 		BeforeEach(func() {
 			uniqueOne = backup.Constraint{Oid: 1, Name: "tablename_i_key", ConType: "u", ConDef: sql.NullString{String: "UNIQUE (i)", Valid: true}, OwningObject: "public.tablename", IsDomainConstraint: false, IsPartitionParent: false}
 			uniqueTwo = backup.Constraint{Oid: 0, Name: "tablename_j_key", ConType: "u", ConDef: sql.NullString{String: "UNIQUE (j)", Valid: true}, OwningObject: "public.tablename", IsDomainConstraint: false, IsPartitionParent: false}
+			uniqueNotValid = backup.Constraint{Oid: 1, Name: "tablename_k_key", ConType: "u", ConDef: sql.NullString{String: "UNIQUE (k) NOT VALID", Valid: true}, OwningObject: "public.tablename", IsDomainConstraint: false, IsPartitionParent: false}
 			primarySingle = backup.Constraint{Oid: 0, Name: "tablename_pkey", ConType: "p", ConDef: sql.NullString{String: "PRIMARY KEY (i)", Valid: true}, OwningObject: "public.tablename", IsDomainConstraint: false, IsPartitionParent: false}
 			primaryComposite = backup.Constraint{Oid: 0, Name: "tablename_pkey", ConType: "p", ConDef: sql.NullString{String: "PRIMARY KEY (i, j)", Valid: true}, OwningObject: "public.tablename", IsDomainConstraint: false, IsPartitionParent: false}
 			foreignOne = backup.Constraint{Oid: 0, Name: "tablename_i_fkey", ConType: "f", ConDef: sql.NullString{String: "FOREIGN KEY (i) REFERENCES other_tablename(a)", Valid: true}, OwningObject: "public.tablename", IsDomainConstraint: false, IsPartitionParent: false}
 			foreignTwo = backup.Constraint{Oid: 0, Name: "tablename_j_fkey", ConType: "f", ConDef: sql.NullString{String: "FOREIGN KEY (j) REFERENCES other_tablename(b)", Valid: true}, OwningObject: "public.tablename", IsDomainConstraint: false, IsPartitionParent: false}
-			trigger = backup.Constraint{Oid: 1, Name: "tablename_t_key", ConType: "t", ConDef: sql.NullString{String: "TRIGGER", Valid: true}, OwningObject: "public.tablename", IsDomainConstraint: false, IsPartitionParent: false}
-			emptyMetadataMap = backup.MetadataMap{}
+			checkConstraint = backup.Constraint{Oid: 0, Name: "check1", ConType: "c", ConDef: sql.NullString{String: "CHECK (VALUE <> 42::numeric)", Valid: true}, OwningObject: "public.tablename", IsDomainConstraint: false, IsPartitionParent: false, ConIsLocal: true}
+
+			objectMetadata = testutils.DefaultMetadata("CONSTRAINT", false, false, false, false)
 		})
 
-		Context("No constraints", func() {
-			It("doesn't print anything", func() {
-				constraints := make([]backup.Constraint, 0)
-				backup.PrintConstraintStatements(backupfile, tocfile, constraints, emptyMetadataMap)
-				testhelper.NotExpectRegexp(buffer, `CONSTRAINT`)
-			})
-		})
-		Context("Trigger constraints", func() {
-			It("doesn't print the trigger constraint", func() {
-				constraints := []backup.Constraint{trigger}
-				constraintMetadataMap := testutils.DefaultMetadataMap("CONSTRAINT", false, false, true, false)
-				backup.PrintConstraintStatements(backupfile, tocfile, constraints, constraintMetadataMap)
-				testhelper.NotExpectRegexp(buffer, `CONSTRAINT`)
-			})
-		})
 		Context("Constraints involving different columns", func() {
 			It("prints an ADD CONSTRAINT statement for one UNIQUE constraint with a comment", func() {
-				constraints := []backup.Constraint{uniqueOne}
-				constraintMetadataMap := testutils.DefaultMetadataMap("CONSTRAINT", false, false, true, false)
-				backup.PrintConstraintStatements(backupfile, tocfile, constraints, constraintMetadataMap)
-				testutils.ExpectEntry(tocfile.PostdataEntries, 0, "", "public.tablename", "tablename_i_key", "CONSTRAINT")
-				testutils.AssertBufferContents(tocfile.PostdataEntries, buffer, "ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_i_key UNIQUE (i);", "COMMENT ON CONSTRAINT tablename_i_key ON public.tablename IS 'This is a constraint comment.';")
+				withCommentMetadata := testutils.DefaultMetadata("CONSTRAINT", false, false, true, false)
+				backup.PrintConstraintStatement(backupfile, tocfile, uniqueOne, withCommentMetadata)
+				testutils.ExpectEntry(tocfile.PredataEntries, 0, "", "public.tablename", "tablename_i_key", "CONSTRAINT")
+				testutils.AssertBufferContents(tocfile.PredataEntries, buffer, 
+					"ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_i_key UNIQUE (i);", 
+					"COMMENT ON CONSTRAINT tablename_i_key ON public.tablename IS 'This is a constraint comment.';")
 			})
 			It("prints an ADD CONSTRAINT statement for one UNIQUE constraint", func() {
-				constraints := []backup.Constraint{uniqueOne}
-				backup.PrintConstraintStatements(backupfile, tocfile, constraints, emptyMetadataMap)
-				testutils.AssertBufferContents(tocfile.PostdataEntries, buffer, `ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_i_key UNIQUE (i);`)
+				backup.PrintConstraintStatement(backupfile, tocfile, uniqueOne, objectMetadata)
+				testutils.AssertBufferContents(tocfile.PredataEntries, buffer, `ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_i_key UNIQUE (i);`)
 			})
 			It("prints ADD CONSTRAINT statements for two UNIQUE constraints", func() {
-				constraints := []backup.Constraint{uniqueOne, uniqueTwo}
-				backup.PrintConstraintStatements(backupfile, tocfile, constraints, emptyMetadataMap)
-				testutils.AssertBufferContents(tocfile.PostdataEntries, buffer,
+				backup.PrintConstraintStatement(backupfile, tocfile, uniqueOne, objectMetadata)
+				backup.PrintConstraintStatement(backupfile, tocfile, uniqueTwo, objectMetadata)
+				testutils.AssertBufferContents(tocfile.PredataEntries, buffer,
 					`ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_i_key UNIQUE (i);`,
 					`ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_j_key UNIQUE (j);`)
 			})
+			It("prints an ADD CONSTRAINT statement in Postdata section for one UNIQUE constraint with a NOT VALID clause", func() {
+				backup.PrintConstraintStatement(backupfile, tocfile, uniqueNotValid, objectMetadata)
+				testutils.ExpectEntryCount(tocfile.PredataEntries, 0)
+				testutils.ExpectEntryCount(tocfile.PostdataEntries, 1)
+				testutils.AssertBufferContents(tocfile.PostdataEntries, buffer, `ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_k_key UNIQUE (k) NOT VALID;`)
+			})
 			It("prints an ADD CONSTRAINT statement for one PRIMARY KEY constraint on one column", func() {
-				constraints := []backup.Constraint{primarySingle}
-				backup.PrintConstraintStatements(backupfile, tocfile, constraints, emptyMetadataMap)
-				testutils.AssertBufferContents(tocfile.PostdataEntries, buffer, `ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_pkey PRIMARY KEY (i);`)
+				backup.PrintConstraintStatement(backupfile, tocfile, primarySingle, objectMetadata)
+				testutils.AssertBufferContents(tocfile.PredataEntries, buffer, `ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_pkey PRIMARY KEY (i);`)
 			})
 			It("prints an ADD CONSTRAINT statement for one composite PRIMARY KEY constraint on two columns", func() {
-				constraints := []backup.Constraint{primaryComposite}
-				backup.PrintConstraintStatements(backupfile, tocfile, constraints, emptyMetadataMap)
-				testutils.AssertBufferContents(tocfile.PostdataEntries, buffer, `ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_pkey PRIMARY KEY (i, j);`)
+				backup.PrintConstraintStatement(backupfile, tocfile, primaryComposite, objectMetadata)
+				testutils.AssertBufferContents(tocfile.PredataEntries, buffer, `ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_pkey PRIMARY KEY (i, j);`)
 			})
 			It("prints an ADD CONSTRAINT statement for one FOREIGN KEY constraint", func() {
-				constraints := []backup.Constraint{foreignOne}
-				backup.PrintConstraintStatements(backupfile, tocfile, constraints, emptyMetadataMap)
-				testutils.AssertBufferContents(tocfile.PostdataEntries, buffer, `ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_i_fkey FOREIGN KEY (i) REFERENCES other_tablename(a);`)
+				backup.PrintConstraintStatement(backupfile, tocfile, foreignOne, objectMetadata)
+				testutils.AssertBufferContents(tocfile.PredataEntries, buffer, `ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_i_fkey FOREIGN KEY (i) REFERENCES other_tablename(a);`)
 			})
 			It("prints ADD CONSTRAINT statements for two FOREIGN KEY constraints", func() {
-				constraints := []backup.Constraint{foreignOne, foreignTwo}
-				backup.PrintConstraintStatements(backupfile, tocfile, constraints, emptyMetadataMap)
-				testutils.AssertBufferContents(tocfile.PostdataEntries, buffer,
+				backup.PrintConstraintStatement(backupfile, tocfile, foreignOne, objectMetadata)
+				backup.PrintConstraintStatement(backupfile, tocfile, foreignTwo, objectMetadata)
+				testutils.AssertBufferContents(tocfile.PredataEntries, buffer,
 					`ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_i_fkey FOREIGN KEY (i) REFERENCES other_tablename(a);`,
 					`ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_j_fkey FOREIGN KEY (j) REFERENCES other_tablename(b);`)
 			})
 			It("prints ADD CONSTRAINT statements for one UNIQUE constraint and one FOREIGN KEY constraint", func() {
-				constraints := []backup.Constraint{foreignTwo, uniqueOne}
-				backup.PrintConstraintStatements(backupfile, tocfile, constraints, emptyMetadataMap)
-				testutils.AssertBufferContents(tocfile.PostdataEntries, buffer,
+				backup.PrintConstraintStatement(backupfile, tocfile, uniqueOne, objectMetadata)
+				backup.PrintConstraintStatement(backupfile, tocfile, foreignTwo, objectMetadata)
+				testutils.AssertBufferContents(tocfile.PredataEntries, buffer,
 					`ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_i_key UNIQUE (i);`,
 					`ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_j_fkey FOREIGN KEY (j) REFERENCES other_tablename(b);`)
 			})
 			It("prints ADD CONSTRAINT statements for one PRIMARY KEY constraint and one FOREIGN KEY constraint", func() {
-				constraints := []backup.Constraint{foreignTwo, primarySingle}
-				backup.PrintConstraintStatements(backupfile, tocfile, constraints, emptyMetadataMap)
-				testutils.AssertBufferContents(tocfile.PostdataEntries, buffer,
+				backup.PrintConstraintStatement(backupfile, tocfile, primarySingle, objectMetadata)
+				backup.PrintConstraintStatement(backupfile, tocfile, foreignTwo, objectMetadata)
+				testutils.AssertBufferContents(tocfile.PredataEntries, buffer,
 					`ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_pkey PRIMARY KEY (i);`,
 					`ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_j_fkey FOREIGN KEY (j) REFERENCES other_tablename(b);`)
 			})
 			It("prints ADD CONSTRAINT statements for one two-column composite PRIMARY KEY constraint and one FOREIGN KEY constraint", func() {
-				constraints := []backup.Constraint{foreignTwo, primaryComposite}
-				backup.PrintConstraintStatements(backupfile, tocfile, constraints, emptyMetadataMap)
-				testutils.AssertBufferContents(tocfile.PostdataEntries, buffer,
+				backup.PrintConstraintStatement(backupfile, tocfile, primaryComposite, objectMetadata)
+				backup.PrintConstraintStatement(backupfile, tocfile, foreignTwo, objectMetadata)
+				testutils.AssertBufferContents(tocfile.PredataEntries, buffer,
 					`ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_pkey PRIMARY KEY (i, j);`,
 					`ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_j_fkey FOREIGN KEY (j) REFERENCES other_tablename(b);`)
 			})
 		})
 		Context("Constraints involving the same column", func() {
 			It("prints ADD CONSTRAINT statements for one UNIQUE constraint and one FOREIGN KEY constraint", func() {
-				constraints := []backup.Constraint{foreignOne, uniqueOne}
-				backup.PrintConstraintStatements(backupfile, tocfile, constraints, emptyMetadataMap)
-				testutils.AssertBufferContents(tocfile.PostdataEntries, buffer,
+				backup.PrintConstraintStatement(backupfile, tocfile, uniqueOne, objectMetadata)
+				backup.PrintConstraintStatement(backupfile, tocfile, foreignOne, objectMetadata)
+				testutils.AssertBufferContents(tocfile.PredataEntries, buffer,
 					`ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_i_key UNIQUE (i);`,
 					`ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_i_fkey FOREIGN KEY (i) REFERENCES other_tablename(a);`)
 			})
 			It("prints ADD CONSTRAINT statements for one PRIMARY KEY constraint and one FOREIGN KEY constraint", func() {
-				constraints := []backup.Constraint{foreignOne, primarySingle}
-				backup.PrintConstraintStatements(backupfile, tocfile, constraints, emptyMetadataMap)
-				testutils.AssertBufferContents(tocfile.PostdataEntries, buffer,
+				backup.PrintConstraintStatement(backupfile, tocfile, primarySingle, objectMetadata)
+				backup.PrintConstraintStatement(backupfile, tocfile, foreignOne, objectMetadata)
+				testutils.AssertBufferContents(tocfile.PredataEntries, buffer,
 					`ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_pkey PRIMARY KEY (i);`,
 					`ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_i_fkey FOREIGN KEY (i) REFERENCES other_tablename(a);`)
 			})
 			It("prints ADD CONSTRAINT statements for a two-column composite PRIMARY KEY constraint and one FOREIGN KEY constraint", func() {
-				constraints := []backup.Constraint{foreignOne, primaryComposite}
-				backup.PrintConstraintStatements(backupfile, tocfile, constraints, emptyMetadataMap)
-				testutils.AssertBufferContents(tocfile.PostdataEntries, buffer,
+				backup.PrintConstraintStatement(backupfile, tocfile, primaryComposite, objectMetadata)
+				backup.PrintConstraintStatement(backupfile, tocfile, foreignOne, objectMetadata)
+				testutils.AssertBufferContents(tocfile.PredataEntries, buffer,
 					`ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_pkey PRIMARY KEY (i, j);`,
 					`ALTER TABLE ONLY public.tablename ADD CONSTRAINT tablename_i_fkey FOREIGN KEY (i) REFERENCES other_tablename(a);`)
 			})
-			It("doesn't print an ADD CONSTRAINT statement for domain check constraint", func() {
-				domainCheckConstraint := backup.Constraint{Oid: 0, Name: "check1", ConType: "c", ConDef: sql.NullString{String: "CHECK (VALUE <> 42::numeric)", Valid: true}, OwningObject: "public.domain1", IsDomainConstraint: true, IsPartitionParent: false}
-				constraints := []backup.Constraint{domainCheckConstraint}
-				backup.PrintConstraintStatements(backupfile, tocfile, constraints, emptyMetadataMap)
-				testhelper.NotExpectRegexp(buffer, `ALTER DOMAIN`)
-			})
 			It("prints an ADD CONSTRAINT statement for a parent partition table", func() {
 				uniqueOne.IsPartitionParent = true
-				constraints := []backup.Constraint{uniqueOne}
-				backup.PrintConstraintStatements(backupfile, tocfile, constraints, emptyMetadataMap)
-				testutils.AssertBufferContents(tocfile.PostdataEntries, buffer, `ALTER TABLE public.tablename ADD CONSTRAINT tablename_i_key UNIQUE (i);`)
+				backup.PrintConstraintStatement(backupfile, tocfile, uniqueOne, objectMetadata)
+				testutils.AssertBufferContents(tocfile.PredataEntries, buffer, `ALTER TABLE public.tablename ADD CONSTRAINT tablename_i_key UNIQUE (i);`)
 			})
 			It("prints an ADD CONSTRAINT [name] CHECK statement without keyword ONLY for a table with descendants (another table inherits it)", func() {
-				checkConstraint := backup.Constraint{Oid: 0, Name: "check1", ConType: "c", ConDef: sql.NullString{String: "CHECK (VALUE <> 42::numeric)", Valid: true}, OwningObject: "public.tablename", IsDomainConstraint: false, IsPartitionParent: false, ConIsLocal: true}
-				constraints := []backup.Constraint{checkConstraint}
-				backup.PrintConstraintStatements(backupfile, tocfile, constraints, emptyMetadataMap)
-				testutils.AssertBufferContents(tocfile.PostdataEntries, buffer, `ALTER TABLE public.tablename ADD CONSTRAINT check1 CHECK (VALUE <> 42::numeric);`)
+				backup.PrintConstraintStatement(backupfile, tocfile, checkConstraint, objectMetadata)
+				testutils.AssertBufferContents(tocfile.PredataEntries, buffer, `ALTER TABLE public.tablename ADD CONSTRAINT check1 CHECK (VALUE <> 42::numeric);`)
 			})
 		})
 	})

--- a/backup/queries_shared.go
+++ b/backup/queries_shared.go
@@ -85,7 +85,13 @@ type Constraint struct {
 }
 
 func (c Constraint) GetMetadataEntry() (string, toc.MetadataEntry) {
-	return "postdata",
+	var tocSection string
+	if c.ConDef.Valid && !strings.Contains(strings.ToUpper(c.ConDef.String), "NOT VALID") {
+		tocSection = "predata"
+	} else {
+		tocSection = "postdata"
+	}
+	return tocSection,
 		toc.MetadataEntry{
 			Schema:          c.Schema,
 			Name:            c.Name,
@@ -137,6 +143,7 @@ func GetConstraints(connectionPool *dbconn.DBConn, includeTables ...Relation) []
 	WHERE %s
 		AND %s
 		AND c.relname IS NOT NULL
+		AND contype != 't'
 		AND conrelid NOT IN (SELECT parchildrelid FROM pg_partition_rule)
 		AND (conrelid, conname) NOT IN (SELECT i.inhrelid, con.conname FROM pg_inherits i JOIN pg_constraint con ON i.inhrelid = con.conrelid JOIN pg_constraint p ON i.inhparent = p.conrelid WHERE con.conname = p.conname)
 	GROUP BY con.oid, conname, contype, c.relname, n.nspname, %s pt.parrelid`, selectConIsLocal, "%s", ExtensionFilterClause("c"), groupByConIsLocal)

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -1372,6 +1372,60 @@ var _ = Describe("backup and restore end to end tests", func() {
 				tableCopyCount := dbconn.MustSelectString(restoreConn, fmt.Sprintf("SELECT count(*) FROM %s WHERE val = 0.100001216::real", tableNameCopy))
 				Expect(tableCopyCount).To(Equal(strconv.Itoa(1)))
 			})
+			It("does not retrieve trigger constraints  with the rest of the constraints", func() {
+				testutils.SkipIfBefore6(backupConn)
+				testhelper.AssertQueryRuns(backupConn,
+					"CREATE TABLE table_multiple_constraints (a int)")
+				defer testhelper.AssertQueryRuns(backupConn,
+					"DROP TABLE IF EXISTS table_multiple_constraints CASCADE;")
+
+				// Add a trigger constraint
+				testhelper.AssertQueryRuns(backupConn, `CREATE FUNCTION public.no_op_trig_fn() RETURNS trigger AS
+$$begin RETURN NULL; end$$
+LANGUAGE plpgsql NO SQL;`)
+				defer testhelper.AssertQueryRuns(backupConn, `DROP FUNCTION IF EXISTS public.no_op_trig_fn() CASCADE`)
+				testhelper.AssertQueryRuns(backupConn, "CREATE TRIGGER  test_trigger AFTER INSERT  ON public.table_multiple_constraints EXECUTE PROCEDURE public.no_op_trig_fn();")
+
+				// Add a non-trigger constraint
+				testhelper.AssertQueryRuns(backupConn,
+					"ALTER TABLE public.table_multiple_constraints ADD CONSTRAINT alter_table_with_primary_key_pkey PRIMARY KEY (a);")
+
+				// retrieve constraints, assert that only one is retrieved
+				constraintsRetrieved := backup.GetConstraints(backupConn)
+				Expect(len(constraintsRetrieved)).To(Equal(1))
+
+				// assert that the single retrieved constraint is the non-trigger constraint
+				constraintRetrieved := constraintsRetrieved[0]
+				Expect(constraintRetrieved.ConType).To(Equal("p"))
+			})
+			It("correctly distinguishes between domain and non-domain constraints", func() {
+				testutils.SkipIfBefore6(backupConn)
+				testhelper.AssertQueryRuns(backupConn,
+					"CREATE TABLE table_multiple_constraints (a int)")
+				defer testhelper.AssertQueryRuns(backupConn,
+					"DROP TABLE IF EXISTS table_multiple_constraints CASCADE;")
+
+				// Add a domain with a constraint
+				testhelper.AssertQueryRuns(backupConn, "CREATE DOMAIN public.const_domain1 AS text CONSTRAINT cons_check1 CHECK (char_length(VALUE) = 5);")
+				defer testhelper.AssertQueryRuns(backupConn, `DROP DOMAIN IF EXISTS public.const_domain1;`)
+
+				// Add a non-trigger constraint
+				testhelper.AssertQueryRuns(backupConn,
+					"ALTER TABLE public.table_multiple_constraints ADD CONSTRAINT alter_table_with_primary_key_pkey PRIMARY KEY (a);")
+
+				// retrieve constraints, assert that two are retrieved, assert that the domain constraint is correctly categorized
+				constraintsRetrieved := backup.GetConstraints(backupConn)
+				Expect(len(constraintsRetrieved)).To(Equal(2))
+				for _, constr := range constraintsRetrieved {
+					if constr.Name == "cons_check1" {
+						Expect(constr.IsDomainConstraint).To(Equal(true))
+					} else if constr.Name == "alter_table_with_primary_key_pkey" {
+						Expect(constr.IsDomainConstraint).To(Equal(false))
+					} else {
+						Fail("Unrecognized constraint in end-to-end test database")
+					}
+				}
+			})
 			It("backup and restore all data when NOT VALID option on constraints is specified", func() {
 				testutils.SkipIfBefore6(backupConn)
 				testhelper.AssertQueryRuns(backupConn,

--- a/testutils/functions.go
+++ b/testutils/functions.go
@@ -442,6 +442,10 @@ func ExpectEntry(entries []toc.MetadataEntry, index int, schema, referenceObject
 	structmatcher.ExpectStructsToMatchExcluding(entries[index], toc.MetadataEntry{Schema: schema, Name: name, ObjectType: objectType, ReferenceObject: referenceObject, StartByte: 0, EndByte: 0}, "StartByte", "EndByte")
 }
 
+func ExpectEntryCount(entries []toc.MetadataEntry, index int,){
+	Expect(len(entries)).To(BeNumerically("==", index))
+}
+
 func ExecuteSQLFile(connectionPool *dbconn.DBConn, filename string) {
 	connStr := []string{
 		"-U", connectionPool.User,


### PR DESCRIPTION
Some View definitions may depend on constraints.
Constraints are printed after views, sometimes resulting in invalid SQL.

Move constraints into sorted dependency procedure.
Move constraints without NOT VALID clause back to predata section.
Move dropping of trigger constraints from printing to retrieval.
Split out domain constraints to keep current approach for those.
Fix some formatting and warnings in dependencies.go.
