### PR TITLE
Update gppkg name

### DIFF
--- a/ci/scripts/build-gppkgs.bash
+++ b/ci/scripts/build-gppkgs.bash
@@ -115,6 +115,12 @@ if [[ ${OS} == "RHEL8" ]]; then
             mv "$file" "${new_name}-RHEL8-x86_64.gppkg"
         fi
     done
+
+    # other build scripts expect the file to be named gpbackup_tools*, even though the package name
+    # is greenplum_backup_restore*
+    set +e
+    rename greenplum_backup_restore gpbackup_tools *.gppkg
+    set -e
     echo "Successfully built gppkg v2 for GPDB7"
 fi
 ########################################################################################

--- a/gppkg/gppkg_v2_spec.yml.in
+++ b/gppkg/gppkg_v2_spec.yml.in
@@ -1,4 +1,4 @@
-Pkgname: gpbackup_tools
+Pkgname: greenplum_backup_restore
 Format: V2
 Architecture: ${ARCH}
 OS: ${OS}


### PR DESCRIPTION
A change in behavior between gppkgv1 and gppkgv2 requires the package name to be updated in gpbcakup's spec files.