### PR TITLE
Fix regression pipeline usage of gppgkv2

### DIFF
--- a/ci/regression/regression_pipeline.yml
+++ b/ci/regression/regression_pipeline.yml
@@ -320,16 +320,14 @@ jobs:
       trigger: true
     - get: pivnet_release_cache
     - get: rocky8-gpdb7-image
-  - in_parallel:
-    - do: # RHEL8
-      - task: build-go-binaries-rhel8
-        file: gpbackup/ci/tasks/build-go-binaries.yml
-        image: rocky8-gpdb7-image
-        params:
-          OS: RHEL8
-      - put: gpbackup-go-components-rhel8
-        params:
-          file: go_components/go_components.tar.gz
+  - task: build-go-binaries-rhel8
+    file: gpbackup/ci/tasks/build-go-binaries.yml
+    image: rocky8-gpdb7-image
+    params:
+      OS: RHEL8
+  - put: gpbackup-go-components-rhel8
+    params:
+      file: go_components/go_components.tar.gz
 
 - name: build_gppkgs
   plan:

--- a/ci/tasks/icw-roundtrip.yml
+++ b/ci/tasks/icw-roundtrip.yml
@@ -10,6 +10,8 @@ inputs:
 - name: gppkgs
 - name: icw_dump
 - name: diffdb_src
+- name: gp-pkg
+  optional: true
 
 
 params:


### PR DESCRIPTION
The recent gppkg changes missed a step when updating the regression pipeline.  It requires the input to be called out in the task yaml for it to appear in the docker filesystem.