### PR TITLE
Rebase fix gp7 incl leaf part

### DIFF
--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -79,10 +79,10 @@ func (r Relation) GetUniqueID() UniqueID {
  * it is currently much simpler than the include case.
  */
 func getUserTableRelations(connectionPool *dbconn.DBConn) []Relation {
-	// TODO: fix for gpdb7 partitioning
 	childPartitionFilter := ""
 	if !MustGetFlagBool(options.LEAF_PARTITION_DATA) && connectionPool.Version.Before("7") {
-		//Filter out non-external child partitions
+		// Filter out non-external child partitions in GPDB6 and earlier.
+		// In GPDB7+ we do not want to exclude child partitions, they function as separate tables.
 		childPartitionFilter = `
 	AND c.oid NOT IN (
 		SELECT p.parchildrelid

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -608,10 +608,11 @@ func backupDependentObjects(metadataFile *utils.FileWithByteCount, tables []Tabl
 	gplog.Verbose("Writing CREATE statements for dependent objects to metadata file")
 
 	backupSet := createBackupSet(sortables)
-	relevantDeps := GetDependencies(connectionPool, backupSet)
+	relevantDeps := GetDependencies(connectionPool, backupSet, tables)
 	if connectionPool.Version.Is("4") && !tableOnly {
 		AddProtocolDependenciesForGPDB4(relevantDeps, tables, protocols)
 	}
+
 	sortedSlice := TopologicalSort(sortables, relevantDeps)
 
 	PrintDependentObjectStatements(metadataFile, globalTOC, sortedSlice, filteredMetadata, domainConstraints, funcInfoMap)

--- a/integration/dependency_queries_test.go
+++ b/integration/dependency_queries_test.go
@@ -22,8 +22,9 @@ var _ = Describe("backup integration tests", func() {
 			fooEntry := backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: oidFoo}
 			barEntry := backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: oidBar}
 			backupSet := map[backup.UniqueID]bool{fooEntry: true, barEntry: true}
+			tables := make([]backup.Table, 0)
 
-			deps := backup.GetDependencies(connectionPool, backupSet)
+			deps := backup.GetDependencies(connectionPool, backupSet, tables)
 
 			Expect(deps).To(HaveLen(1))
 			Expect(deps[barEntry]).To(HaveLen(1))
@@ -53,8 +54,9 @@ var _ = Describe("backup integration tests", func() {
 			protocolEntry := backup.UniqueID{ClassID: backup.PG_EXTPROTOCOL_OID, Oid: protocolOid}
 			functionEntry := backup.UniqueID{ClassID: backup.PG_PROC_OID, Oid: functionOid}
 			backupSet := map[backup.UniqueID]bool{tableEntry: true, protocolEntry: true, functionEntry: true}
+			tables := make([]backup.Table, 0)
 
-			deps := backup.GetDependencies(connectionPool, backupSet)
+			deps := backup.GetDependencies(connectionPool, backupSet, tables)
 			if connectionPool.Version.Is("4") {
 				tableRelations := backup.GetIncludedUserTableRelations(connectionPool, []string{})
 				tables := backup.ConstructDefinitionsForTables(connectionPool, tableRelations)
@@ -84,8 +86,9 @@ var _ = Describe("backup integration tests", func() {
 			parent2Entry := backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: parent2Oid}
 			childEntry := backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: childOid}
 			backupSet := map[backup.UniqueID]bool{parent1Entry: true, parent2Entry: true, childEntry: true}
+			tables := make([]backup.Table, 0)
 
-			deps := backup.GetDependencies(connectionPool, backupSet)
+			deps := backup.GetDependencies(connectionPool, backupSet, tables)
 
 			Expect(deps).To(HaveLen(1))
 			Expect(deps[childEntry]).To(HaveLen(2))
@@ -111,8 +114,9 @@ var _ = Describe("backup integration tests", func() {
 			parent2Entry := backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: parent2Oid}
 			childEntry := backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: childOid}
 			backupSet := map[backup.UniqueID]bool{parent1Entry: true, parent2Entry: true, childEntry: true}
+			tables := make([]backup.Table, 0)
 
-			deps := backup.GetDependencies(connectionPool, backupSet)
+			deps := backup.GetDependencies(connectionPool, backupSet, tables)
 
 			Expect(deps).To(HaveLen(1))
 			Expect(deps[childEntry]).To(HaveLen(2))
@@ -134,8 +138,9 @@ object-relational database management system');`)
 			configID := testutils.UniqueIDFromObjectName(connectionPool, "public", "testconfig", backup.TYPE_TSCONFIGURATION)
 			viewID := testutils.UniqueIDFromObjectName(connectionPool, "public", "ts_config_view", backup.TYPE_RELATION)
 			backupSet := map[backup.UniqueID]bool{parserID: true, configID: true, viewID: true}
+			tables := make([]backup.Table, 0)
 
-			deps := backup.GetDependencies(connectionPool, backupSet)
+			deps := backup.GetDependencies(connectionPool, backupSet, tables)
 			Expect(deps).To(HaveLen(2))
 			Expect(deps[configID]).To(HaveLen(1))
 			Expect(deps[configID]).To(HaveKey(parserID))
@@ -159,8 +164,9 @@ object-relational database management system');`)
 				functionOid := testutils.OidFromObjectName(connectionPool, "public", "add", backup.TYPE_FUNCTION)
 				funcEntry := backup.UniqueID{ClassID: backup.PG_PROC_OID, Oid: functionOid}
 				backupSet := map[backup.UniqueID]bool{funcEntry: true, compositeEntry: true}
+				tables := make([]backup.Table, 0)
 
-				functionDeps := backup.GetDependencies(connectionPool, backupSet)
+				functionDeps := backup.GetDependencies(connectionPool, backupSet, tables)
 
 				Expect(functionDeps).To(HaveLen(1))
 				Expect(functionDeps[funcEntry]).To(HaveLen(1))
@@ -173,8 +179,9 @@ object-relational database management system');`)
 				functionOid := testutils.OidFromObjectName(connectionPool, "public", "compose", backup.TYPE_FUNCTION)
 				funcEntry := backup.UniqueID{ClassID: backup.PG_PROC_OID, Oid: functionOid}
 				backupSet := map[backup.UniqueID]bool{funcEntry: true, compositeEntry: true}
+				tables := make([]backup.Table, 0)
 
-				functionDeps := backup.GetDependencies(connectionPool, backupSet)
+				functionDeps := backup.GetDependencies(connectionPool, backupSet, tables)
 
 				Expect(functionDeps).To(HaveLen(1))
 				Expect(functionDeps[funcEntry]).To(HaveLen(1))
@@ -194,8 +201,9 @@ object-relational database management system');`)
 				baseOid := testutils.OidFromObjectName(connectionPool, "public", "base_type", backup.TYPE_TYPE)
 				baseEntry := backup.UniqueID{ClassID: backup.PG_TYPE_OID, Oid: baseOid}
 				backupSet := map[backup.UniqueID]bool{funcEntry: true, compositeEntry: true, baseEntry: true}
+				tables := make([]backup.Table, 0)
 
-				functionDeps := backup.GetDependencies(connectionPool, backupSet)
+				functionDeps := backup.GetDependencies(connectionPool, backupSet, tables)
 
 				Expect(functionDeps).To(HaveLen(1))
 				Expect(functionDeps[funcEntry]).To(HaveLen(2))
@@ -232,8 +240,9 @@ object-relational database management system');`)
 				domainEntry := backup.UniqueID{ClassID: backup.PG_TYPE_OID, Oid: domainOid}
 				domain2Entry := backup.UniqueID{ClassID: backup.PG_TYPE_OID, Oid: domain2Oid}
 				backupSet := map[backup.UniqueID]bool{domainEntry: true, domain2Entry: true}
+				tables := make([]backup.Table, 0)
 
-				deps := backup.GetDependencies(connectionPool, backupSet)
+				deps := backup.GetDependencies(connectionPool, backupSet, tables)
 
 				Expect(deps).To(HaveLen(1))
 				Expect(deps[domain2Entry]).To(HaveLen(1))
@@ -247,8 +256,9 @@ object-relational database management system');`)
 				baseInEntry := backup.UniqueID{ClassID: backup.PG_PROC_OID, Oid: baseInOid}
 				baseOutEntry := backup.UniqueID{ClassID: backup.PG_PROC_OID, Oid: baseOutOid}
 				backupSet := map[backup.UniqueID]bool{baseEntry: true, baseInEntry: true, baseOutEntry: true}
+				tables := make([]backup.Table, 0)
 
-				deps := backup.GetDependencies(connectionPool, backupSet)
+				deps := backup.GetDependencies(connectionPool, backupSet, tables)
 
 				Expect(deps).To(HaveLen(1))
 				Expect(deps[baseEntry]).To(HaveLen(2))
@@ -262,8 +272,9 @@ object-relational database management system');`)
 				compositeOid := testutils.OidFromObjectName(connectionPool, "public", "comp_type", backup.TYPE_TYPE)
 				compositeEntry := backup.UniqueID{ClassID: backup.PG_TYPE_OID, Oid: compositeOid}
 				backupSet := map[backup.UniqueID]bool{baseEntry: true, compositeEntry: true}
+				tables := make([]backup.Table, 0)
 
-				deps := backup.GetDependencies(connectionPool, backupSet)
+				deps := backup.GetDependencies(connectionPool, backupSet, tables)
 
 				Expect(deps).To(HaveLen(1))
 				Expect(deps[compositeEntry]).To(HaveLen(1))
@@ -284,8 +295,9 @@ object-relational database management system');`)
 				compositeOid := testutils.OidFromObjectName(connectionPool, "public", "comp_type", backup.TYPE_TYPE)
 				compositeEntry := backup.UniqueID{ClassID: backup.PG_TYPE_OID, Oid: compositeOid}
 				backupSet := map[backup.UniqueID]bool{baseEntry: true, base2Entry: true, compositeEntry: true}
+				tables := make([]backup.Table, 0)
 
-				deps := backup.GetDependencies(connectionPool, backupSet)
+				deps := backup.GetDependencies(connectionPool, backupSet, tables)
 
 				Expect(deps).To(HaveLen(1))
 				Expect(deps[compositeEntry]).To(HaveLen(2))
@@ -299,8 +311,9 @@ object-relational database management system');`)
 				compositeOid := testutils.OidFromObjectName(connectionPool, "public", "comp_type", backup.TYPE_TYPE)
 				compositeEntry := backup.UniqueID{ClassID: backup.PG_TYPE_OID, Oid: compositeOid}
 				backupSet := map[backup.UniqueID]bool{baseEntry: true, compositeEntry: true}
+				tables := make([]backup.Table, 0)
 
-				deps := backup.GetDependencies(connectionPool, backupSet)
+				deps := backup.GetDependencies(connectionPool, backupSet, tables)
 
 				Expect(deps).To(HaveLen(1))
 				Expect(deps[compositeEntry]).To(HaveLen(1))
@@ -318,8 +331,9 @@ object-relational database management system');`)
 				tableEntry := backup.UniqueID{ClassID: backup.PG_CLASS_OID, Oid: tableOid}
 				typeEntry := backup.UniqueID{ClassID: backup.PG_TYPE_OID, Oid: typeOid}
 				backupSet := map[backup.UniqueID]bool{tableEntry: true, typeEntry: true}
+				tables := make([]backup.Table, 0)
 
-				deps := backup.GetDependencies(connectionPool, backupSet)
+				deps := backup.GetDependencies(connectionPool, backupSet, tables)
 
 				Expect(deps).To(HaveLen(1))
 				Expect(deps[typeEntry]).To(HaveLen(1))

--- a/options/options.go
+++ b/options/options.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
+	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"github.com/greenplum-db/gp-common-go-libs/iohelper"
 	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/pkg/errors"
@@ -269,6 +270,77 @@ func (o *Options) QuoteExcludeRelations(conn *dbconn.DBConn) error {
 	return nil
 }
 
+// given a set of table oids, return a deduplicated set of other tables that EITHER depend
+// on them, OR that they depend on. The behavior for which is set with recurseDirection.
+func (o *Options) recurseTableDepend(conn *dbconn.DBConn, includeOids []string, recurseSource string) ([]string, error) {
+	var err error
+	var dependQuery string
+
+	expandedIncludeOids := make(map[string]bool)
+	for _, oid := range includeOids {
+		expandedIncludeOids[oid] = true
+	}
+
+	if recurseSource == "child" {
+		dependQuery = `
+			SELECT dep.refobjid
+			FROM
+				pg_depend dep
+				INNER JOIN pg_class cls ON dep.refobjid = cls.oid
+			WHERE
+				dep.objid in (%s)
+				AND cls.relkind in ('r', 'p', 'f')`
+	} else if recurseSource == "parent" {
+		dependQuery = `
+			SELECT dep.objid
+			FROM
+				pg_depend dep
+				INNER JOIN pg_class cls ON dep.objid = cls.oid
+			WHERE
+				dep.refobjid in (%s)
+				AND cls.relkind in ('r', 'p', 'f')`
+	} else {
+		gplog.Error("Please fix calling of this function recurseTableDepend. Argument recurseSource only accepts 'parent' or 'child'.")
+	}
+
+	// here we loop until no further table dependencies are found.  implemented iteratively, but functions like a recursion
+	foundDeps := true
+	loopOids := includeOids
+	for foundDeps {
+		foundDeps = false
+		depOids := make([]string, 0)
+		loopDepQuery := fmt.Sprintf(dependQuery, strings.Join(loopOids, ", "))
+		err = conn.Select(&depOids, loopDepQuery)
+		if err != nil {
+			gplog.Warn("Table dependency query failed: %s", loopDepQuery)
+			return nil, err
+		}
+
+		// confirm that any table dependencies are found
+		// save the table dependencies for both output and for next recursion
+		loopOids = loopOids[:]
+		for _, depOid := range depOids {
+			// must exclude oids already captured to avoid circular dependencies
+			// causing an infinite loop
+			if !expandedIncludeOids[depOid] {
+				foundDeps = true
+				loopOids = append(loopOids, depOid)
+				expandedIncludeOids[depOid] = true
+			}
+		}
+	}
+
+	// capture deduplicated oids from map keys, return as array
+	// done as a direct array assignment loop because it's faster and we know the length
+	expandedIncludeOidsArr := make([]string, len(expandedIncludeOids))
+	arrayIdx := 0
+	for idx := range expandedIncludeOids {
+		expandedIncludeOidsArr[arrayIdx] = idx
+		arrayIdx++
+	}
+	return expandedIncludeOidsArr, err
+}
+
 func (o Options) getUserTableRelationsWithIncludeFiltering(connectionPool *dbconn.DBConn, includedRelationsQuoted []string) ([]FqnStruct, error) {
 	includeOids, err := getOidsFromRelationList(connectionPool, includedRelationsQuoted)
 	if err != nil {
@@ -327,15 +399,25 @@ func (o Options) getUserTableRelationsWithIncludeFiltering(connectionPool *dbcon
 			)
 		)`, oidStr)
 	} else {
-		childPartitionFilter = fmt.Sprintf(`
-		-- Get leaf partitions whose roots are in the include list
-		OR pg_partition_root(c.oid) IN (%s)`, oidStr)
+		// GPDB7+ reworks the nature of partition tables.  It is no longer sufficient
+		// to pull parents and children in one step.  Instead we must recursively climb/descend
+		// the pg_depend ladder, filtering to only members of pg_class at each step, until the
+		// full hierarchy has been retrieved
+		childOids, err := o.recurseTableDepend(connectionPool, includeOids, "parent")
+		if err != nil {
+			return nil, err
+		}
+		if len(childOids) > 0 {
+			childPartitionFilter = fmt.Sprintf(`OR c.oid IN (%s)`, strings.Join(childOids, ", "))
+		}
 
-		parentAndExternalPartitionFilter = fmt.Sprintf(`
-		-- Get parent partition tables whose children are in the include list
-		OR c.oid IN (
-			SELECT DISTINCT pg_partition_root(unnest(ARRAY[%s]))::oid
-		)`, oidStr)
+		parentOids, err := o.recurseTableDepend(connectionPool, includeOids, "child")
+		if err != nil {
+			return nil, err
+		}
+		if len(parentOids) > 0 {
+			parentAndExternalPartitionFilter = fmt.Sprintf(`OR c.oid IN (%s)`, strings.Join(parentOids, ", "))
+		}
 	}
 
 	query := fmt.Sprintf(`


### PR DESCRIPTION
This includes the e2e test leftover from the partition suffix change, and work to correct include filtering and oid list expansion for partitioned tables on GPDB7+.  Details are in the commit messages.