### PR TITLE
Add file count verification to resize restores

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -287,7 +287,7 @@ func backupData(tables []Table) {
 		initialPipes := CreateInitialSegmentPipes(oidList, globalCluster, connectionPool, globalFPInfo)
 		// Do not pass through the --on-error-continue flag or the resizeClusterMap because neither apply to gpbackup
 		utils.StartGpbackupHelpers(globalCluster, globalFPInfo, "--backup-agent",
-			MustGetFlagString(options.PLUGIN_CONFIG), compressStr, false, false, &wasTerminated, initialPipes, true, 0, 0)
+			MustGetFlagString(options.PLUGIN_CONFIG), compressStr, false, false, &wasTerminated, initialPipes, true, false, 0, 0)
 	}
 	gplog.Info("Writing data to file")
 	rowsCopiedMaps := backupDataForAllTables(tables)

--- a/helper/helper.go
+++ b/helper/helper.go
@@ -53,6 +53,7 @@ var (
 	isFiltered       *bool
 	copyQueue        *int
 	singleDataFile   *bool
+	isResizeRestore  *bool
 	origSize         *int
 	destSize         *int
 	replicationFile  *string
@@ -104,6 +105,7 @@ func InitializeGlobals() {
 	isFiltered = flag.Bool("with-filters", false, "Used with table/schema filters")
 	copyQueue = flag.Int("copy-queue-size", 1, "Used to know how many COPIES are being queued up")
 	singleDataFile = flag.Bool("single-data-file", false, "Used with single data file restore.")
+	isResizeRestore = flag.Bool("resize-cluster", false, "Used with resize cluster restore.")
 	origSize = flag.Int("orig-seg-count", 0, "Used with resize restore.  Gives the segment count of the backup.")
 	destSize = flag.Int("dest-seg-count", 0, "Used with resize restore.  Gives the segment count of the current cluster.")
 	replicationFile = flag.String("replication-file", "", "Used with resize restore.  Gives the list of replicated tables.")

--- a/restore/remote_test.go
+++ b/restore/remote_test.go
@@ -39,7 +39,7 @@ var _ = Describe("restore/remote tests", func() {
 			}
 			testCluster.Executor = testExecutor
 			restore.SetCluster(testCluster)
-			restore.VerifyBackupFileCountOnSegments(2)
+			restore.VerifyBackupFileCountOnSegments()
 			Expect((*testExecutor).NumExecutions).To(Equal(1))
 		})
 		It("panics if backup file counts do not match on all segments", func() {
@@ -52,7 +52,7 @@ var _ = Describe("restore/remote tests", func() {
 			testCluster.Executor = testExecutor
 			restore.SetCluster(testCluster)
 			defer testhelper.ShouldPanicWithMessage("Found incorrect number of backup files on 2 segments")
-			restore.VerifyBackupFileCountOnSegments(2)
+			restore.VerifyBackupFileCountOnSegments()
 		})
 		It("panics if backup file counts do not match on some segments", func() {
 			testExecutor.ClusterOutput = &cluster.RemoteOutput{
@@ -63,7 +63,7 @@ var _ = Describe("restore/remote tests", func() {
 			testCluster.Executor = testExecutor
 			restore.SetCluster(testCluster)
 			defer testhelper.ShouldPanicWithMessage("Found incorrect number of backup files on 1 segment")
-			restore.VerifyBackupFileCountOnSegments(2)
+			restore.VerifyBackupFileCountOnSegments()
 		})
 		It("panics if it cannot verify some backup file counts", func() {
 			testExecutor.ClusterOutput = &cluster.RemoteOutput{
@@ -75,7 +75,7 @@ var _ = Describe("restore/remote tests", func() {
 			testCluster.Executor = testExecutor
 			restore.SetCluster(testCluster)
 			defer testhelper.ShouldPanicWithMessage("Could not verify backup file count on 1 segment")
-			restore.VerifyBackupFileCountOnSegments(2)
+			restore.VerifyBackupFileCountOnSegments()
 		})
 	})
 })

--- a/restore/validate.go
+++ b/restore/validate.go
@@ -293,9 +293,7 @@ func ValidateSafeToResizeCluster() {
 	// allow a restore to a different-size cluster.  Any backups that do have a SegmentCount will have that checked
 	// when attempting a normal restore, so that the user doesn't accidentally restore a different-size backup without
 	// using the --resize-cluster flag.
-	resizeCluster := MustGetFlagBool(options.RESIZE_CLUSTER)
-	origSize := backupConfig.SegmentCount
-	destSize := len(globalCluster.ContentIDs) - 1
+	origSize, destSize, resizeCluster := GetResizeClusterInfo()
 
 	if resizeCluster {
 		if origSize == 0 {

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -230,9 +230,7 @@ func RecoverMetadataFilesUsingPlugin() {
 	for _, fpInfo := range fpInfoList {
 		pluginConfig.MustRestoreFile(fpInfo.GetTOCFilePath())
 		if backupConfig.SingleDataFile {
-			isResizeRestore := MustGetFlagBool(options.RESIZE_CLUSTER)
-			origSize := backupConfig.SegmentCount
-			destSize := len(globalCluster.ContentIDs) - 1
+			origSize, destSize, isResizeRestore := GetResizeClusterInfo()
 			pluginConfig.RestoreSegmentTOCs(globalCluster, fpInfo, isResizeRestore, origSize, destSize)
 		}
 	}

--- a/utils/agent_remote.go
+++ b/utils/agent_remote.go
@@ -121,7 +121,7 @@ func VerifyHelperVersionOnSegments(version string, c *cluster.Cluster) {
 	}
 }
 
-func StartGpbackupHelpers(c *cluster.Cluster, fpInfo filepath.FilePathInfo, operation string, pluginConfigFile string, compressStr string, onErrorContinue bool, isFilter bool, wasTerminated *bool, copyQueue int, isSingleDataFile bool, origSize int, destSize int) {
+func StartGpbackupHelpers(c *cluster.Cluster, fpInfo filepath.FilePathInfo, operation string, pluginConfigFile string, compressStr string, onErrorContinue bool, isFilter bool, wasTerminated *bool, copyQueue int, isSingleDataFile bool, resizeCluster bool, origSize int, destSize int) {
 	// A mutex lock for cleaning up and starting gpbackup helpers prevents a
 	// race condition that causes gpbackup_helpers to be orphaned if
 	// gpbackup_helper cleanup happens before they are started.
@@ -151,8 +151,8 @@ func StartGpbackupHelpers(c *cluster.Cluster, fpInfo filepath.FilePathInfo, oper
 		singleDataFileStr = " --single-data-file"
 	}
 	resizeStr := ""
-	if origSize > 0 && destSize > 0 {
-		resizeStr = fmt.Sprintf(" --orig-seg-count %d --dest-seg-count %d", origSize, destSize)
+	if resizeCluster {
+		resizeStr = fmt.Sprintf(" --resize-cluster --orig-seg-count %d --dest-seg-count %d", origSize, destSize)
 	}
 	remoteOutput := c.GenerateAndExecuteCommand("Starting gpbackup_helper agent", cluster.ON_SEGMENTS, func(contentID int) string {
 		tocFile := fpInfo.GetSegmentTOCFilePath(contentID)

--- a/utils/agent_remote_test.go
+++ b/utils/agent_remote_test.go
@@ -126,14 +126,14 @@ var _ = Describe("agent remote", func() {
 	Describe("StartGpbackupHelpers()", func() {
 		It("Correctly propagates --on-error-continue flag to gpbackup_helper", func() {
 			wasTerminated := false
-			utils.StartGpbackupHelpers(testCluster, fpInfo, "operation", "/tmp/pluginConfigFile.yml", " compressStr", true, false, &wasTerminated, 1, true, 0, 0)
+			utils.StartGpbackupHelpers(testCluster, fpInfo, "operation", "/tmp/pluginConfigFile.yml", " compressStr", true, false, &wasTerminated, 1, true, false, 0, 0)
 
 			cc := testExecutor.ClusterCommands[0]
 			Expect(cc[1].CommandString).To(ContainSubstring(" --on-error-continue"))
 		})
 		It("Correctly propagates --copy-queue-size value to gpbackup_helper", func() {
 			wasTerminated := false
-			utils.StartGpbackupHelpers(testCluster, fpInfo, "operation", "/tmp/pluginConfigFile.yml", " compressStr", false, false, &wasTerminated, 4, true, 0, 0)
+			utils.StartGpbackupHelpers(testCluster, fpInfo, "operation", "/tmp/pluginConfigFile.yml", " compressStr", false, false, &wasTerminated, 4, true, false, 0, 0)
 
 			cc := testExecutor.ClusterCommands[0]
 			Expect(cc[1].CommandString).To(ContainSubstring(" --copy-queue-size 4"))


### PR DESCRIPTION
In the resize-restore case, expected file counts will vary based on the sizes of the source and destination clusters.  Add logic to calculate the expected sizes, and fail if the correct number of files are not found.