### PR TITLE
Add a history migration to incremental test with old binaries

### DIFF
--- a/end_to_end/incremental_test.go
+++ b/end_to_end/incremental_test.go
@@ -124,6 +124,8 @@ var _ = Describe("End to End incremental tests", func() {
 
 			gpbackupPathOld, backupHelperPathOld := gpbackupPath, backupHelperPath
 			gpbackupPath, backupHelperPath, _ = buildAndInstallBinaries()
+			migrateCommand := exec.Command("gpbackup_manager", "migrate-history")
+			mustRunCommand(migrateCommand)
 
 			testhelper.AssertQueryRuns(backupConn,
 				"INSERT into sales values(2, '2017-02-01', 88.88)")
@@ -302,8 +304,6 @@ var _ = Describe("End to End incremental tests", func() {
 
 					gpbackupPathOld, backupHelperPathOld := gpbackupPath, backupHelperPath
 					gpbackupPath, backupHelperPath, _ = buildAndInstallBinaries()
-					// TODO -- ensure that this is installed and we have a path to it?  Only called
-					// in CI currently
 					migrateCommand := exec.Command("gpbackup_manager", "migrate-history")
 					mustRunCommand(migrateCommand)
 


### PR DESCRIPTION
Add a missing call out to backup-manager to migrate history from legacy yaml file.