### PR TITLE
Fix unfinished copy progress bars

### DIFF
--- a/restore/data.go
+++ b/restore/data.go
@@ -97,6 +97,12 @@ func CopyTableIn(connectionPool *dbconn.DBConn, tableName string, entry toc.Coor
 		}
 		// send signal to channel whether tracking or not, just to avoid race condition weirdness
 		done <- true
+
+		// Manually set the progress to maximum if COPY succeeded, as we won't be able to get the last few tuples
+		// from the view (or any tuples, for especially small tables) and we don't want users to worry that any
+		// tuples were missed.
+		progressBar := dataProgressBar.TuplesBars[whichConn-1]
+		progressBar.Set(dataProgressBar.TuplesCounts[whichConn-1])
 	}
 	return numRows, err
 }

--- a/utils/progress_bar_test.go
+++ b/utils/progress_bar_test.go
@@ -227,6 +227,8 @@ var _ = Describe("utils/log tests", func() {
 			close(done)
 
 			tupleBar := mpb.TuplesBars[0].GetBar()
+			// as in our COPY calls, manually set the bar at the end to ensure it always shows full
+			tupleBar.Set(50)
 			Expect(tupleBar.Total).To(Equal(int64(50)))
 			Expect(tupleBar.Get()).To(Equal(int64(50)))
 			testhelper.NotExpectRegexp(logfile, "public.foo:")
@@ -261,6 +263,7 @@ var _ = Describe("utils/log tests", func() {
 			mock.ExpectQuery("SELECT tuples_processed .*").WillReturnRows(rowEmpty)
 			mock.ExpectQuery("SELECT tuples_processed .*").WillReturnRows(row30)
 			mock.ExpectQuery("SELECT tuples_processed .*").WillReturnRows(row40)
+			mock.ExpectQuery("SELECT tuples_processed .*").WillReturnRows(row50)
 
 			go mpb.TrackCopyProgress("public.foo", 1, 50, connectionPool, 0, 0, done)
 			time.Sleep(time.Second)


### PR DESCRIPTION
The recent perf changes introduced a previously-prevented visual bug where the bar may not show progression to 100%. While this doesn't hurt anything, it is bad UI and might make users nervous. Manually set progress to 100% after copy finishes to prevent this.