### PR TITLE
Correctly restore tables with inherited generated columns

### DIFF
--- a/backup/predata_relations.go
+++ b/backup/predata_relations.go
@@ -207,7 +207,12 @@ func printColumnDefinitions(metadataFile *utils.FileWithByteCount, columnDefs []
 		}
 		if column.HasDefault {
 			if column.AttGenerated != "" {
-				line += fmt.Sprintf(" GENERATED ALWAYS AS %s %s", column.DefaultVal, column.AttGenerated)
+				// Unlike most keywords, GENERATED cannot be applied to a column that inherits from a parent table,
+				// even if the specified generation expression is identical to that of the column it inherits,
+				// so we skip printing it in that case.
+				if !column.IsInherited {
+					line += fmt.Sprintf(" GENERATED ALWAYS AS %s %s", column.DefaultVal, column.AttGenerated)
+				}
 			} else {
 				line += fmt.Sprintf(" DEFAULT %s", column.DefaultVal)
 			}


### PR DESCRIPTION
In GPDB 7, if a table has a generated column and another table inherits that table, the child table cannot use the GENERATED keyword to define a default for that column (whether or not it matches that of the parent's corresponding column) or GPDB will refuse to create the table.

Thus, when backing up such child tables, we need to omit the GENERATED statement from the definition of any attributes inherited from another table.