### PR TITLE
Add granular COPY progress reporting for GPDB 7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/blang/vfs v1.0.0
-	github.com/greenplum-db/gp-common-go-libs v1.0.12
+	github.com/greenplum-db/gp-common-go-libs v1.0.13
 	github.com/jackc/pgconn v1.14.0
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/klauspost/compress v1.15.15

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,10 @@ github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLe
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/greenplum-db/gp-common-go-libs v1.0.12 h1:Aow8icaKPodFi04wOV5EeWyqjBxTK/d9if9wRb6D9vs=
 github.com/greenplum-db/gp-common-go-libs v1.0.12/go.mod h1:ZElr7gGpsxAUXkjbT3ycGtQuAaEUfcR/4LRrpoaVZjM=
+github.com/greenplum-db/gp-common-go-libs v1.0.13-0.20230830105641-dd9840a49252 h1:wSyCt3uHnGV1Nb8QDczXqCMOC69usn1cVM6fRjkuHB0=
+github.com/greenplum-db/gp-common-go-libs v1.0.13-0.20230830105641-dd9840a49252/go.mod h1:ZElr7gGpsxAUXkjbT3ycGtQuAaEUfcR/4LRrpoaVZjM=
+github.com/greenplum-db/gp-common-go-libs v1.0.13 h1:z4XuWPysdNFQmXu5M26eXqI8f0FkzqR/koI0eI4p05w=
+github.com/greenplum-db/gp-common-go-libs v1.0.13/go.mod h1:ZElr7gGpsxAUXkjbT3ycGtQuAaEUfcR/4LRrpoaVZjM=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/restore/data_test.go
+++ b/restore/data_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/greenplum-db/gpbackup/history"
 	"github.com/greenplum-db/gpbackup/options"
 	"github.com/greenplum-db/gpbackup/restore"
+	"github.com/greenplum-db/gpbackup/toc"
 	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/jackc/pgconn"
 
