### PR TITLE
Fix expected error message in test

### DIFF
--- a/integration/data_backup_test.go
+++ b/integration/data_backup_test.go
@@ -81,7 +81,7 @@ var _ = Describe("backup integration tests", func() {
 				Extension:     ".dne",
 			}
 			utils.SetPipeThroughProgram(dummyPipeThrough)
-            defer testhelper.ShouldPanicWithMessage("doesnotexist: not found")
+			defer testhelper.ShouldPanicWithMessage("doesnotexist")
 			backup.BackupDataForAllTables(testTables)
 		})
 	})


### PR DESCRIPTION
Some of our CI systems have a different "not found" error for this test than others.  Expect a more general message to keep CI happy.