### PR TITLE
Modify filepath to be able to work with mirrors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/blang/vfs v1.0.0
-	github.com/greenplum-db/gp-common-go-libs v1.0.11
+	github.com/greenplum-db/gp-common-go-libs v1.0.12
 	github.com/jackc/pgconn v1.14.0
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/klauspost/compress v1.15.15

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,8 @@ github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeN
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE=
 github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/greenplum-db/gp-common-go-libs v1.0.11 h1:aU66dEvRqaoMUymOPvcP3dxZ+5ayX4W7WZY+VhDbDQQ=
-github.com/greenplum-db/gp-common-go-libs v1.0.11/go.mod h1:ZElr7gGpsxAUXkjbT3ycGtQuAaEUfcR/4LRrpoaVZjM=
+github.com/greenplum-db/gp-common-go-libs v1.0.12 h1:Aow8icaKPodFi04wOV5EeWyqjBxTK/d9if9wRb6D9vs=
+github.com/greenplum-db/gp-common-go-libs v1.0.12/go.mod h1:ZElr7gGpsxAUXkjbT3ycGtQuAaEUfcR/4LRrpoaVZjM=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/restore/wrappers_test.go
+++ b/restore/wrappers_test.go
@@ -226,7 +226,7 @@ singledatafile: true
 timestamp: "20180415154238"
 withstatistics: false
 `
-		var executor testutils.TestExecutorMultiple
+		var executor testhelper.TestExecutor
 		var testConfigPath = "/tmp/unit_test_plugin_config.yml"
 		var oldWd string
 		var mdd string
@@ -240,8 +240,9 @@ withstatistics: false
 			err = cmdFlags.Set(options.PLUGIN_CONFIG, testConfigPath)
 			Expect(err).ToNot(HaveOccurred())
 
-			executor = testutils.TestExecutorMultiple{
+			executor = testhelper.TestExecutor{
 				ClusterOutputs: make([]*cluster.RemoteOutput, 2),
+				UseLastOutput:  true,
 			}
 			executor.ClusterOutputs[0] = &cluster.RemoteOutput{
 				Commands: []cluster.ShellCommand{

--- a/utils/plugin_test.go
+++ b/utils/plugin_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/iohelper"
 	"github.com/greenplum-db/gp-common-go-libs/operating"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
-	"github.com/greenplum-db/gpbackup/testutils"
 	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/pkg/errors"
 
@@ -24,7 +23,7 @@ import (
 
 var _ = Describe("utils/plugin tests", func() {
 	var testCluster *cluster.Cluster
-	var executor testutils.TestExecutorMultiple
+	var executor testhelper.TestExecutor
 	var subject utils.PluginConfig
 	var tempDir string
 
@@ -38,8 +37,9 @@ var _ = Describe("utils/plugin tests", func() {
 			Options:        make(map[string]string),
 		}
 		subject.Options = make(map[string]string)
-		executor = testutils.TestExecutorMultiple{
+		executor = testhelper.TestExecutor{
 			ClusterOutputs: make([]*cluster.RemoteOutput, 2),
+			UseLastOutput:  true,
 		}
 		executor.ClusterOutputs[0] = &cluster.RemoteOutput{
 			Commands: []cluster.ShellCommand{
@@ -115,7 +115,7 @@ options:
 			subject.SetBackupPluginVersion("myTimestamp", "my.test.version")
 			subject.CopyPluginConfigToAllHosts(testCluster)
 
-			Expect(executor.NumRemoteExecutions).To(Equal(1))
+			Expect(executor.NumClusterExecutions).To(Equal(1))
 			cc := executor.ClusterCommands[0]
 			Expect(len(cc)).To(Equal(3))
 			Expect(cc[0].Content).To(Equal(-1))
@@ -337,7 +337,7 @@ options:
 
 				subject.DeletePluginConfigWhenEncrypting(testCluster)
 
-				Expect(executor.NumRemoteExecutions).To(Equal(1))
+				Expect(executor.NumClusterExecutions).To(Equal(1))
 				cc := executor.ClusterCommands[0]
 				Expect(len(cc)).To(Equal(3))
 				Expect(cc[0].Content).To(Equal(-1))


### PR DESCRIPTION
While gpbackup doesn't deal with mirrors, gpbackup_manager uses the filepath module and it does need to interact with mirrors, so this commit modifies the filepath constructor to be able to either retrieve information for the primaries (and coordinator) or the mirrors (and standby), defaulting to the primaries to preserve current behavior.