@@ -21,6 +22,7 @@ import (
 
 var _ = Describe("restore/data tests", func() {
 	Describe("CopyTableIn", func() {
+		cdEntry := toc.CoordinatorDataEntry{AttributeString: "(i,j)"}
 		BeforeEach(func() {
 			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "cat", OutputCommand: "cat -", InputCommand: "cat -", Extension: ""})
 			backup.SetPluginConfig(nil)
@@ -33,7 +35,7 @@ var _ = Describe("restore/data tests", func() {
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.gz | gzip -d -c' WITH CSV DELIMITER ',' ON SEGMENT")
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.gz"
-			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", cdEntry, filename, false, 0, nil)
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -42,7 +44,7 @@ var _ = Describe("restore/data tests", func() {
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.zst | zstd --decompress -c' WITH CSV DELIMITER ',' ON SEGMENT")
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.zst"
-			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", cdEntry, filename, false, 0, nil)
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -50,7 +52,7 @@ var _ = Describe("restore/data tests", func() {
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456 | cat -' WITH CSV DELIMITER ',' ON SEGMENT")
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456"
-			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", cdEntry, filename, false, 0, nil)
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -58,7 +60,7 @@ var _ = Describe("restore/data tests", func() {
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456 | cat -' WITH CSV DELIMITER ',' ON SEGMENT")
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456"
-			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, true, 0)
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", cdEntry, filename, true, 0, nil)
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -71,7 +73,7 @@ var _ = Describe("restore/data tests", func() {
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz"
-			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", cdEntry, filename, false, 0, nil)
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -84,7 +86,7 @@ var _ = Describe("restore/data tests", func() {
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.zst"
-			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", cdEntry, filename, false, 0, nil)
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -96,7 +98,7 @@ var _ = Describe("restore/data tests", func() {
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz"
-			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", cdEntry, filename, false, 0, nil)
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -110,7 +112,7 @@ var _ = Describe("restore/data tests", func() {
 			}
 			mock.ExpectExec(execStr).WillReturnError(pgErr)
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456"
-			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", cdEntry, filename, false, 0, nil)
 
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("Error loading data into table public.foo: " +

--- a/restore/parallel.go
+++ b/restore/parallel.go
@@ -69,7 +69,7 @@ func ExecuteStatements(statements []toc.StatementWithType, progressBar utils.Pro
 		executeStatementsForConn(tasks, &fatalErr, &numErrors, progressBar, connNum, executeInParallel)
 	} else {
 		panicChan := make(chan error)
-		for i := 0; i < connectionPool.NumConns; i++ {
+		for i := 1; i < connectionPool.NumConns; i++ {
 			workerPool.Add(1)
 			go func(connNum int) {
 				defer func() {

--- a/utils/progress_bar.go
+++ b/utils/progress_bar.go
@@ -5,8 +5,10 @@ package utils
  */
 
 import (
+	"fmt"
 	"time"
 
+	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"gopkg.in/cheggaaa/pb.v1"
 )
@@ -45,14 +47,26 @@ func NewProgressBar(count int, prefix string, showProgressBar int) ProgressBar {
 		verboseProgressBar.ProgressBar = progressBar
 		return verboseProgressBar
 	}
-	return progressBar
+	return &InfoProgressBar{ProgressBar: progressBar}
 }
 
 type ProgressBar interface {
 	Start() *pb.ProgressBar
 	Finish()
+	Prefix(string) *pb.ProgressBar
 	Increment() int
 	Add(int) int
+	Set(int) *pb.ProgressBar
+	Reset(int) *pb.ProgressBar
+	GetBar() *pb.ProgressBar
+}
+
+type InfoProgressBar struct {
+	*pb.ProgressBar
+}
+
+func (ipb *InfoProgressBar) GetBar() *pb.ProgressBar {
+	return ipb.ProgressBar
 }
 
 type VerboseProgressBar struct {
@@ -60,21 +74,49 @@ type VerboseProgressBar struct {
 	total              int
 	prefix             string
 	nextPercentToPrint int
+	ShouldPrintCount   bool
 	*pb.ProgressBar
 }
 
 func NewVerboseProgressBar(count int, prefix string) *VerboseProgressBar {
-	newPb := VerboseProgressBar{total: count, prefix: prefix, nextPercentToPrint: INCR_PERCENT}
+	newPb := VerboseProgressBar{total: count, prefix: prefix, nextPercentToPrint: INCR_PERCENT, ShouldPrintCount: true}
 	return &newPb
 }
 
+func (vpb *VerboseProgressBar) GetBar() *pb.ProgressBar {
+	return vpb.ProgressBar
+}
+
 func (vpb *VerboseProgressBar) Increment() int {
-	vpb.ProgressBar.Increment()
 	if vpb.current < vpb.total {
 		vpb.current++
 		vpb.checkPercent()
 	}
-	return vpb.current
+	return vpb.ProgressBar.Increment()
+}
+
+func (vpb *VerboseProgressBar) Add(add int) int {
+	if vpb.current < vpb.total {
+		vpb.current += add
+		vpb.checkPercent()
+	}
+	return vpb.ProgressBar.Add(add)
+}
+
+func (vpb *VerboseProgressBar) Set(current int) *pb.ProgressBar {
+	vpb.current = current
+	return vpb.ProgressBar.Set(current)
+}
+
+func (vpb *VerboseProgressBar) Reset(total int) *pb.ProgressBar {
+	vpb.current = 0
+	vpb.total = total
+	return vpb.ProgressBar.Reset(total)
+}
+
+func (vpb *VerboseProgressBar) Prefix(prefix string) *pb.ProgressBar {
+	vpb.prefix = prefix
+	return vpb.ProgressBar.Prefix(prefix)
 }
 
 /*
@@ -87,7 +129,129 @@ func (vpb *VerboseProgressBar) checkPercent() {
 	closestMult := currPercent / INCR_PERCENT * INCR_PERCENT
 	if closestMult >= vpb.nextPercentToPrint {
 		vpb.nextPercentToPrint = closestMult
-		gplog.Verbose("%s %d%% (%d/%d)", vpb.prefix, vpb.nextPercentToPrint, vpb.current, vpb.total)
+		message := fmt.Sprintf("%s %d%%%%", vpb.prefix, vpb.nextPercentToPrint)
+		if vpb.ShouldPrintCount {
+			message += fmt.Sprintf(" (%d/%d)", vpb.current, vpb.total)
+		}
+		gplog.Verbose(message)
 		vpb.nextPercentToPrint += INCR_PERCENT
 	}
+}
+
+type MultiProgressBar struct {
+	TablesBar    ProgressBar
+	TuplesBars   []ProgressBar
+	Verbosity    int
+	ProgressPool *pb.Pool
+}
+
+func NewMultiProgressBar(tablesBarTotal int, tablesBarLabel string, numTuplesBars int, verbose bool) *MultiProgressBar {
+	verbosity := PB_INFO
+	if verbose {
+		verbosity = PB_VERBOSE
+	}
+	tablesBar := NewProgressBar(tablesBarTotal, tablesBarLabel, verbosity)
+	tablesBar.GetBar().ShowFinalTime = false
+	tablesBar.GetBar().NotPrint = verbose
+	progressBars := &MultiProgressBar{
+		TablesBar: tablesBar,
+		Verbosity: verbosity,
+	}
+	if numTuplesBars > 0 {
+		progressBars.TuplesBars = make([]ProgressBar, numTuplesBars)
+		// In order to get all of the progress bars to play nicely with one another we have to
+		// create and start all of them in a single pool upfront, then edit their prefixes and
+		// totals later, instead of starting them one by one when each COPY is ready, so we don't
+		// initialize prefixes or totals here.
+		for i := 0; i < numTuplesBars; i++ {
+			tupleBar := NewProgressBar(0, "", verbosity)
+			tupleBar.GetBar().ShowFinalTime = false
+			tupleBar.GetBar().NotPrint = verbose
+			if verbose {
+				tupleBar.(*VerboseProgressBar).ShouldPrintCount = false
+			}
+			progressBars.TuplesBars[i] = tupleBar
+		}
+	}
+	return progressBars
+}
+
+func (mpb *MultiProgressBar) Start() error {
+	if mpb.Verbosity == PB_VERBOSE {
+		// We're not printing the bars, so this is a no-op
+		return nil
+	}
+	bars := []*pb.ProgressBar{mpb.TablesBar.GetBar()}
+	for _, bar := range mpb.TuplesBars {
+		bars = append(bars, bar.GetBar())
+	}
+	pool, err := pb.StartPool(bars...)
+	if err != nil {
+		return err
+	}
+	mpb.ProgressPool = pool
+	// Calling Start on a bar with a 0 total disables printing percentages, so we need
+	// to explicitly reenable that here.  Also, we don't want to print tuple counts, as
+	// on the backup side we're only using estimated tuple counts and don't want users
+	// to think we're backing up the wrong number of tuples, so we disable the built-in
+	// counters on these bars.
+	for _, bar := range mpb.TuplesBars {
+		bar.GetBar().ShowPercent = true
+		bar.GetBar().ShowCounters = false
+	}
+	return nil
+}
+
+func (mpb *MultiProgressBar) Finish() {
+	if mpb.Verbosity == PB_VERBOSE {
+		// We're not printing the bars, so this is a no-op
+		return
+	}
+	mpb.TablesBar.Finish()
+	for _, bar := range mpb.TuplesBars {
+		bar.Finish()
+	}
+	mpb.ProgressPool.Stop()
+}
+
+func (mpb *MultiProgressBar) TrackCopyProgress(tablename string, oid uint32, numTuples int, conn *dbconn.DBConn, whichConn int, tableNum int, done chan bool) {
+	progressBar := mpb.TuplesBars[tableNum]
+	progressBar.Prefix(fmt.Sprintf("%s: ", tablename))
+
+	// We call Finish and Reset at the beginning instead of the end because we start the whole process
+	// with empty progress bars that need to be set and there's no need to special-case those.
+	progressBar.Finish()
+	progressBar.Reset(numTuples)
+
+	go func(done chan bool) {
+		processed := 0
+		for {
+			select {
+			case succeeded := <-done:
+				if succeeded {
+					// Manually set the progress to maximum if COPY succeeded, as we won't be able to get the last few tuples
+					// from the view (or any tuples, for especially small tables) and we don't want users to worry that any
+					// tuples were missed.
+					progressBar.Set(numTuples)
+				}
+				return
+			default:
+				// Ignore any error on this query: if there's a hiccup we'll get the number on the next pass, and if there's
+				// a real connection problem the COPY itself should error out elsewhere.
+				tuplesProcessed, _ := dbconn.SelectInt(conn, fmt.Sprintf("SELECT tuples_processed FROM gp_stat_progress_copy_summary WHERE relid = %d", oid), whichConn)
+				if tuplesProcessed == 0 { // Don't stop tracking yet, sometimes the table hiccups and has no rows for a bit
+					break
+				}
+				delta := int(tuplesProcessed) - processed
+				// TODO: There's a server bug that underreports tuples so it looks like the number processed went down.
+				// For now, if we see a negative delta, simply don't update the progress bar and wait for the next loop.
+				if delta < 0 {
+					break
+				}
+				progressBar.Add(delta)
+				processed += delta
+			}
+			time.Sleep(100 * time.Millisecond)
+		}
+	}(done)
 }

--- a/utils/progress_bar_test.go
+++ b/utils/progress_bar_test.go
@@ -1,113 +1,73 @@
 package utils_test
 
 import (
-	"io"
-	"os"
-	"os/user"
 	"time"
 
+	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
-	"github.com/greenplum-db/gp-common-go-libs/operating"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup/utils"
-	"gopkg.in/cheggaaa/pb.v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("utils/log tests", func() {
-	var (
-		fakeInfo os.FileInfo
-	)
-
-	BeforeEach(func() {
-		err := operating.System.MkdirAll("/tmp/log_dir", 0755)
-		Expect(err).ToNot(HaveOccurred())
-		fakeInfo, err = os.Stat("/tmp/log_dir")
-		Expect(err).ToNot(HaveOccurred())
-
-		operating.System.OpenFileWrite = func(name string, flag int, perm os.FileMode) (io.WriteCloser, error) { return buffer, nil }
-		operating.System.CurrentUser = func() (*user.User, error) { return &user.User{Username: "testUser", HomeDir: "testDir"}, nil }
-		operating.System.Getpid = func() int { return 0 }
-		operating.System.Hostname = func() (string, error) { return "testHost", nil }
-		operating.System.IsNotExist = func(err error) bool { return false }
-		operating.System.Now = func() time.Time { return time.Date(2017, time.January, 1, 1, 1, 1, 1, time.Local) }
-		operating.System.Stat = func(name string) (os.FileInfo, error) { return fakeInfo, nil }
-	})
-	AfterEach(func() {
-		operating.System = operating.InitializeSystemFunctions()
-	})
-
 	Describe("NewProgressBar", func() {
 		Context("PB_NONE", func() {
 			It("will not print when passed a none value", func() {
-				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_NONE)
-				infoPb, ok := progressBar.(*pb.ProgressBar)
-				Expect(ok).To(BeTrue())
-				Expect(infoPb.NotPrint).To(Equal(true))
+				infoPb := utils.NewProgressBar(10, "test progress bar", utils.PB_NONE)
+				Expect(infoPb.GetBar().NotPrint).To(Equal(true))
 			})
 		})
 		Context("PB_INFO", func() {
-			It("will create a pb.ProgressBar when passed an info value", func() {
+			It("will create an InfoProgressBar when passed an info value", func() {
 				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_INFO)
-				_, ok := progressBar.(*pb.ProgressBar)
+				_, ok := progressBar.(*utils.InfoProgressBar)
 				Expect(ok).To(BeTrue())
 			})
 			It("will not print with verbosity LOGERROR", func() {
 				gplog.SetVerbosity(gplog.LOGERROR)
-				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_INFO)
-				infoPb, _ := progressBar.(*pb.ProgressBar)
-				Expect(infoPb.NotPrint).To(Equal(true))
+				infoPb := utils.NewProgressBar(10, "test progress bar", utils.PB_INFO)
+				Expect(infoPb.GetBar().NotPrint).To(Equal(true))
 			})
 			It("will print with verbosity LOGINFO", func() {
 				gplog.SetVerbosity(gplog.LOGINFO)
-				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_INFO)
-				infoPb, _ := progressBar.(*pb.ProgressBar)
-				Expect(infoPb.NotPrint).To(Equal(false))
+				infoPb := utils.NewProgressBar(10, "test progress bar", utils.PB_INFO)
+				Expect(infoPb.GetBar().NotPrint).To(Equal(false))
 			})
 			It("will not print with verbosity LOGVERBOSE", func() {
 				gplog.SetVerbosity(gplog.LOGVERBOSE)
-				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_INFO)
-				infoPb, _ := progressBar.(*pb.ProgressBar)
-				Expect(infoPb.NotPrint).To(Equal(true))
+				infoPb := utils.NewProgressBar(10, "test progress bar", utils.PB_INFO)
+				Expect(infoPb.GetBar().NotPrint).To(Equal(true))
 			})
 		})
 		Context("PB_VERBOSE", func() {
-			It("will create a verboseProgressBar when passed a verbose value", func() {
+			It("will create a VerboseProgressBar when passed a verbose value", func() {
 				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_VERBOSE)
 				_, ok := progressBar.(*utils.VerboseProgressBar)
 				Expect(ok).To(BeTrue())
 			})
 			It("verboseProgressBar's infoPb will not print with verbosity LOGERROR", func() {
 				gplog.SetVerbosity(gplog.LOGERROR)
-				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_VERBOSE)
-				vPb, _ := progressBar.(*utils.VerboseProgressBar)
-				Expect(vPb.ProgressBar.NotPrint).To(Equal(true))
+				vPb := utils.NewProgressBar(10, "test progress bar", utils.PB_VERBOSE)
+				Expect(vPb.GetBar().NotPrint).To(Equal(true))
 			})
 			It("verboseProgressBar's infoPb will print with verbosity LOGINFO", func() {
 				gplog.SetVerbosity(gplog.LOGINFO)
-				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_VERBOSE)
-				vPb, _ := progressBar.(*utils.VerboseProgressBar)
-				Expect(vPb.ProgressBar.NotPrint).To(Equal(false))
+				vPb := utils.NewProgressBar(10, "test progress bar", utils.PB_VERBOSE)
+				Expect(vPb.GetBar().NotPrint).To(Equal(false))
 			})
 			It("verboseProgressBar's infoPb will not print with verbosity LOGVERBOSE", func() {
 				gplog.SetVerbosity(gplog.LOGVERBOSE)
-				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_VERBOSE)
-				vPb, _ := progressBar.(*utils.VerboseProgressBar)
-				Expect(vPb.ProgressBar.NotPrint).To(Equal(true))
+				vPb := utils.NewProgressBar(10, "test progress bar", utils.PB_VERBOSE)
+				Expect(vPb.GetBar().NotPrint).To(Equal(true))
 			})
 		})
 	})
 	Describe("Increment", func() {
-		var vPb *utils.VerboseProgressBar
-		BeforeEach(func() {
-			progressBar := utils.NewProgressBar(10, "test progress bar:", utils.PB_VERBOSE)
-			vPb, _ = progressBar.(*utils.VerboseProgressBar)
-		})
 		It("writes to the log file at 10% increments", func() {
-			progressBar := utils.NewProgressBar(10, "test progress bar:", utils.PB_VERBOSE)
-			vPb, _ = progressBar.(*utils.VerboseProgressBar)
+			vPb := utils.NewProgressBar(10, "test progress bar:", utils.PB_VERBOSE)
 			vPb.Increment()
 			expectedMessage := "test progress bar: 10% (1/10)"
 			testhelper.ExpectRegexp(logfile, expectedMessage)
@@ -116,8 +76,7 @@ var _ = Describe("utils/log tests", func() {
 			testhelper.ExpectRegexp(logfile, expectedMessage)
 		})
 		It("only logs when it hits a new % marker", func() {
-			progressBar := utils.NewProgressBar(20, "test progress bar:", utils.PB_VERBOSE)
-			vPb, _ = progressBar.(*utils.VerboseProgressBar)
+			vPb := utils.NewProgressBar(20, "test progress bar:", utils.PB_VERBOSE)
 
 			expectedMessage := "test progress bar: 10% (2/20)"
 			vPb.Increment()
@@ -131,8 +90,7 @@ var _ = Describe("utils/log tests", func() {
 			testhelper.ExpectRegexp(logfile, expectedMessage)
 		})
 		It("writes accurate percentages if < 10 items", func() {
-			progressBar := utils.NewProgressBar(5, "test progress bar:", utils.PB_VERBOSE)
-			vPb, _ = progressBar.(*utils.VerboseProgressBar)
+			vPb := utils.NewProgressBar(5, "test progress bar:", utils.PB_VERBOSE)
 			vPb.Increment()
 			expectedMessage := "test progress bar: 20% (1/5)"
 			testhelper.ExpectRegexp(logfile, expectedMessage)
@@ -141,13 +99,194 @@ var _ = Describe("utils/log tests", func() {
 			testhelper.ExpectRegexp(logfile, expectedMessage)
 		})
 		It("does not log if called again after hitting 100%", func() {
-			progressBar := utils.NewProgressBar(1, "test progress bar:", utils.PB_VERBOSE)
-			vPb, _ = progressBar.(*utils.VerboseProgressBar)
+			vPb := utils.NewProgressBar(1, "test progress bar:", utils.PB_VERBOSE)
 			vPb.Increment()
 			expectedMessage := "test progress bar: 100% (1/1)"
 			testhelper.ExpectRegexp(logfile, expectedMessage)
 			vPb.Increment()
 			testhelper.NotExpectRegexp(logfile, expectedMessage)
+		})
+		It("does not log the count if ShouldPrintCount is false", func() {
+			vPb := utils.NewProgressBar(1, "test progress bar:", utils.PB_VERBOSE)
+			vPb.(*utils.VerboseProgressBar).ShouldPrintCount = false
+			vPb.Increment()
+			expectedMessage := "test progress bar: 100%"
+			testhelper.ExpectRegexp(logfile, expectedMessage)
+		})
+	})
+	Describe("NewMultiProgressBar", func() {
+		It("can create a MultiProgressBar with info verbosity", func() {
+			multiPb := utils.NewMultiProgressBar(10, "test multi progress bar", 2, false)
+
+			Expect(multiPb.TablesBar).ToNot(BeNil())
+			Expect(multiPb.TuplesBars).ToNot(BeNil())
+			Expect(len(multiPb.TuplesBars)).To(Equal(2))
+			infoTablesBar, ok := multiPb.TablesBar.(*utils.InfoProgressBar)
+			Expect(ok).To(BeTrue())
+			Expect(infoTablesBar.GetBar().NotPrint).To(BeFalse())
+			infoTuplesBar1, ok := multiPb.TuplesBars[0].(*utils.InfoProgressBar)
+			Expect(ok).To(BeTrue())
+			Expect(infoTuplesBar1.GetBar().NotPrint).To(BeFalse())
+			infoTuplesBar2, ok := multiPb.TuplesBars[1].(*utils.InfoProgressBar)
+			Expect(ok).To(BeTrue())
+			Expect(infoTuplesBar2.GetBar().NotPrint).To(BeFalse())
+
+			Expect(multiPb.TablesBar.GetBar().Get()).To(Equal(int64(0)))
+			Expect(multiPb.Verbosity).To(Equal(utils.PB_INFO))
+			Expect(multiPb.ProgressPool).To(BeNil())
+		})
+		It("can create a MultiProgressBar with verbose verbosity", func() {
+			multiPb := utils.NewMultiProgressBar(10, "test multi progress bar", 2, true)
+
+			Expect(multiPb.TablesBar).ToNot(BeNil())
+			Expect(multiPb.TuplesBars).ToNot(BeNil())
+			Expect(len(multiPb.TuplesBars)).To(Equal(2))
+			verboseTablesBar, ok := multiPb.TablesBar.(*utils.VerboseProgressBar)
+			Expect(ok).To(BeTrue())
+			Expect(verboseTablesBar.GetBar().NotPrint).To(BeTrue())
+			verboseTuplesBar1, ok := multiPb.TuplesBars[0].(*utils.VerboseProgressBar)
+			Expect(ok).To(BeTrue())
+			Expect(verboseTuplesBar1.GetBar().NotPrint).To(BeTrue())
+			verboseTuplesBar2, ok := multiPb.TuplesBars[1].(*utils.VerboseProgressBar)
+			Expect(ok).To(BeTrue())
+			Expect(verboseTuplesBar2.GetBar().NotPrint).To(BeTrue())
+
+			Expect(multiPb.TablesBar.GetBar().Get()).To(Equal(int64(0)))
+			Expect(multiPb.Verbosity).To(Equal(utils.PB_VERBOSE))
+			Expect(multiPb.ProgressPool).To(BeNil())
+		})
+		It("can handle a MultiProgressBar without tuple progress bars", func() {
+			multiPb := utils.NewMultiProgressBar(10, "test multi progress bar", 0, false)
+
+			Expect(multiPb.TablesBar).ToNot(BeNil())
+			Expect(multiPb.TuplesBars).To(BeNil())
+			_, ok := multiPb.TablesBar.(*utils.InfoProgressBar)
+			Expect(ok).To(BeTrue())
+
+			Expect(multiPb.TablesBar.GetBar().Get()).To(Equal(int64(0)))
+			Expect(multiPb.ProgressPool).To(BeNil())
+		})
+	})
+	Describe("GetBar", func() {
+		It("returns a modifiable pb.ProgressBar struct", func() {
+			infoPb := utils.NewProgressBar(10, "test progress bar", utils.PB_NONE)
+			Expect(infoPb.GetBar().NotPrint).To(BeTrue())
+			infoPb.GetBar().NotPrint = false
+			Expect(infoPb.GetBar().NotPrint).To(BeFalse())
+		})
+	})
+	Describe("TrackCopyProgress", func() {
+		var (
+			row10       *sqlmock.Rows
+			row20       *sqlmock.Rows
+			row30       *sqlmock.Rows
+			row40       *sqlmock.Rows
+			row50       *sqlmock.Rows
+			rowNegative *sqlmock.Rows
+			rowEmpty    *sqlmock.Rows
+			mpb         *utils.MultiProgressBar
+			done        chan bool
+		)
+		BeforeEach(func() {
+			row10 = sqlmock.NewRows([]string{"tuples_processed"}).AddRow("10")
+			row20 = sqlmock.NewRows([]string{"tuples_processed"}).AddRow("20")
+			row30 = sqlmock.NewRows([]string{"tuples_processed"}).AddRow("30")
+			row40 = sqlmock.NewRows([]string{"tuples_processed"}).AddRow("40")
+			row50 = sqlmock.NewRows([]string{"tuples_processed"}).AddRow("50")
+			rowNegative = sqlmock.NewRows([]string{"tuples_processed"}).AddRow("-25")
+			rowEmpty = sqlmock.NewRows([]string{"tuples_processed"})
+			mpb = utils.NewMultiProgressBar(0, "test multi progress bar", 1, true)
+			done = make(chan bool)
+		})
+		It("tracks a table's progress from start to finish", func() {
+			mock.ExpectQuery("SELECT .*").WillReturnRows(row10)
+			mock.ExpectQuery("SELECT .*").WillReturnRows(row20)
+			mock.ExpectQuery("SELECT .*").WillReturnRows(row30)
+			mock.ExpectQuery("SELECT .*").WillReturnRows(row40)
+			mock.ExpectQuery("SELECT .*").WillReturnRows(row50)
+
+			mpb.TrackCopyProgress("public.foo", 0, 50, connectionPool, 0, 0, done)
+			time.Sleep(time.Second)
+			done <- true
+			close(done)
+
+			tupleBar := mpb.TuplesBars[0].GetBar()
+			Expect(tupleBar.Total).To(Equal(int64(50)))
+			Expect(tupleBar.Get()).To(Equal(int64(50)))
+			testhelper.ExpectRegexp(logfile, "public.foo:  20%")
+			testhelper.ExpectRegexp(logfile, "public.foo:  40%")
+			testhelper.ExpectRegexp(logfile, "public.foo:  60%")
+			testhelper.ExpectRegexp(logfile, "public.foo:  80%")
+			testhelper.ExpectRegexp(logfile, "public.foo:  100%")
+		})
+		It("handles a table so small it never appears in gp_stat_progress_copy_summary", func() {
+			mpb.TrackCopyProgress("public.foo", 0, 50, connectionPool, 0, 0, done)
+			done <- true
+			close(done)
+
+			tupleBar := mpb.TuplesBars[0].GetBar()
+			Expect(tupleBar.Total).To(Equal(int64(50)))
+			Expect(tupleBar.Get()).To(Equal(int64(50)))
+			testhelper.NotExpectRegexp(logfile, "public.foo:")
+		})
+		It("handles an instance of the database returning a negative tuple count", func() {
+			mock.ExpectQuery("SELECT .*").WillReturnRows(row10)
+			mock.ExpectQuery("SELECT .*").WillReturnRows(row20)
+			mock.ExpectQuery("SELECT .*").WillReturnRows(rowNegative)
+			mock.ExpectQuery("SELECT .*").WillReturnRows(row30)
+			mock.ExpectQuery("SELECT .*").WillReturnRows(row40)
+			mock.ExpectQuery("SELECT .*").WillReturnRows(row50)
+
+			mpb.TrackCopyProgress("public.foo", 0, 50, connectionPool, 0, 0, done)
+			time.Sleep(time.Second)
+			done <- true
+			close(done)
+
+			tupleBar := mpb.TuplesBars[0].GetBar()
+			Expect(tupleBar.Total).To(Equal(int64(50)))
+			Expect(tupleBar.Get()).To(Equal(int64(50)))
+			testhelper.ExpectRegexp(logfile, "public.foo:  20%")
+			testhelper.ExpectRegexp(logfile, "public.foo:  40%")
+			testhelper.ExpectRegexp(logfile, "public.foo:  60%")
+			testhelper.ExpectRegexp(logfile, "public.foo:  80%")
+			testhelper.ExpectRegexp(logfile, "public.foo:  100%")
+		})
+		It("handles instances of the table temporarily not appearing in gp_stat_progress_copy_summary", func() {
+			mock.ExpectQuery("SELECT tuples_processed .*").WillReturnRows(row10)
+			mock.ExpectQuery("SELECT tuples_processed .*").WillReturnRows(row20)
+			mock.ExpectQuery("SELECT tuples_processed .*").WillReturnRows(rowEmpty)
+			mock.ExpectQuery("SELECT tuples_processed .*").WillReturnRows(rowEmpty)
+			mock.ExpectQuery("SELECT tuples_processed .*").WillReturnRows(row30)
+			mock.ExpectQuery("SELECT tuples_processed .*").WillReturnRows(row40)
+
+			mpb.TrackCopyProgress("public.foo", 0, 50, connectionPool, 0, 0, done)
+			time.Sleep(time.Second)
+			done <- true
+			close(done)
+
+			tupleBar := mpb.TuplesBars[0].GetBar()
+			Expect(tupleBar.Total).To(Equal(int64(50)))
+			Expect(tupleBar.Get()).To(Equal(int64(50)))
+			testhelper.ExpectRegexp(logfile, "public.foo:  20%")
+			testhelper.ExpectRegexp(logfile, "public.foo:  40%")
+			testhelper.ExpectRegexp(logfile, "public.foo:  60%")
+			testhelper.ExpectRegexp(logfile, "public.foo:  80%")
+		})
+		It("handles a COPY failure", func() {
+			mock.ExpectQuery("SELECT tuples_processed .*").WillReturnRows(row10)
+			mock.ExpectQuery("SELECT tuples_processed .*").WillReturnRows(row20)
+			mock.ExpectQuery("SELECT tuples_processed .*").WillReturnRows(row30)
+
+			mpb.TrackCopyProgress("public.foo", 0, 50, connectionPool, 0, 0, done)
+			time.Sleep(time.Second)
+			close(done)
+
+			tupleBar := mpb.TuplesBars[0].GetBar()
+			Expect(tupleBar.Total).To(Equal(int64(50)))
+			Expect(tupleBar.Get()).To(Equal(int64(30)))
+			testhelper.ExpectRegexp(logfile, "public.foo:  20%")
+			testhelper.ExpectRegexp(logfile, "public.foo:  40%")
+			testhelper.ExpectRegexp(logfile, "public.foo:  60%")
 		})
 	})
 })


### PR DESCRIPTION
With the introduction of the gp_stat_progress_copy_summary catalog table, we can now track the number of tuples being copied in or out while a COPY is in progress, allowing us to provide more detailed progress reporting during data backup and restore in GPDB 7 and above.

This takes the form of additional progress bars below the main table progress bar, one for each connection.  We constantly poll the above catalog table on an available database connection while the backup or restore is in progress to calculate the completion percentage for the table currently being copied, using either estimated row counts (on the backup side) or exact row counts (on the restore side) for each table's total.

Progress reporting in GPDB 6 and below is unchanged.