### PR TITLE
Clean plugin test

### DIFF
--- a/ci/cleanup/plugin-cleanup.yml
+++ b/ci/cleanup/plugin-cleanup.yml
@@ -1,0 +1,101 @@
+# Fly this pipeline with the command: 
+# fly -t TARGET sp -p gpbackup_clean_plugin_storage -c gpbackup/ci/cleanup/plugin-cleanup.yml -v gpbackup-git-branch=main -v source_host=SOURCE_IP -v dest_host=DEST_IP
+---
+##############################################
+groups:
+- name: All
+  jobs:
+  - clean-plugin-storage
+##############################################
+
+##############################################
+resource_types:
+- name: gcs
+  type: registry-image
+  source:
+    repository: frodenas/gcs-resource
+##############################################
+
+##############################################
+resources:
+- name: gpdb6_src
+  type: git
+  icon: github-circle
+  source:
+    uri: https://github.com/greenplum-db/gpdb
+    branch: 6X_STABLE
+
+- name: weekly-trigger
+  type: time
+  source:
+    location: America/Los_Angeles
+    days: [Sunday]
+    start: 6:00 AM
+    stop: 7:00 AM
+
+- name: rocky8-gpdb6-image
+  type: registry-image
+  source:
+    repository: gcr.io/data-gpdb-public-images/gpdb6-rocky8-test
+    tag: latest
+
+- name: bin_gpdb_6x_rhel8
+  type: gcs
+  source:
+    bucket: ((dp/prod/gcs-ci-bucket))
+    json_key: ((concourse-gcs-resources-service-account-key))
+    regexp: server/published/gpdb6/server-rc-(.*)-rhel8_x86_64((dp/dev/rc-build-type-gcs)).tar.gz
+
+- name: gpbackup
+  type: git
+  icon: github-circle
+  source:
+    uri: https://github.com/greenplum-db/gpbackup
+    branch: ((gpbackup-git-branch))
+
+- name: gppkgs
+  type: gcs
+  icon: google
+  source:
+    bucket: ((dp/dev/gcs-ci-bucket))
+    json_key: ((dp/dev/gcp_svc_acct_key))
+    versioned_file: gpbackup/intermediates/gpbackup-gppkgs.tar.gz
+##############################################
+
+##############################################
+anchors:
+- &ddboost_params
+  # TODO -- this is currently flown by providing with IP addresses passed to command line.  
+    # This prevents needing to duplicate dev/prod files, and also avoids rewriting gen_pipeline.py
+    # If we move to a one-concourse approach, these can easily be interpolated from Vault again
+  DD_SOURCE_HOST: ((source_host))
+  DD_DEST_HOST: ((dest_host))
+  DD_USER: ((dp/prod/datadomain_user))
+  DD_PW: ((dp/prod/datadomain_711_password_gcp))
+  DD_ENCRYPTED_PW: ((dp/prod/encrypted_datadomain_711_password_gcp))
+##############################################
+
+##############################################
+jobs:
+- name: clean-plugin-storage
+  plan: 
+  - in_parallel:
+    - get: gpdb_src
+      resource: gpdb6_src
+    - get: bin_gpdb
+      resource: bin_gpdb_6x_rhel8
+    - get: rocky8-gpdb6-image
+    - get: gpbackup
+    - get: gppkgs
+    - get: weekly-trigger
+      trigger: true
+  - task: clean-plugins
+    image: rocky8-gpdb6-image
+    file: gpbackup/ci/tasks/clean-plugins.yml
+    params:
+      <<: *ddboost_params
+      REGION: us-west-2
+      AWS_ACCESS_KEY_ID: ((aws-bucket-access-key-id))
+      AWS_SECRET_ACCESS_KEY: ((aws-bucket-secret-access-key))
+      BUCKET: ((dp/dev/gpbackup-s3-plugin-test-bucket))
+##############################################

