### PR TITLE
Update restore CI job filepath

### DIFF
--- a/ci/scripts/icw-migr-restore.bash
+++ b/ci/scripts/icw-migr-restore.bash
@@ -52,7 +52,7 @@ else
 fi
 
 # extract timestamp from saved folder, use it to run a restore
-TS=\$(ls $(pwd)/backups/demoDataDir-1/backups/*)
+TS=\$(ls $(pwd)/backups/backups/*)
 gprestore --timestamp=\$TS --backup-dir=$(pwd)/backups --create-db --with-globals --on-error-continue | tee /tmp/gpbackup_test.log
 
 # We expect some errors, so we have to use on-error-continue, but we want to parse for unexpected


### PR DESCRIPTION
We changed the directory structure for backup-dir backups, and this job was still looking for the old structure.