### PR TITLE
Update resource group handling for 7, and fix some other broken tests.

### DIFF
--- a/backup/metadata_globals_test.go
+++ b/backup/metadata_globals_test.go
@@ -141,21 +141,21 @@ GRANT TEMPORARY,CONNECT ON DATABASE testdb TO testrole;`,
 		var emptyResGroupMetadata = backup.MetadataMap{}
 		It("prints resource groups", func() {
 			testhelper.SetDBVersion(connectionPool, "5.9.0")
-			someGroup := backup.ResourceGroup{Oid: 1, Name: "some_group", CPURateLimit: "10", MemoryLimit: "20", Concurrency: "15", MemorySharedQuota: "25", MemorySpillRatio: "30"}
-			someGroup2 := backup.ResourceGroup{Oid: 2, Name: "some_group2", CPURateLimit: "20", MemoryLimit: "30", Concurrency: "25", MemorySharedQuota: "35", MemorySpillRatio: "10"}
-			resGroups := []backup.ResourceGroup{someGroup, someGroup2}
+			someGroup := backup.ResourceGroupBefore7{ResourceGroup: backup.ResourceGroup{Oid: 1, Name: "some_group", Concurrency: "15"}, CPURateLimit: "10", MemoryLimit: "20", MemorySharedQuota: "25", MemorySpillRatio: "30"}
+			someGroup2 := backup.ResourceGroupBefore7{ResourceGroup: backup.ResourceGroup{Oid: 2, Name: "some_group2", Concurrency: "25"}, CPURateLimit: "20", MemoryLimit: "30", MemorySharedQuota: "35", MemorySpillRatio: "10"}
+			resGroups := []backup.ResourceGroupBefore7{someGroup, someGroup2}
 
-			backup.PrintCreateResourceGroupStatements(backupfile, tocfile, resGroups, emptyResGroupMetadata)
+			backup.PrintCreateResourceGroupStatementsBefore7(backupfile, tocfile, resGroups, emptyResGroupMetadata)
 			testutils.ExpectEntry(tocfile.GlobalEntries, 0, "", "", "some_group", "RESOURCE GROUP")
 			testutils.AssertBufferContents(tocfile.GlobalEntries, buffer,
 				`CREATE RESOURCE GROUP some_group WITH (CPU_RATE_LIMIT=10, MEMORY_AUDITOR=vmtracker, MEMORY_LIMIT=20, MEMORY_SHARED_QUOTA=25, MEMORY_SPILL_RATIO=30, CONCURRENCY=15);`,
 				`CREATE RESOURCE GROUP some_group2 WITH (CPU_RATE_LIMIT=20, MEMORY_AUDITOR=vmtracker, MEMORY_LIMIT=30, MEMORY_SHARED_QUOTA=35, MEMORY_SPILL_RATIO=10, CONCURRENCY=25);`)
 		})
 		It("prints ALTER statement for default_group resource group", func() {
-			defaultGroup := backup.ResourceGroup{Oid: 1, Name: "default_group", CPURateLimit: "10", MemoryLimit: "20", Concurrency: "15", MemorySharedQuota: "25", MemorySpillRatio: "30"}
-			resGroups := []backup.ResourceGroup{defaultGroup}
+			defaultGroup := backup.ResourceGroupBefore7{ResourceGroup: backup.ResourceGroup{Oid: 1, Name: "default_group", Concurrency: "15"}, CPURateLimit: "10", MemoryLimit: "20", MemorySharedQuota: "25", MemorySpillRatio: "30"}
+			resGroups := []backup.ResourceGroupBefore7{defaultGroup}
 
-			backup.PrintCreateResourceGroupStatements(backupfile, tocfile, resGroups, emptyResGroupMetadata)
+			backup.PrintCreateResourceGroupStatementsBefore7(backupfile, tocfile, resGroups, emptyResGroupMetadata)
 			testutils.ExpectEntry(tocfile.GlobalEntries, 0, "", "", "default_group", "RESOURCE GROUP")
 			testutils.AssertBufferContents(tocfile.GlobalEntries, buffer,
 				`ALTER RESOURCE GROUP default_group SET MEMORY_LIMIT 20;`,
@@ -166,12 +166,12 @@ GRANT TEMPORARY,CONNECT ON DATABASE testdb TO testrole;`,
 		})
 		It("prints memory_auditor resource groups", func() {
 			testhelper.SetDBVersion(connectionPool, "5.8.0")
-			someGroup := backup.ResourceGroup{Oid: 1, Name: "some_group", CPURateLimit: "10", MemoryLimit: "20", Concurrency: "15", MemorySharedQuota: "25", MemorySpillRatio: "30"}
-			someGroup2 := backup.ResourceGroup{Oid: 2, Name: "some_group2", CPURateLimit: "10", MemoryLimit: "30", Concurrency: "0", MemorySharedQuota: "35", MemorySpillRatio: "10", MemoryAuditor: "1"}
-			someGroup3 := backup.ResourceGroup{Oid: 3, Name: "some_group3", CPURateLimit: "10", MemoryLimit: "30", Concurrency: "25", MemorySharedQuota: "35", MemorySpillRatio: "10", MemoryAuditor: "0"}
-			resGroups := []backup.ResourceGroup{someGroup, someGroup2, someGroup3}
+			someGroup := backup.ResourceGroupBefore7{ResourceGroup: backup.ResourceGroup{Oid: 1, Name: "some_group", Concurrency: "15"}, CPURateLimit: "10", MemoryLimit: "20", MemorySharedQuota: "25", MemorySpillRatio: "30"}
+			someGroup2 := backup.ResourceGroupBefore7{ResourceGroup: backup.ResourceGroup{Oid: 2, Name: "some_group2", Concurrency: "0"}, CPURateLimit: "10", MemoryLimit: "30", MemorySharedQuota: "35", MemorySpillRatio: "10", MemoryAuditor: "1"}
+			someGroup3 := backup.ResourceGroupBefore7{ResourceGroup: backup.ResourceGroup{Oid: 3, Name: "some_group3", Concurrency: "25"}, CPURateLimit: "10", MemoryLimit: "30", MemorySharedQuota: "35", MemorySpillRatio: "10", MemoryAuditor: "0"}
+			resGroups := []backup.ResourceGroupBefore7{someGroup, someGroup2, someGroup3}
 
-			backup.PrintCreateResourceGroupStatements(backupfile, tocfile, resGroups, emptyResGroupMetadata)
+			backup.PrintCreateResourceGroupStatementsBefore7(backupfile, tocfile, resGroups, emptyResGroupMetadata)
 			testutils.ExpectEntry(tocfile.GlobalEntries, 0, "", "", "some_group", "RESOURCE GROUP")
 			testutils.AssertBufferContents(tocfile.GlobalEntries, buffer,
 				`CREATE RESOURCE GROUP some_group WITH (CPU_RATE_LIMIT=10, MEMORY_AUDITOR=vmtracker, MEMORY_LIMIT=20, MEMORY_SHARED_QUOTA=25, MEMORY_SPILL_RATIO=30, CONCURRENCY=15);`,
@@ -180,11 +180,11 @@ GRANT TEMPORARY,CONNECT ON DATABASE testdb TO testrole;`,
 		})
 		It("prints cpuset resource groups", func() {
 			testhelper.SetDBVersion(connectionPool, "5.9.0")
-			someGroup := backup.ResourceGroup{Oid: 1, Name: "some_group", CPURateLimit: "10", MemoryLimit: "20", Concurrency: "15", MemorySharedQuota: "25", MemorySpillRatio: "30"}
-			someGroup2 := backup.ResourceGroup{Oid: 2, Name: "some_group2", CPURateLimit: "-1", Cpuset: "0-3", MemoryLimit: "30", Concurrency: "25", MemorySharedQuota: "35", MemorySpillRatio: "10"}
-			resGroups := []backup.ResourceGroup{someGroup, someGroup2}
+			someGroup := backup.ResourceGroupBefore7{ResourceGroup: backup.ResourceGroup{Oid: 1, Name: "some_group", Concurrency: "15"}, CPURateLimit: "10", MemoryLimit: "20", MemorySharedQuota: "25", MemorySpillRatio: "30"}
+			someGroup2 := backup.ResourceGroupBefore7{ResourceGroup: backup.ResourceGroup{Oid: 2, Name: "some_group2", Concurrency: "25", Cpuset: "0-3"}, CPURateLimit: "-1", MemoryLimit: "30", MemorySharedQuota: "35", MemorySpillRatio: "10"}
+			resGroups := []backup.ResourceGroupBefore7{someGroup, someGroup2}
 
-			backup.PrintCreateResourceGroupStatements(backupfile, tocfile, resGroups, emptyResGroupMetadata)
+			backup.PrintCreateResourceGroupStatementsBefore7(backupfile, tocfile, resGroups, emptyResGroupMetadata)
 			testutils.ExpectEntry(tocfile.GlobalEntries, 0, "", "", "some_group", "RESOURCE GROUP")
 			testutils.AssertBufferContents(tocfile.GlobalEntries, buffer,
 				`CREATE RESOURCE GROUP some_group WITH (CPU_RATE_LIMIT=10, MEMORY_AUDITOR=vmtracker, MEMORY_LIMIT=20, MEMORY_SHARED_QUOTA=25, MEMORY_SPILL_RATIO=30, CONCURRENCY=15);`,
@@ -194,13 +194,13 @@ GRANT TEMPORARY,CONNECT ON DATABASE testdb TO testrole;`,
 		It("prints memory_spill_ratio resource groups in new syntax", func() {
 			testhelper.SetDBVersion(connectionPool, "5.2.0")
 
-			defaultGroup := backup.ResourceGroup{Oid: 1, Name: "default_group", CPURateLimit: "10", MemoryLimit: "20", Concurrency: "15", MemorySharedQuota: "25", MemorySpillRatio: "30 MB"}
-			adminGroup := backup.ResourceGroup{Oid: 2, Name: "admin_group", CPURateLimit: "10", MemoryLimit: "20", Concurrency: "15", MemorySharedQuota: "25", MemorySpillRatio: "30"}
-			someGroup := backup.ResourceGroup{Oid: 3, Name: "some_group", CPURateLimit: "20", MemoryLimit: "30", Concurrency: "25", MemorySharedQuota: "35", MemorySpillRatio: "40 MB"}
-			someGroup2 := backup.ResourceGroup{Oid: 4, Name: "some_group2", CPURateLimit: "20", MemoryLimit: "30", Concurrency: "25", MemorySharedQuota: "35", MemorySpillRatio: "40"}
-			resGroups := []backup.ResourceGroup{defaultGroup, adminGroup, someGroup, someGroup2}
+			defaultGroup := backup.ResourceGroupBefore7{ResourceGroup: backup.ResourceGroup{Oid: 1, Name: "default_group", Concurrency: "15"}, CPURateLimit: "10", MemoryLimit: "20", MemorySharedQuota: "25", MemorySpillRatio: "30 MB"}
+			adminGroup := backup.ResourceGroupBefore7{ResourceGroup: backup.ResourceGroup{Oid: 2, Name: "admin_group", Concurrency: "15"}, CPURateLimit: "10", MemoryLimit: "20", MemorySharedQuota: "25", MemorySpillRatio: "30"}
+			someGroup := backup.ResourceGroupBefore7{ResourceGroup: backup.ResourceGroup{Oid: 3, Name: "some_group", Concurrency: "25"}, CPURateLimit: "20", MemoryLimit: "30", MemorySharedQuota: "35", MemorySpillRatio: "40 MB"}
+			someGroup2 := backup.ResourceGroupBefore7{ResourceGroup: backup.ResourceGroup{Oid: 4, Name: "some_group2", Concurrency: "25"}, CPURateLimit: "20", MemoryLimit: "30", MemorySharedQuota: "35", MemorySpillRatio: "40"}
+			resGroups := []backup.ResourceGroupBefore7{defaultGroup, adminGroup, someGroup, someGroup2}
 
-			backup.PrintCreateResourceGroupStatements(backupfile, tocfile, resGroups, emptyResGroupMetadata)
+			backup.PrintCreateResourceGroupStatementsBefore7(backupfile, tocfile, resGroups, emptyResGroupMetadata)
 			testutils.ExpectEntry(tocfile.GlobalEntries, 0, "", "", "default_group", "RESOURCE GROUP")
 			testutils.AssertBufferContents(tocfile.GlobalEntries, buffer,
 				`ALTER RESOURCE GROUP default_group SET MEMORY_LIMIT 20;`,
@@ -219,11 +219,11 @@ GRANT TEMPORARY,CONNECT ON DATABASE testdb TO testrole;`,
 		It("prints correct CREATE RESOURCE GROUP syntax for old resource groups on GPDB 5.8", func() {
 			// Memory Auditor reslimittype was added in GPDB 5.8. Make sure the older resource group object will have the proper default.
 			testhelper.SetDBVersion(connectionPool, "5.8.0")
-			resGroup52 := backup.ResourceGroup{Oid: 3, Name: "resGroup52", CPURateLimit: "20", MemoryLimit: "30", Concurrency: "25", MemorySharedQuota: "35", MemorySpillRatio: "40"}
-			resGroup58 := backup.ResourceGroup{Oid: 4, Name: "resGroup58", CPURateLimit: "20", MemoryLimit: "30", Concurrency: "25", MemorySharedQuota: "35", MemorySpillRatio: "40", MemoryAuditor: "1"}
-			resGroups := []backup.ResourceGroup{resGroup52, resGroup58}
+			resGroup52 := backup.ResourceGroupBefore7{ResourceGroup: backup.ResourceGroup{Oid: 3, Name: "resGroup52", Concurrency: "25"}, CPURateLimit: "20", MemoryLimit: "30", MemorySharedQuota: "35", MemorySpillRatio: "40"}
+			resGroup58 := backup.ResourceGroupBefore7{ResourceGroup: backup.ResourceGroup{Oid: 4, Name: "resGroup58", Concurrency: "25"}, CPURateLimit: "20", MemoryLimit: "30", MemorySharedQuota: "35", MemorySpillRatio: "40", MemoryAuditor: "1"}
+			resGroups := []backup.ResourceGroupBefore7{resGroup52, resGroup58}
 
-			backup.PrintCreateResourceGroupStatements(backupfile, tocfile, resGroups, emptyResGroupMetadata)
+			backup.PrintCreateResourceGroupStatementsBefore7(backupfile, tocfile, resGroups, emptyResGroupMetadata)
 			testutils.AssertBufferContents(tocfile.GlobalEntries, buffer,
 				`CREATE RESOURCE GROUP resGroup52 WITH (CPU_RATE_LIMIT=20, MEMORY_AUDITOR=vmtracker, MEMORY_LIMIT=30, MEMORY_SHARED_QUOTA=35, MEMORY_SPILL_RATIO=40, CONCURRENCY=25);`,
 				`CREATE RESOURCE GROUP resGroup58 WITH (CPU_RATE_LIMIT=20, MEMORY_AUDITOR=cgroup, MEMORY_LIMIT=30, MEMORY_SHARED_QUOTA=35, MEMORY_SPILL_RATIO=40, CONCURRENCY=25);`)
@@ -232,12 +232,12 @@ GRANT TEMPORARY,CONNECT ON DATABASE testdb TO testrole;`,
 			// Cpuset reslimittype was added in GPDB 5.9. Make sure the older resource group objects
 			// will have the proper default. In this case, you either have cpu_rate_limit or cpuset.
 			testhelper.SetDBVersion(connectionPool, "5.9.0")
-			resGroup52 := backup.ResourceGroup{Oid: 3, Name: "resGroup52", CPURateLimit: "20", MemoryLimit: "30", Concurrency: "25", MemorySharedQuota: "35", MemorySpillRatio: "40"}
-			resGroup58 := backup.ResourceGroup{Oid: 4, Name: "resGroup58", CPURateLimit: "20", MemoryLimit: "30", Concurrency: "25", MemorySharedQuota: "35", MemorySpillRatio: "40", MemoryAuditor: "1"}
-			resGroup59 := backup.ResourceGroup{Oid: 5, Name: "resGroup59", CPURateLimit: "-1", MemoryLimit: "30", Concurrency: "25", MemorySharedQuota: "35", MemorySpillRatio: "40", MemoryAuditor: "1", Cpuset: "1"}
-			resGroups := []backup.ResourceGroup{resGroup52, resGroup58, resGroup59}
+			resGroup52 := backup.ResourceGroupBefore7{ResourceGroup: backup.ResourceGroup{Oid: 3, Name: "resGroup52", Concurrency: "25"}, CPURateLimit: "20", MemoryLimit: "30", MemorySharedQuota: "35", MemorySpillRatio: "40"}
+			resGroup58 := backup.ResourceGroupBefore7{ResourceGroup: backup.ResourceGroup{Oid: 4, Name: "resGroup58", Concurrency: "25"}, CPURateLimit: "20", MemoryLimit: "30", MemorySharedQuota: "35", MemorySpillRatio: "40", MemoryAuditor: "1"}
+			resGroup59 := backup.ResourceGroupBefore7{ResourceGroup: backup.ResourceGroup{Oid: 5, Name: "resGroup59", Concurrency: "25", Cpuset: "1"}, CPURateLimit: "-1", MemoryLimit: "30", MemorySharedQuota: "35", MemorySpillRatio: "40", MemoryAuditor: "1"}
+			resGroups := []backup.ResourceGroupBefore7{resGroup52, resGroup58, resGroup59}
 
-			backup.PrintCreateResourceGroupStatements(backupfile, tocfile, resGroups, emptyResGroupMetadata)
+			backup.PrintCreateResourceGroupStatementsBefore7(backupfile, tocfile, resGroups, emptyResGroupMetadata)
 			testutils.AssertBufferContents(tocfile.GlobalEntries, buffer,
 				`CREATE RESOURCE GROUP resGroup52 WITH (CPU_RATE_LIMIT=20, MEMORY_AUDITOR=vmtracker, MEMORY_LIMIT=30, MEMORY_SHARED_QUOTA=35, MEMORY_SPILL_RATIO=40, CONCURRENCY=25);`,
 				`CREATE RESOURCE GROUP resGroup58 WITH (CPU_RATE_LIMIT=20, MEMORY_AUDITOR=cgroup, MEMORY_LIMIT=30, MEMORY_SHARED_QUOTA=35, MEMORY_SPILL_RATIO=40, CONCURRENCY=25);`,
@@ -248,11 +248,22 @@ GRANT TEMPORARY,CONNECT ON DATABASE testdb TO testrole;`,
 		It("prints prepare resource groups", func() {
 			backup.PrintResetResourceGroupStatements(backupfile, tocfile)
 			testutils.ExpectEntry(tocfile.GlobalEntries, 0, "", "", "admin_group", "RESOURCE GROUP")
-			testutils.AssertBufferContents(tocfile.GlobalEntries, buffer,
-				`ALTER RESOURCE GROUP admin_group SET CPU_RATE_LIMIT 1;`,
-				`ALTER RESOURCE GROUP admin_group SET MEMORY_LIMIT 1;`,
-				`ALTER RESOURCE GROUP default_group SET CPU_RATE_LIMIT 1;`,
-				`ALTER RESOURCE GROUP default_group SET MEMORY_LIMIT 1;`)
+			if connectionPool.Version.Before("7") {
+				testutils.AssertBufferContents(tocfile.GlobalEntries, buffer,
+					`ALTER RESOURCE GROUP admin_group SET CPU_RATE_LIMIT 1;`,
+					`ALTER RESOURCE GROUP admin_group SET MEMORY_LIMIT 1;`,
+					`ALTER RESOURCE GROUP default_group SET CPU_RATE_LIMIT 1;`,
+					`ALTER RESOURCE GROUP default_group SET MEMORY_LIMIT 1;`)
+			} else { // GPDB7+
+				testutils.AssertBufferContents(tocfile.GlobalEntries, buffer,
+					`ALTER RESOURCE GROUP admin_group SET CPU_HARD_QUOTA_LIMIT 1;`,
+					`ALTER RESOURCE GROUP admin_group SET CPU_SOFT_PRIORITY 100;`,
+					`ALTER RESOURCE GROUP default_group SET CPU_HARD_QUOTA_LIMIT 1;`,
+					`ALTER RESOURCE GROUP default_group SET CPU_SOFT_PRIORITY 100;`,
+					`ALTER RESOURCE GROUP system_group SET CPU_HARD_QUOTA_LIMIT 1;`,
+					`ALTER RESOURCE GROUP system_group SET CPU_SOFT_PRIORITY 100;`)
+
+			}
 		})
 	})
 	Describe("PrintCreateRoleStatements", func() {

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -495,11 +495,19 @@ func backupResourceGroups(metadataFile *utils.FileWithByteCount) {
 		return
 	}
 	gplog.Verbose("Writing CREATE RESOURCE GROUP statements to metadata file")
-	resGroups := GetResourceGroups(connectionPool)
-	objectCounts["Resource Groups"] = len(resGroups)
-	resGroupMetadata := GetCommentsForObjectType(connectionPool, TYPE_RESOURCEGROUP)
-	PrintResetResourceGroupStatements(metadataFile, globalTOC)
-	PrintCreateResourceGroupStatements(metadataFile, globalTOC, resGroups, resGroupMetadata)
+	if connectionPool.Version.Before("7") {
+		resGroups := GetResourceGroups[ResourceGroupBefore7](connectionPool)
+		objectCounts["Resource Groups"] = len(resGroups)
+		resGroupMetadata := GetCommentsForObjectType(connectionPool, TYPE_RESOURCEGROUP)
+		PrintResetResourceGroupStatements(metadataFile, globalTOC)
+		PrintCreateResourceGroupStatementsBefore7(metadataFile, globalTOC, resGroups, resGroupMetadata)
+	} else { // GPDB7+
+		resGroups := GetResourceGroups[ResourceGroupAtLeast7](connectionPool)
+		objectCounts["Resource Groups"] = len(resGroups)
+		resGroupMetadata := GetCommentsForObjectType(connectionPool, TYPE_RESOURCEGROUP)
+		PrintResetResourceGroupStatements(metadataFile, globalTOC)
+		PrintCreateResourceGroupStatementsAtLeast7(metadataFile, globalTOC, resGroups, resGroupMetadata)
+	}
 }
 
 func backupRoles(metadataFile *utils.FileWithByteCount) {

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -298,8 +298,12 @@ func createGlobalObjects(conn *dbconn.DBConn) {
 	testhelper.AssertQueryRuns(conn, "CREATE DATABASE global_db TABLESPACE test_tablespace;")
 	testhelper.AssertQueryRuns(conn, "ALTER DATABASE global_db OWNER TO global_role;")
 	testhelper.AssertQueryRuns(conn, "ALTER ROLE global_role SET search_path TO public,pg_catalog;")
-	if conn.Version.AtLeast("5") {
+	if conn.Version.Is("5") || conn.Version.Is("6") {
 		testhelper.AssertQueryRuns(conn, "CREATE RESOURCE GROUP test_group WITH (CPU_RATE_LIMIT=1, MEMORY_LIMIT=1);")
+	} else if conn.Version.AtLeast("7") {
+		testhelper.AssertQueryRuns(conn, "CREATE RESOURCE GROUP test_group WITH (CPU_HARD_QUOTA_LIMIT=1, MEMORY_LIMIT=1);")
+	}
+	if conn.Version.AtLeast("5") {
 		testhelper.AssertQueryRuns(conn, "ALTER ROLE global_role RESOURCE GROUP test_group;")
 	}
 }
@@ -1724,7 +1728,6 @@ LANGUAGE plpgsql NO SQL;`)
 				defer testhelper.AssertQueryRuns(restoreConn, `DROP SCHEMA IF EXISTS schematwo CASCADE;`)
 				defer testhelper.AssertQueryRuns(restoreConn, `DROP SCHEMA IF EXISTS schemathree CASCADE;`)
 
-
 				if !testUsesPlugin { // No need to manually move files when using a plugin
 					isMultiNode := (backupCluster.GetHostForContent(0) != backupCluster.GetHostForContent(-1))
 					moveSegmentBackupFiles(tarBaseName, extractDirectory, isMultiNode, fullTimestamp, incrementalTimestamp)
@@ -1859,7 +1862,6 @@ LANGUAGE plpgsql NO SQL;`)
 					}
 					extractDirectory := extractSavedTarFile(backupDir, tarBaseName)
 					defer testhelper.AssertQueryRuns(restoreConn, `DROP SCHEMA IF EXISTS schemaone CASCADE;`)
-
 
 					isMultiNode := (backupCluster.GetHostForContent(0) != backupCluster.GetHostForContent(-1))
 					moveSegmentBackupFiles(tarBaseName, extractDirectory, isMultiNode, fullTimestamp)

--- a/integration/predata_externals_queries_test.go
+++ b/integration/predata_externals_queries_test.go
@@ -113,7 +113,7 @@ SEGMENT REJECT LIMIT 10 PERCENT
 				Command: "", RejectLimit: 10, RejectLimitType: "p", LogErrors: true, Encoding: "UTF8",
 				Writable: false, URIs: []string{"file://tmp/myfile.txt"}}
 			if connectionPool.Version.AtLeast("7") {
-				extTable.FormatOpts = "formatter 'fixedwidth_out'i '20'"
+				extTable.FormatOpts = "formatter 'fixedwidth_out' i '20'"
 			}
 
 			structmatcher.ExpectStructsToMatchExcluding(&extTable, &result, "Oid")

--- a/integration/predata_relations_create_test.go
+++ b/integration/predata_relations_create_test.go
@@ -493,8 +493,10 @@ SET SUBPARTITION TEMPLATE ` + `
 		BeforeEach(func() {
 			if connectionPool.Version.Before("6") {
 				viewDef = sql.NullString{String: "SELECT 1;", Valid: true}
-			} else {
+			} else if connectionPool.Version.Is("6") {
 				viewDef = sql.NullString{String: " SELECT 1;", Valid: true}
+			} else { // GPDB7+
+				viewDef = sql.NullString{String: " SELECT 1 AS \"?column?\";", Valid: true}
 			}
 		})
 		It("creates a view with privileges, owner, security label, and comment", func() {

--- a/integration/predata_relations_create_test.go
+++ b/integration/predata_relations_create_test.go
@@ -113,13 +113,14 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultTable := backup.ConstructDefinitionsForTables(connectionPool, []backup.Relation{testTable.Relation})[0]
 			if connectionPool.Version.AtLeast("7") {
 				// For GPDB 7+, the storage options no longer store the appendonly and orientation field
-				testTable.StorageOpts = "compresstype=zlib, blocksize=32768, compresslevel=1"
+				testTable.TableDefinition.StorageOpts = "compresstype=zlib, blocksize=32768, compresslevel=1, checksum=true"
 				testTable.TableDefinition.AccessMethodName = "ao_column"
 			}
 			structmatcher.ExpectStructsToMatchExcluding(testTable.TableDefinition, resultTable.TableDefinition, "ColumnDefs.Oid", "ExtTableDef")
 		})
 		It("creates a basic GPDB 7+ append-optimized table", func() {
 			testutils.SkipIfBefore7(connectionPool)
+			testTable.TableDefinition.StorageOpts = "blocksize=32768, compresslevel=0, compresstype=none, checksum=true"
 			testTable.TableDefinition.AccessMethodName = "ao_column"
 
 			backup.PrintRegularTableCreateStatement(backupfile, tocfile, testTable)

--- a/integration/predata_relations_queries_test.go
+++ b/integration/predata_relations_queries_test.go
@@ -403,8 +403,10 @@ PARTITION BY LIST (gender)
 		BeforeEach(func() {
 			if connectionPool.Version.Before("6") {
 				viewDef = sql.NullString{String: "SELECT 1;", Valid: true}
-			} else {
+			} else if connectionPool.Version.Is("6") {
 				viewDef = sql.NullString{String: " SELECT 1;", Valid: true}
+			} else { // GPDB7+
+				viewDef = sql.NullString{String: " SELECT 1 AS \"?column?\";", Valid: true}
 			}
 		})
 		It("returns a slice for a basic view", func() {

--- a/integration/predata_table_defs_queries_test.go
+++ b/integration/predata_table_defs_queries_test.go
@@ -750,8 +750,9 @@ SET SUBPARTITION TEMPLATE
 			if connectionPool.Version.Before("7") {
 				Expect(result[oid]).To(Equal("appendonly=true"))
 			} else {
-				// For GPDB 7+, storage options no longer contain appendonly and orientation
-				Expect(result[oid]).To(Equal(""))
+				// For GPDB 7+, storage options no longer contain appendonly and orientation,
+				// instead populates with default compression values
+				Expect(result[oid]).To(Equal("blocksize=32768, compresslevel=0, compresstype=none, checksum=true"))
 			}
 		})
 	})


### PR DESCRIPTION
- Resource groups had several breaking changes made for GPDB7.  Using either genericized or separate functions, support both the legacy and new structures.
- View definition for anonymous columns has been changed in GPDB7 to show a ?column? name.  Update our tests to match that behavior.
- Changes to the spacing and storage defaults in GPDB7 beta broke some of our more rigid tests. Update them so they pass again.
- Update Makefile to use gpsync if present.  Fall back to gpscp if gpsync isn't present, for backwards-compatibility