### PR TITLE
Fix GP7 tests for gp_toolkit and statistics

### DIFF
--- a/integration/predata_acl_queries_test.go
+++ b/integration/predata_acl_queries_test.go
@@ -1014,7 +1014,12 @@ LANGUAGE SQL`)
 				uniqueID := testutils.UniqueIDFromObjectName(connectionPool, "", "plperl", backup.TYPE_EXTENSION)
 				resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_EXTENSION)
 
-				Expect(resultMetadataMap).To(HaveLen(1))
+				if connectionPool.Version.Before("7") {
+					Expect(resultMetadataMap).To(HaveLen(1))
+				} else {
+					// gp_toolkit is installed by default as an extension in GPDB7+
+					Expect(resultMetadataMap).To(HaveLen(2))
+				}
 				resultMetadata := resultMetadataMap[uniqueID]
 				structmatcher.ExpectStructsToMatch(&extensionMetadata, &resultMetadata)
 			})

--- a/integration/predata_functions_create_test.go
+++ b/integration/predata_functions_create_test.go
@@ -650,7 +650,12 @@ var _ = Describe("backup integration create statement tests", func() {
 			resultExtensions := backup.GetExtensions(connectionPool)
 			resultMetadataMap := backup.GetCommentsForObjectType(connectionPool, backup.TYPE_EXTENSION)
 			plperlExtension.Oid = testutils.OidFromObjectName(connectionPool, "", "plperl", backup.TYPE_EXTENSION)
-			Expect(resultExtensions).To(HaveLen(1))
+			if connectionPool.Version.Before("7") {
+				Expect(resultExtensions).To(HaveLen(1))
+			} else {
+				// gp_toolkit is installed by default as an extension in GPDB7+
+				Expect(resultExtensions).To(HaveLen(2))
+			}
 			plperlMetadata := resultMetadataMap[plperlExtension.GetUniqueID()]
 			structmatcher.ExpectStructsToMatch(&plperlExtension, &resultExtensions[0])
 			structmatcher.ExpectStructsToMatch(&extensionMetadata, &plperlMetadata)

--- a/integration/predata_functions_queries_test.go
+++ b/integration/predata_functions_queries_test.go
@@ -880,10 +880,19 @@ LANGUAGE SQL`)
 
 			results := backup.GetExtensions(connectionPool)
 
-			Expect(results).To(HaveLen(1))
+			if connectionPool.Version.Before("7") {
+				Expect(results).To(HaveLen(1))
+			} else {
+				// gp_toolkit is installed by default as an extension in GPDB7+
+				Expect(results).To(HaveLen(2))
+			}
 
 			plperlDef := backup.Extension{Oid: 0, Name: "plperl", Schema: "pg_catalog"}
