### PR TITLE
Fix filtering of tables with inheritance

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -126,7 +126,7 @@ func DoBackup() {
 	gplog.Info("Gathering table state information")
 	metadataTables, dataTables := RetrieveAndProcessTables()
 	dataTables, numExtOrForeignTables := GetBackupDataSet(dataTables)
-	if len(dataTables) == 0 {
+	if len(dataTables) == 0 && !backupReport.MetadataOnly {
 		gplog.Warn("No tables in backup set contain data. Performing metadata-only backup instead.")
 		backupReport.MetadataOnly = true
 	}

--- a/backup/validate.go
+++ b/backup/validate.go
@@ -114,6 +114,9 @@ func validateFlagCombinations(flags *pflag.FlagSet) {
 	if MustGetFlagBool(options.INCREMENTAL) && !MustGetFlagBool(options.LEAF_PARTITION_DATA) {
 		gplog.Fatal(errors.Errorf("--leaf-partition-data must be specified with --incremental"), "")
 	}
+	if MustGetFlagBool(options.NO_INHERIT) && !(FlagChanged(options.INCLUDE_RELATION) || FlagChanged(options.INCLUDE_RELATION_FILE)) {
+		gplog.Fatal(errors.Errorf("--no-inherit must be specified with either --include-table or --include-table-file"), "")
+	}
 }
 
 func validateFlagValues() {

--- a/options/flag.go
+++ b/options/flag.go
@@ -51,6 +51,7 @@ const (
 	TRUNCATE_TABLE        = "truncate-table"
 	WITHOUT_GLOBALS       = "without-globals"
 	RESIZE_CLUSTER        = "resize-cluster"
+	NO_INHERIT            = "no-inherit"
 )
 
 func SetBackupFlagDefaults(flagSet *pflag.FlagSet) {
@@ -84,6 +85,7 @@ func SetBackupFlagDefaults(flagSet *pflag.FlagSet) {
 	flagSet.Bool(VERBOSE, false, "Print verbose log messages")
 	flagSet.Bool(WITH_STATS, false, "Back up query plan statistics")
 	flagSet.Bool(WITHOUT_GLOBALS, false, "Skip backup of global metadata")
+	flagSet.Bool(NO_INHERIT, false, "For a filtered backup, don't back up all tables that inherit included tables")
 }
 
 func SetRestoreFlagDefaults(flagSet *pflag.FlagSet) {

--- a/options/options.go
+++ b/options/options.go
@@ -2,6 +2,7 @@ package options
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
@@ -214,7 +215,7 @@ func (o *Options) ExpandIncludesForPartitions(conn *dbconn.DBConn, flags *pflag.
 		return err
 	}
 
-	allFqnStructs, err := o.getUserTableRelationsWithIncludeFiltering(conn, quotedIncludeRelations)
+	allFqnStructs, err := o.getUserTableRelationsWithIncludeFiltering(conn, quotedIncludeRelations, MustGetFlagBool(flags, NO_INHERIT))
 	if err != nil {
 		return err
 	}
@@ -239,12 +240,17 @@ func (o *Options) ExpandIncludesForPartitions(conn *dbconn.DBConn, flags *pflag.
 		}
 	}
 
+	if len(diff) > 0 {
+		gplog.Info("The filtered table set has been expanded to include additional dependent tables; see the log file for a full list of tables that have been added")
+		sort.Strings(diff)
+	}
 	for _, fqn := range diff {
 		err = flags.Set(INCLUDE_RELATION, fqn)
 		if err != nil {
 			return err
 		}
 		o.AddIncludedRelation(fqn)
+		gplog.Verbose("Added %s to the backup set", fqn)
 	}
 
 	return nil
@@ -272,7 +278,7 @@ func (o *Options) QuoteExcludeRelations(conn *dbconn.DBConn) error {
 
 // given a set of table oids, return a deduplicated set of other tables that EITHER depend
 // on them, OR that they depend on. The behavior for which is set with recurseDirection.
-func (o *Options) recurseTableDepend(conn *dbconn.DBConn, includeOids []string, recurseSource string) ([]string, error) {
+func (o *Options) recurseTableDepend(conn *dbconn.DBConn, includeOids []string, recurseSource string, getLeafPartitions bool) ([]string, error) {
 	var err error
 	var dependQuery string
 
@@ -281,26 +287,58 @@ func (o *Options) recurseTableDepend(conn *dbconn.DBConn, includeOids []string, 
 		expandedIncludeOids[oid] = true
 	}
 
-	if recurseSource == "child" {
-		dependQuery = `
+	childQuery := `
 			SELECT dep.refobjid
 			FROM
 				pg_depend dep
 				INNER JOIN pg_class cls ON dep.refobjid = cls.oid
 			WHERE
-				dep.objid in (%s)
-				AND cls.relkind in ('r', 'p', 'f')`
-	} else if recurseSource == "parent" {
-		dependQuery = `
+				dep.objid IN (%[1]s)
+				AND cls.relkind IN ('r', 'p', 'f')`
+	parentQuery := `
 			SELECT dep.objid
 			FROM
 				pg_depend dep
 				INNER JOIN pg_class cls ON dep.objid = cls.oid
 			WHERE
-				dep.refobjid in (%s)
-				AND cls.relkind in ('r', 'p', 'f')`
+				dep.refobjid IN (%[1]s)
+				AND cls.relkind IN ('r', 'p', 'f')`
+
+	if conn.Version.Before("7") {
+		if getLeafPartitions {
+			// Get external partitions and leaves in the include list
+			// Also get leaves of root partitions that currently have no leaves in the include list,
+			// i.e. those that have no filtering on their leaves and so should be fully expanded.
+			parentQuery += `
+				AND (
+					-- External partitions
+					dep.objid NOT IN (SELECT parchildrelid FROM pg_partition_rule WHERE parchildrelid NOT IN (SELECT reloid FROM pg_exttable))
+					-- Leaf partitions in the include list
+					OR dep.objid IN (%[1]s)
+					-- Leaves of root partitions that currently have no leaves in the include list
+					OR dep.refobjid NOT IN (SELECT parrelid FROM pg_partition p JOIN pg_partition_rule r ON p.oid = r.paroid WHERE r.parchildrelid in (%[1]s))
+				)`
+		} else {
+			// Only get external partitions; specifically, exclude non-external leaf partitions, since we can't just
+			// grab external partitions because we need to deal with non-partition tables as well.
+			parentQuery += `
+				AND dep.objid NOT IN (SELECT parchildrelid FROM pg_partition_rule WHERE parchildrelid NOT IN (SELECT reloid FROM pg_exttable))`
+		}
+	}
+
+	if recurseSource == "child" {
+		// Given a child partition table, find the parent partition above it
+		dependQuery = childQuery
+	} else if recurseSource == "parent" {
+		// Given a parent partition table, find all the child partitions below it
+		dependQuery = parentQuery
+	} else if recurseSource == "both" {
+		// Given a table that inherits or is inherited by another table, find all
+		// other tables above and below it
+		dependQuery = fmt.Sprintf(`%[1]s
+			UNION %[2]s`, childQuery, parentQuery)
 	} else {
-		gplog.Error("Please fix calling of this function recurseTableDepend. Argument recurseSource only accepts 'parent' or 'child'.")
+		gplog.Error(`Please fix calling of this function recurseTableDepend. Argument recurseSource only accepts "parent", "child", or "both."`)
 	}
 
 	// here we loop until no further table dependencies are found.  implemented iteratively, but functions like a recursion
@@ -341,82 +379,57 @@ func (o *Options) recurseTableDepend(conn *dbconn.DBConn, includeOids []string, 
 	return expandedIncludeOidsArr, err
 }
 
-func (o Options) getUserTableRelationsWithIncludeFiltering(connectionPool *dbconn.DBConn, includedRelationsQuoted []string) ([]FqnStruct, error) {
+func (o Options) getUserTableRelationsWithIncludeFiltering(connectionPool *dbconn.DBConn, includedRelationsQuoted []string, no_inherit bool) ([]FqnStruct, error) {
 	includeOids, err := getOidsFromRelationList(connectionPool, includedRelationsQuoted)
 	if err != nil {
 		return nil, err
 	}
 
 	oidStr := strings.Join(includeOids, ", ")
-	childPartitionFilter := ""
-	parentAndExternalPartitionFilter := ""
-	if connectionPool.Version.Before("7") {
-		if o.isLeafPartitionData {
-			//Get all leaf partition tables whose parents are in the include list
-			childPartitionFilter = fmt.Sprintf(`
-		OR c.oid IN (
-			SELECT
-				r.parchildrelid
-			FROM pg_partition p
-			JOIN pg_partition_rule r ON p.oid = r.paroid
-			WHERE p.paristemplate = false
-			AND p.parrelid IN (%s))`, oidStr)
-		} else {
-			//Get only external partition tables whose parents are in the include list
-			childPartitionFilter = fmt.Sprintf(`
-		OR c.oid IN (
-			SELECT
-				r.parchildrelid
-			FROM pg_partition p
-			JOIN pg_partition_rule r ON p.oid = r.paroid
-			JOIN pg_exttable e ON r.parchildrelid = e.reloid
-			WHERE p.paristemplate = false
-			AND e.reloid IS NOT NULL
-			AND p.parrelid IN (%s))`, oidStr)
-		}
-
-		parentAndExternalPartitionFilter = fmt.Sprintf(`
-		-- Get parent partition tables whose children are in the include list
-		OR c.oid IN (
-			SELECT
-				p.parrelid
-			FROM pg_partition p
-			JOIN pg_partition_rule r ON p.oid = r.paroid
-			WHERE p.paristemplate = false
-			AND r.parchildrelid IN (%[1]s)
-		)
-		-- Get external partition tables whose siblings are in the include list
-		OR c.oid IN (
-			SELECT
-				r.parchildrelid
-			FROM pg_partition_rule r
-			JOIN pg_exttable e ON r.parchildrelid = e.reloid
-			WHERE r.paroid IN (
-				SELECT
-					pr.paroid
-				FROM pg_partition_rule pr
-				WHERE pr.parchildrelid IN (%[1]s)
-			)
-		)`, oidStr)
-	} else {
-		// GPDB7+ reworks the nature of partition tables.  It is no longer sufficient
-		// to pull parents and children in one step.  Instead we must recursively climb/descend
-		// the pg_depend ladder, filtering to only members of pg_class at each step, until the
-		// full hierarchy has been retrieved
-		childOids, err := o.recurseTableDepend(connectionPool, includeOids, "parent")
+	var childPartitionFilter, parentAndExternalPartitionFilter, inheritancePartitionFilter string
+	// GPDB7+ reworks the nature of partition tables.  It is no longer sufficient
+	// to pull parents and children in one step.  Instead we must recursively climb/descend
+	// the pg_depend ladder, filtering to only members of pg_class at each step, until the
+	// full hierarchy has been retrieved.
+	//
+	// While we could query pg_partition and pg_partition_rule for this information in 6 and
+	// earlier, this inheritance-based approach still works in those earlier versions and it's
+	// good to keep the logic as similar as possible between the earlier and later versions.
+	//
+	// If --no-inherit is passed, we retrieve parent tables (so that filtering on partition
+	// leaves works) but skip retrieving child tables.
+	if !no_inherit {
+		childOids, err := o.recurseTableDepend(connectionPool, includeOids, "parent", o.isLeafPartitionData)
 		if err != nil {
 			return nil, err
 		}
 		if len(childOids) > 0 {
 			childPartitionFilter = fmt.Sprintf(`OR c.oid IN (%s)`, strings.Join(childOids, ", "))
 		}
+	}
 
-		parentOids, err := o.recurseTableDepend(connectionPool, includeOids, "child")
-		if err != nil {
-			return nil, err
+	parentOids, err := o.recurseTableDepend(connectionPool, includeOids, "child", o.isLeafPartitionData)
+	if err != nil {
+		return nil, err
+	}
+	if len(parentOids) > 0 {
+		parentAndExternalPartitionFilter = fmt.Sprintf(`OR c.oid IN (%s)`, strings.Join(parentOids, ", "))
+	}
+	if !no_inherit {
+		expandedOids := make([]string, 0)
+		// We shouldn't need anywhere near 100 iterations to get all dependencies; we just need a cap to prevent an infinite loop
+		for i := 0; i < 100; i++ {
+			expandedOids, err = o.recurseTableDepend(connectionPool, includeOids, "both", o.isLeafPartitionData)
+			if err != nil {
+				return nil, err
+			}
+			if len(expandedOids) == len(includeOids) { // no new ones found, stop recursing
+				break
+			}
+			includeOids = expandedOids[:]
 		}
-		if len(parentOids) > 0 {
-			parentAndExternalPartitionFilter = fmt.Sprintf(`OR c.oid IN (%s)`, strings.Join(parentOids, ", "))
+		if len(expandedOids) > 0 {
+			inheritancePartitionFilter = fmt.Sprintf(`OR c.oid IN (%s)`, strings.Join(expandedOids, ", "))
 		}
 	}
 
@@ -433,10 +446,11 @@ AND (
 	c.oid IN (%s)
 	%s
 	%s
+	%s
 )
 AND relkind IN ('r', 'f', 'p')
 AND %s
-ORDER BY c.oid;`, o.schemaFilterClause("n"), oidStr, parentAndExternalPartitionFilter, childPartitionFilter, ExtensionFilterClause("c"))
+ORDER BY c.oid;`, o.schemaFilterClause("n"), oidStr, parentAndExternalPartitionFilter, childPartitionFilter, inheritancePartitionFilter, ExtensionFilterClause("c"))
 
 	results := make([]FqnStruct, 0)
 	err = connectionPool.Select(&results, query)

--- a/show_coverage.sh
+++ b/show_coverage.sh
@@ -1,17 +1,25 @@
 #!/bin/bash
 
-DIR="github.com/greenplum-db/gpbackup"
 RESULTS="/tmp/results.out"
-go test -coverpkg $DIR/backup $DIR/integration -coverprofile=/tmp/coverage.out 2> /dev/null | awk '{print $2 " test " $4 "\t" $5}' | awk -F"/" '{print $4}' > $RESULTS
-for PACKAGE in "backup" "restore" "utils"; do
-  # Generate code coverage statistics for all packages, write the coverage statistics to a file, and print the coverage percentage to the shell
-  go test -coverpkg "$DIR/$PACKAGE" "$DIR/$PACKAGE" -coverprofile="/tmp/unit_$PACKAGE.out" | awk '{print $2 " unit test " $4 "\t" $5}' | awk -F"/" '{print $4}' >> $RESULTS
+
+# The actual coverage numbers appear on lines in the form "coverage: ##.#% of statements in [package]", so the grep and awk statements parse those out and record them
+# Note that this statement only generates coverage for integration tests that are actually executed, so e.g. running this against a 7 cluster won't show coverage for 5- or 6-specific code sections
+go test -coverpkg=./backup,./filepath,./history,./options,./report,./restore,./toc,./utils ./integration -coverprofile=/tmp/coverage.out 2> /dev/null | grep "coverage:" | awk '{print "integration tests:\t" $2}' > $RESULTS
+
+for PACKAGE in "backup" "filepath" "history" "options" "report" "restore" "toc" "utils" ; do
+  # Generate unit test coverage statistics for all packages, write the statistics to a file, and print the coverage percentage to the shell
+  go test -coverpkg "./$PACKAGE" "./$PACKAGE" -coverprofile="/tmp/unit_$PACKAGE.out" | grep "coverage:" | awk '{print $9 " unit tests:\t" $5}' >> $RESULTS
   # Filter out the first "mode: set" line from each coverage file and concatenate them all
   cat "/tmp/unit_$PACKAGE.out" | awk '{if($1!="mode:") {print $1 " " $2 " " $3}}' >> /tmp/coverage.out
 done
 
 # Print the total coverage percentage and generate a coverage HTML page
-go tool cover -func=/tmp/coverage.out | awk '{if($1=="total:") {print $1 "\t\t\t\t" $3}}' >> $RESULTS
+go tool cover -func=/tmp/coverage.out | awk '{if($1=="total:") {print $1 "\t\t\t" $3}}' >> $RESULTS
 cat $RESULTS
 rm $RESULTS
+rm /tmp/unit_*.out
 exit 0
+
+# To display the results in HTML format, run the following command:
+#
+#	go tool cover -html=/tmp/coverage.out


### PR DESCRIPTION
If tables are included in a backup set that inherit from, or are inherited by, other tables and those other parent or child tables are not included in the backup set, gpbackup should ignore those inheritance links when constructing CREATE TABLE statements for included tables.
    
This commit also adds a --no-inherit flag, which will cause filtered backups to ignore child tables of included tables to preserve the old behavior.