--- a/ci/scripts/clean-plugins.bash
+++ b/ci/scripts/clean-plugins.bash
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+# We deliberately do not set -e here, because these commands error if the 
+# directory happens to have already been deleted, which we do not want.
+set -x
+
+# Add locale for locale tests
+localedef -c -i de_DE -f UTF-8 de_DE
+echo LANG=\"de_DE\" >> /etc/locale.conf
+source /etc/locale.conf
+
+## old versions of ld have a bug that our CGO libs exercise. update binutils to avoid it
+OLDLDVERSION=$(ld --version | grep "2.25");
+if [[ ${OS} == "RHEL6" ]]; then
+    ## have to use vault to update because centos6 is EOL
+    sudo yum install -y centos-release-scl
+    echo "https://vault.centos.org/6.10/os/x86_64/" > /var/cache/yum/x86_64/6/C6.10-base/mirrorlist.txt
+    echo "http://vault.centos.org/6.10/extras/x86_64/" > /var/cache/yum/x86_64/6/C6.10-extras/mirrorlist.txt
+    echo "http://vault.centos.org/6.10/updates/x86_64/" > /var/cache/yum/x86_64/6/C6.10-updates/mirrorlist.txt
+    mkdir /var/cache/yum/x86_64/6/centos-sclo-rh/
+    echo "http://vault.centos.org/6.10/sclo/x86_64/rh" > /var/cache/yum/x86_64/6/centos-sclo-rh/mirrorlist.txt
+    mkdir /var/cache/yum/x86_64/6/centos-sclo-sclo/
+    echo "http://vault.centos.org/6.10/sclo/x86_64/sclo" > /var/cache/yum/x86_64/6/centos-sclo-sclo/mirrorlist.txt
+    sudo yum install -y devtoolset-7-binutils*
+    \cp /opt/rh/devtoolset-7/root/usr/bin/ld /usr/bin/ld
+elif [[ $OLDLDVERSION != "" ]]; then
+    yum install -y binutils
+fi
+
+mkdir /tmp/untarred
+tar -xzf gppkgs/gpbackup-gppkgs.tar.gz -C /tmp/untarred
+
+if [[ ! -f bin_gpdb/bin_gpdb.tar.gz ]] ; then
+  mv bin_gpdb/*.tar.gz bin_gpdb/bin_gpdb.tar.gz
+fi
+source gpdb_src/concourse/scripts/common.bash
+time install_gpdb
+time ./gpdb_src/concourse/scripts/setup_gpadmin_user.bash
+time NUM_PRIMARY_MIRROR_PAIRS=${LOCAL_CLUSTER_SIZE} make_cluster
+
+# generate configs for the CI storage used in our tests
+cat << CONFIG > /tmp/ddboost_config_local.yaml
+executablepath: \${GPHOME}/bin/gpbackup_ddboost_plugin
+options:
+  hostname: ${DD_SOURCE_HOST}
+  username: ${DD_USER}
+  storage_unit: GPDB
+  directory: gpbackup_tests6
+  pgport: 6000
+  password: ${DD_ENCRYPTED_PW}
+  password_encryption: "on"
+  gpbackup_ddboost_plugin: 66706c6c6e677a6965796f68343365303133336f6c73366b316868326764
+CONFIG
+
+cat << CONFIG > /tmp/ddboost_config_remote.yaml
+executablepath: \${GPHOME}/bin/gpbackup_ddboost_plugin
+options:
+  hostname: ${DD_DEST_HOST}
+  username: ${DD_USER}
+  storage_unit: GPDB
+  directory: gpbackup_tests6
+  pgport: 6000
+  password: ${DD_ENCRYPTED_PW}
+  password_encryption: "on"
+  gpbackup_ddboost_plugin: 66706c6c6e677a6965796f68343365303133336f6c73366b316868326764
+CONFIG
+
+  cat << CONFIG > /tmp/s3_config.yaml
+executablepath: \${GPHOME}/bin/gpbackup_s3_plugin
+options:
+  region: ${REGION}
+  aws_access_key_id: ${AWS_ACCESS_KEY_ID}
+  aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
+  bucket: ${BUCKET}
+  folder: test/backup
+  backup_multipart_chunksize: 100MB
+  restore_multipart_chunksize: 100MB
+CONFIG
+
+cat <<SCRIPT > /tmp/run_clean.bash
+#!/bin/bash
+
+set -x
+
+# use "temp build dir" of parent shell
+export GOPATH=\${HOME}/go
+export PATH=/usr/local/go/bin:\$PATH:\${GOPATH}/bin:/opt/rh/devtoolset-7/root/usr/bin/
+if [[ -f /opt/gcc_env.sh ]]; then
+    source /opt/gcc_env.sh
+fi
+mkdir -p \${GOPATH}/bin \${GOPATH}/src/github.com/greenplum-db
+cp -R $(pwd)/gpbackup \${GOPATH}/src/github.com/greenplum-db/
+
+source /usr/local/greenplum-db-devel/greenplum_path.sh
+source $(pwd)/gpdb_src/gpAux/gpdemo/gpdemo-env.sh
+
+mkdir -p "\${GPHOME}/postgresql"
+
+# Install gpbackup_tools
+out=\$(psql postgres -c "select version();")
+GPDB_VERSION=\$(echo \$out | sed -n 's/.*Greenplum Database \([0-9]\).*/\1/p')
+gppkg -i /tmp/untarred/gpbackup_tools*gp\${GPDB_VERSION}*${OS}*.gppkg
+
+# Install pgcrypto so ddboost plugin will work
+psql -d postgres -c "CREATE EXTENSION IF NOT EXISTS pgcrypto"
+
+# Invoke delete directory on parent directories we use for our tests
+\${GPHOME}/bin/gpbackup_ddboost_plugin delete_directory /tmp/ddboost_config_local.yaml gpbackup_tests5
+\${GPHOME}/bin/gpbackup_ddboost_plugin delete_directory /tmp/ddboost_config_remote.yaml gpbackup_tests5
+\${GPHOME}/bin/gpbackup_ddboost_plugin delete_directory /tmp/ddboost_config_local.yaml gpbackup_tests6
+\${GPHOME}/bin/gpbackup_ddboost_plugin delete_directory /tmp/ddboost_config_remote.yaml gpbackup_tests6
+# TODO -- add deletes for gpdb7 when we add plugin tests for that
+\${GPHOME}/bin/gpbackup_s3_plugin delete_directory /tmp/s3_config.yaml test/backup
+
+echo "Contents of plugin storage directories deleted"
+SCRIPT
+
+chmod +x /tmp/run_clean.bash
+su - gpadmin "/tmp/run_clean.bash"
+

