### PR TITLE
Ensure gpbackup_history is always written correctly

### DIFF
--- a/backup/incremental.go
+++ b/backup/incremental.go
@@ -70,13 +70,14 @@ func GetLatestMatchingBackupConfig(historyDBPath string, currentBackupConfig *hi
 	historyDB, _ := history.InitializeHistoryDatabase(historyDBPath)
 
 	whereClause := fmt.Sprintf(`backup_dir = '%s' AND database_name = '%s' AND leaf_partition_data = %v
-		AND plugin = '%s' AND single_data_file = %v AND compressed = %v AND date_deleted = ''`,
+		AND plugin = '%s' AND single_data_file = %v AND compressed = %v AND date_deleted = '' AND status = '%s'`,
 		MustGetFlagString(options.BACKUP_DIR),
 		currentBackupConfig.DatabaseName,
 		MustGetFlagBool(options.LEAF_PARTITION_DATA),
 		currentBackupConfig.Plugin,
 		MustGetFlagBool(options.SINGLE_DATA_FILE),
-		currentBackupConfig.Compressed)
+		currentBackupConfig.Compressed,
+        history.BackupStatusSucceed)
 
 	getBackupTimetampsQuery := fmt.Sprintf(`
 		SELECT timestamp

--- a/backup/incremental_test.go
+++ b/backup/incremental_test.go
@@ -96,6 +96,7 @@ var _ = Describe("backup/incremental tests", func() {
 			{
 				DatabaseName:     "test1",
 				Timestamp:        "timestamp3",
+				Status:           history.BackupStatusSucceed,
 				ExcludeRelations: []string{},
 				ExcludeSchemas:   []string{},
 				IncludeRelations: []string{},
@@ -104,6 +105,7 @@ var _ = Describe("backup/incremental tests", func() {
 			{
 				DatabaseName:     "test2",
 				Timestamp:        "timestamp2",
+				Status:           history.BackupStatusSucceed,
 				ExcludeRelations: []string{},
 				ExcludeSchemas:   []string{},
 				IncludeRelations: []string{},
@@ -113,6 +115,7 @@ var _ = Describe("backup/incremental tests", func() {
 			{
 				DatabaseName:     "test1",
 				Timestamp:        "timestamp1",
+				Status:           history.BackupStatusSucceed,
 				ExcludeRelations: []string{},
 				ExcludeSchemas:   []string{},
 				IncludeRelations: []string{},

--- a/backup/wrappers.go
+++ b/backup/wrappers.go
@@ -133,7 +133,7 @@ func NewBackupConfig(dbName string, dbVersion string, backupVersion string, plug
 		Timestamp:             timestamp,
 		WithoutGlobals:        MustGetFlagBool(options.WITHOUT_GLOBALS),
 		WithStatistics:        MustGetFlagBool(options.WITH_STATS),
-		Status:                history.BackupStatusFailed,
+		Status:                history.BackupStatusInProgress,
 	}
 
 	return &backupConfig
@@ -156,6 +156,8 @@ func initializeBackupReport(opts options.Options) {
 		//Potentially expensive query
 		dbSize = GetDBSize(connectionPool)
 	}
+
+	config.SegmentCount = len(globalCluster.ContentIDs) - 1
 
 	backupReport = &report.Report{
 		DatabaseSize: dbSize,

--- a/history/history.go
+++ b/history/history.go
@@ -20,6 +20,7 @@ type RestorePlanEntry struct {
 }
 
 const (
+    BackupStatusInProgress = "In Progress"
 	BackupStatusSucceed = "Success"
 	BackupStatusFailed  = "Failure"
 )

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -336,7 +336,7 @@ restore status:          Success but non-fatal errors occurred. See log file .+ 
 				Plugin:               "/tmp/plugin.sh",
 				Timestamp:            "timestamp1",
 				IncludeTableFiltered: true,
-				Status:               history.BackupStatusFailed,
+				Status:               history.BackupStatusInProgress,
 			}, backupConfig)
 		})
 	})


### PR DESCRIPTION
* cd41fa30e7bb239aefdfc56bb099a4dc8fe5df4e
    * Restructure writes to gpbackup_history so that the record is written out very early with an "In Progress" status, then updated to "Success" or "Failure" as part of DoCleanup
* 383554d13eaef305e873d9a873636184fac45fc7
    * Our DoCleanup relies on golang's `recover`, which will not fire if a panic happens inside a goroutine.  Identify 4 goroutines that can panic, and add individual `recover` handling to each of them.