### PR TITLE
Roll back directory change

### DIFF
--- a/ci/scripts/setup-centos-env.bash
+++ b/ci/scripts/setup-centos-env.bash
@@ -32,7 +32,8 @@ set -ex
     export GOPATH=/home/gpadmin/go
     source ${GPHOME}/greenplum_path.sh
     export PGPORT=5432
-    export COORDINATOR_DATA_DIRECTORY=/data/gpdata/coordinator/gpseg-1
+    # NOTE: this path is not set to coordinator by common script yet.  breaking GP7 CI
+    export COORDINATOR_DATA_DIRECTORY=/data/gpdata/master/gpseg-1
     export MASTER_DATA_DIRECTORY=/data/gpdata/master/gpseg-1
     export PATH=\\\${GOPATH}/bin:/usr/local/go/bin:\\\${PATH}
     if [[ -f /opt/gcc_env.sh ]]; then


### PR DESCRIPTION
Common set up scripts for concourse CI still reference master data directory. This is used across repos, so rollback change for now until we can move it forward again.