--- a/ci/scripts/ddboost-plugin-tests.bash
+++ b/ci/scripts/ddboost-plugin-tests.bash
@@ -84,9 +84,9 @@ CONFIG
 
 pushd \${GOPATH}/src/github.com/greenplum-db/gpbackup/plugins
 
-./plugin_test.sh \${GPHOME}/bin/gpbackup_ddboost_plugin \${HOME}/ddboost_config_replication.yaml \${HOME}/ddboost_config_replication_restore.yaml
+./plugin_test.sh \${GPHOME}/bin/gpbackup_ddboost_plugin \${HOME}/ddboost_config_replication.yaml gpbackup_tests${GPDB_VERSION} \${HOME}/ddboost_config_replication_restore.yaml
 
-./plugin_test.sh \${GPHOME}/bin/gpbackup_ddboost_plugin \${HOME}/ddboost_config.yaml \${HOME}/ddboost_config_replication_restore.yaml
+./plugin_test.sh \${GPHOME}/bin/gpbackup_ddboost_plugin \${HOME}/ddboost_config.yaml gpbackup_tests${GPDB_VERSION} \${HOME}/ddboost_config_replication_restore.yaml
 
 # exercise boostfs, which is mounted at /data/gpdata/dd_dir
 pushd \${GOPATH}/src/github.com/greenplum-db/gpbackup

--- a/ci/scripts/s3-plugin-tests.bash
+++ b/ci/scripts/s3-plugin-tests.bash
@@ -30,7 +30,7 @@ options:
 CONFIG
 
   pushd ~/go/src/github.com/greenplum-db/gpbackup/plugins
-    ./plugin_test.sh \${GPHOME}/bin/gpbackup_s3_plugin \${HOME}/s3_config.yaml
+    ./plugin_test.sh \${GPHOME}/bin/gpbackup_s3_plugin \${HOME}/s3_config.yaml test/backup 
   popd
 SCRIPT
 

