### PR TITLE
Update gp7 external table query

### DIFF
--- a/backup/queries_externals.go
+++ b/backup/queries_externals.go
@@ -86,7 +86,7 @@ func GetExternalTableDefinitions(connectionPool *dbconn.DBConn) map[uint32]Exter
 		coalesce(e.rejectlimit, 0) AS rejectlimit,
 		coalesce(e.rejectlimittype, '') AS rejectlimittype,
 		e.logerrors,
-		coalesce('log_errors=p' = any(ft.ftoptions), false) AS logerrpersist,
+		coalesce('log_errors=persistently' = any(ft.ftoptions), false) AS logerrpersist,
 		pg_encoding_to_char(e.encoding) AS encoding,
 		e.writable
 	FROM pg_exttable e


### PR DESCRIPTION
A recent commit to the server in GPDB7 updated the values for external table options, and one of our queries for that needs to be updated to match.