-			structmatcher.ExpectStructsToMatchExcluding(&plperlDef, &results[0], "Oid")
+			for _, result := range results {
+				if result.Name == "plperl" {
+					structmatcher.ExpectStructsToMatchExcluding(&plperlDef, &results[0], "Oid")
+				}
+			}
 		})
 	})
 	Describe("GetProceduralLanguages", func() {

--- a/integration/statistics_queries_test.go
+++ b/integration/statistics_queries_test.go
@@ -22,6 +22,8 @@ var _ = Describe("backup integration tests", func() {
 		tableOid = testutils.OidFromObjectName(connectionPool, "public", "foo", backup.TYPE_RELATION)
 		testhelper.AssertQueryRuns(connectionPool, "INSERT INTO public.foo VALUES (1, 'a', 't')")
 		testhelper.AssertQueryRuns(connectionPool, "INSERT INTO public.foo VALUES (2, 'b', 'f')")
+		testhelper.AssertQueryRuns(connectionPool, "INSERT INTO public.foo VALUES (3, 'c', 't')")
+		testhelper.AssertQueryRuns(connectionPool, "INSERT INTO public.foo VALUES (4, 'd', 'f')")
 		testhelper.AssertQueryRuns(connectionPool, "ANALYZE public.foo")
 	})
 	AfterEach(func() {
@@ -43,22 +45,22 @@ var _ = Describe("backup integration tests", func() {
 			 */
 			expectedStats4I := backup.AttributeStatistic{Oid: tableOid, Schema: "public", Table: "foo", AttName: "i",
 				Type: "int4", Relid: tableOid, AttNumber: 1, Width: 4, Distinct: -1, Kind1: 1, Kind2: 0, Operator1: 96,
-				Operator2: 0, Numbers1: []string{"0.5", "0.5"}, Values1: []string{"1", "2"}}
+				Operator2: 0, Numbers1: []string{"0.5", "0.5"}, Values1: []string{"1", "2", "3", "4"}}
 			expectedStats4J := backup.AttributeStatistic{Oid: tableOid, Schema: "public", Table: "foo", AttName: "j",
 				Type: "text", Relid: tableOid, AttNumber: 2, Width: 2, Distinct: -1, Kind1: 1, Kind2: 0, Operator1: 98,
-				Operator2: 0, Numbers1: []string{"0.5", "0.5"}, Values1: []string{"a", "b"}}
+				Operator2: 0, Numbers1: []string{"0.5", "0.5"}, Values1: []string{"a", "b", "c", "d"}}
 			expectedStats4K := backup.AttributeStatistic{Oid: tableOid, Schema: "public", Table: "foo", AttName: "k",
 				Type: "bool", Relid: tableOid, AttNumber: 3, Width: 1, Distinct: 2, Kind1: 1, Kind2: 0, Operator1: 91,
 				Operator2: 0, Numbers1: []string{"0.5", "0.5"}, Values1: []string{"f", "t"}}
 			expectedStats5I := backup.AttributeStatistic{Oid: tableOid, Schema: "public", Table: "foo", AttName: "i",
 				Type: "int4", Relid: tableOid, AttNumber: 1, Inherit: false, Width: 4, Distinct: -1, Kind1: 2, Kind2: 3, Operator1: 97,
-				Operator2: 97, Numbers2: []string{"1"}, Values1: []string{"1", "2"}}
+				Operator2: 97, Numbers2: []string{"1"}, Values1: []string{"1", "2", "3", "4"}}
 			expectedStats5J := backup.AttributeStatistic{Oid: tableOid, Schema: "public", Table: "foo", AttName: "j",
 				Type: "text", Relid: tableOid, AttNumber: 2, Inherit: false, Width: 2, Distinct: -1, Kind1: 2, Kind2: 3, Operator1: 664,
-				Operator2: 664, Numbers2: []string{"1"}, Values1: []string{"a", "b"}}
+				Operator2: 664, Numbers2: []string{"1"}, Values1: []string{"a", "b", "c", "d"}}
 			expectedStats5K := backup.AttributeStatistic{Oid: tableOid, Schema: "public", Table: "foo", AttName: "k",
-				Type: "bool", Relid: tableOid, AttNumber: 3, Inherit: false, Width: 1, Distinct: -1, Kind1: 2, Kind2: 3, Operator1: 58,
-				Operator2: 58, Numbers2: []string{"-1"}, Values1: []string{"f", "t"}}
+				Type: "bool", Relid: tableOid, AttNumber: 3, Inherit: false, Width: 1, Distinct: -0.5, Kind1: 1, Kind2: 3, Operator1: 91,
+				Operator2: 58, Numbers1: []string{"0.5", "0.5"}, Numbers2: []string{"0.5"}, Values1: []string{"f", "t"}}
 			if connectionPool.Version.AtLeast("7") {
 				expectedStats5J.Collation1 = 100
 				expectedStats5J.Collation2 = 100
@@ -86,7 +88,7 @@ var _ = Describe("backup integration tests", func() {
 			tableTupleStats := tupleStats[tableOid]
 
 			// Tuple statistics will not vary by GPDB version. Relpages may vary based on the hardware.
-			expectedStats := backup.TupleStatistic{Oid: tableOid, Schema: "public", Table: "foo", RelTuples: 2}
+			expectedStats := backup.TupleStatistic{Oid: tableOid, Schema: "public", Table: "foo", RelTuples: 4}
 
 			structmatcher.ExpectStructsToMatchExcluding(&expectedStats, &tableTupleStats, "RelPages")
 		})


### PR DESCRIPTION
gp_toolkit is now installed by default. Also ANALYZE wasn't generating stats for all values in GP7 so add a few more rows to get it to populate and adjust tests as needed.

Pipeline here: https://dp.ci.gpdb.pivotal.io/teams/main/pipelines/dev:gpbackup_gp7_toolkit