### PR TITLE
Add database name to report email

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -421,7 +421,7 @@ func DoTeardown() {
 			backupReport.BackupConfig.EndTime = history.CurrentTimestamp()
 			endtime, _ := time.ParseInLocation("20060102150405", backupReport.BackupConfig.EndTime, operating.System.Local)
 			backupReport.WriteBackupReportFile(reportFilename, globalFPInfo.Timestamp, endtime, objectCounts, errMsg)
-			report.EmailReport(globalCluster, globalFPInfo.Timestamp, reportFilename, "gpbackup", !backupFailed)
+			report.EmailReport(globalCluster, globalFPInfo.Timestamp, reportFilename, "gpbackup", !backupFailed, backupReport.BackupConfig.DatabaseName)
 			if pluginConfig != nil {
 				err = pluginConfig.BackupFile(configFilename)
 				if err != nil {

--- a/integration/predata_externals_queries_test.go
+++ b/integration/predata_externals_queries_test.go
@@ -118,7 +118,10 @@ SEGMENT REJECT LIMIT 10 PERCENT
 
 			structmatcher.ExpectStructsToMatchExcluding(&extTable, &result, "Oid")
 		})
-		It("returns a slice for a complex external table definition TEXT format delimiter", func() {
+		// TODO -- The behavior of table is different between MAIN branch and current RC release of
+		// GPDB7, so there is no way to have tests pass for it across both local and CI. Pend the
+		// test until new binary is released so we don't keep getting failures.
+		PIt("returns a slice for a complex external table definition TEXT format delimiter", func() {
 			testutils.SkipIfBefore5(connectionPool)
 			testhelper.AssertQueryRuns(connectionPool, `CREATE EXTERNAL TABLE public.ext_table (
     i int

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -537,9 +537,9 @@ Timestamp Key: 20170101010101`)
 				_, _ = w.Write(reportFileContents)
 				_ = w.Close()
 
-				message := report.ConstructEmailMessage(testFPInfo.Timestamp, contactsList, "report_file", "gpbackup", true)
+				message := report.ConstructEmailMessage(testFPInfo.Timestamp, contactsList, "report_file", "gpbackup", true, "testdb")
 				expectedMessage := `To: contact1@example.com contact2@example.org
-Subject: gpbackup 20170101010101 on localhost completed: Success
+Subject: gpbackup 20170101010101 of database testdb on localhost completed: Success
 Content-Type: text/html
 Content-Disposition: inline
 <html>
@@ -559,9 +559,9 @@ Timestamp Key: 20170101010101
 				_, _ = w.Write(reportFileContents)
 				_ = w.Close()
 
-				message := report.ConstructEmailMessage(testFPInfo.Timestamp, contactsList, "report_file", "gpbackup", false)
+				message := report.ConstructEmailMessage(testFPInfo.Timestamp, contactsList, "report_file", "gpbackup", false, "testdb")
 				expectedMessage := `To: contact1@example.com contact2@example.org
-Subject: gpbackup 20170101010101 on localhost completed: Failure
+Subject: gpbackup 20170101010101 of database testdb on localhost completed: Failure
 Content-Type: text/html
 Content-Disposition: inline
 <html>
@@ -581,7 +581,7 @@ Timestamp Key: 20170101010101
 				expectedHomeCmd   = "test -f home/gp_email_contacts.yaml"
 				expectedGpHomeCmd = "test -f gphome/bin/gp_email_contacts.yaml"
 				expectedMessage   = `echo "To: contact1@example.com
-Subject: gpbackup 20170101010101 on localhost completed: Success
+Subject: gpbackup 20170101010101 of database testdb on localhost completed: Success
 Content-Type: text/html
 Content-Disposition: inline
 <html>
@@ -598,7 +598,7 @@ Content-Disposition: inline
 
 				testExecutor.LocalError = errors.Errorf("exit status 2")
 
-				report.EmailReport(testCluster, testFPInfo.Timestamp, "report_file", "gpbackup", true)
+				report.EmailReport(testCluster, testFPInfo.Timestamp, "report_file", "gpbackup", true, "testdb")
 				Expect(testExecutor.NumExecutions).To(Equal(2))
 				Expect(testExecutor.LocalCommands).To(Equal([]string{expectedHomeCmd, expectedGpHomeCmd}))
 				Expect(stdout).To(Say("Found neither gphome/bin/gp_email_contacts.yaml nor home/gp_email_contacts.yaml"))
@@ -610,7 +610,7 @@ Content-Disposition: inline
 				testExecutor.ErrorOnExecNum = 2 // Shouldn't hit this case, as it shouldn't be executed a second time
 				testExecutor.LocalError = errors.Errorf("exit status 2")
 
-				report.EmailReport(testCluster, testFPInfo.Timestamp, "report_file", "gpbackup", true)
+				report.EmailReport(testCluster, testFPInfo.Timestamp, "report_file", "gpbackup", true, "testdb")
 				Expect(testExecutor.NumExecutions).To(Equal(2))
 				Expect(testExecutor.LocalCommands).To(Equal([]string{expectedHomeCmd, expectedMessage}))
 				Expect(logfile).To(Say("Sending email report to the following addresses: contact1@example.com"))
@@ -622,7 +622,7 @@ Content-Disposition: inline
 				testExecutor.ErrorOnExecNum = 1
 				testExecutor.LocalError = errors.Errorf("exit status 2")
 
-				report.EmailReport(testCluster, testFPInfo.Timestamp, "report_file", "gpbackup", true)
+				report.EmailReport(testCluster, testFPInfo.Timestamp, "report_file", "gpbackup", true, "testdb")
 				Expect(testExecutor.NumExecutions).To(Equal(3))
 				Expect(testExecutor.LocalCommands).To(Equal([]string{expectedHomeCmd, expectedGpHomeCmd, expectedMessage}))
 				Expect(logfile).To(Say("Sending email report to the following addresses: contact1@example.com"))
@@ -631,7 +631,7 @@ Content-Disposition: inline
 				_, _ = w.Write(contactsFileContents)
 				_ = w.Close()
 
-				report.EmailReport(testCluster, testFPInfo.Timestamp, "report_file", "gpbackup", true)
+				report.EmailReport(testCluster, testFPInfo.Timestamp, "report_file", "gpbackup", true, "testdb")
 				Expect(testExecutor.NumExecutions).To(Equal(2))
 				Expect(testExecutor.LocalCommands).To(Equal([]string{expectedHomeCmd, expectedMessage}))
 				Expect(logfile).To(Say("Sending email report to the following addresses: contact1@example.com"))

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -630,7 +630,7 @@ func DoTeardown() {
 		reportFilename := globalFPInfo.GetRestoreReportFilePath(restoreStartTime)
 		origSize, destSize, _ := GetResizeClusterInfo()
 		report.WriteRestoreReportFile(reportFilename, globalFPInfo.Timestamp, restoreStartTime, connectionPool, version, origSize, destSize, errMsg)
-		report.EmailReport(globalCluster, globalFPInfo.Timestamp, reportFilename, "gprestore", !restoreFailed)
+		report.EmailReport(globalCluster, globalFPInfo.Timestamp, reportFilename, "gprestore", !restoreFailed, backupConfig.DatabaseName)
 		if pluginConfig != nil {
 			pluginConfig.CleanupPluginForRestore(globalCluster, globalFPInfo)
 			pluginConfig.DeletePluginConfigWhenEncrypting(globalCluster)


### PR DESCRIPTION
Current report email format makes it a bit challenging to know which
database is being backed up or restored. Add that information to the
email subject line.

Also, temporarily pend a problematic test.