### PR TITLE
Move constraints back to postdata for data load performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,17 @@ To run only unit tests, use
 ```bash
 make unit
 ```
-To run only integration tests (requires a running GPDB instance), use
+To run only integration tests
 ```bash
 make integration
 ```
+Integration test requirements
+ - Running GPDB instance
+ - GPDB's gpcloud extension
+```bash
+make -C gpcontrib/gpcloud/ install
+```
+ - GPDB configured with `--with-perl`
 
 To run end to end tests (requires a running GPDB instance), use
 ```bash

--- a/backup/backup.go
+++ b/backup/backup.go
@@ -276,11 +276,15 @@ func backupPredata(metadataFile *utils.FileWithByteCount, tables []Table, tableO
 
 	retrieveViews(&objects)
 	sequences := retrieveAndBackupSequences(metadataFile, relationMetadata)
-	domainConstraints := retrieveConstraints(&objects, metadataMap)
+	domainConstraints, nonDomainConstraints, conMetadata := retrieveConstraints(&objects, metadataMap)
 
-	backupDependentObjects(metadataFile, tables, protocols, metadataMap, domainConstraints, objects, sequences, funcInfoMap, tableOnly)
+	viewsDependingOnConstraints := backupDependentObjects(metadataFile, tables, protocols, metadataMap, domainConstraints, objects, sequences, funcInfoMap, tableOnly)
 
 	backupConversions(metadataFile)
+
+	// These two are actually in postdata, but we print them here to avoid passing information around too much
+	backupConstraints(metadataFile, nonDomainConstraints, conMetadata)
+	backupViewsDependingOnConstraints(metadataFile, viewsDependingOnConstraints)
 
 	logCompletionMessage("Pre-data metadata metadata backup")
 }

--- a/backup/dependencies.go
+++ b/backup/dependencies.go
@@ -417,7 +417,11 @@ func PrintDependentObjectStatements(metadataFile *utils.FileWithByteCount, objTo
 		case ExternalProtocol:
 			PrintCreateExternalProtocolStatement(metadataFile, objToc, obj, funcInfoMap, objMetadata)
 		case View:
-			PrintCreateViewStatement(metadataFile, objToc, obj, objMetadata)
+			if obj.NeedsDummy {
+				PrintCreateDummyViewStatement(metadataFile, objToc, obj, objMetadata)
+			} else {
+				PrintCreateViewStatement(metadataFile, objToc, obj, objMetadata)
+			}
 		case TextSearchParser:
 			PrintCreateTextSearchParserStatement(metadataFile, objToc, obj, objMetadata)
 		case TextSearchConfiguration:
@@ -441,13 +445,40 @@ func PrintDependentObjectStatements(metadataFile *utils.FileWithByteCount, objTo
 		case UserMapping:
 			PrintCreateUserMappingStatement(metadataFile, objToc, obj)
 		case Constraint:
-			PrintConstraintStatement(metadataFile, objToc, obj, objMetadata)
+			// Constraints have been moved to postdata, but we need to include
+			// them for dependency sorting
+			continue
 		case Transform:
 			PrintCreateTransformStatement(metadataFile, objToc, obj, funcInfoMap, objMetadata)
 		}
 		// Remove ACLs from metadataMap for the current object since they have been processed
 		delete(metadataMap, object.GetUniqueID())
 	}
+
 	//  Process ACLs for left over objects in the metadata map
 	printExtensionFunctionACLs(metadataFile, objToc, metadataMap, funcInfoMap)
+}
+
+func MarkViewsDependingOnConstraints(sortableObjs []Sortable, depMap DependencyMap) []View {
+	var viewsDependingOnConstraints []View
+	for i, _ := range sortableObjs {
+		view, ok := sortableObjs[i].(View)
+		if !ok {
+			continue
+		}
+
+		relationsViewDependsOn, ok := depMap[view.GetUniqueID()]
+		if !ok {
+			continue
+		}
+
+		for relation := range relationsViewDependsOn {
+			if relation.ClassID == PG_CONSTRAINT_OID {
+				view.NeedsDummy = true
+				sortableObjs[i] = view
+				viewsDependingOnConstraints = append(viewsDependingOnConstraints, view)
+			}
+		}
+	}
+	return viewsDependingOnConstraints
 }

--- a/backup/queries_relation_test.go
+++ b/backup/queries_relation_test.go
@@ -38,6 +38,10 @@ var _ = Describe("backup internal tests", func() {
 	})
 	Describe("GetAllViews", func() {
 		It("GetAllViews properly handles NULL view definitions", func() {
+			columnDefHeader := []string{"attrelid", "attnum", "name", "attnotnull", "atthasdef", "type", "encoding", "attstattarget", "storagetype", "defaultval", "comment", "privileges", "kind", "options", "fdwoptions", "collation", "securitylabelprovider", "securitylabel", "attgenerated", "isinherited"}
+			fakeColumnDef := sqlmock.NewRows(columnDefHeader)
+			mock.ExpectQuery(`SELECT (.*)`).WillReturnRows(fakeColumnDef)
+
 			header := []string{"oid", "schema", "name", "options", "definition", "tablespace", "ismaterialized"}
 			rowOne := []driver.Value{"1", "mock_schema", "mock_table", "mock_options", "mock_def", "mock_tablespace", false}
 			rowTwo := []driver.Value{"2", "mock_schema2", "mock_table2", "mock_options2", nil, "mock_tablespace2", false}

--- a/backup/queries_relations.go
+++ b/backup/queries_relations.go
@@ -352,6 +352,8 @@ type View struct {
 	Tablespace     string
 	IsMaterialized bool
 	DistPolicy     string
+	NeedsDummy     bool
+	ColumnDefs     []ColumnDefinition
 }
 
 func (v View) GetMetadataEntry() (string, toc.MetadataEntry) {
@@ -383,6 +385,7 @@ func (v View) ObjectType() string {
 
 // This function retrieves both regular views and materialized views.
 func GetAllViews(connectionPool *dbconn.DBConn) []View {
+	columnDefs := GetColumnDefinitions(connectionPool)
 
 	// When querying the view definition using pg_get_viewdef(), the pg function
 	// obtains dependency locks that are not released until the transaction is
@@ -461,8 +464,8 @@ func GetAllViews(connectionPool *dbconn.DBConn) []View {
 		if result.IsMaterialized {
 			result.DistPolicy = distPolicies[result.Oid]
 		}
+		result.ColumnDefs = columnDefs[result.Oid]
 		verifiedResults = append(verifiedResults, result)
-
 	}
 
 	return verifiedResults

--- a/backup/queries_shared.go
+++ b/backup/queries_shared.go
@@ -85,13 +85,7 @@ type Constraint struct {
 }
 
 func (c Constraint) GetMetadataEntry() (string, toc.MetadataEntry) {
-	var tocSection string
-	if c.Def.Valid && !strings.Contains(strings.ToUpper(c.Def.String), "NOT VALID") {
-		tocSection = "predata"
-	} else {
-		tocSection = "postdata"
-	}
-	return tocSection,
+	return "postdata",
 		toc.MetadataEntry{
 			Schema:          c.Schema,
 			Name:            c.Name,

--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -1901,6 +1901,33 @@ LANGUAGE plpgsql NO SQL;`)
 				stdout := string(output)
 				Expect(stdout).To(ContainSubstring("Backup completed successfully"))
 			})
