### PR TITLE
Enhancements to backup directory functionality

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -66,10 +66,9 @@ func DoSetup() {
 
 	segConfig := cluster.MustGetSegmentConfiguration(clusterConfigConn)
 	globalCluster = cluster.NewCluster(segConfig)
-	segPrefix := filepath.GetSegPrefix(clusterConfigConn)
 	clusterConfigConn.Close()
 
-	globalFPInfo = filepath.NewFilePathInfo(globalCluster, MustGetFlagString(options.BACKUP_DIR), timestamp, segPrefix)
+	globalFPInfo = filepath.NewFilePathInfo(globalCluster, MustGetFlagString(options.BACKUP_DIR), timestamp, "")
 	if MustGetFlagBool(options.METADATA_ONLY) {
 		_, err = globalCluster.ExecuteLocalCommand(fmt.Sprintf("mkdir -p %s", globalFPInfo.GetDirForContent(-1)))
 		gplog.FatalOnError(err)
@@ -112,8 +111,7 @@ func DoBackup() {
 	var targetBackupFPInfo filepath.FilePathInfo
 	if MustGetFlagBool(options.INCREMENTAL) {
 		targetBackupTimestamp = GetTargetBackupTimestamp()
-		targetBackupFPInfo = filepath.NewFilePathInfo(globalCluster, globalFPInfo.UserSpecifiedBackupDir,
-			targetBackupTimestamp, globalFPInfo.UserSpecifiedSegPrefix)
+		targetBackupFPInfo = filepath.NewFilePathInfo(globalCluster, globalFPInfo.UserSpecifiedBackupDir, targetBackupTimestamp, "")
 
 		if pluginConfigFlag != "" {
 			// These files need to be downloaded from the remote system into the local filesystem

--- a/backup/validate.go
+++ b/backup/validate.go
@@ -137,8 +137,7 @@ func validateFlagValues() {
 }
 
 func validateFromTimestamp(fromTimestamp string) {
-	fromTimestampFPInfo := filepath.NewFilePathInfo(globalCluster, globalFPInfo.UserSpecifiedBackupDir,
-		fromTimestamp, globalFPInfo.UserSpecifiedSegPrefix)
+	fromTimestampFPInfo := filepath.NewFilePathInfo(globalCluster, globalFPInfo.UserSpecifiedBackupDir, fromTimestamp, "")
 	if MustGetFlagString(options.PLUGIN_CONFIG) != "" {
 		// The config file needs to be downloaded from the remote system into the local filesystem
 		pluginConfig.MustRestoreFile(fromTimestampFPInfo.GetConfigFilePath())

--- a/end_to_end/plugin_test.go
+++ b/end_to_end/plugin_test.go
@@ -29,7 +29,7 @@ func copyPluginToAllHosts(conn *dbconn.DBConn, pluginPath string) {
 }
 
 func forceMetadataFileDownloadFromPlugin(conn *dbconn.DBConn, timestamp string) {
-	fpInfo := filepath.NewFilePathInfo(backupCluster, "", timestamp, filepath.GetSegPrefix(conn))
+	fpInfo := filepath.NewFilePathInfo(backupCluster, "", timestamp, "")
 	remoteOutput := backupCluster.GenerateAndExecuteCommand(
 		fmt.Sprintf("Removing backups on all segments for "+
 			"timestamp %s", timestamp),

--- a/filepath/filepath.go
+++ b/filepath/filepath.go
@@ -238,3 +238,31 @@ func ParseSegPrefix(backupDir string) (string, error) {
 
 	return segPrefix, nil
 }
+
+func GetTimestampFromBackupDirectory(backupDir string) (string, error) {
+	if backupDir == "" {
+		return "", fmt.Errorf("No backup directory provided, please specify a timestamp using the --timestamp flag")
+	}
+
+	var timestampDirs []string
+	_, err := operating.System.Stat(fmt.Sprintf("%s/backups", backupDir))
+	if err == nil {
+		timestampDirs, err = operating.System.Glob(fmt.Sprintf("%s/backups/*/*", backupDir))
+	} else if os.IsNotExist(err) {
+		timestampDirs, err = operating.System.Glob(fmt.Sprintf("%s/*-1/backups/*/*", backupDir))
+	}
+
+	if err != nil {
+		return "", fmt.Errorf("Failure while trying to determine timestamp from backup directory %s. Error: %s", backupDir, err.Error())
+	}
+
+	if len(timestampDirs) == 0 {
+		return "", fmt.Errorf("No timestamp directories found under %s", backupDir)
+	}
+	if len(timestampDirs) != 1 {
+		return "", fmt.Errorf("Multiple timestamp directories found under %s, please specify a timestamp using the --timestamp flag", backupDir)
+	}
+
+	timestamp := path.Base(string(timestampDirs[0]))
+	return timestamp, nil
+}

--- a/filepath/filepath.go
+++ b/filepath/filepath.go
@@ -55,14 +55,6 @@ func NewFilePathInfo(c *cluster.Cluster, userSpecifiedBackupDir string, timestam
 }
 
 /*
- * Set user specified dir for report.
- * Currently used for restore only.
- */
-func (backupFPInfo *FilePathInfo) SetReportDir(userSpecifiedReportDir string) {
-	backupFPInfo.UserSpecifiedReportDir = userSpecifiedReportDir
-}
-
-/*
  * Restoring a future-dated backup is allowed (e.g. the backup was taken in a
  * different time zone that is ahead of the restore time zone), so only check
  * format, not whether the timestamp is earlier than the current time.
@@ -90,12 +82,11 @@ func (backupFPInfo *FilePathInfo) GetDirForContent(contentID int) string {
 	return path.Join(baseDir, "backups", backupFPInfo.Timestamp[0:8], backupFPInfo.Timestamp)
 }
 
-func (backupFPInfo *FilePathInfo) GetDirForReport(contentID int) string {
+func (backupFPInfo *FilePathInfo) GetReportDirectoryPath() string {
 	if backupFPInfo.UserSpecifiedReportDir != "" {
-		segDir := fmt.Sprintf("%s%d", backupFPInfo.UserSpecifiedSegPrefix, contentID)
-		return path.Join(backupFPInfo.UserSpecifiedReportDir, segDir, "backups", backupFPInfo.Timestamp[0:8], backupFPInfo.Timestamp)
+		return backupFPInfo.UserSpecifiedReportDir
 	}
-	return backupFPInfo.GetDirForContent(contentID);
+	return backupFPInfo.GetDirForContent(-1)
 }
 
 func (backupFPInfo *FilePathInfo) replaceCopyFormatStringsInPath(templateFilePath string, contentID int) string {
@@ -176,7 +167,7 @@ func (backupFPInfo *FilePathInfo) GetBackupReportFilePath() string {
 }
 
 func (backupFPInfo *FilePathInfo) GetRestoreFilePath(restoreTimestamp string, filetype string) string {
-	return path.Join(backupFPInfo.GetDirForReport(-1), fmt.Sprintf("gprestore_%s_%s_%s", backupFPInfo.Timestamp, restoreTimestamp, metadataFilenameMap[filetype]))
+	return path.Join(backupFPInfo.GetReportDirectoryPath(), fmt.Sprintf("gprestore_%s_%s_%s", backupFPInfo.Timestamp, restoreTimestamp, metadataFilenameMap[filetype]))
 }
 
 func (backupFPInfo *FilePathInfo) GetRestoreReportFilePath(restoreTimestamp string) string {

--- a/filepath/filepath_test.go
+++ b/filepath/filepath_test.go
@@ -150,9 +150,9 @@ var _ = Describe("filepath tests", func() {
 		})
 		It("returns different report file paths based on user specified report path for backup and restore command", func() {
 			fpInfo := NewFilePathInfo(c, "/foo/bar", "20170101010101", "gpseg")
-			fpInfo.SetReportDir("/bar/foo")
+			fpInfo.UserSpecifiedReportDir = "/bar/foo"
 			Expect(fpInfo.GetBackupReportFilePath()).To(Equal("/foo/bar/gpseg-1/backups/20170101/20170101010101/gpbackup_20170101010101_report"))
-			Expect(fpInfo.GetRestoreReportFilePath("20200101010101")).To(Equal("/bar/foo/gpseg-1/backups/20170101/20170101010101/gprestore_20170101010101_20200101010101_report"))
+			Expect(fpInfo.GetRestoreReportFilePath("20200101010101")).To(Equal("/bar/foo/gprestore_20170101010101_20200101010101_report"))
 		})
 	})
 	Describe("GetTableBackupFilePath", func() {

--- a/integration/agent_remote_test.go
+++ b/integration/agent_remote_test.go
@@ -21,7 +21,7 @@ var _ = Describe("agent remote", func() {
 		oidList = []string{"1", "2", "3"}
 		segConfig := cluster.MustGetSegmentConfiguration(connectionPool)
 		testCluster = cluster.NewCluster(segConfig)
-		filePath = filepath.NewFilePathInfo(testCluster, "my_dir", "20190102030405", filepath.GetSegPrefix(connectionPool))
+		filePath = filepath.NewFilePathInfo(testCluster, "my_dir", "20190102030405", "")
 	})
 	Describe("WriteOidListToSegments()", func() {
 		It("writes oids to a temp file and copies it to all segments", func() {

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/cluster"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/greenplum-db/gp-common-go-libs/operating"
 	"github.com/greenplum-db/gpbackup/filepath"
 	"github.com/greenplum-db/gpbackup/history"
 	"github.com/greenplum-db/gpbackup/options"
@@ -76,9 +77,9 @@ func DoSetup() {
 	gplog.FatalOnError(err)
 	globalFPInfo = filepath.NewFilePathInfo(globalCluster, MustGetFlagString(options.BACKUP_DIR), backupTimestamp, segPrefix)
 	if reportDir := MustGetFlagString(options.REPORT_DIR); reportDir != "" {
-		globalFPInfo.SetReportDir(reportDir)
-		info, err := globalCluster.ExecuteLocalCommand(fmt.Sprintf("mkdir -p %s", globalFPInfo.GetDirForReport(-1)))
-		gplog.FatalOnError(err, info)
+		globalFPInfo.UserSpecifiedReportDir = reportDir
+		err := operating.System.MkdirAll(globalFPInfo.GetReportDirectoryPath(), 0775)
+		gplog.FatalOnError(err)
 	}
 
 	// Get restore metadata from plugin


### PR DESCRIPTION
This PR slightly "flattens" the directory hierarchy created by --backup-dir and allows omitting the --timestamp flag if only one backup exists in a given directory.

See individual commit messages for further details.