### PR TITLE
Improve BackupDataForAllTables

### DIFF
--- a/backup/data.go
+++ b/backup/data.go
@@ -149,8 +149,8 @@ func BackupDataForAllTables(tables []Table) []map[uint32]int64 {
 	 */
 	tasks := make(chan Table, len(tables))
 	var oidMap sync.Map
+	var isErroredBackup atomic.Bool
 	var workerPool sync.WaitGroup
-	var copyErr error
 	// Record and track tables in a hashmap of oids and table states (preloaded with value Unknown).
 	// The tables are loaded into the tasks channel for the subsequent goroutines to work on.
 	for _, table := range tables {
@@ -183,34 +183,33 @@ func BackupDataForAllTables(tables []Table) []map[uint32]int64 {
 			 * transaction commits and the locks are released.
 			 */
 			for table := range tasks {
-				if wasTerminated || copyErr != nil {
+				if wasTerminated || isErroredBackup.Load() {
 					counters.ProgressBar.(*pb.ProgressBar).NotPrint = true
 					return
 				}
 				if backupSnapshot != "" && connectionPool.Tx[whichConn] == nil {
 					err := SetSynchronizedSnapshot(connectionPool, whichConn, backupSnapshot)
-					if err != nil {
-						gplog.FatalOnError(err)
-					}
+					gplog.FatalOnError(err)
 				}
-				// If a random external SQL command had queued an AccessExclusiveLock acquisition request
-				// against this next table, the --job worker thread would deadlock on the COPY attempt.
-				// To prevent gpbackup from hanging, we attempt to acquire an AccessShareLock on the
-				// relation with the NOWAIT option before we run COPY. If the LOCK TABLE NOWAIT call
-				// fails, we catch the error and defer the table to the main worker thread, worker 0.
-				// Afterwards, we break early and terminate the worker since its transaction is now in an
-				// aborted state. We do not need to do this with the main worker thread because it has
-				// already acquired AccessShareLocks on all tables before the metadata dumping part.
+				// If a random external SQL command had queued an AccessExclusiveLock acquisition
+				// request against this next table, the --job worker thread would deadlock on the
+				// COPY attempt. To prevent gpbackup from hanging, we attempt to acquire an
+				// AccessShareLock on the relation with the NOWAIT option before we run COPY. If
+				// the LOCK TABLE NOWAIT call fails, we catch the error and defer the table to the
+				// main worker thread, worker 0. Afterwards, if we are in a local transaction
+				// instead of a distributed snapshot, we break early and terminate the worker since
+				// its transaction is now in an aborted state. We do not need to do this with the
+				// main worker thread because it has already acquired AccessShareLocks on all
+				// tables before the metadata dumping part.
 				err := LockTableNoWait(table, whichConn)
 				if err != nil {
 					if pgErr, ok := err.(*pgconn.PgError); ok && pgErr.Code != PG_LOCK_NOT_AVAILABLE {
-						copyErr = err
-						oidMap.Store(table.Oid, Deferred)
+						isErroredBackup.Store(true)
 						err = connectionPool.Rollback(whichConn)
 						if err != nil {
 							gplog.Warn("Worker %d: %s", whichConn, err)
 						}
-						continue
+						gplog.Fatal(fmt.Errorf("Unexpectedly unable to take lock on table %s, %s", table.FQN(), pgErr.Error()), "")
 					}
 					if gplog.GetVerbosity() < gplog.LOGVERBOSE {
 						// Add a newline to interrupt the progress bar so that
@@ -235,9 +234,11 @@ func BackupDataForAllTables(tables []Table) []map[uint32]int64 {
 				}
 				err = BackupSingleTableData(table, rowsCopiedMaps[whichConn], &counters, whichConn)
 				if err != nil {
-					copyErr = err
-					oidMap.Store(table.Oid, Complete)
-					continue
+					// if copy isn't working, skip remaining backups, and let downstream panic
+					// handling deal with it
+					counters.ProgressBar.(*pb.ProgressBar).NotPrint = true
+					isErroredBackup.Store(true)
+					gplog.Fatal(err, "")
 				} else {
 					oidMap.Store(table.Oid, Complete)
 				}
@@ -264,13 +265,17 @@ func BackupDataForAllTables(tables []Table) []map[uint32]int64 {
 		}()
 		for _, table := range tables {
 			for {
+				if wasTerminated || isErroredBackup.Load() {
+					return
+				}
 				state, _ := oidMap.Load(table.Oid)
 				if state.(int) == Unknown {
 					time.Sleep(time.Millisecond * 50)
 				} else if state.(int) == Deferred {
 					err := BackupSingleTableData(table, rowsCopiedMaps[0], &counters, 0)
 					if err != nil {
-						copyErr = err
+						isErroredBackup.Store(true)
+						gplog.Fatal(err, "")
 					}
 					oidMap.Store(table.Oid, Complete)
 					break
@@ -300,7 +305,7 @@ func BackupDataForAllTables(tables []Table) []map[uint32]int64 {
 	if backupSnapshot == "" {
 		allWorkersTerminatedLogged := false
 		for _, table := range tables {
-			if wasTerminated || copyErr != nil {
+			if wasTerminated || isErroredBackup.Load() {
 				counters.ProgressBar.(*pb.ProgressBar).NotPrint = true
 				break
 			}
@@ -318,12 +323,7 @@ func BackupDataForAllTables(tables []Table) []map[uint32]int64 {
 	// Main goroutine waits for deferred worker 0 by waiting on this channel
 	<-deferredWorkerDone
 	agentErr := utils.CheckAgentErrorsOnSegments(globalCluster, globalFPInfo)
-	if copyErr != nil && agentErr != nil {
-		gplog.Error(agentErr.Error())
-		gplog.Fatal(copyErr, "")
-	} else if copyErr != nil {
-		gplog.Fatal(copyErr, "")
-	} else if agentErr != nil {
+	if agentErr != nil {
 		gplog.Fatal(agentErr, "")
 	}
 

--- a/backup/global_variables.go
+++ b/backup/global_variables.go
@@ -20,7 +20,7 @@ import (
  */
 
 /*
- Table backup state constants
+Table backup state constants
 */
 const (
 	Unknown int = iota
@@ -82,6 +82,14 @@ func SetFPInfo(fpInfo filepath.FilePathInfo) {
 
 func GetFPInfo() filepath.FilePathInfo {
 	return globalFPInfo
+}
+
+func SetBackupSnapshot(snapshot string) {
+	backupSnapshot = snapshot
+}
+
+func GetBackupSnapshot() string {
+	return backupSnapshot
 }
 
 func SetPluginConfig(config *utils.PluginConfig) {

--- a/integration/data_backup_test.go
+++ b/integration/data_backup_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup/backup"
 	"github.com/greenplum-db/gpbackup/filepath"
+	"github.com/greenplum-db/gpbackup/testutils"
 	"github.com/greenplum-db/gpbackup/utils"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -24,6 +25,9 @@ var _ = Describe("backup integration tests", func() {
 			origPipeThroughProgram utils.PipeThroughProgram
 		)
 		BeforeEach(func() {
+			if connectionPool.Version.Before(backup.SNAPSHOT_GPDB_MIN_VERSION) {
+				Skip(fmt.Sprintf("Test only applicable to GPDB %s and above", backup.SNAPSHOT_GPDB_MIN_VERSION))
+			}
 			if useOldBackupVersion && oldBackupSemVer.LT(semver.MustParse("1.29.0")) {
 				Skip(fmt.Sprintf("Test does not apply to gpbackup gpbackup %s", oldBackupSemVer))
 			}
@@ -39,6 +43,18 @@ var _ = Describe("backup integration tests", func() {
 
 			origPipeThroughProgram = utils.GetPipeThroughProgram()
 
+			testhelper.AssertQueryRuns(connectionPool, `CREATE SCHEMA dataTest;`)
+		})
+		AfterEach(func() {
+			testhelper.AssertQueryRuns(connectionPool, `DROP SCHEMA dataTest CASCADE;`)
+			os.RemoveAll(fpInfo.BaseDataDir)
+			backup.SetFPInfo(origFPInfo)
+			utils.SetPipeThroughProgram(origPipeThroughProgram)
+		})
+		It("backs up multiple tables with valid data", func() {
+
+			testhelper.AssertQueryRuns(connectionPool, `CREATE TABLE dataTest.testtable1 (i int) DISTRIBUTED BY (i);`)
+			testhelper.AssertQueryRuns(connectionPool, `CREATE TABLE dataTest.testtable2 (i int) DISTRIBUTED BY (i);`)
 			testTables = []backup.Table{{
 				Relation:        backup.Relation{Oid: 0, Schema: "dataTest", Name: "testtable1"},
 				TableDefinition: backup.TableDefinition{IsExternal: false},
@@ -48,21 +64,19 @@ var _ = Describe("backup integration tests", func() {
 					TableDefinition: backup.TableDefinition{IsExternal: false},
 				},
 			}
-			testhelper.AssertQueryRuns(connectionPool, `CREATE SCHEMA dataTest;`)
-			testhelper.AssertQueryRuns(connectionPool, `CREATE TABLE dataTest.testtable1 (i int) DISTRIBUTED BY (i);`)
-			testhelper.AssertQueryRuns(connectionPool, `CREATE TABLE dataTest.testtable2 (i int) DISTRIBUTED BY (i);`)
-		})
-		AfterEach(func() {
-			testhelper.AssertQueryRuns(connectionPool, `DROP SCHEMA dataTest CASCADE;`)
-			os.RemoveAll(fpInfo.BaseDataDir)
-			backup.SetFPInfo(origFPInfo)
-			utils.SetPipeThroughProgram(origPipeThroughProgram)
-		})
-		It("backs up multiple tables with valid data", func() {
+			// set up a backupsnapshot to ensure the code flow we're testing is the intended case
+			connectionPool.MustBegin()
+			testSnapshot, err := backup.GetSynchronizedSnapshot(connectionPool)
+			Expect(err).ToNot(HaveOccurred())
+			backup.SetBackupSnapshot(testSnapshot)
+			Expect(err).ToNot(HaveOccurred())
+
 			Expect(func() { backup.BackupDataForAllTables(testTables) }).ShouldNot(Panic())
 
+			connectionPool.MustCommit()
+
 			// Assert that at least one segment's worth of files for both tables were written out
-			_, err := os.Stat("/tmp/backup_data_test/backups/20170101/20170101010101/gpbackup_0_20170101010101_0")
+			_, err = os.Stat("/tmp/backup_data_test/backups/20170101/20170101010101/gpbackup_0_20170101010101_0")
 			Expect(err).ToNot(HaveOccurred())
 			_, err = os.Stat("/tmp/backup_data_test/backups/20170101/20170101010101/gpbackup_0_20170101010101_1")
 			Expect(err).ToNot(HaveOccurred())
@@ -71,9 +85,7 @@ var _ = Describe("backup integration tests", func() {
 		It("correctly errors if a piped copy command fails", func() {
 			// We had a bug for a while where this would result in a permanent hang, instead of an
 			// error. This coverage is meant to prevent that from reocurring in future refactors,
-			// which that function needs.  We could consider doing some fancier timeout detection,
-			// as waiting around for 10 minutes while this times out is not ideal.  This is good
-			// for now.
+			// which that function needs.
 			dummyPipeThrough := utils.PipeThroughProgram{
 				Name:          "dummy",
 				OutputCommand: "doesnotexist",
@@ -81,8 +93,64 @@ var _ = Describe("backup integration tests", func() {
 				Extension:     ".dne",
 			}
 			utils.SetPipeThroughProgram(dummyPipeThrough)
-			defer testhelper.ShouldPanicWithMessage("doesnotexist")
-			backup.BackupDataForAllTables(testTables)
+
+			testhelper.AssertQueryRuns(connectionPool, `CREATE TABLE dataTest.test2table1 (i int) DISTRIBUTED BY (i);`)
+			testhelper.AssertQueryRuns(connectionPool, `CREATE TABLE dataTest.test2table2 (i int) DISTRIBUTED BY (i);`)
+			testTables = []backup.Table{{
+				Relation:        backup.Relation{Oid: 0, Schema: "dataTest", Name: "test2table1"},
+				TableDefinition: backup.TableDefinition{IsExternal: false},
+			},
+				{
+					Relation:        backup.Relation{Oid: 1, Schema: "dataTest", Name: "test2table2"},
+					TableDefinition: backup.TableDefinition{IsExternal: false},
+				},
+			}
+			connectionPool.MustBegin()
+
+			testSnapshot, err := backup.GetSynchronizedSnapshot(connectionPool)
+			Expect(err).ToNot(HaveOccurred())
+			backup.SetBackupSnapshot(testSnapshot)
+
+			Expect(func() { backup.BackupDataForAllTables(testTables) }).Should(Panic())
+
+			connectionPool.MustRollback()
+
+			// Terminate the hanging copy command or it breaks test suite cleanup. We do not need
+			// to worry about GPDB5- syntax here because these tests don't apply to that
+			cleanupConn := testutils.SetupTestDbConn("testdb")
+			defer cleanupConn.Close()
+			query := `
+			    SELECT pg_terminate_backend(pid)
+			    FROM pg_stat_activity
+			    WHERE application_name = ''
+			    AND query like '%COPY%PROGRAM%doesnotexist%'
+                AND pid <> pg_backend_pid();`
+			cleanupConn.MustExec(query)
+
+		})
+
+		It("correctly errors if an unexpected error occurs taking a lock", func() {
+
+			testhelper.AssertQueryRuns(connectionPool, `CREATE TABLE dataTest.test3table1 (i int) DISTRIBUTED BY (i);`)
+			// do not create second table, so taking a lock on it will error
+			testTables = []backup.Table{{
+				Relation:        backup.Relation{Oid: 0, Schema: "dataTest", Name: "test3table1"},
+				TableDefinition: backup.TableDefinition{IsExternal: false},
+			},
+				{
+					Relation:        backup.Relation{Oid: 1, Schema: "dataTest", Name: "test3table2"},
+					TableDefinition: backup.TableDefinition{IsExternal: false},
+				},
+			}
+			connectionPool.MustBegin()
+
+			testSnapshot, err := backup.GetSynchronizedSnapshot(connectionPool)
+			Expect(err).ToNot(HaveOccurred())
+			backup.SetBackupSnapshot(testSnapshot)
+
+			Expect(func() { backup.BackupDataForAllTables(testTables) }).Should(Panic())
+
+			connectionPool.MustRollback()
 		})
 	})
 })

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -58,7 +58,9 @@ var _ = BeforeSuite(func() {
 	}
 	Expect(err).To(BeNil())
 	_, stderr, logFile = testhelper.SetupTestLogger()
-	connectionPool = testutils.SetupTestDbConn("testdb")
+	connectionPool = dbconn.NewDBConnFromEnvironment("testdb")
+	// we want multiple connections to facilitate testing the more common path in BackupData
+	connectionPool.MustConnect(2)
 	// We can't use AssertQueryRuns since if a role already exists it will error
 	_, _ = connectionPool.Exec("CREATE ROLE testrole SUPERUSER")
 	_, _ = connectionPool.Exec("CREATE ROLE anothertestrole SUPERUSER")


### PR DESCRIPTION
Previous changes in support distributed snapshots for backing up data introduced bugs in how we handle errors when piping copy commands to the server. A prior attempt at fixing this was insufficient, so here we overhaul how the goroutines doing distributed data backup inform of errors, and how those errors are handled.

Also, some changes are necessary to our integration test suite to support testing of this code path. Specifically, the distributed code path is only invoked if there are multiple connections to the cluster available. So, we update to run all our tests with two connections open.