### PR TITLE
Support backup and restore database containing an extension with creating user mappinger

### DIFF
--- a/backup/predata_functions.go
+++ b/backup/predata_functions.go
@@ -484,7 +484,7 @@ func PrintCreateServerStatement(metadataFile *utils.FileWithByteCount, objToc *t
 
 func PrintCreateUserMappingStatement(metadataFile *utils.FileWithByteCount, objToc *toc.TOC, mapping UserMapping) {
 	start := metadataFile.ByteCount
-	metadataFile.MustPrintf("\n\nCREATE USER MAPPING FOR %s\n\tSERVER %s", mapping.User, mapping.Server)
+	metadataFile.MustPrintf("\n\nCREATE USER MAPPING IF NOT EXISTS FOR %s\n\tSERVER %s", mapping.User, mapping.Server)
 	if mapping.Options != "" {
 		metadataFile.MustPrintf("\n\tOPTIONS (%s)", mapping.Options)
 	}


### PR DESCRIPTION
gp_backup backup user mappings in pg_user_mappings catalog, and gp_restore restore user mappings in target database using create user mapping SQL. However, If user create an extension, in which code a user mapping is created. in such condition, target user mapping entry is inserted into pg_user_mappings catalog in source database.

when doing restore, the extension is recreated in target database. When creating the extension, the corresponding user mapping is created because of the redoing extension code. However, gp_restore will also restore the user mapping in pg_user_mapping catalog. So an error "user mapping xxx already exists." will be raised.

I open a MR and add IF EXISTS to CREATE USER MAPPING SQL in backup/predata_functions.go. Please have a look at this.