### PR TITLE
Update scale perf CI

### DIFF
--- a/ci/scale/scale_pipeline.yml
+++ b/ci/scale/scale_pipeline.yml
@@ -1,11 +1,10 @@
 # USAGE: fly -t dp set-pipeline  -p scale_test_refactor -c ~/workspace/gpbackup/ci/scale/scale_pipeline.yml -v gpbackup-git-branch=BRANCH_NAME
 ---
 groups:
-- name: Scale
+- name: scale
   jobs:
-  - build_binaries
-  - build_gppkgs
-  - scale-test
+  - load-data-gpdb6
+  - scale-perf-tests-gpdb6
 
 resource_types:
 - name: terraform
@@ -40,22 +39,10 @@ resource_types:
 
 resources:
 ##### Docker Images #####
-- name: centos6-image
+- name: rocky8-gpdb7-image
   type: registry-image
   source:
-    repository: gcr.io/data-gpdb-public-images/gpdb5-centos6-build-test
-    tag: latest
-  
-- name: centos7-image
-  type: registry-image
-  source:
-    repository: gcr.io/data-gpdb-public-images/gpdb5-centos7-build-test
-    tag: latest
-
-- name: gpdb7-centos7-image
-  type: registry-image
-  source:
-    repository: gcr.io/data-gpdb-public-images/gpdb7-centos7-build
+    repository: gcr.io/data-gpdb-public-images/gpdb7-rocky8-test
     tag: latest
 
 ##### Source Code ####
@@ -73,28 +60,13 @@ resources:
     uri: https://github.com/greenplum-db/gpdb
     branch: 6X_STABLE
 
-- name: gpbackup_manager_src
+- name: ccp_src
   type: git
   icon: github-circle
   source:
-    branch: main
-    private_key: ((dp/dev/gp-backup-manager-remote-deploy-key))
-    uri: ((dp/gp-backup-manager-git-remote))
-
-- name: gpbackup_s3_plugin
-  type: git
-  icon: github-circle
-  source:
-    branch: ((dp/dev/gpbackup-s3-plugin-git-branch))
-    uri: https://github.com/greenplum-db/gpbackup-s3-plugin
-
-- name: gpbackup_ddboost_plugin
-  type: git
-  icon: github-circle
-  source:
-    branch: ((dp/gpbackup-ddboost-plugin-branch)) 
-    private_key: ((dp/gpbackup-ddboost-plugin-remote-key))
-    uri: ((dp/gpbackup-ddboost-plugin-git-remote))
+    branch: ((dp/ccp-git-branch))
+    private_key: ((gp-concourse-cluster-provisioner-git-key))
+    uri: ((dp/ccp-git-remote))
 
 #### Binaries ####
 - name: bin_gpdb_6x_stable_centos7
@@ -134,51 +106,20 @@ resources:
     url: ((dp/webhook_url))
     disable: false
 
-- name: gpbackup-go-components
-  type: s3
-  icon: amazon
-  source:
-    access_key_id: ((aws-bucket-access-key-id))
-    bucket: ((dp/dev/gpdb-stable-bucket-name))
-    region_name: ((dp/aws-region))
-    secret_access_key: ((aws-bucket-secret-access-key))
-    versioned_file: gpbackup-go-components/go_components.tar.gz
-
 - name: gppkgs
-  type: s3
-  icon: amazon
-  source:
-    access_key_id: ((aws-bucket-access-key-id))
-    bucket: ((dp/dev/gpdb-stable-bucket-name))
-    region_name: ((dp/aws-region))
-    secret_access_key: ((aws-bucket-secret-access-key))
-    versioned_file: gppkgs/intermediates/gpbackup-gppkgs.tar.gz
-
-- name: gpbackup-release-license
   type: gcs
   icon: google
   source:
-    bucket: gpbackup-release-licenses
+    bucket: ((dp/dev/gcs-ci-bucket))
     json_key: ((dp/dev/gcp_svc_acct_key))
-    regexp: open_source_license_VMware_Greenplum_Backup_and_Restore_(.*)_.*.txt
+    versioned_file: gpbackup/intermediates/gpbackup-gppkgs.tar.gz
 
