### PR TITLE
Remove e2e test hang prevention, add ENXIO err timeout

### DIFF
--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -1646,11 +1646,6 @@ LANGUAGE plpgsql NO SQL;`)
 			testhelper.AssertQueryRuns(restoreConn, fmt.Sprintf("REASSIGN OWNED BY testrole TO %s;", backupConn.User))
 			testhelper.AssertQueryRuns(restoreConn, "DROP ROLE testrole;")
 		})
-		// TODO: This test fails intermittently in Concourse due to issues with gpbackup_helper hanging when it is unable
-		// to open a pipe.  We've been unable to reproduce the issue on local machines, despite testing a variety of OSes
-		// and such, and the current Concourse setup makes debugging difficult and the use of dlv impossible.
-		// In order to avoid flakes, and to save resources, the current plan is to just stop gprestore with a goroutine
-		// to end the test if it takes too long, treating that scenario as a skipped test and leaving actual failures alone.
 		DescribeTable("",
 			func(fullTimestamp string, incrementalTimestamp string, tarBaseName string, isIncrementalRestore bool, isFilteredRestore bool, isSingleDataFileRestore bool) {
 				if isSingleDataFileRestore && segmentCount != 3 {
@@ -1683,25 +1678,29 @@ LANGUAGE plpgsql NO SQL;`)
 					}
 				}
 
-				// This block stops the test if it hangs, and can be removed when the above TODO is addressed.
-				completed := make(chan bool)
-				defer func() { completed <- true }() // Whether the test succeeds or fails, mark it as complete
-				go func() {
-					// No test run has been observed to take more than a few minutes without a hang,
-					// so loop 5 times and check for success after 1 minute each
-					for i := 0; i < 5; i++ {
-						select {
-						case <-completed:
-							return
-						default:
-							time.Sleep(time.Minute)
-						}
-					}
-					// If we get here, this test is hanging, stop the processes.
-					// If the test succeeded or failed, we'll return before here.
-					_ = exec.Command("pkill", "-9", "gpbackup_helper").Run()
-					_ = exec.Command("pkill", "-9", "gprestore").Run()
-				}()
+				// This block stops the test if it hangs.  It was introduced to prevent hangs causing timeout failures in Concourse CI.
+				// Those flakes have stop being observed, and can no longer be reproduced.  Some changes have since been made
+				// that may obviate the original cause of the hangs, but a definitive RCA was never accomplished.
+				// This block is elegant is kept around for now in case the hangs reappear.
+				// TODO: if pipe-related hangs have not been observed by 6/1/2023, remove this code as it is not needed.
+				// completed := make(chan bool)
+				// defer func() { completed <- true }() // Whether the test succeeds or fails, mark it as complete
+				// go func() {
+				// 	// No test run has been observed to take more than a few minutes without a hang,
+				// 	// so loop 5 times and check for success after 1 minute each
+				// 	for i := 0; i < 5; i++ {
+				// 		select {
+				// 		case <-completed:
+				// 			return
+				// 		default:
+				// 			time.Sleep(time.Minute)
+				// 		}
+				// 	}
+				// 	// If we get here, this test is hanging, stop the processes.
+				// 	// If the test succeeded or failed, we'll return before here.
+				// 	_ = exec.Command("pkill", "-9", "gpbackup_helper").Run()
+				// 	_ = exec.Command("pkill", "-9", "gprestore").Run()
+				// }()
 
 				gprestoreArgs := []string{
 					"--timestamp", fullTimestamp,


### PR DESCRIPTION
Remove the block preventing CI timeouts in our e2e test suite. This is being removed so that if the hangs in pipe creation reappear, it will be and another attempt at RCA will be made.

A timeout is added in the case of ENXIO pipe creation errors. While no definitive RCA was made on the Concourse hangs, this is a likely candidate.  Further, no infinite loop should be left possible in the codebase if it can be so easily addressed.

From fifo(7), possible cause might be: "A process can open a FIFO in nonblocking mode. In this case, opening for read only will succeed even if no-one has opened on the write side yet, opening for write only will fail with ENXIO (no such device or address) unless the other end has already been opened."