### PR TITLE
Fix bugs in new directory structure

### DIFF
--- a/filepath/filepath.go
+++ b/filepath/filepath.go
@@ -208,12 +208,13 @@ func (backupFPInfo *FilePathInfo) GetHelperLogPath() string {
  * Helper functions
  */
 
-func ParseSegPrefix(backupDir string) (string, error) {
-	if backupDir == "" {
+func ParseSegPrefix(backupDir string, timestamp string) (string, error) {
+	if backupDir == "" || timestamp == "" {
 		return "", nil
 	}
 
-	_, err := operating.System.Stat(fmt.Sprintf("%s/backups", backupDir))
+	dateString := timestamp[:8]
+	_, err := operating.System.Stat(fmt.Sprintf("%s/backups/%s/%s", backupDir, dateString, timestamp))
 	if err == nil {
 		// We're using the current directory format, there's no prefix to parse
 		return "", nil

--- a/filepath/filepath_test.go
+++ b/filepath/filepath_test.go
@@ -181,25 +181,25 @@ var _ = Describe("filepath tests", func() {
 			operating.System.Glob = func(pattern string) (matches []string, err error) {
 				return []string{"/tmp/foo/gpseg-1/backups"}, nil
 			}
-			res, err := ParseSegPrefix("/tmp/foo")
+			res, err := ParseSegPrefix("/tmp/foo", "00000000000000")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(Equal("gpseg"))
 		})
 		It("returns empty string if backup directory is empty", func() {
-			res, err := ParseSegPrefix("")
+			res, err := ParseSegPrefix("", "00000000000000")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res).To(Equal(""))
 		})
 		It("returns an error when coordinator backup directory does not exist", func() {
 			operating.System.Glob = func(pattern string) (matches []string, err error) { return []string{}, nil }
-			_, err := ParseSegPrefix("/tmp/foo")
+			_, err := ParseSegPrefix("/tmp/foo", "00000000000000")
 			Expect(err.Error()).To(Equal("Backup directory in /tmp/foo missing"))
 		})
 		It("returns an error when there is an error accessing coordinator backup directory", func() {
 			operating.System.Glob = func(pattern string) (matches []string, err error) {
 				return []string{""}, os.ErrPermission
 			}
-			_, err := ParseSegPrefix("/tmp/foo")
+			_, err := ParseSegPrefix("/tmp/foo", "00000000000000")
 			Expect(err.Error()).To(Equal("Failure while trying to locate backup directory in /tmp/foo. Error: permission denied"))
 		})
 		It("returns an error when multiple coordinator backup directories", func() {
@@ -210,7 +210,7 @@ var _ = Describe("filepath tests", func() {
 					return []string{}, nil
 				}
 			}
-			_, err := ParseSegPrefix("/tmp/foo")
+			_, err := ParseSegPrefix("/tmp/foo", "00000000000000")
 			Expect(err.Error()).To(Equal("Multiple backup directories in /tmp/foo"))
 		})
 		Describe("IsValidTimestamp", func() {

--- a/restore/remote.go
+++ b/restore/remote.go
@@ -50,8 +50,9 @@ func VerifyBackupFileCountOnSegments() {
 		// Coordinator backup files (and any gprestore report files) will be mixed in with segment backup files on a single-node cluster,
 		// so we explicitly look for filenames in the segment filename format.  In a smaller-to-larger restore, the contents list for a segment
 		// outside the destination array will be "[]", which the find command can handle safely in this context.
-		contentsList := fmt.Sprintf("[%s]", strings.Join(contentMap[contentID], "|"))
-		return fmt.Sprintf(`find %s -type f -name "gpbackup_%s_%s*" | wc -l`, globalFPInfo.GetDirForContent(contentID), contentsList, globalFPInfo.Timestamp)
+		contentsList := fmt.Sprintf("(%s)", strings.Join(contentMap[contentID], "|"))
+		cmdString := fmt.Sprintf(`find %s -type f -regextype posix-extended -regex ".*gpbackup_%s_%s.*" | wc -l`, globalFPInfo.GetDirForContent(contentID), contentsList, globalFPInfo.Timestamp)
+		return cmdString
 	})
 	globalCluster.CheckClusterError(remoteOutput, "Could not verify backup file count", func(contentID int) string {
 		return "Could not verify backup file count"

--- a/restore/restore.go
+++ b/restore/restore.go
@@ -84,7 +84,7 @@ func DoSetup() {
 	err = opts.QuoteExcludeRelations(connectionPool)
 	gplog.FatalOnError(err)
 
-	segPrefix, err = filepath.ParseSegPrefix(MustGetFlagString(options.BACKUP_DIR))
+	segPrefix, err = filepath.ParseSegPrefix(MustGetFlagString(options.BACKUP_DIR), backupTimestamp)
 	gplog.FatalOnError(err)
 	globalFPInfo = filepath.NewFilePathInfo(globalCluster, MustGetFlagString(options.BACKUP_DIR), backupTimestamp, segPrefix)
 	if reportDir := MustGetFlagString(options.REPORT_DIR); reportDir != "" {

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -346,7 +346,7 @@ func ExecuteRestoreMetadataStatements(statements []toc.StatementWithType, object
 func GetBackupFPInfoListFromRestorePlan() []filepath.FilePathInfo {
 	fpInfoList := make([]filepath.FilePathInfo, 0)
 	for _, entry := range backupConfig.RestorePlan {
-		segPrefix, err := filepath.ParseSegPrefix(MustGetFlagString(options.BACKUP_DIR))
+		segPrefix, err := filepath.ParseSegPrefix(MustGetFlagString(options.BACKUP_DIR), entry.Timestamp)
 		gplog.FatalOnError(err)
 
 		fpInfo := filepath.NewFilePathInfo(globalCluster, MustGetFlagString(options.BACKUP_DIR), entry.Timestamp, segPrefix)
@@ -357,7 +357,7 @@ func GetBackupFPInfoListFromRestorePlan() []filepath.FilePathInfo {
 }
 
 func GetBackupFPInfoForTimestamp(timestamp string) filepath.FilePathInfo {
-	segPrefix, err := filepath.ParseSegPrefix(MustGetFlagString(options.BACKUP_DIR))
+	segPrefix, err := filepath.ParseSegPrefix(MustGetFlagString(options.BACKUP_DIR), timestamp)
 	gplog.FatalOnError(err)
 	fpInfo := filepath.NewFilePathInfo(globalCluster, MustGetFlagString(options.BACKUP_DIR), timestamp, segPrefix)
 	return fpInfo


### PR DESCRIPTION
The 1.30.0 changes to backup directory structure had some bugs. This commit fixes those.

* The find command for counting files per segment had an error in the regex that was previously hidden by each segment's files being in separate folders. We update the regex used by find to be correct in the case of multiple-digit content IDs.
* Parsing segment prefix fails if both the old and the new structures are present alongside each other and the desired backup is in the old structure. We update the function to accept timestamp and check the expected location of the specific backup being restored.