-- name: pivnet_release_cache
-  type: s3
-  icon: amazon
+- name: cluster-metadata
+  type: gcs
   source:
-    access_key_id: ((aws-bucket-access-key-id))
-    bucket: ((dp/dev/pivnet_bucket_name))
-    region_name: ((dp/aws-region))
-    secret_access_key: ((aws-bucket-secret-access-key))
-    regexp: pivnet_release_version/v-(.*)
-
-- name: ccp_src
-  type: git
-  icon: github-circle
-  source:
-    branch: ((dp/ccp-git-branch))
-    private_key: ((gp-concourse-cluster-provisioner-git-key))
-    uri: ((dp/ccp-git-remote))
+    bucket: ((dp/dev/gcs-ci-bucket))
+    json_key: ((dp/dev/gcp_svc_acct_key))
+    versioned_file: gpbackup/intermediates/cluster-metadata.tar.gz
 
 - name: terraform.d
   type: s3
@@ -288,7 +229,7 @@ anchors:
   params:
     text: |
       [gpbackup/$BUILD_JOB_NAME] failed:
-      https://prod.ci.gpdb.pivotal.io/teams/main/pipelines/gpbackup/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
+      https://dp.ci.gpdb.pivotal.io/teams/main/pipelines/scale_test_refactor/jobs/$BUILD_JOB_NAME/builds/$BUILD_NAME
 
 ## ======================================================================
 ##    _       _
@@ -300,84 +241,19 @@ anchors:
 ## ======================================================================
 
 jobs:
-- name: build_binaries
-  plan:
-  - in_parallel:
-    - get: gpbackup_s3_plugin
-      trigger: true
-    - get: gpbackup_manager_src
-      trigger: true
-    - get: gpbackup
-      trigger: true
-    - get: pivnet_release_cache
-  - task: build-go-binaries
-    file: gpbackup/ci/tasks/build-go-binaries.yml
-  - put: gpbackup-go-components
-    params:
-      file: go_components/go_components.tar.gz
-  
-- name: build_gppkgs
-  plan:
-  - in_parallel:
-    - get: centos7-image
-    - get: gpdb_src
-      resource: gpdb6_src
-    - get: gpbackup-go-components
-      trigger: true
-      passed: [build_binaries]
-    - get: bin_gpdb_6x_stable_centos7
-    - get: gpbackup
-      passed: [build_binaries]
-    - get: gpbackup_ddboost_plugin
-      trigger: true
-    - get: pivnet_release_cache
-    - get: gpbackup-release-license
-  - task: gpbackup-tools-versions
-    image: centos7-image
-    file: gpbackup/ci/tasks/gpbackup-tools-versions.yml
-  - in_parallel:
-    - do: # RHEL
-      - task: build-ddboost-RHEL
-        image: centos7-image
-        file: gpbackup/ci/tasks/build-ddboost.yml
-        input_mapping:
-          bin_gpdb: bin_gpdb_6x_stable_centos7
-      - task: tar-binaries-RHEL
-        image: centos7-image
-        file: gpbackup/ci/tasks/build-os-tars.yml
-      - task: build_gppkgs-RHEL
-        image: centos7-image
-        file: gpbackup/ci/tasks/build-gppkg.yml
-        input_mapping:
-          bin_gpdb: bin_gpdb_6x_stable_centos7
-        output_mapping:
-          gppkgs: rhel-gppkg
-        params:
-          OS: RHEL
-  - task: tar-gppkgs
-    image: centos7-image
-    file: gpbackup/ci/tasks/tar-gppkgs.yml
-  - put: gppkgs
-    params:
-      file: gppkgs/gpbackup-gppkgs.tar.gz
-
-- name: scale-test
+- name: load-data-gpdb6
   plan:
   - in_parallel:
     - get: weekly-trigger
       trigger: true
-    - get: centos6-image
-    - get: centos7-image
-    - get: gpdb7-centos7-image
+    - get: rocky8-gpdb7-image
     - get: gpbackup
-      passed: [build_gppkgs]
     - get: gpdb_binary
       resource: bin_gpdb_6x_stable_centos7
-    - get: ccp_src
     - get: gpdb_src
       resource: gpdb6_src
     - get: gppkgs
