### PR TITLE
Require bckup-dir if timestamp is not provided

### DIFF
--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -2477,12 +2477,12 @@ LANGUAGE plpgsql NO SQL;`)
 			os.RemoveAll("/tmp/no-timestamp-tests")
 		})
 
-		It("functions normally if there is a single backup in the normal backup location", func() {
+		It("throws an error if there is a single backup in the normal backup location", func() {
 			gpbackup(gpbackupPath, backupHelperPath, "--verbose", "--metadata-only")
 
 			output, err := exec.Command(gprestorePath, "--verbose", "--redirect-db", "restoredb").CombinedOutput()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(string(output)).To(ContainSubstring("Restore completed successfully"))
+			Expect(err).To(HaveOccurred())
+			Expect(string(output)).ToNot(ContainSubstring("Restore completed successfully"))
 		})
 		It("functions normally if there is a single backup in a user-provided backup directory", func() {
 			gpbackup(gpbackupPath, backupHelperPath, "--verbose", "--metadata-only", "--backup-dir", "/tmp/no-timestamp-tests")
@@ -2491,23 +2491,10 @@ LANGUAGE plpgsql NO SQL;`)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(output)).To(ContainSubstring("Restore completed successfully"))
 		})
-		It("errors out if there are no backups in the normal backup location", func() {
-			output, err := exec.Command(gprestorePath, "--verbose").CombinedOutput()
-			Expect(err).To(HaveOccurred())
-			Expect(string(output)).To(ContainSubstring("No timestamp directories found"))
-		})
 		It("errors out if there are no backups in a user-provided backup directory", func() {
 			output, err := exec.Command(gprestorePath, "--verbose", "--backup-dir", "/tmp/no-timestamp-tests").CombinedOutput()
 			Expect(err).To(HaveOccurred())
 			Expect(string(output)).To(ContainSubstring("No timestamp directories found"))
-		})
-		It("errors out if there are multiple backups in the normal backup location", func() {
-			gpbackup(gpbackupPath, backupHelperPath, "--verbose", "--metadata-only")
-			gpbackup(gpbackupPath, backupHelperPath, "--verbose", "--metadata-only")
-
-			output, err := exec.Command(gprestorePath, "--verbose").CombinedOutput()
-			Expect(err).To(HaveOccurred())
-			Expect(string(output)).To(ContainSubstring("Multiple timestamp directories found"))
 		})
 		It("errors out if there are multiple backups in a user-provided backup directory", func() {
 			gpbackup(gpbackupPath, backupHelperPath, "--verbose", "--metadata-only", "--backup-dir", "/tmp/no-timestamp-tests")

--- a/restore/validate.go
+++ b/restore/validate.go
@@ -286,6 +286,9 @@ func ValidateFlagCombinations(flags *pflag.FlagSet) {
 	if flags.Changed(options.INCREMENTAL) && !flags.Changed(options.DATA_ONLY) {
 		gplog.Fatal(errors.Errorf("Cannot use --incremental without --data-only"), "")
 	}
+	if !flags.Changed(options.TIMESTAMP) && !flags.Changed(options.BACKUP_DIR) {
+		gplog.Fatal(errors.Errorf("Must provide --backup-dir if --timestamp is not provided"), "")
+	}
 	options.CheckExclusiveFlags(flags, options.RUN_ANALYZE, options.WITH_STATS)
 }
 

--- a/restore/validate_test.go
+++ b/restore/validate_test.go
@@ -321,80 +321,80 @@ var _ = Describe("restore/validate tests", func() {
 			 * Below are all the different filter combinations
 			 */
 			// --exclude-schema combinations with other filters
-			Entry("--exclude-schema combos", "--exclude-schema schema1 --include-table schema.table2", false),
-			Entry("--exclude-schema combos", "--exclude-schema schema1 --include-table-file /tmp/file2", false),
-			Entry("--exclude-schema combos", "--exclude-schema schema1 --include-schema schema2", false),
-			Entry("--exclude-schema combos", "--exclude-schema schema1 --include-schema-file /tmp/file2", true), // TODO: Verify this.
-			Entry("--exclude-schema combos", "--exclude-schema schema1 --exclude-table schema.table2", false),
-			Entry("--exclude-schema combos", "--exclude-schema schema1 --exclude-table-file /tmp/file2", false),
-			Entry("--exclude-schema combos", "--exclude-schema schema1 --exclude-schema schema2", true),
-			Entry("--exclude-schema combos", "--exclude-schema schema1 --exclude-schema-file /tmp/file2", true), // TODO: Verify this.
+			Entry("--exclude-schema combos", "--timestamp=0 --exclude-schema schema1 --include-table schema.table2", false),
+			Entry("--exclude-schema combos", "--timestamp=0 --exclude-schema schema1 --include-table-file /tmp/file2", false),
+			Entry("--exclude-schema combos", "--timestamp=0 --exclude-schema schema1 --include-schema schema2", false),
+			Entry("--exclude-schema combos", "--timestamp=0 --exclude-schema schema1 --include-schema-file /tmp/file2", true), // TODO: Verify this.
+			Entry("--exclude-schema combos", "--timestamp=0 --exclude-schema schema1 --exclude-table schema.table2", false),
+			Entry("--exclude-schema combos", "--timestamp=0 --exclude-schema schema1 --exclude-table-file /tmp/file2", false),
+			Entry("--exclude-schema combos", "--timestamp=0 --exclude-schema schema1 --exclude-schema schema2", true),
+			Entry("--exclude-schema combos", "--timestamp=0 --exclude-schema schema1 --exclude-schema-file /tmp/file2", true), // TODO: Verify this.
 
 			// --exclude-schema-file combinations with other filters
-			Entry("--exclude-schema-file combos", "--exclude-schema-file /tmp/file --include-table schema.table2", true),    // TODO: Verify this.
-			Entry("--exclude-schema-file combos", "--exclude-schema-file /tmp/file --include-table-file /tmp/file2", true),  // TODO: Verify this.
-			Entry("--exclude-schema-file combos", "--exclude-schema-file /tmp/file --include-schema schema2", true),         // TODO: Verify this.
-			Entry("--exclude-schema-file combos", "--exclude-schema-file /tmp/file --include-schema-file /tmp/file2", true), // TODO: Verify this.
-			Entry("--exclude-schema-file combos", "--exclude-schema-file /tmp/file --exclude-table schema.table2", true),    // TODO: Verify this.
-			Entry("--exclude-schema-file combos", "--exclude-schema-file /tmp/file --exclude-table-file /tmp/file2", true),  // TODO: Verify this.
+			Entry("--exclude-schema-file combos", "--timestamp=0 --exclude-schema-file /tmp/file --include-table schema.table2", true),    // TODO: Verify this.
+			Entry("--exclude-schema-file combos", "--timestamp=0 --exclude-schema-file /tmp/file --include-table-file /tmp/file2", true),  // TODO: Verify this.
+			Entry("--exclude-schema-file combos", "--timestamp=0 --exclude-schema-file /tmp/file --include-schema schema2", true),         // TODO: Verify this.
+			Entry("--exclude-schema-file combos", "--timestamp=0 --exclude-schema-file /tmp/file --include-schema-file /tmp/file2", true), // TODO: Verify this.
+			Entry("--exclude-schema-file combos", "--timestamp=0 --exclude-schema-file /tmp/file --exclude-table schema.table2", true),    // TODO: Verify this.
+			Entry("--exclude-schema-file combos", "--timestamp=0 --exclude-schema-file /tmp/file --exclude-table-file /tmp/file2", true),  // TODO: Verify this.
 
 			// --exclude-table combinations with other filters
-			Entry("--exclude-table combos", "--exclude-table schema.table --include-table schema.table2", false),
-			Entry("--exclude-table combos", "--exclude-table schema.table --include-table-file /tmp/file2", false),
-			Entry("--exclude-table combos", "--exclude-table schema.table --include-schema schema2", true),
-			Entry("--exclude-table combos", "--exclude-table schema.table --include-schema-file /tmp/file2", true),
-			Entry("--exclude-table combos", "--exclude-table schema.table --exclude-table schema.table2", true),
-			Entry("--exclude-table combos", "--exclude-table schema.table --exclude-table-file /tmp/file2", false),
+			Entry("--exclude-table combos", "--timestamp=0 --exclude-table schema.table --include-table schema.table2", false),
+			Entry("--exclude-table combos", "--timestamp=0 --exclude-table schema.table --include-table-file /tmp/file2", false),
+			Entry("--exclude-table combos", "--timestamp=0 --exclude-table schema.table --include-schema schema2", true),
+			Entry("--exclude-table combos", "--timestamp=0 --exclude-table schema.table --include-schema-file /tmp/file2", true),
+			Entry("--exclude-table combos", "--timestamp=0 --exclude-table schema.table --exclude-table schema.table2", true),
+			Entry("--exclude-table combos", "--timestamp=0 --exclude-table schema.table --exclude-table-file /tmp/file2", false),
 
 			// --exclude-table-file combinations with other filters
-			Entry("--exclude-table-file combos", "--exclude-table-file /tmp/file --include-table schema.table2", false),
-			Entry("--exclude-table-file combos", "--exclude-table-file /tmp/file --include-table-file /tmp/file2", false),
-			Entry("--exclude-table-file combos", "--exclude-table-file /tmp/file --include-schema schema2", true),
-			Entry("--exclude-table-file combos", "--exclude-table-file /tmp/file --include-schema-file /tmp/file2", true),
+			Entry("--exclude-table-file combos", "--timestamp=0 --exclude-table-file /tmp/file --include-table schema.table2", false),
+			Entry("--exclude-table-file combos", "--timestamp=0 --exclude-table-file /tmp/file --include-table-file /tmp/file2", false),
+			Entry("--exclude-table-file combos", "--timestamp=0 --exclude-table-file /tmp/file --include-schema schema2", true),
+			Entry("--exclude-table-file combos", "--timestamp=0 --exclude-table-file /tmp/file --include-schema-file /tmp/file2", true),
 
 			// --include-schema combinations with other filters
-			Entry("--include-schema combos", "--include-schema schema1 --include-table schema.table2", false),
-			Entry("--include-schema combos", "--include-schema schema1 --include-table-file /tmp/file2", false),
-			Entry("--include-schema combos", "--include-schema schema1 --include-schema schema2", true),
-			Entry("--include-schema combos", "--include-schema schema1 --include-schema-file /tmp/file2", true), // TODO: Verify this.
+			Entry("--include-schema combos", "--timestamp=0 --include-schema schema1 --include-table schema.table2", false),
+			Entry("--include-schema combos", "--timestamp=0 --include-schema schema1 --include-table-file /tmp/file2", false),
+			Entry("--include-schema combos", "--timestamp=0 --include-schema schema1 --include-schema schema2", true),
+			Entry("--include-schema combos", "--timestamp=0 --include-schema schema1 --include-schema-file /tmp/file2", true), // TODO: Verify this.
 
 			// --include-schema-file combinations with other filters
-			Entry("--include-schema-file combos", "--include-schema-file /tmp/file --include-table schema.table2", true),   // TODO: Verify this.
-			Entry("--include-schema-file combos", "--include-schema-file /tmp/file --include-table-file /tmp/file2", true), // TODO: Verify this.
+			Entry("--include-schema-file combos", "--timestamp=0 --include-schema-file /tmp/file --include-table schema.table2", true),   // TODO: Verify this.
+			Entry("--include-schema-file combos", "--timestamp=0 --include-schema-file /tmp/file --include-table-file /tmp/file2", true), // TODO: Verify this.
 
 			// --include-table combinations with other filters
-			Entry("--include-table combos", "--include-table schema.table --include-table schema.table2", true),
-			Entry("--include-table combos", "--include-table schema.table --include-table-file /tmp/file2", false),
+			Entry("--include-table combos", "--timestamp=0 --include-table schema.table --include-table schema.table2", true),
+			Entry("--include-table combos", "--timestamp=0 --include-table schema.table --include-table-file /tmp/file2", false),
 
 			/*
 			 * Below are various different incremental combinations
 			 */
-			Entry("incremental combos", "--incremental", false),
-			Entry("incremental combos", "--incremental --data-only", true),
+			Entry("incremental combos", "--timestamp=0 --incremental", false),
+			Entry("incremental combos", "--timestamp=0 --incremental --data-only", true),
 
 			/*
 			 * Below are various different truncate combinations
 			 */
-			Entry("truncate combos", "--truncate-table", false),
-			Entry("truncate combos", "--truncate-table --include-table schema.table2", true),
-			Entry("truncate combos", "--truncate-table --include-table-file /tmp/file2", true),
-			Entry("truncate combos", "--truncate-table --include-table schema.table2 --redirect-db foodb", true),
-			Entry("truncate combos", "--truncate-table --include-table schema.table2 --redirect-schema schema2", false),
+			Entry("truncate combos", "--timestamp=0 --truncate-table", false),
+			Entry("truncate combos", "--timestamp=0 --truncate-table --include-table schema.table2", true),
+			Entry("truncate combos", "--timestamp=0 --truncate-table --include-table-file /tmp/file2", true),
+			Entry("truncate combos", "--timestamp=0 --truncate-table --include-table schema.table2 --redirect-db foodb", true),
+			Entry("truncate combos", "--timestamp=0 --truncate-table --include-table schema.table2 --redirect-schema schema2", false),
 
 			/*
 			 * Below are various different redirect-schema combinations
 			 */
-			Entry("--redirect-schema combos", "--redirect-schema schema1", false),
-			Entry("--redirect-schema combos", "--redirect-schema schema1 --include-table schema.table2", true),
-			Entry("--redirect-schema combos", "--redirect-schema schema1 --include-table-file /tmp/file2", true),
-			Entry("--redirect-schema combos", "--redirect-schema schema1 --include-schema schema2", true),
-			Entry("--redirect-schema combos", "--redirect-schema schema1 --include-schema-file /tmp/file2", true),
-			Entry("--redirect-schema combos", "--redirect-schema schema1 --exclude-table schema.table2", false),
-			Entry("--redirect-schema combos", "--redirect-schema schema1 --exclude-table-file /tmp/file2", false),
-			Entry("--redirect-schema combos", "--redirect-schema schema1 --exclude-schema schema2", false),
-			Entry("--redirect-schema combos", "--redirect-schema schema1 --exclude-schema-file /tmp/file2", false),
-			Entry("--redirect-schema combos", "--redirect-schema schema1 --include-table schema.table2 --metadata-only", true),
-			Entry("--redirect-schema combos", "--redirect-schema schema1 --include-table schema.table2 --data-only", true),
+			Entry("--redirect-schema combos", "--timestamp=0 --redirect-schema schema1", false),
+			Entry("--redirect-schema combos", "--timestamp=0 --redirect-schema schema1 --include-table schema.table2", true),
+			Entry("--redirect-schema combos", "--timestamp=0 --redirect-schema schema1 --include-table-file /tmp/file2", true),
+			Entry("--redirect-schema combos", "--timestamp=0 --redirect-schema schema1 --include-schema schema2", true),
+			Entry("--redirect-schema combos", "--timestamp=0 --redirect-schema schema1 --include-schema-file /tmp/file2", true),
+			Entry("--redirect-schema combos", "--timestamp=0 --redirect-schema schema1 --exclude-table schema.table2", false),
+			Entry("--redirect-schema combos", "--timestamp=0 --redirect-schema schema1 --exclude-table-file /tmp/file2", false),
+			Entry("--redirect-schema combos", "--timestamp=0 --redirect-schema schema1 --exclude-schema schema2", false),
+			Entry("--redirect-schema combos", "--timestamp=0 --redirect-schema schema1 --exclude-schema-file /tmp/file2", false),
+			Entry("--redirect-schema combos", "--timestamp=0 --redirect-schema schema1 --include-table schema.table2 --metadata-only", true),
+			Entry("--redirect-schema combos", "--timestamp=0 --redirect-schema schema1 --include-table schema.table2 --data-only", true),
 		)
 	})
 	Describe("ValidateBackupFlagCombinations", func() {


### PR DESCRIPTION
The recent change to allow finding a backup timestamp if only one is present should only work with backup-dir functionality.  Add a check that at least one of those flags is provided.