### PR TITLE
Don't fail if unable to write a restore report

### DIFF
--- a/report/report.go
+++ b/report/report.go
@@ -177,7 +177,7 @@ func (report *Report) WriteBackupReportFile(reportFilename string, timestamp str
 func WriteRestoreReportFile(reportFilename string, backupTimestamp string, startTimestamp string, connectionPool *dbconn.DBConn, restoreVersion string, origSize int, destSize int, errMsg string) {
 	reportFile, err := iohelper.OpenFileForWriting(reportFilename)
 	if err != nil {
-		gplog.Error("Unable to open restore report file %s", reportFilename)
+		gplog.Warn("Unable to open restore report file %s, skipping report creation", reportFilename)
 		return
 	}
 

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -303,6 +303,17 @@ duration:                4:03:01
 
 restore status:          Success but non-fatal errors occurred. See log file .+ for details.`))
 		})
+		It("warns if the report file cannot be written", func() {
+			operating.System.OpenFileWrite = func(name string, flag int, perm os.FileMode) (io.WriteCloser, error) {
+				// Normally no handle would be returned on error, we return buffer here so we can check that it isn't used
+				return buffer, errors.New("Cannot access /tmp/backup-dir: Permission denied")
+			}
+			report.WriteRestoreReportFile("filename", timestamp, restoreStartTime, connectionPool, restoreVersion, 3, 3, "")
+			Expect(stdout).To(Say("skipping report creation"))
+			Expect(buffer).ToNot(Say("Greenplum Database Restore Report"))
+			Expect(gplog.GetErrorCode()).To(Equal(0))
+
+		})
 	})
 	Describe("SetBackupParamFromFlags", func() {
 		AfterEach(func() {


### PR DESCRIPTION
In a scenario where a user is restoring a backup in a read-only backup directory, gprestore will currently fail at the end because it cannot write the restore report file to that directory.  This is a legitimate use case, so we should treat this as a warning rather than an error.