-      passed: [build_gppkgs]
+    - get: ccp_src
     - get: terraform.d
       params:
         unpack: true
@@ -399,10 +275,35 @@ jobs:
   - task: gpinitsystem
     file: ccp_src/ci/tasks/gpinitsystem.yml
   - task: setup-centos-env
-    image: centos6-image
+    image: rocky8-gpdb7-image
     file: gpbackup/ci/tasks/setup-centos-env.yml
+  - task: scale-perf-load
+    image: rocky8-gpdb7-image
+    file: gpbackup/ci/tasks/scale-perf-load.yml
+    params:
+      GOOGLE_CREDENTIALS: ((dp/dev/google-service-account-key))
+    on_failure:
+      *slack_alert
+  - put: cluster-metadata
+    params:
+      file: cluster-metadata/cluster-metadata.tar.gz
+
+- name: scale-perf-tests-gpdb6
+  plan:
+  - in_parallel:
+    - get: cluster-metadata
+      passed: ['load-data-gpdb6']
+      trigger: true
+    - get: rocky8-gpdb7-image
+    - get: gpbackup
+    - get: gpdb_binary
+      resource: bin_gpdb_6x_stable_centos7
+    - get: gpdb_src
+      resource: gpdb6_src
+    - get: gppkgs
+    - get: ccp_src
   - task: scale-perf-tests
-    image: centos6-image
+    image: rocky8-gpdb7-image
     file: gpbackup/ci/tasks/scale-perf-tests.yml
     params:
       RESULTS_LOG_FILE: /tmp/gpbackup.log
@@ -410,19 +311,14 @@ jobs:
       RESULTS_DATABASE_USER: postgres
       RESULTS_DATABASE_NAME: gpbackup_refdb
       RESULTS_DATABASE_PASSWORD: ((dp/dev/gcp_refdb_admin_password))
-      GOOGLE_CREDENTIALS: ((dp/dev/google-service-account-key))
-      GOOGLE_PROJECT_ID: ((dp/dev/google-project-id))
-      GOOGLE_ZONE: ((dp/dev/google-zone))
-      GOOGLE_SERVICE_ACCOUNT: ((dp/dev/google-service-account))
-      BUCKET_NAME: ((dp/dev/scale_test_bucket))
     on_failure:
       *slack_alert
   - task: scale-test-slack-notify
-    image: gpdb7-centos7-image
+    image: rocky8-gpdb7-image
     file: gpbackup/ci/tasks/scale-tests-slack-notify.yml
     params:
       RESULTS_DATABASE_HOST: 10.122.32.4
       RESULTS_DATABASE_USER: postgres
       RESULTS_DATABASE_NAME: gpbackup_refdb
       SLACK_WEBHOOK_URL: ((dp/webhook_url))
-      RESULTS_DATABASE_PASSWORD: ((dp/dev/gcp_refdb_admin_password))
+ 

