### PR TITLE
Always clean up helper processes

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -467,10 +467,8 @@ func DoCleanup(backupFailed bool) {
 				// It is possible for the COPY command to become orphaned if an agent process is stopped
 				utils.TerminateHangingCopySessions(connectionPool, globalFPInfo, fmt.Sprintf("gpbackup_%s", globalFPInfo.Timestamp))
 			}
-			if backupFailed {
-				// Cleanup only if terminated or fataled
-				utils.CleanUpSegmentHelperProcesses(globalCluster, globalFPInfo, "backup")
-			}
+			// We can have helper processes hanging around even without failures, so call this cleanup routine whether successful or not.
+			utils.CleanUpSegmentHelperProcesses(globalCluster, globalFPInfo, "backup")
 			utils.CleanUpHelperFilesOnAllHosts(globalCluster, globalFPInfo)
 		}
 

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -804,8 +804,8 @@ var _ = Describe("backup and restore end to end tests", func() {
 
 			segConn.Commit(0)
 			homeDir := os.Getenv("HOME")
-			helperLogs, _ := path.Glob(path.Join(homeDir, "gpAdminLogs/gpbackup_helper*"))
-			cmdStr := fmt.Sprintf("tail -n 40 %s | grep \"Skip file has been discovered for entry\" || true", helperLogs[len(helperLogs)-1])
+			helperLogs, _ := path.Glob(path.Join(homeDir, "gpAdminLogs/gprestore_*"))
+			cmdStr := fmt.Sprintf("tail -n 40 %s | grep \"Creating skip file\" || true", helperLogs[len(helperLogs)-1])
 
 			attemts := 1000
 			err = errors.New("Timeout to discover skip file")

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -760,9 +760,9 @@ func DoCleanup(restoreFailed bool) {
 			if wasTerminated { // These should all end on their own in a successful restore
 				utils.TerminateHangingCopySessions(connectionPool, fpInfo, fmt.Sprintf("gprestore_%s_%s", fpInfo.Timestamp, restoreStartTime))
 			}
-			if restoreFailed {
-				utils.CleanUpSegmentHelperProcesses(globalCluster, fpInfo, "restore")
-			}
+
+			// We can have helper processes hanging around even without failures, so call this cleanup routine whether successful or not.
+			utils.CleanUpSegmentHelperProcesses(globalCluster, fpInfo, "restore")
 			utils.CleanUpHelperFilesOnAllHosts(globalCluster, fpInfo)
 		}
 	}


### PR DESCRIPTION
We have been seeing zombie helper processes on occasional test runs, and sometimes even on live systems. There are no obvious goroutines or other such "permanent hang" risks, and we already have a cleanup routine for these in case of failure. Call it even for successes, to ensure we don't leave a mess.