### PR TITLE
Compress hang

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -290,7 +290,7 @@ func backupData(tables []Table) {
 			MustGetFlagString(options.PLUGIN_CONFIG), compressStr, false, false, &wasTerminated, initialPipes, true, false, 0, 0)
 	}
 	gplog.Info("Writing data to file")
-	rowsCopiedMaps := backupDataForAllTables(tables)
+	rowsCopiedMaps := BackupDataForAllTables(tables)
 	AddTableDataEntriesToTOC(tables, rowsCopiedMaps)
 	if MustGetFlagBool(options.SINGLE_DATA_FILE) && MustGetFlagString(options.PLUGIN_CONFIG) != "" {
 		pluginConfig.BackupSegmentTOCs(globalCluster, globalFPInfo)

--- a/backup/data.go
+++ b/backup/data.go
@@ -134,10 +134,10 @@ func BackupSingleTableData(table Table, rowsCopiedMap map[uint32]int64, counters
 * If synchronized snapshot is not supported and worker is unable to acquire a lock, the
 * worker must be terminated because the session no longer has a valid distributed snapshot
 *
-* FIXME: Simplify backupDataForAllTables by having one function for snapshot workflow and
+* FIXME: Simplify BackupDataForAllTables by having one function for snapshot workflow and
 * another without, then extract common portions into their own functions.
  */
-func backupDataForAllTables(tables []Table) []map[uint32]int64 {
+func BackupDataForAllTables(tables []Table) []map[uint32]int64 {
 	counters := BackupProgressCounters{NumRegTables: 0, TotalRegTables: int64(len(tables))}
 	counters.ProgressBar = utils.NewProgressBar(int(counters.TotalRegTables), "Tables backed up: ", utils.PB_INFO)
 	counters.ProgressBar.Start()

--- a/backup/data.go
+++ b/backup/data.go
@@ -230,7 +230,8 @@ func backupDataForAllTables(tables []Table) []map[uint32]int64 {
 				err = BackupSingleTableData(table, rowsCopiedMaps[whichConn], &counters, whichConn)
 				if err != nil {
 					copyErr = err
-					break
+					oidMap.Store(table.Oid, Complete)
+					continue
 				} else {
 					oidMap.Store(table.Oid, Complete)
 				}

--- a/backup/global_variables.go
+++ b/backup/global_variables.go
@@ -80,6 +80,10 @@ func SetFPInfo(fpInfo filepath.FilePathInfo) {
 	globalFPInfo = fpInfo
 }
 
+func GetFPInfo() filepath.FilePathInfo {
+	return globalFPInfo
+}
+
 func SetPluginConfig(config *utils.PluginConfig) {
 	pluginConfig = config
 }

--- a/filepath/filepath.go
+++ b/filepath/filepath.go
@@ -26,6 +26,7 @@ type FilePathInfo struct {
 	Timestamp              string
 	UserSpecifiedBackupDir string
 	UserSpecifiedSegPrefix string
+	BaseDataDir            string
 }
 
 func NewFilePathInfo(c *cluster.Cluster, userSpecifiedBackupDir string, timestamp string, userSegPrefix string, useMirrors ...bool) FilePathInfo {
@@ -35,6 +36,7 @@ func NewFilePathInfo(c *cluster.Cluster, userSpecifiedBackupDir string, timestam
 	backupFPInfo.UserSpecifiedSegPrefix = userSegPrefix
 	backupFPInfo.Timestamp = timestamp
 	backupFPInfo.SegDirMap = make(map[int]string)
+	backupFPInfo.BaseDataDir = "<SEG_DATA_DIR>"
 
 	// While gpbackup doesn't care about mirrors, gpbackup_manager uses FilePathInfo and needs
 	// to record mirror information for deleting backups, so we add that functionality here.
@@ -97,7 +99,7 @@ func (backupFPInfo *FilePathInfo) GetTableBackupFilePathForCopyCommand(tableOid 
 	}
 
 	backupFilePath += extension
-	baseDir := "<SEG_DATA_DIR>"
+	baseDir := backupFPInfo.BaseDataDir
 	if backupFPInfo.IsUserSpecifiedBackupDir() {
 		baseDir = path.Join(backupFPInfo.UserSpecifiedBackupDir, fmt.Sprintf("%s<SEGID>", backupFPInfo.UserSpecifiedSegPrefix))
 	}

--- a/integration/data_backup_test.go
+++ b/integration/data_backup_test.go
@@ -1,0 +1,88 @@
+package integration
+
+import (
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/blang/semver"
+	"github.com/greenplum-db/gp-common-go-libs/testhelper"
+	"github.com/greenplum-db/gpbackup/backup"
+	"github.com/greenplum-db/gpbackup/filepath"
+	"github.com/greenplum-db/gpbackup/utils"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("backup integration tests", func() {
+	Describe("BackupDataForAllTables", func() {
+		var (
+			testTables             []backup.Table
+			fpInfo                 filepath.FilePathInfo
+			origFPInfo             filepath.FilePathInfo
+			origPipeThroughProgram utils.PipeThroughProgram
+		)
+		BeforeEach(func() {
+			if useOldBackupVersion && oldBackupSemVer.LT(semver.MustParse("1.29.0")) {
+				Skip(fmt.Sprintf("Test does not apply to gpbackup gpbackup %s", oldBackupSemVer))
+			}
+
+			fpInfo = filepath.NewFilePathInfo(testCluster, "", "20170101010101", "gpseg")
+			fpInfo.BaseDataDir = "/tmp/backup_data_test"
+			os.MkdirAll(path.Join(fpInfo.BaseDataDir, "backups", "20170101", "20170101010101"), 0777)
+
+			backup.SetCluster(testCluster)
+
+			origFPInfo = backup.GetFPInfo()
+			backup.SetFPInfo(fpInfo)
+
+			origPipeThroughProgram = utils.GetPipeThroughProgram()
+
+			testTables = []backup.Table{{
+				Relation:        backup.Relation{Oid: 0, Schema: "dataTest", Name: "testtable1"},
+				TableDefinition: backup.TableDefinition{IsExternal: false},
+			},
+				{
+					Relation:        backup.Relation{Oid: 1, Schema: "dataTest", Name: "testtable2"},
+					TableDefinition: backup.TableDefinition{IsExternal: false},
+				},
+			}
+			testhelper.AssertQueryRuns(connectionPool, `CREATE SCHEMA dataTest;`)
+			testhelper.AssertQueryRuns(connectionPool, `CREATE TABLE dataTest.testtable1 (i int) DISTRIBUTED BY (i);`)
+			testhelper.AssertQueryRuns(connectionPool, `CREATE TABLE dataTest.testtable2 (i int) DISTRIBUTED BY (i);`)
+		})
+		AfterEach(func() {
+			testhelper.AssertQueryRuns(connectionPool, `DROP SCHEMA dataTest CASCADE;`)
+			os.RemoveAll(fpInfo.BaseDataDir)
+			backup.SetFPInfo(origFPInfo)
+			utils.SetPipeThroughProgram(origPipeThroughProgram)
+		})
+		It("backs up multiple tables with valid data", func() {
+			Expect(func() { backup.BackupDataForAllTables(testTables) }).ShouldNot(Panic())
+
+			// Assert that at least one segment's worth of files for both tables were written out
+			_, err := os.Stat("/tmp/backup_data_test/backups/20170101/20170101010101/gpbackup_0_20170101010101_0")
+			Expect(err).ToNot(HaveOccurred())
+			_, err = os.Stat("/tmp/backup_data_test/backups/20170101/20170101010101/gpbackup_0_20170101010101_1")
+			Expect(err).ToNot(HaveOccurred())
+
+		})
+		It("correctly errors if a piped copy command fails", func() {
+			// We had a bug for a while where this would result in a permanent hang, instead of an
+			// error. This coverage is meant to prevent that from reocurring in future refactors,
+			// which that function needs.  We could consider doing some fancier timeout detection,
+			// as waiting around for 10 minutes while this times out is not ideal.  This is good
+			// for now.
+			dummyPipeThrough := utils.PipeThroughProgram{
+				Name:          "dummy",
+				OutputCommand: "doesnotexist",
+				InputCommand:  "doesnotexist",
+				Extension:     ".dne",
+			}
+			utils.SetPipeThroughProgram(dummyPipeThrough)
+            defer testhelper.ShouldPanicWithMessage("doesnotexist: not found")
+			backup.BackupDataForAllTables(testTables)
+		})
+	})
+})

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"testing"
 
+	"github.com/blang/semver"
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
@@ -39,6 +40,9 @@ var (
 	memAuditDefault       = "0"
 	cpuSetDefault         = "-1"
 	includeSecurityLabels = false
+
+	useOldBackupVersion = false
+	oldBackupSemVer     semver.Version
 )
 
 func TestQueries(t *testing.T) {
@@ -93,6 +97,12 @@ var _ = BeforeSuite(func() {
 		memSpillDefault = "0"
 
 		includeSecurityLabels = true
+	}
+
+	// handle backwards-compatibility tests
+	useOldBackupVersion = os.Getenv("OLD_BACKUP_VERSION") != ""
+	if useOldBackupVersion {
+		oldBackupSemVer = semver.MustParse(os.Getenv("OLD_BACKUP_VERSION"))
 	}
 })
 


### PR DESCRIPTION
A previous change to this code restructured how we track which tables
are being backed up, and their status.  This led to the case where, if a
piped copy command failed, the error was captured but never displayed.
Instead we'd spin forever on an "Unknown" state in our sync.Map, causing
permanent hangs.

This PR restores the original behavior, where if a pipe fails the
backup of the table is marked "Complete" in the sync.map, and the error
is handled correctly downstream.

Given the issues with this function misbehaving, it needs better
coverage.  This PR adds some basic test coverage of it.  We also
tweak how FilePathInfo is structured, so that it is simpler to mock out
where data is copied out to during backup.