--- a/ci/scripts/scale-perf-load.bash
+++ b/ci/scripts/scale-perf-load.bash
@@ -1,0 +1,81 @@
+#!/bin/bash
+
+set -ex
+
+# setup cluster and load necessary tools and data to it
+ccp_src/scripts/setup_ssh_to_cluster.sh
+out=$(ssh -t cdw 'source env.sh && psql postgres -c "select version();"')
+GPDB_VERSION=$(echo ${out} | sed -n 's/.*Greenplum Database \([0-9]\).*/\1/p')
+mkdir -p /tmp/untarred
+tar -xzf gppkgs/gpbackup-gppkgs.tar.gz -C /tmp/untarred
+scp /tmp/untarred/gpbackup_tools*gp${GPDB_VERSION}*${OS}*.gppkg cdw:/home/gpadmin
+scp gpbackup/ci/scripts/analyze_run.py cdw:/home/gpadmin/analyze_run.py
+scp gpbackup/ci/scale/sql/scaletestdb_bigschema_ddl.sql cdw:/home/gpadmin/scaletestdb_bigschema_ddl.sql
+scp gpbackup/ci/scale/sql/scaletestdb_wideschema_ddl.sql cdw:/home/gpadmin/scaletestdb_wideschema_ddl.sql
+scp gpbackup/ci/scale/sql/etl_job.sql cdw:/home/gpadmin/etl_job.sql
+scp gpbackup/ci/scale/sql/pull_rowcount.sql cdw:/home/gpadmin/pull_rowcount.sql
+scp gpbackup/ci/scale/sql/valid_metadata.sql cdw:/home/gpadmin/valid_metadata.sql
+scp -r gpbackup/ci/scale/gpload_yaml cdw:/home/gpadmin/gpload_yaml
+
+set +x
+printf "%s" "${GOOGLE_CREDENTIALS}" > "/tmp/keyfile.json"
+set -x
+
+scp /tmp/keyfile.json cdw:/home/gpadmin/keyfile.json && rm -f /tmp/keyfile.json
+
+cat <<SCRIPT > /tmp/load_data.bash
+#!/bin/bash
+source env.sh
+
+# set GCS credentials and mount gcs bucket with gcsfuse
+export GOOGLE_APPLICATION_CREDENTIALS=/home/gpadmin/keyfile.json
+gcloud auth activate-service-account --key-file=/home/gpadmin/keyfile.json
+rm -rf /home/gpadmin/bucket && mkdir /home/gpadmin/bucket
+gcsfuse --implicit-dirs dp-gpbackup-scale-test-data /home/gpadmin/bucket
+
+# Double the vmem protect limit default on the coordinator segment to
+# prevent query cancels on large table creations (e.g. scale_db1.sql)
+gpconfig -c gp_vmem_protect_limit -v 16384 --masteronly
+gpconfig -c client_min_messages -v error
+gpstop -air
+
+# only install if not installed already
+is_installed_output=\$(source env.sh; gppkg -q gpbackup*gp*.gppkg)
+set +e
+echo \$is_installed_output | grep 'is installed'
+if [ \$? -ne 0 ] ; then
+  set -e
+  gppkg -i gpbackup*gp*.gppkg
+fi
+set -e
+
+### Data scale tests ###
+echo "## Loading data into database for scale tests ##"
+createdb scaletestdb
+psql -d scaletestdb -q -f scaletestdb_bigschema_ddl.sql
+gpload -f /home/gpadmin/gpload_yaml/customer.yml
+gpload -f /home/gpadmin/gpload_yaml/lineitem.yml
+gpload -f /home/gpadmin/gpload_yaml/orders.yml
+gpload -f /home/gpadmin/gpload_yaml/orders_2.yml
+gpload -f /home/gpadmin/gpload_yaml/orders_3.yml
+gpload -f /home/gpadmin/gpload_yaml/nation.yml
+gpload -f /home/gpadmin/gpload_yaml/part.yml
+gpload -f /home/gpadmin/gpload_yaml/partsupp.yml
+gpload -f /home/gpadmin/gpload_yaml/region.yml
+gpload -f /home/gpadmin/gpload_yaml/supplier.yml
+
+# clean out credentials after data is loaded
+rm -f /home/gpadmin/keyfile.json
+
+# unmount bucket before exiting
+fusermount -u /home/gpadmin/bucket
+
+SCRIPT
+
+# tar up files for this cluster so that later jobs can connect to it
+tar -czf cluster-metadata/cluster-metadata.tar.gz cluster_env_files/
+
+chmod +x /tmp/load_data.bash
+scp /tmp/load_data.bash cdw:/home/gpadmin/load_data.bash
+ssh -t cdw "/home/gpadmin/load_data.bash"
+

--- a/ci/scripts/scale-perf-tests.bash
+++ b/ci/scripts/scale-perf-tests.bash
@@ -2,26 +2,9 @@
 
 set -ex
 
-# setup cluster and install gpbackup tools using gppkg
+# retrieve cluster set up by previous job, and set up SSH to it
+tar -xvf "cluster-metadata/cluster-metadata.tar.gz"
 ccp_src/scripts/setup_ssh_to_cluster.sh
