### PR TITLE
Reduce CI flakiness

### DIFF
--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -1721,7 +1721,7 @@ LANGUAGE plpgsql NO SQL;`)
 			})
 		})
 	})
-	Describe("Restore to a different-sized cluster", func() {
+	Describe("Restore to a different-sized cluster", FlakeAttempts(3), func() {
 		if useOldBackupVersion {
 			Skip("This test is not needed for old backup versions")
 		}
@@ -1763,6 +1763,7 @@ LANGUAGE plpgsql NO SQL;`)
 				// These hangs are still being observed only in CI, and a definitive RCA has not yet been accomplished
 				completed := make(chan bool)
 				defer func() { completed <- true }() // Whether the test succeeds or fails, mark it as complete
+				defer GinkgoRecover()
 				go func() {
 					// No test run has been observed to take more than a few minutes without a hang,
 					// so loop 5 times and check for success after 1 minute each
@@ -1778,6 +1779,7 @@ LANGUAGE plpgsql NO SQL;`)
 					// If the test succeeded or failed, we'll return before here.
 					_ = exec.Command("pkill", "-9", "gpbackup_helper").Run()
 					_ = exec.Command("pkill", "-9", "gprestore").Run()
+					Fail("Resize-restore end-to-end test is hanging. Failing test.")
 				}()
 
 				gprestoreArgs := []string{

--- a/end_to_end/signal_handler_test.go
+++ b/end_to_end/signal_handler_test.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-var _ = Describe("Signal handler tests", FlakeAttempts(3), func() {
+var _ = Describe("Signal handler tests", FlakeAttempts(5), func() {
 	BeforeEach(func() {
 		end_to_end_setup()
 		testhelper.AssertQueryRuns(backupConn, "CREATE table bigtable(id int unique); INSERT INTO bigtable SELECT generate_series(1,10000000)")
@@ -32,11 +32,10 @@ var _ = Describe("Signal handler tests", FlakeAttempts(3), func() {
 			cmd := exec.Command(gpbackupPath, args...)
 			go func() {
 				/*
-				* We use a random delay for the sleep in this test (between
-				* 1.0s and 1.5s) so that gpbackup will be interrupted at a
-				* different point in the backup process every time to help
-				* catch timing issues with the cleanup.
-				*/
+				 * We use a random delay for the sleep in this test (between 1.0s and 1.5s) so that
+				 * gpbackup will be interrupted at a different point in the backup process every time to help catch
+				 * timing issues with the cleanup.
+				 */
 				rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 				time.Sleep(time.Duration(rng.Intn(1000)+500) * time.Millisecond)
 				_ = cmd.Process.Signal(unix.SIGINT)
@@ -66,7 +65,7 @@ var _ = Describe("Signal handler tests", FlakeAttempts(3), func() {
 				* 0.5s and 0.8s) so that gpbackup will be interrupted at a
 				* different point in the backup process every time to help
 				* catch timing issues with the cleanup.
-				*/
+				 */
 				rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 				time.Sleep(time.Duration(rng.Intn(300)+500) * time.Millisecond)
 				_ = cmd.Process.Signal(unix.SIGINT)
@@ -201,7 +200,7 @@ var _ = Describe("Signal handler tests", FlakeAttempts(3), func() {
 				* 1.0s and 1.5s) so that gprestore will be interrupted at a
 				* different point in the backup process every time to help
 				* catch timing issues with the cleanup.
-				*/
+				 */
 				rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 				time.Sleep(time.Duration(rng.Intn(1000)+500) * time.Millisecond)
 				_ = cmd.Process.Signal(unix.SIGINT)
@@ -234,7 +233,7 @@ var _ = Describe("Signal handler tests", FlakeAttempts(3), func() {
 				* 1.0s and 1.5s) so that gprestore will be interrupted at a
 				* different point in the backup process every time to help
 				* catch timing issues with the cleanup.
-				*/
+				 */
 				rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 				time.Sleep(time.Duration(rng.Intn(1000)+500) * time.Millisecond)
 				_ = cmd.Process.Signal(unix.SIGINT)
@@ -263,7 +262,7 @@ var _ = Describe("Signal handler tests", FlakeAttempts(3), func() {
 				* 1.0s and 1.5s) so that gpbackup will be interrupted at a
 				* different point in the backup process every time to help
 				* catch timing issues with the cleanup.
-				*/
+				 */
 				rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 				time.Sleep(time.Duration(rng.Intn(1000)+500) * time.Millisecond)
 				_ = cmd.Process.Signal(unix.SIGTERM)
@@ -394,7 +393,7 @@ var _ = Describe("Signal handler tests", FlakeAttempts(3), func() {
 				* 1.0s and 1.5s) so that gpbackup will be interrupted at a
 				* different point in the backup process every time to help
 				* catch timing issues with the cleanup.
-				*/
+				 */
 				rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 				time.Sleep(time.Duration(rng.Intn(1000)+500) * time.Millisecond)
 				_ = cmd.Process.Signal(unix.SIGTERM)
@@ -427,7 +426,7 @@ var _ = Describe("Signal handler tests", FlakeAttempts(3), func() {
 				* 1.0s and 1.5s) so that gprestore will be interrupted at a
 				* different point in the backup process every time to help
 				* catch timing issues with the cleanup.
-				*/
+				 */
 				rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 				time.Sleep(time.Duration(rng.Intn(1000)+500) * time.Millisecond)
 				_ = cmd.Process.Signal(unix.SIGTERM)
@@ -459,7 +458,7 @@ var _ = Describe("Signal handler tests", FlakeAttempts(3), func() {
 				* 1.0s and 1.5s) so that gprestore will be interrupted at a
 				* different point in the backup process every time to help
 				* catch timing issues with the cleanup.
-				*/
+				 */
 				rng := rand.New(rand.NewSource(time.Now().UnixNano()))
 				time.Sleep(time.Duration(rng.Intn(1000)+500) * time.Millisecond)
 				_ = cmd.Process.Signal(unix.SIGTERM)

--- a/integration/helper_test.go
+++ b/integration/helper_test.go
@@ -148,7 +148,7 @@ var _ = Describe("gpbackup_helper end to end integration tests", func() {
 			Expect(err).ToNot(HaveOccurred())
 			assertBackupArtifactsWithCompression("zstd", true)
 		})
-		It("Generates error file when backup agent interrupted", func() {
+		It("Generates error file when backup agent interrupted", FlakeAttempts(5), func() {
 			helperCmd := gpbackupHelper(gpbackupHelperPath, "--backup-agent", "--compression-level", "0", "--data-file", dataFileFullPath)
 			waitForPipeCreation()
 			err := helperCmd.Process.Signal(unix.SIGINT)


### PR DESCRIPTION
We've had issues with our concourse CI handling some of these tests poorly. Add some flake protection to help improve the signal to noise ratio on our tests.