### PR TITLE
Reorganize reader open logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ depend :
 	go mod download
 
 $(GINKGO) : # v1.14.0 is compatible with centos6 default gcc version
-	go install github.com/onsi/ginkgo/v2/ginkgo@latest
+	go install github.com/onsi/ginkgo/v2/ginkgo@v2.2.0
 
 $(GOIMPORTS) :
 	go install golang.org/x/tools/cmd/goimports@latest


### PR DESCRIPTION
Pre-open readers in map to avoid seek perf penalty.

Pin ginkgo version in Makefile.
v2.2.3 has a bug that is breaking our CI.  Pin to v2.2.0 for now.

Co-authored-by: Jamie McAtamney <jmcatamney@vmware.com>