### PR TITLE
Do not consider deleted backups when looking for most recent match

### DIFF
--- a/backup/incremental.go
+++ b/backup/incremental.go
@@ -70,7 +70,7 @@ func GetLatestMatchingBackupConfig(historyDBPath string, currentBackupConfig *hi
 	historyDB, _ := history.InitializeHistoryDatabase(historyDBPath)
 
 	whereClause := fmt.Sprintf(`backup_dir = '%s' AND database_name = '%s' AND leaf_partition_data = %v
-		AND plugin = '%s' AND single_data_file = %v AND compressed = %v`,
+		AND plugin = '%s' AND single_data_file = %v AND compressed = %v AND date_deleted = ''`,
 		MustGetFlagString(options.BACKUP_DIR),
 		currentBackupConfig.DatabaseName,
 		MustGetFlagBool(options.LEAF_PARTITION_DATA),


### PR DESCRIPTION
Incremental backups look for the most recent "matching" backup before allowing the backup to proceed.  These should not consider deleted backups, as this will cause the backup to subsequently fail when the backup data cannot be found.