+			It("Restores views that depend on a constraint by printing a dummy view", func() {
+				testutils.SkipIfBefore6(backupConn)
+				if useOldBackupVersion {
+					Skip("This test is not needed for old backup versions")
+				}
+				testhelper.AssertQueryRuns(backupConn, `CREATE TABLE view_base_table (key int PRIMARY KEY, data varchar(20))`)
+				testhelper.AssertQueryRuns(backupConn, `CREATE VIEW key_dependent_view AS SELECT key, data COLLATE "C" FROM view_base_table GROUP BY key;`)
+				testhelper.AssertQueryRuns(backupConn, `CREATE VIEW key_dependent_view_no_cols AS SELECT FROM view_base_table GROUP BY key HAVING length(data) > 0`)
+				defer testhelper.AssertQueryRuns(backupConn, "DROP TABLE view_base_table CASCADE")
+
+				timestamp := gpbackup(gpbackupPath, backupHelperPath, "--backup-dir", backupDir)
+
+				contents := string(getMetdataFileContents(backupDir, timestamp, "metadata.sql"))
+				Expect(contents).To(ContainSubstring("CREATE VIEW public.key_dependent_view AS \nSELECT\n\tNULL::integer AS key,\n\tNULL::character varying(20) COLLATE pg_catalog.\"C\" AS data;"))
+				Expect(contents).To(ContainSubstring("CREATE VIEW public.key_dependent_view_no_cols AS \nSELECT;"))
+				Expect(contents).To(ContainSubstring("ALTER TABLE ONLY public.view_base_table ADD CONSTRAINT view_base_table_pkey PRIMARY KEY (key);"))
+				Expect(contents).To(ContainSubstring("CREATE OR REPLACE VIEW public.key_dependent_view AS  SELECT view_base_table.key,\n    (view_base_table.data COLLATE \"C\") AS data\n   FROM public.view_base_table\n  GROUP BY view_base_table.key;"))
+				Expect(contents).To(ContainSubstring("CREATE OR REPLACE VIEW public.key_dependent_view_no_cols AS  SELECT\n   FROM public.view_base_table\n  GROUP BY view_base_table.key\n HAVING (length((view_base_table.data)::text) > 0);"))
+
+				gprestoreArgs := []string{
+					"--timestamp", timestamp,
+					"--redirect-db", "restoredb",
+					"--backup-dir", backupDir}
+				gprestoreCmd := exec.Command(gprestorePath, gprestoreArgs...)
+				_, err := gprestoreCmd.CombinedOutput()
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 	})
 	Describe("Restore to a different-sized cluster", FlakeAttempts(5), func() {

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/jmoiron/sqlx v1.3.5
 	github.com/klauspost/compress v1.15.15
 	github.com/lib/pq v1.10.7
-	github.com/mattn/go-sqlite3 v2.0.3+incompatible
+	github.com/mattn/go-sqlite3 v1.14.19
 	github.com/nightlyone/lockfile v1.0.0
 	github.com/onsi/ginkgo/v2 v2.8.4
 	github.com/onsi/gomega v1.27.2

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPn
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+github.com/mattn/go-sqlite3 v1.14.19 h1:fhGleo2h1p8tVChob4I9HpmVFIAkKGpiukdrgQbWfGI=
+github.com/mattn/go-sqlite3 v1.14.19/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
 github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJKjyR5WD3HYQSd+U=
 github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/nightlyone/lockfile v1.0.0 h1:RHep2cFKK4PonZJDdEl4GmkabuhbsRMgk/k3uAmxBiA=

--- a/integration/predata_relations_create_test.go
+++ b/integration/predata_relations_create_test.go
@@ -521,7 +521,7 @@ SET SUBPARTITION TEMPLATE ` + `
 			view.Oid = testutils.OidFromObjectName(connectionPool, "public", "simpleview", backup.TYPE_RELATION)
 			Expect(resultViews).To(HaveLen(1))
 			resultMetadata := resultMetadataMap[view.GetUniqueID()]
-			structmatcher.ExpectStructsToMatch(&view, &resultViews[0])
+			structmatcher.ExpectStructsToMatchExcluding(&view, &resultViews[0], "ColumnDefs")
 			structmatcher.ExpectStructsToMatch(&viewMetadata, &resultMetadata)
 		})
 		It("creates a view with options", func() {
@@ -537,7 +537,7 @@ SET SUBPARTITION TEMPLATE ` + `
 
 			view.Oid = testutils.OidFromObjectName(connectionPool, "public", "simpleview", backup.TYPE_RELATION)
 			Expect(resultViews).To(HaveLen(1))
-			structmatcher.ExpectStructsToMatch(&view, &resultViews[0])
+			structmatcher.ExpectStructsToMatchExcluding(&view, &resultViews[0], "ColumnDefs")
 		})
 	})
 	Describe("PrintMaterializedCreateViewStatements", func() {
@@ -561,7 +561,7 @@ SET SUBPARTITION TEMPLATE ` + `
 			view.Oid = testutils.OidFromObjectName(connectionPool, "public", "simplemview", backup.TYPE_RELATION)
 			Expect(resultViews).To(HaveLen(1))
 			resultMetadata := resultMetadataMap[view.GetUniqueID()]
-			structmatcher.ExpectStructsToMatch(&view, &resultViews[0])
+			structmatcher.ExpectStructsToMatchExcluding(&view, &resultViews[0], "ColumnDefs")
 			structmatcher.ExpectStructsToMatch(&viewMetadata, &resultMetadata)
 		})
 		It("creates a materialized view with options", func() {
@@ -576,7 +576,7 @@ SET SUBPARTITION TEMPLATE ` + `
 
 			view.Oid = testutils.OidFromObjectName(connectionPool, "public", "simplemview", backup.TYPE_RELATION)
 			Expect(resultViews).To(HaveLen(1))
-			structmatcher.ExpectStructsToMatch(&view, &resultViews[0])
+			structmatcher.ExpectStructsToMatchExcluding(&view, &resultViews[0], "ColumnDefs")
 		})
 	})
 	Describe("PrintCreateSequenceStatements", func() {

--- a/integration/predata_relations_queries_test.go
+++ b/integration/predata_relations_queries_test.go
@@ -457,8 +457,9 @@ PARTITION BY LIST (gender)
 			results := backup.GetAllViews(connectionPool)
 			view := backup.View{Oid: 1, Schema: "public", Name: "simpleview", Definition: viewDef}
 
+			view.Oid = testutils.OidFromObjectName(connectionPool, "public", "simpleview", backup.TYPE_RELATION)
 			Expect(results).To(HaveLen(1))
-			structmatcher.ExpectStructsToMatchExcluding(&view, &results[0], "Oid")
+			structmatcher.ExpectStructsToMatchExcluding(&view, &results[0], "ColumnDefs")
 		})
 		It("returns a slice for view in a specific schema", func() {
 			testhelper.AssertQueryRuns(connectionPool, "CREATE VIEW public.simpleview AS SELECT 1")
@@ -472,8 +473,9 @@ PARTITION BY LIST (gender)
 			results := backup.GetAllViews(connectionPool)
 			view := backup.View{Oid: 1, Schema: "testschema", Name: "simpleview", Definition: viewDef}
 
+			view.Oid = testutils.OidFromObjectName(connectionPool, "testschema", "simpleview", backup.TYPE_RELATION)
 			Expect(results).To(HaveLen(1))
-			structmatcher.ExpectStructsToMatchExcluding(&view, &results[0], "Oid")
+			structmatcher.ExpectStructsToMatchExcluding(&view, &results[0], "ColumnDefs")
 		})
 		It("PANIC on views with anyarray typecasts in its view definition", func() {
 			// The view definition gets incorrectly converted and stored as
@@ -497,8 +499,9 @@ PARTITION BY LIST (gender)
 			results := backup.GetAllViews(connectionPool)
 			view := backup.View{Oid: 1, Schema: "public", Name: "simpleview", Definition: viewDef, Options: " WITH (security_barrier=true)"}
 
+			view.Oid = testutils.OidFromObjectName(connectionPool, "public", "simpleview", backup.TYPE_RELATION)
 			Expect(results).To(HaveLen(1))
-			structmatcher.ExpectStructsToMatchExcluding(&view, &results[0], "Oid")
+			structmatcher.ExpectStructsToMatchExcluding(&view, &results[0], "ColumnDefs")
 		})
 		It("returns a slice for materialized views", func() {
 			if connectionPool.Version.Before("6.2") {
@@ -510,8 +513,9 @@ PARTITION BY LIST (gender)
 			results := backup.GetAllViews(connectionPool)
 			materialView := backup.View{Oid: 1, Schema: "public", Name: "simplematerialview", Definition: sql.NullString{String: " SELECT 1 AS a;", Valid: true}, IsMaterialized: true, DistPolicy: "DISTRIBUTED BY (a)"}
 
+			materialView.Oid = testutils.OidFromObjectName(connectionPool, "public", "simplematerialview", backup.TYPE_RELATION)
 			Expect(results).To(HaveLen(1))
-			structmatcher.ExpectStructsToMatchExcluding(&materialView, &results[0], "Oid")
+			structmatcher.ExpectStructsToMatchExcluding(&materialView, &results[0], "ColumnDefs")
 		})
 		It("returns a slice for materialized views with storage parameters", func() {
 			if connectionPool.Version.Before("6.2") {
@@ -523,8 +527,9 @@ PARTITION BY LIST (gender)
 			results := backup.GetAllViews(connectionPool)
 			materialView := backup.View{Oid: 1, Schema: "public", Name: "simplematerialview", Definition: sql.NullString{String: " SELECT 1 AS a;", Valid: true}, Options: " WITH (fillfactor=50, autovacuum_enabled=false)", IsMaterialized: true, DistPolicy: "DISTRIBUTED BY (a)"}
 
+			materialView.Oid = testutils.OidFromObjectName(connectionPool, "public", "simplematerialview", backup.TYPE_RELATION)
 			Expect(results).To(HaveLen(1))
-			structmatcher.ExpectStructsToMatchExcluding(&materialView, &results[0], "Oid")
+			structmatcher.ExpectStructsToMatchExcluding(&materialView, &results[0], "ColumnDefs")
 		})
 		It("returns a slice for materialized views with tablespaces", func() {
 			if connectionPool.Version.Before("6.2") {
@@ -539,7 +544,7 @@ PARTITION BY LIST (gender)
 			materialView := backup.View{Oid: 1, Schema: "public", Name: "simplematerialview", Definition: sql.NullString{String: " SELECT 1 AS a;", Valid: true}, Tablespace: "test_tablespace", IsMaterialized: true, DistPolicy: "DISTRIBUTED BY (a)"}
 
 			Expect(results).To(HaveLen(1))
-			structmatcher.ExpectStructsToMatchExcluding(&materialView, &results[0], "Oid")
+			structmatcher.ExpectStructsToMatchExcluding(&materialView, &results[0], "Oid", "ColumnDefs")
 		})
 	})
 })


