### PR TITLE
Convert index name exchange to go code

### DIFF
--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -2156,7 +2156,7 @@ LANGUAGE plpgsql NO SQL;`)
 			expectedValue := false
 			indexSuffix := "idx"
 			if backupConn.Version.Is("6") {
-				// In GPDB6 and below, indexes are automatically cascaded down and so in exchange case they must be renamed to avoid name collision breaking restore
+				// In GPDB6, indexes are automatically cascaded down and so in exchange case they must be renamed to avoid name collision breaking restore
 				expectedValue = true
 			}
 			Expect(strings.Contains(string(metadataFileContents), fmt.Sprintf("CREATE INDEX like_table_a_%s ON schemaone.like_table USING btree (a) WHERE (b > 10);",


### PR DESCRIPTION
The current query is much too slow on large customer installs, so convert to a faster, simpler SQL query and handle the name processing in application code.