### PR TITLE
Prevent trampling existing EndTime values on backup records

### DIFF
--- a/history/history.go
+++ b/history/history.go
@@ -194,7 +194,10 @@ func storeAuxTable(tx *sql.Tx, arrayValues []string, tablename string, timestamp
 }
 
 func StoreBackupHistory(db *sql.DB, currentBackupConfig *BackupConfig) error {
-	currentBackupConfig.EndTime = CurrentTimestamp()
+	if currentBackupConfig.EndTime == "" {
+		// If we're migrating in prior backup records, we don't want to overwrite pre-existing EndTime values
+		currentBackupConfig.EndTime = CurrentTimestamp()
+	}
 	tx, _ := db.Begin()
 
 	_, err := tx.Exec("INSERT INTO backups VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?);",


### PR DESCRIPTION
StoreBackupHistory is used for both storing a backup record at the time of backup, and for migrating pre-existing records into sqlite.  The logic for marking EndTime should not overwrite existing values to prevent corrupting that value.