--- a/ci/tasks/clean-plugins.yml
+++ b/ci/tasks/clean-plugins.yml
@@ -1,0 +1,17 @@
+platform: linux
+
+image_resource:
+  type: registry-image
+
+inputs:
+- name: gpbackup
+- name: gpdb_src
+- name: bin_gpdb
+- name: gppkgs
+
+params:
+  LOCAL_CLUSTER_SIZE: 3
+  OS: RHEL8
+
+run:
+  path: gpbackup/ci/scripts/clean-plugins.bash

--- a/ci/templates/gpbackup-tpl.yml
+++ b/ci/templates/gpbackup-tpl.yml
@@ -77,6 +77,16 @@ groups:
   - ddboost_plugin_perf
 {% endif %}
 
+- name: Plugins
+  jobs: 
+  - s3_plugin_tests
+  - ddboost_plugin_and_boostfs_tests_6x
+{% if is_prod and "gpbackup-release" != pipeline_name %}
+  - ddboost_plugin_and_boostfs_tests_5x
+  - s3_plugin_perf
+  - ddboost_plugin_perf
+{% endif %}
+
 {% if "gpbackup-release" == pipeline_name %}
 - name: Packaging and Release
   jobs:
@@ -1216,6 +1226,9 @@ jobs:
       <<: *ccp_destroy_nvme
   ensure:
     <<: *set_failed
+
+{% if "gpbackup-release" != pipeline_name %}
+{% endif %}
 
 {% if is_prod or "gpbackup-release" == pipeline_name %}
 - name: GPDB6-ubuntu

