### PR TITLE
Refactor restore plan historydb schema

### DIFF
--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -328,16 +328,10 @@ func getMetdataFileContents(backupDir string, timestamp string, fileSuffix strin
 }
 
 func saveHistory(myCluster *cluster.Cluster) {
-	// move history file out of the way, and replace in "after". This is because the
-	// history file might have newer backups, with more attributes, and thus the newer
-	// history could be a longer file than when read and rewritten by the old history
-	// code (the history code reads in history, inserts a new config at top, and writes
-	// the entire file). We have known bugs in the underlying common library about
-	// closing a file after reading, and also a bug with not using OS_TRUNC when opening
-	// a file for writing.
+	// move history file out of the way, and replace in "after". This avoids adding junk to an existing gpackup_history.db
 
 	mdd := myCluster.GetDirForContent(-1)
-	historyFilePath = path.Join(mdd, "gpbackup_history.yaml")
+	historyFilePath = path.Join(mdd, "gpbackup_history.db")
 	_ = utils.CopyFile(historyFilePath, saveHistoryFilePath)
 }
 
@@ -1724,7 +1718,6 @@ LANGUAGE plpgsql NO SQL;`)
 				defer testhelper.AssertQueryRuns(restoreConn, `DROP SCHEMA IF EXISTS schematwo CASCADE;`)
 				defer testhelper.AssertQueryRuns(restoreConn, `DROP SCHEMA IF EXISTS schemathree CASCADE;`)
 
-
 				if !testUsesPlugin { // No need to manually move files when using a plugin
 					isMultiNode := (backupCluster.GetHostForContent(0) != backupCluster.GetHostForContent(-1))
 					moveSegmentBackupFiles(tarBaseName, extractDirectory, isMultiNode, fullTimestamp, incrementalTimestamp)
@@ -1859,7 +1852,6 @@ LANGUAGE plpgsql NO SQL;`)
 					}
 					extractDirectory := extractSavedTarFile(backupDir, tarBaseName)
 					defer testhelper.AssertQueryRuns(restoreConn, `DROP SCHEMA IF EXISTS schemaone CASCADE;`)
-
 
 					isMultiNode := (backupCluster.GetHostForContent(0) != backupCluster.GetHostForContent(-1))
 					moveSegmentBackupFiles(tarBaseName, extractDirectory, isMultiNode, fullTimestamp)

--- a/history/history_test.go
+++ b/history/history_test.go
@@ -84,7 +84,8 @@ var _ = Describe("backup/history tests", func() {
 			Expect(tableNames[2]).To(Equal("exclude_schemas"))
 			Expect(tableNames[3]).To(Equal("include_relations"))
 			Expect(tableNames[4]).To(Equal("include_schemas"))
-			Expect(tableNames[5]).To(Equal("restore_plans"))
+			Expect(tableNames[5]).To(Equal("restore_plan_tables"))
+			Expect(tableNames[6]).To(Equal("restore_plans"))
 
 		})
 


### PR DESCRIPTION
Update the historydb schema to support zero-table restore plans in a backup config, in the case of incremental backups with only heap tables, or other such edge cases.