-out=$(ssh -t cdw 'source env.sh && psql postgres -c "select version();"')
-GPDB_VERSION=$(echo ${out} | sed -n 's/.*Greenplum Database \([0-9]\).*/\1/p')
-mkdir -p /tmp/untarred
-tar -xzf gppkgs/gpbackup-gppkgs.tar.gz -C /tmp/untarred
-scp /tmp/untarred/gpbackup_tools*gp${GPDB_VERSION}*${OS}*.gppkg cdw:/home/gpadmin
-scp gpbackup/ci/scripts/analyze_run.py cdw:/home/gpadmin/analyze_run.py
-scp gpbackup/ci/scale/sql/scaletestdb_bigschema_ddl.sql cdw:/home/gpadmin/scaletestdb_bigschema_ddl.sql
-scp gpbackup/ci/scale/sql/scaletestdb_wideschema_ddl.sql cdw:/home/gpadmin/scaletestdb_wideschema_ddl.sql
-scp gpbackup/ci/scale/sql/etl_job.sql cdw:/home/gpadmin/etl_job.sql
-scp gpbackup/ci/scale/sql/pull_rowcount.sql cdw:/home/gpadmin/pull_rowcount.sql
-scp gpbackup/ci/scale/sql/valid_metadata.sql cdw:/home/gpadmin/valid_metadata.sql
-scp -r gpbackup/ci/scale/gpload_yaml cdw:/home/gpadmin/gpload_yaml
-
-set +x
-printf "%s" "${GOOGLE_CREDENTIALS}" > "/tmp/keyfile.json"
-set -x
-
-scp /tmp/keyfile.json cdw:/home/gpadmin/keyfile.json && rm -f /tmp/keyfile.json
 
 cat <<SCRIPT > /tmp/run_tests.bash
 #!/bin/bash
@@ -37,56 +20,14 @@ export RESULTS_DATABASE_USER=${RESULTS_DATABASE_USER}
 export RESULTS_DATABASE_NAME=${RESULTS_DATABASE_NAME}
 export RESULTS_DATABASE_PASSWORD=${RESULTS_DATABASE_PASSWORD}
 
-# set GCS credentials and mount gcs bucket with gcsfuse
-export GOOGLE_APPLICATION_CREDENTIALS=/home/gpadmin/keyfile.json
-gcloud auth activate-service-account --key-file=/home/gpadmin/keyfile.json
-rm -rf /home/gpadmin/bucket && mkdir /home/gpadmin/bucket
-gcsfuse --implicit-dirs dp-gpbackup-scale-test-data /home/gpadmin/bucket
-
-
-# Double the vmem protect limit default on the coordinator segment to
-# prevent query cancels on large table creations (e.g. scale_db1.sql)
-gpconfig -c gp_vmem_protect_limit -v 16384 --masteronly
-gpconfig -c client_min_messages -v error
-gpstop -air
-
-# only install if not installed already
-is_installed_output=\$(source env.sh; gppkg -q gpbackup*gp*.gppkg)
-set +e
-echo \$is_installed_output | grep 'is installed'
-if [ \$? -ne 0 ] ; then
-  set -e
-  gppkg -i gpbackup*gp*.gppkg
-fi
-set -e
-
 # capture installed versions for later storage in run stats
 gpstart --version > /home/gpadmin/gpversion.txt
 gpbackup --version > /home/gpadmin/gpbversion.txt
 export GPDB_VERSION=\$(cat /home/gpadmin/gpversion.txt)
 export GPB_VERSION=\$(cat /home/gpadmin/gpbversion.txt)
 
-### Data scale tests ###
-echo "## Loading data into database for scale tests ##"
-createdb scaletestdb
-psql -d scaletestdb -q -f scaletestdb_bigschema_ddl.sql
-gpload -f /home/gpadmin/gpload_yaml/customer.yml
-gpload -f /home/gpadmin/gpload_yaml/lineitem.yml
-gpload -f /home/gpadmin/gpload_yaml/orders.yml
-gpload -f /home/gpadmin/gpload_yaml/orders_2.yml
-gpload -f /home/gpadmin/gpload_yaml/orders_3.yml
-gpload -f /home/gpadmin/gpload_yaml/nation.yml
-gpload -f /home/gpadmin/gpload_yaml/part.yml
-gpload -f /home/gpadmin/gpload_yaml/partsupp.yml
-gpload -f /home/gpadmin/gpload_yaml/region.yml
-gpload -f /home/gpadmin/gpload_yaml/supplier.yml
-
-# clean out credentials after data is loaded
-rm -f /home/gpadmin/keyfile.json
-
 echo "## Capturing row counts for comparison ##"
 psql -d scaletestdb -f /home/gpadmin/pull_rowcount.sql -o /home/gpadmin/rowcounts_orig.txt