### PR DESCRIPTION
Originally, constraints were dumped in predata. This caused a restore
issue with tables that used constraints that used the `NOT VALID`
clause. This is because there were scenarios where there was data
grandfathered into tables that violate the constraint that has not yet
been resolved by users, but allowed because of the `NOT VALID` clause.
Because of this issue, and the assumption that nothing can depend on
constraints, constraints were moved from predata to postdata to allow
tables with data that violate `NOT VALID` constraints to restore.
https://github.com/greenplum-db/gpbackup/commit/90b3b54b83fe01f8107a329f2bd10652abd67bd6

It was then later discovered that views can depend on constraints. All
constraints, expect ones with `NOT VALID` clause, were moved back into
predata.
https://github.com/greenplum-db/gpbackup/commit/5895076a2678b00e50455e889d7df93d003fd3e8

While this fixes the dependency issues, this is a significant
performance regression because it is much more performant to restore
constraints after all data has been restored. This is because
constraints use internal indexes. If constraints are restored during
predata, data load would slow down considerably because every row insert
would trigger constraint index update.

In order resolve both the performance regression and original issue, we
can move constraint restore back into postdata and resolve the circular
dependency of a predata view depending on a postdata constraint using a
dummy view in predata. Now if a view that depends on a constraint is
detected, a dummy view that satisfies dependency conditions for other
relations gets dumped in predata. The dummy view and will eventually get
replaced by the dump of the full view definition in postdata after
constraints are dumped.

This circular dependency of predata views depending on postdata
constraints is not applicable to 5X. View dependency on constraints
exist because of the feature to allow incomplete GROUP BY lists that was
introduced in GPDB6 (postgres 9.1). 
https://github.com/greenplum-db/gpdb/commit/e49ae8d3bc588294d07ce1a1272b31718cfca5ef

gpbackup pipeline:
https://dp.ci.gpdb.pivotal.io/teams/main/pipelines/dump-constraints-postdata
