### PR TITLE
Remove foreign key constraint on restore_plan_timestamp

### DIFF
--- a/history/history.go
+++ b/history/history.go
@@ -155,13 +155,15 @@ func InitializeHistoryDatabase(historyDBPath string) (*sql.DB, error) {
 		}
 	}
 
+	// TODO -- consider warning if restore_plan_timestamp references a backup timestamp not present
+	// in historyDB? This scenario may be caused by lack of migration of legacy files, and may cause
+	// future backup-manager functionality such as CASCADE or cleanup to perform in unexpected ways.
 	createRestorePlansTable := `
 		CREATE TABLE IF NOT EXISTS restore_plans (
 			timestamp TEXT NOT NULL,
 			restore_plan_timestamp TEXT NOT NULL,
 			table_fqn TEXT NOT NULL,
-			FOREIGN KEY(timestamp) REFERENCES backups(timestamp),
-			FOREIGN KEY(restore_plan_timestamp) REFERENCES backups(timestamp)
+			FOREIGN KEY(timestamp) REFERENCES backups(timestamp)
 		);`
 	_, err = tx.Exec(createRestorePlansTable)
 	if err != nil {


### PR DESCRIPTION
While restore_plan_timestamp should technically always reference the timestamp of a prior backup, in many circumstances the backup history database may not be complete. Enforcing this relationship will cause an otherwise valid backup to fail, and it is better to allow it to succeed.  So remove the constraint.

Also add a TODO to consider logging a warning when such a backup is taken.