### PR TITLE
Under certain flags, place timestamp+pid lockfile in backup-dir

### DIFF
--- a/backup/queries_globals.go
+++ b/backup/queries_globals.go
@@ -295,7 +295,7 @@ func GetResourceGroups[T ResourceGroupBefore7 | ResourceGroupAtLeast7](connectio
 	}
 
 	results := make([]T, 0)
-	err := connectionPool.Select(&results, query) // AJR TODO -- not sure this is smart enough to deserialize into a generic struct.  let's find out!
+	err := connectionPool.Select(&results, query)
 	gplog.FatalOnError(err)
 	return results
 }

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -166,7 +166,15 @@ func initializeBackupReport(opts options.Options) {
 
 func createBackupLockFile(timestamp string) {
 	var err error
-	timestampLockFile := fmt.Sprintf("/tmp/%s.lck", timestamp)
+	var timestampLockFile string
+	metadataOnly := MustGetFlagBool(options.METADATA_ONLY)
+	backupDir := MustGetFlagString(options.BACKUP_DIR)
+	noHistory := MustGetFlagBool(options.NO_HISTORY)
+	if metadataOnly && noHistory && backupDir != "" {
+		timestampLockFile = fmt.Sprintf("%s/%s.lck", backupDir, timestamp)
+	} else {
+		timestampLockFile = fmt.Sprintf("/tmp/%s.lck", timestamp)
+	}
 	backupLockFile, err = lockfile.New(timestampLockFile)
 	gplog.FatalOnError(err)
 	err = backupLockFile.TryLock()


### PR DESCRIPTION
To support specific use cases, currently mainly gpcopy, if the correct flags are provided gpbackup should place its timestamp+pid lockfile in the backupdir, instead of in /tmp.

This is to facilitate the highly-parallel metadata-only backups that gpcopy uses when dumping metadata.

The flags required to elicit this behavior are: metadata-only, no-history, and backup-dir.