### PR TITLE
Add --no-privileges flag to gpbackup

### DIFF
--- a/backup/backup.go
+++ b/backup/backup.go
@@ -230,7 +230,9 @@ func backupGlobals(metadataFile *utils.FileWithByteCount) {
 	backupResourceQueues(metadataFile)
 	backupResourceGroups(metadataFile)
 	backupRoles(metadataFile)
-	backupRoleGrants(metadataFile)
+	if !MustGetFlagBool(options.NO_PRIVILEGES) {
+		backupRoleGrants(metadataFile)
+	}
 	backupTablespaces(metadataFile)
 	backupCreateDatabase(metadataFile)
 	backupDatabaseGUCs(metadataFile)
@@ -333,7 +335,9 @@ func backupPostdata(metadataFile *utils.FileWithByteCount) {
 	backupRules(metadataFile)
 	backupTriggers(metadataFile)
 	if connectionPool.Version.AtLeast("6") {
-		backupDefaultPrivileges(metadataFile)
+		if !MustGetFlagBool(options.NO_PRIVILEGES) {
+			backupDefaultPrivileges(metadataFile)
+		}
 		if len(MustGetFlagStringArray(options.INCLUDE_SCHEMA)) == 0 {
 			backupEventTriggers(metadataFile)
 		}

--- a/backup/dependencies.go
+++ b/backup/dependencies.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/greenplum-db/gpbackup/options"
 	"github.com/greenplum-db/gpbackup/toc"
 	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/pkg/errors"
@@ -449,5 +450,7 @@ func PrintDependentObjectStatements(metadataFile *utils.FileWithByteCount, objTo
 		delete(metadataMap, object.GetUniqueID())
 	}
 	//  Process ACLs for left over objects in the metadata map
-	printExtensionFunctionACLs(metadataFile, objToc, metadataMap, funcInfoMap)
+	if !MustGetFlagBool(options.NO_PRIVILEGES) {
+		printExtensionFunctionACLs(metadataFile, objToc, metadataMap, funcInfoMap)
+	}
 }

--- a/backup/predata_functions.go
+++ b/backup/predata_functions.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/greenplum-db/gpbackup/options"
 	"github.com/greenplum-db/gpbackup/toc"
 	"github.com/greenplum-db/gpbackup/utils"
 )
@@ -358,20 +359,27 @@ func PrintCreateLanguageStatements(metadataFile *utils.FileWithByteCount, objToc
 		 * the inline and validator functions can be in a different schema and must be schema-qualified.
 		 */
 
+		addPrivileges := !MustGetFlagBool(options.NO_PRIVILEGES)
 		if procLang.Handler != 0 {
 			handlerInfo := funcInfoMap[procLang.Handler]
 			paramsStr += fmt.Sprintf(" HANDLER %s", handlerInfo.QualifiedName)
-			alterStr += fmt.Sprintf("\nALTER FUNCTION %s(%s) OWNER TO %s;", handlerInfo.QualifiedName, handlerInfo.Arguments.String, procLang.Owner)
+			if addPrivileges {
+				alterStr += fmt.Sprintf("\nALTER FUNCTION %s(%s) OWNER TO %s;", handlerInfo.QualifiedName, handlerInfo.Arguments.String, procLang.Owner)
+			}
 		}
 		if procLang.Inline != 0 {
 			inlineInfo := funcInfoMap[procLang.Inline]
 			paramsStr += fmt.Sprintf(" INLINE %s", inlineInfo.QualifiedName)
-			alterStr += fmt.Sprintf("\nALTER FUNCTION %s(%s) OWNER TO %s;", inlineInfo.QualifiedName, inlineInfo.Arguments.String, procLang.Owner)
+			if addPrivileges {
+				alterStr += fmt.Sprintf("\nALTER FUNCTION %s(%s) OWNER TO %s;", inlineInfo.QualifiedName, inlineInfo.Arguments.String, procLang.Owner)
+			}
 		}
 		if procLang.Validator != 0 {
 			validatorInfo := funcInfoMap[procLang.Validator]
 			paramsStr += fmt.Sprintf(" VALIDATOR %s", validatorInfo.QualifiedName)
-			alterStr += fmt.Sprintf("\nALTER FUNCTION %s(%s) OWNER TO %s;", validatorInfo.QualifiedName, validatorInfo.Arguments.String, procLang.Owner)
+			if addPrivileges {
+				alterStr += fmt.Sprintf("\nALTER FUNCTION %s(%s) OWNER TO %s;", validatorInfo.QualifiedName, validatorInfo.Arguments.String, procLang.Owner)
+			}
 		}
 		metadataFile.MustPrintf("%s;", paramsStr)
 

--- a/backup/predata_types.go
+++ b/backup/predata_types.go
@@ -164,10 +164,10 @@ func PrintCreateCompositeTypeStatement(metadataFile *utils.FileWithByteCount, ob
 
 func printPostCreateCompositeTypeStatement(metadataFile *utils.FileWithByteCount, objToc *toc.TOC, composite CompositeType, typeMetadata ObjectMetadata, tier []uint32) {
 	PrintObjectMetadata(metadataFile, objToc, typeMetadata, composite, "", tier)
-	statements := make([]string, 0)
+	statements := make([]toc.StatementWithType, 0)
 	for _, att := range composite.Attributes {
 		if att.Comment != "" {
-			statements = append(statements, fmt.Sprintf("COMMENT ON COLUMN %s.%s IS %s;", composite.FQN(), att.Name, att.Comment))
+			statements = append(statements, toc.StatementWithType{Statement: fmt.Sprintf("COMMENT ON COLUMN %s.%s IS %s;", composite.FQN(), att.Name, att.Comment), ObjectType: toc.OBJ_TYPE})
 		}
 	}
 	PrintStatements(metadataFile, objToc, composite, statements, tier)

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -2633,4 +2633,32 @@ LANGUAGE plpgsql NO SQL;`)
 			Expect(err).To(HaveOccurred())
 		})
 	})
+	Describe("Backup and restore with the --no-privileges flag", func() {
+		It("handles backup and restore of all sections", func() {
+			if useOldBackupVersion {
+				Skip("This test is not needed for old backup versions")
+			}
+			testhelper.AssertQueryRuns(backupConn, `CREATE TABLE public.bar(i int);`)
+			testhelper.AssertQueryRuns(backupConn, `CREATE TABLE public.baz(i int);`)
+			testhelper.AssertQueryRuns(backupConn, `CREATE ROLE temprole;`)
+			testhelper.AssertQueryRuns(backupConn, `ALTER TABLE public.bar OWNER TO temprole`)
+			testhelper.AssertQueryRuns(backupConn, `GRANT SELECT ON public.baz TO temprole`)
+			defer testhelper.AssertQueryRuns(backupConn, "DROP ROLE temprole")
+			defer testhelper.AssertQueryRuns(backupConn, "DROP TABLE public.bar")
+			defer testhelper.AssertQueryRuns(backupConn, "DROP TABLE public.baz")
+
+			timestamp := gpbackup(gpbackupPath, backupHelperPath, "--backup-dir", backupDir, "--no-privileges")
+
+			contents := string(getMetdataFileContents(backupDir, timestamp, "metadata.sql"))
+			Expect(contents).ToNot(ContainSubstring("ALTER SCHEMA public OWNER"))
+			Expect(contents).ToNot(ContainSubstring("REVOKE ALL ON SCHEMA"))
+			Expect(contents).ToNot(ContainSubstring("GRANT ALL ON SCHEMA"))
+			Expect(contents).ToNot(ContainSubstring("GRANT SELECT ON"))
+			Expect(contents).ToNot(ContainSubstring("OWNER TO"))
+
+			gprestore(gprestorePath, restoreHelperPath, timestamp,
+				"--backup-dir", backupDir,
+				"--redirect-db", "restoredb")
+		})
+	})
 })

--- a/options/flag.go
+++ b/options/flag.go
@@ -38,6 +38,7 @@ const (
 	NO_COMPRESSION        = "no-compression"
 	NO_HISTORY            = "no-history"
 	NO_INHERITS           = "no-inherits"
+	NO_PRIVILEGES         = "no-privileges"
 	ON_ERROR_CONTINUE     = "on-error-continue"
 	PLUGIN_CONFIG         = "plugin-config"
 	QUIET                 = "quiet"
@@ -68,6 +69,7 @@ func SetBackupFlagDefaults(flagSet *pflag.FlagSet) {
 	flagSet.Bool(NO_COMPRESSION, false, "Skip compression of data files")
 	flagSet.Bool(NO_HISTORY, false, "Do not write a backup entry to the gpbackup_history database")
 	flagSet.Bool(NO_INHERITS, false, "For a filtered backup, don't back up all tables that inherit included tables")
+	flagSet.Bool(NO_PRIVILEGES, false, "Do not back up owner or privilege information for objects in the backup")
 	flagSet.Bool(QUIET, false, "Suppress non-warning, non-error log messages")
 	flagSet.Bool(SINGLE_BACKUP_DIR, false, "Back up all data to a single directory instead of split by segment")
 	flagSet.Bool(SINGLE_DATA_FILE, false, "Back up all data to a single file instead of one per table")


### PR DESCRIPTION
This flag causes gpbackup to omit statements related to object ownership and privileges from the metadata file, in order to (among other things) allow a predata restore to be done without needing all of the original roles to exist in the target database or needing to perform a restore of globals beforehand.

This commit does not add the same flag to gprestore to allow ignoring ownership and privilege statements for objects during a restore that does include them, but it does refactor the ToC logic to assign those statements their own types (as they are currently treated as tables) to enable that functionality to be more easily added to gprestore in a later commit.

pipeline: https://dp.ci.gpdb.pivotal.io/teams/main/pipelines/no-priv-on-1.30.x