### PR TITLE
Improve performance of index rename query

### DIFF
--- a/backup/queries_postdata.go
+++ b/backup/queries_postdata.go
@@ -254,12 +254,10 @@ func GetRenameExchangedPartitionQuery(connection *dbconn.DBConn) string {
 	// tables.  In GPDB6 and below this renaming was done automatically by server code.
 	cteClause := ""
 	if connectionPool.Version.Before("7") {
-		cteClause = `SELECT DISTINCT cl.relname
-            FROM pg_class cl
-                INNER JOIN pg_partitions pts
-					ON cl.relname = pts.partitiontablename
-					AND cl.relname != pts.tablename
-            WHERE cl.relkind IN ('r', 'f')`
+		cteClause = `SELECT c.relname
+             FROM pg_class c
+             INNER JOIN pg_partition_rule p
+             ON c.oid = p.parchildrelid`
 	} else {
 		cteClause = `SELECT DISTINCT cl.relname
              FROM pg_class cl


### PR DESCRIPTION
Joining on pg_partitions in the CTE in GetRenameExchangedPartitionQuery is very performance-intensive, as it already has several joins in its definition.

Joining on pg_partition_rule instead greatly simplifies the overall query plan and decreases the CTE cost by several orders of magnitude, which should hopefully improve performance when backing up databases that include many partition tables.