-
 
 #####################################################################
 ##################################################################### 
@@ -114,7 +55,6 @@ ROWCOUNTS_DIFF=\$(diff -w /home/gpadmin/rowcounts_orig.txt /home/gpadmin/rowcoun
 if [ "\$ROWCOUNTS_DIFF" != "" ] 
 then
   echo "Failed result from gpr_single_data_file_copy_q8 -- mismatched row counts.  Exiting early with failure code."
-  fusermount -u /home/gpadmin/bucket
   exit 1
 fi
 
@@ -153,7 +93,6 @@ ROWCOUNTS_DIFF=\$(diff -w /home/gpadmin/rowcounts_orig.txt /home/gpadmin/rowcoun
 if [ "\$ROWCOUNTS_DIFF" != "" ] 
 then
   echo "Failed result from gpr_scale_multi_data_file -- mismatched row counts.  Exiting early with failure code."
-  fusermount -u /home/gpadmin/bucket
   exit 1
 fi
 
@@ -192,7 +131,6 @@ ROWCOUNTS_DIFF=\$(diff -w /home/gpadmin/rowcounts_orig.txt /home/gpadmin/rowcoun
 if [ "\$ROWCOUNTS_DIFF" != "" ] 
 then
   echo "Failed result from gpr_scale_multi_data_file_zstd -- mismatched row counts.  Exiting early with failure code."
-  fusermount -u /home/gpadmin/bucket
   exit 1
 fi
 
@@ -231,7 +169,6 @@ ROWCOUNTS_DIFF=\$(diff -w /home/gpadmin/rowcounts_orig.txt /home/gpadmin/rowcoun
 if [ "\$ROWCOUNTS_DIFF" != "" ] 
 then
   echo "Failed result from gpr_scale_single_data_file -- mismatched row counts.  Exiting early with failure code."
-  fusermount -u /home/gpadmin/bucket
   exit 1
 fi
 
@@ -270,7 +207,6 @@ ROWCOUNTS_DIFF=\$(diff -w /home/gpadmin/rowcounts_orig.txt /home/gpadmin/rowcoun
 if [ "\$ROWCOUNTS_DIFF" != "" ] 
 then
   echo "Failed result from gpr_scale_single_data_file_zstd -- mismatched row counts.  Exiting early with failure code."
-  fusermount -u /home/gpadmin/bucket
   exit 1
 fi
 
@@ -359,7 +295,6 @@ ROWCOUNTS_DIFF=\$(diff -w /home/gpadmin/rowcounts_orig.txt /home/gpadmin/rowcoun
 if [ "\$ROWCOUNTS_DIFF" != "" ] 
 then
   echo "Failed result from gpr_distr_snap_edit_data -- mismatched row counts.  Exiting early with failure code."
-  fusermount -u /home/gpadmin/bucket
   exit 1
 fi
 
@@ -441,7 +376,6 @@ ROWCOUNTS_DIFF=\$(diff -w /home/gpadmin/rowcounts_orig.txt /home/gpadmin/rowcoun
 if [ "\$ROWCOUNTS_DIFF" != "" ] 
 then
   echo "Failed result from gpb_distr_snap_high_conc -- mismatched row counts.  Exiting early with failure code."
-  fusermount -u /home/gpadmin/bucket
   exit 1
 fi
 
@@ -477,7 +411,6 @@ echo "got past metadata diff"
 if [ "\$METADATA_DIFF" != "" ] 
 then
   echo "Failed result from gpb_scale_metadata -- mismatched metadata output.  Exiting early with failure code."
-  fusermount -u /home/gpadmin/bucket
   exit 1
 fi
 
@@ -503,7 +436,6 @@ METADATA_DIFF=\$(diff -w /home/gpadmin/valid_metadata.sql \$test_metadata)
 if [ "\$METADATA_DIFF" != "" ] 
 then
   echo "Failed result from gpr_scale_metadata -- mismatched metadata output.  Exiting early with failure code."
-  fusermount -u /home/gpadmin/bucket
   exit 1
 fi
 
@@ -515,9 +447,6 @@ yes y | gpbackup_manager delete-backup "\$timestamp"
 #####################################################################
 #####################################################################
 
-
-# if successful run, unmount bucket before exiting
-# fusermount -u /home/gpadmin/bucket
 SCRIPT
 
 chmod +x /tmp/run_tests.bash

--- a/ci/scripts/scale-test-slack-notify.bash
+++ b/ci/scripts/scale-test-slack-notify.bash
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -x
+set -euo pipefail
+
+yum install -y postgresql-devel
+pip3 install psycopg2-binary
+pip3 install slack-sdk
+
+python3 gpbackup/ci/scripts/scale-test-slack-notify.py

--- a/ci/scripts/scale-test-slack-notify.py
+++ b/ci/scripts/scale-test-slack-notify.py
@@ -83,10 +83,15 @@ def send_slack_notification(unreported_failures):
 
 def main():
     try:
+        print("Examining runtime database to report test failures")
         unreported_failures = get_unreported_failures()
         if unreported_failures:
+            print("Reporting test failures")
             send_slack_notification(unreported_failures)
             update_unreported_failures()
+        else:
+            print("No test failures found to report")
+
     except Exception as e:
         print("Python script errored: {}".format(e))
         return

--- a/ci/scripts/scale_test_slack_notify.bash
+++ b/ci/scripts/scale_test_slack_notify.bash
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -x
-set -euo pipefail
-
-yum install -y postgresql-devel python-dev
-pip3 install psycopg2-binary
-pip3 install slack-sdk
-
-python3 gpbackup/ci/scripts/scale_test_slack_notify.py

--- a/ci/tasks/scale-perf-load.yml
+++ b/ci/tasks/scale-perf-load.yml
@@ -1,0 +1,20 @@
+platform: linux
+
+image_resource:
+  type: registry-image
+
+inputs:
+- name: gpbackup
+- name: ccp_src
+- name: cluster_env_files
+- name: gppkgs
+
+outputs:
+- name: cluster-metadata
+
+params:
+  GOOGLE_CREDENTIALS:
+  OS: RHEL
+
+run:
+  path: gpbackup/ci/scripts/scale-perf-load.bash

--- a/ci/tasks/scale-perf-tests.yml
+++ b/ci/tasks/scale-perf-tests.yml
@@ -6,8 +6,8 @@ image_resource:
 inputs:
 - name: gpbackup
 - name: ccp_src
-- name: cluster_env_files
 - name: gppkgs
+- name: cluster-metadata
 
 params:
   RESULTS_LOG_FILE:
@@ -15,12 +15,7 @@ params:
   RESULTS_DATABASE_USER:
   RESULTS_DATABASE_NAME:
   RESULTS_DATABASE_PASSWORD:
-  GOOGLE_CREDENTIALS:
-  GOOGLE_PROJECT_ID:
-  GOOGLE_ZONE:
-  GOOGLE_SERVICE_ACCOUNT:
-  BUCKET_NAME:
   OS: RHEL
 
 run:
-  path: gpbackup/ci/scripts/scale_perf_tests.bash
+  path: gpbackup/ci/scripts/scale-perf-tests.bash

--- a/ci/tasks/scale-tests-slack-notify.yml
+++ b/ci/tasks/scale-tests-slack-notify.yml
@@ -14,4 +14,4 @@ params:
   SLACK_WEBHOOK_URL:
 
 run:
-  path: gpbackup/ci/scripts/scale_test_slack_notify.bash
+  path: gpbackup/ci/scripts/scale-test-slack-notify.bash


### PR DESCRIPTION
Our scale perf CI was using some outdated resources, and had some room to be cleaned up and optimized.

This commit:
* removes unnecessary build and package steps from this pipeline
* updates the gppkgs location so we're testing on latest builds
* updates the docker containers being used to maintained ones
* splits the data load and test run into separate jobs so that tests can be re-run without needing to re-load the data