### PR TITLE
Refactor query strings for clarity

### DIFF
--- a/backup/queries_externals.go
+++ b/backup/queries_externals.go
@@ -76,7 +76,7 @@ func GetExternalTableDefinitions(connectionPool *dbconn.DBConn) map[uint32]Exter
 	// Cannot use unnest() in CASE statements anymore in GPDB 7+ so convert
 	// it to a LEFT JOIN LATERAL. We do not use LEFT JOIN LATERAL for GPDB 6
 	// because the CASE unnest() logic is more performant.
-	version7Query := `
+	atLeast7Query := `
 	SELECT e.reloid AS oid,
 		ljl_unnest AS location,
 		array_to_string(e.execlocation, ',') AS execlocation,
@@ -100,8 +100,8 @@ func GetExternalTableDefinitions(connectionPool *dbconn.DBConn) map[uint32]Exter
 		query = version5Query
 	} else if connectionPool.Version.Is("6") {
 		query = version6Query
-	} else if connectionPool.Version.Is("7") {
-		query = version7Query
+	} else if connectionPool.Version.AtLeast("7") {
+		query = atLeast7Query
 	}
 
 	results := make([]ExternalTableDefinition, 0)

--- a/backup/queries_statistics.go
+++ b/backup/queries_statistics.go
@@ -109,7 +109,8 @@ func GetAttributeStatistics(connectionPool *dbconn.DBConn, tables []Table) map[u
 		s.stavalues4
 	FROM pg_class c
 		JOIN pg_namespace n ON c.relnamespace = n.oid
-		JOIN pg_attribute a ON a.attrelid = c.oid
+
+	JOIN pg_attribute a ON a.attrelid = c.oid
 		JOIN pg_statistic s ON (c.oid = s.starelid AND a.attnum = s.staattnum)
 		JOIN pg_type t ON a.atttypid = t.oid
 	WHERE %s
@@ -152,7 +153,7 @@ func GetTupleStatistics(connectionPool *dbconn.DBConn, tables []Table) map[uint3
 	WHERE %s
 		AND quote_ident(n.nspname) || '.' || quote_ident(c.relname) IN (%s)
 	ORDER BY n.nspname, c.relname`,
-	SchemaFilterClause("n"), utils.SliceToQuotedString(tablenames))
+		SchemaFilterClause("n"), utils.SliceToQuotedString(tablenames))
 
 	results := make([]TupleStatistic, 0)
 	err := connectionPool.Select(&results, query)

--- a/backup/queries_textsearch.go
+++ b/backup/queries_textsearch.go
@@ -116,7 +116,7 @@ func GetTextSearchTemplates(connectionPool *dbconn.DBConn) []TextSearchTemplate 
 	WHERE %s
 		AND %s
 	ORDER BY tmplname`,
-	SchemaFilterClause("n"), ExtensionFilterClause("p"))
+		SchemaFilterClause("n"), ExtensionFilterClause("p"))
 
 	results := make([]TextSearchTemplate, 0)
 	err := connectionPool.Select(&results, query)
@@ -166,7 +166,7 @@ func GetTextSearchDictionaries(connectionPool *dbconn.DBConn) []TextSearchDictio
 	WHERE %s
 		AND %s
 	ORDER BY dictname`,
-	SchemaFilterClause("dict_ns"), ExtensionFilterClause("d"))
+		SchemaFilterClause("dict_ns"), ExtensionFilterClause("d"))
 
 	results := make([]TextSearchDictionary, 0)
 	err := connectionPool.Select(&results, query)
@@ -216,7 +216,7 @@ func GetTextSearchConfigurations(connectionPool *dbconn.DBConn) []TextSearchConf
 	WHERE %s
 		AND %s
 	ORDER BY cfgname`,
-	SchemaFilterClause("cfg_ns"), ExtensionFilterClause("c"))
+		SchemaFilterClause("cfg_ns"), ExtensionFilterClause("c"))
 
 	results := make([]struct {
 		Schema    string


### PR DESCRIPTION
Adding multiple levels of interpolation for version support has reduced readability of some queries.  Clean up a few of them where possible.