--- a/end_to_end/plugin_test.go
+++ b/end_to_end/plugin_test.go
@@ -456,7 +456,7 @@ var _ = Describe("End to End plugin tests", func() {
 			}
 			pluginsDir := fmt.Sprintf("%s/src/github.com/greenplum-db/gpbackup/plugins", os.Getenv("GOPATH"))
 			copyPluginToAllHosts(backupConn, fmt.Sprintf("%s/example_plugin.bash", pluginsDir))
-			command := exec.Command("bash", "-c", fmt.Sprintf("%s/plugin_test.sh %s/example_plugin.bash %s/example_plugin_config.yaml", pluginsDir, pluginsDir, pluginsDir))
+            command := exec.Command("bash", "-c", fmt.Sprintf("%s/plugin_test.sh %s/example_plugin.bash %s/example_plugin_config.yaml /tmp/plugin_dest", pluginsDir, pluginsDir, pluginsDir))
 			mustRunCommand(command)
 
 			_ = os.RemoveAll("/tmp/plugin_dest")

--- a/plugins/example_plugin.bash
+++ b/plugins/example_plugin.bash
@@ -90,9 +90,19 @@ delete_backup() {
 
 }
 
+list_directory() {
+  echo "list_directory $1 /tmp/plugin_dest" >> /tmp/plugin_out.txt
+  ls /tmp/plugin_dest
+}
+
+delete_directory() {
+  echo "delete_directory $1 /tmp/plugin_dest" >> /tmp/plugin_out.txt
+  rm -rf /tmp/plugin_dest
+}
+
 plugin_api_version(){
-  echo "0.4.0"
-  echo "0.4.0" >> /tmp/plugin_out.txt
+  echo "0.5.0"
+  echo "0.5.0" >> /tmp/plugin_out.txt
 }
 
 --version(){

--- a/plugins/plugin_test.sh
+++ b/plugins/plugin_test.sh
@@ -4,7 +4,8 @@ set -o pipefail
 
 plugin=$1
 plugin_config=$2
-secondary_plugin_config=$3
+plugin_dir=$3
+secondary_plugin_config=$4
 MINIMUM_API_VERSION="0.4.0"
 
 # ----------------------------------------------
@@ -12,9 +13,9 @@ MINIMUM_API_VERSION="0.4.0"
 # This will put small amounts of data in the
 # plugin destination location
 # ----------------------------------------------
-if [ $# -lt 2 ] || [ $# -gt 3 ]
+if [ $# -lt 3 ] || [ $# -gt 4 ]
   then
-    echo "Usage: plugin_test.sh [path_to_executable] [plugin_config] [optional_config_for_secondary_destination]"
+    echo "Usage: plugin_test.sh [path_to_executable] [plugin_config] [plugin_testdir] [optional_config_for_secondary_destination]"
     exit 1
 fi
 
@@ -36,8 +37,9 @@ testdata="$testdir/testdata_$time_second.txt"
 test_no_data="$testdir/test_no_data_$time_second.txt"
 testdatasmall="$testdir/testdatasmall_$time_second.txt"
 testdatalarge="$testdir/testdatalarge_$time_second.txt"
-
 logdir="/tmp/test_bench_logs"
+
+plugin_testdir="$plugin_dir/${current_date}/${time_second}"
 
 text="this is some text"
 data=`LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 1000 ; echo`
@@ -57,16 +59,18 @@ cleanup_test_dir() {
   fi
 
   testdir_to_clean=$1
+  set +e
 
-  $plugin cleanup_plugin_for_backup $plugin_config $testdir_to_clean coordinator \"-1\"
-  $plugin cleanup_plugin_for_backup $plugin_config $testdir_to_clean segment_host
-  $plugin cleanup_plugin_for_backup $plugin_config $testdir_to_clean segment \"0\"
-  echo "[PASSED - CLEANUP] cleanup_plugin_for_backup"
+  echo "[RUNNING] delete_directory on plugin: $testdir_to_clean"
+  $plugin delete_directory $plugin_config $testdir_to_clean 
+  echo "[PASSED] delete_directory on plugin: $testdir_to_clean"
 
-  $plugin cleanup_plugin_for_restore $plugin_config $testdir_to_clean coordinator \"-1\"
-  $plugin cleanup_plugin_for_restore $plugin_config $testdir_to_clean segment_host
-  $plugin cleanup_plugin_for_restore $plugin_config $testdir_to_clean segment \"0\"
-  echo "[PASSED - CLEANUP] cleanup_plugin_for_restore"
+if [[ "$plugin" == *gpbackup_ddboost_plugin ]] && [[ "$plugin_config" == *ddboost_config_replication.yaml ]] && [[ -n "$secondary_plugin_config" ]]; then
+  echo "[RUNNING] delete_directory on plugin remote: $testdir_to_clean"
+  $plugin delete_directory $secondary_plugin_config $testdir_to_clean 
+  echo "[PASSED] delete_directory on plugin remote: $testdir_to_clean"
+fi
+  set -e
 }
 
 echo "# ----------------------------------------------"
@@ -152,7 +156,8 @@ echo "[PASSED] setup_plugin_for_backup"
 echo "[PASSED] backup_file"
 echo "[PASSED] setup_plugin_for_restore"
 echo "[PASSED] restore_file"
-cleanup_test_dir $testdir
+# TODO -- This test is still not getting cleaned up.  The "backup_file" path construction logic places files 
+# very strangely, making delete_directory inappropraite for this case.
 
 # ----------------------------------------------
 # Backup/Restore data functions
@@ -179,7 +184,6 @@ if [[ "$plugin_config" == *ddboost_config_replication.yaml ]] && [[ -n "$seconda
 fi
 echo "[PASSED] backup_data"
 echo "[PASSED] restore_data"
-cleanup_test_dir $testdir
 
 echo "[RUNNING] backup_data with no data"
 echo -n "" | $plugin backup_data $plugin_config $test_no_data
@@ -202,7 +206,6 @@ if [[ "$plugin_config" == *ddboost_config_replication.yaml ]] && [[ -n "$seconda
 fi
 echo "[PASSED] backup_data with no data"
 echo "[PASSED] restore_data with no data"
-cleanup_test_dir $testdir
 
 # ----------------------------------------------
 # Restore subset data functions
@@ -240,10 +243,11 @@ if [[ "$plugin" == *gpbackup_ddboost_plugin ]]; then
   data_part2=$(echo $data_large | cut -c900001-900001)
   if [ "$output" != "$data_part1$data_part2" ]; then
     echo "Failure restore_data_subset of two partitions from large data"
+    cleanup_test_dir $plugin_testdir
     exit 1
   fi
   echo "[PASSED] restore_data_subset of two partitions from large data"
-  cleanup_test_dir $testdir
+  cleanup_test_dir $plugin_testdir
 fi
 
 # ----------------------------------------------
@@ -255,10 +259,12 @@ current_date_for_del=$(echo $time_second_for_del | cut -c 1-8)
 time_second_for_del2=$(expr $time_second_for_del + 1)
 current_date_for_del2=$(echo $time_second_for_del2 | cut -c 1-8)
 
+plugin_testdir_for_del="$plugin_dir/${current_date_for_del}/${time_second_for_del}"
 testdir_for_del="/tmp/testseg/backups/${current_date_for_del}/${time_second_for_del}"
 testdata_for_del="$testdir_for_del/testdata_$time_second_for_del.txt"
 testfile_for_del="$testdir_for_del/testfile_$time_second_for_del.txt"
 
+plugin_testdir_for_del2="$plugin_dir/${current_date_for_del2}/${time_second_for_del2}"
 testdir_for_del2="/tmp/testseg/backups/${current_date_for_del2}/${time_second_for_del2}"
 testdata_for_del2="$testdir_for_del2/testdata_$time_second_for_del2.txt"
 testfile_for_del2="$testdir_for_del2/testfile_$time_second_for_del2.txt"
@@ -335,7 +341,8 @@ fi
 
 set -e
 echo "[PASSED] delete_backup"
-cleanup_test_dir $testdir_for_del
+# cleanup_test_dir $plugin_testdir_for_del
+# cleanup_test_dir $plugin_testdir_for_del2
 
 # ----------------------------------------------
 # Replicate backup function
@@ -344,6 +351,7 @@ if [[ "$plugin" == *gpbackup_ddboost_plugin ]] && [[ "$plugin_config" == *ddboos
     time_second_for_repl=$(expr 99999999999999 - $(od -vAn -N5 -tu < /dev/urandom | tr -d ' \n'))
     current_date_for_repl=$(echo $time_second_for_repl | cut -c 1-8)
 
+    plugin_testdir_for_repl="$plugin_dir/${current_date_for_repl}/${time_second_for_repl}"
     testdir_for_repl="/tmp/testseg/backups/${current_date_for_repl}/${time_second_for_repl}"
     testdata_for_repl="$testdir_for_repl/testdata_$time_second_for_repl.txt"
 
@@ -381,7 +389,7 @@ if [[ "$plugin" == *gpbackup_ddboost_plugin ]] && [[ "$plugin_config" == *ddboos
         fi
     fi
     echo "[PASSED] replicate backup"
-    cleanup_test_dir $testdir_for_repl
+    cleanup_test_dir $plugin_testdir_for_repl
 fi
 
 set +e
@@ -401,6 +409,7 @@ if [[ "$plugin" == *gpbackup_ddboost_plugin ]] && [[ "$plugin_config" == *ddboos
     time_second_for_repl=$(expr 99999999999999 - $(od -vAn -N5 -tu < /dev/urandom | tr -d ' \n'))
     current_date_for_repl=$(echo $time_second_for_repl | cut -c 1-8)
 
+    plugin_testdir_for_repl="$plugin_dir/${current_date_for_repl}/${time_second_for_repl}"
     testdir_for_repl="/tmp/testseg/backups/${current_date_for_repl}/${time_second_for_repl}"
     testdata_for_repl="$testdir_for_repl/testdata_$time_second_for_repl.txt"
 
@@ -430,6 +439,7 @@ if [[ "$plugin" == *gpbackup_ddboost_plugin ]] && [[ "$plugin_config" == *ddboos
     echo "[PASSED] delete_replica again to verify warning"
     set -e
 
+    cleanup_test_dir $plugin_testdir_for_repl
 fi
 
 # ----------------------------------------------


### PR DESCRIPTION
Use the new delete_directory commands to clean up the plugin storage we use in our CI by refactoring the cleanup commands in our plugin-test script.
 
Also add a new CI job to clean up the remainder on a weekly basis.