### PR TITLE
Use type TABLE when printing GRANT statements for views

### DIFF
--- a/backup/predata_acl.go
+++ b/backup/predata_acl.go
@@ -295,7 +295,7 @@ func (obj ObjectMetadata) GetPrivilegesStatements(objectName string, objectType 
 	statements := make([]string, 0)
 	typeStr := fmt.Sprintf("%s ", objectType)
 	if objectType == toc.OBJ_VIEW || objectType == toc.OBJ_FOREIGN_TABLE || objectType == toc.OBJ_MATERIALIZED_VIEW {
-		typeStr = ""
+		typeStr = "TABLE "
 	} else if objectType == toc.OBJ_COLUMN {
 		typeStr = "TABLE "
 	} else if objectType == toc.OBJ_AGGREGATE {

--- a/backup/predata_relations_other_test.go
+++ b/backup/predata_relations_other_test.go
@@ -312,9 +312,9 @@ SELECT pg_catalog.setval('public.seq_name', 10, true);`, getSeqDefReplace()),
 			expectedEntries := []string{"CREATE VIEW shamwow.shazam AS SELECT count(*) FROM pg_tables;",
 				"COMMENT ON VIEW shamwow.shazam IS 'This is a view comment.';",
 				fmt.Sprintf("ALTER %s shamwow.shazam OWNER TO testrole;", keywordReplace),
-				`REVOKE ALL ON shamwow.shazam FROM PUBLIC;
-REVOKE ALL ON shamwow.shazam FROM testrole;
-GRANT ALL ON shamwow.shazam TO testrole;`}
+				`REVOKE ALL ON TABLE shamwow.shazam FROM PUBLIC;
+REVOKE ALL ON TABLE shamwow.shazam FROM testrole;
+GRANT ALL ON TABLE shamwow.shazam TO testrole;`}
 
 			if connectionPool.Version.AtLeast("6") {
 				expectedEntries = append(expectedEntries, "SECURITY LABEL FOR dummy ON VIEW shamwow.shazam IS 'unclassified';")
@@ -639,7 +639,7 @@ GRANT ALL ON shamwow.shazam TO testrole;`}
 WITH NO DATA
 DISTRIBUTED BY (tablename);`)
 		})
-		It("can print a view with privileges, an owner, and a comment", func() {
+		It("can print a materialized view with privileges, an owner, and a comment", func() {
 			mviewMetadata := testutils.DefaultMetadata(toc.OBJ_MATERIALIZED_VIEW, true, true, true, false)
 			backup.PrintCreateViewStatement(backupfile, tocfile, mview, mviewMetadata)
 			expectedEntries := []string{`CREATE MATERIALIZED VIEW schema1.mview1 AS SELECT count(*) FROM pg_tables
@@ -647,9 +647,9 @@ WITH NO DATA
 DISTRIBUTED BY (tablename);`,
 				"COMMENT ON MATERIALIZED VIEW schema1.mview1 IS 'This is a materialized view comment.';",
 				"ALTER MATERIALIZED VIEW schema1.mview1 OWNER TO testrole;",
-				`REVOKE ALL ON schema1.mview1 FROM PUBLIC;
-REVOKE ALL ON schema1.mview1 FROM testrole;
-GRANT ALL ON schema1.mview1 TO testrole;`}
+				`REVOKE ALL ON TABLE schema1.mview1 FROM PUBLIC;
+REVOKE ALL ON TABLE schema1.mview1 FROM testrole;
+GRANT ALL ON TABLE schema1.mview1 TO testrole;`}
 			testutils.AssertBufferContents(tocfile.PredataEntries, buffer, expectedEntries...)
 		})
 		It("can print a materialized view with options and a tablespace", func() {

--- a/backup/predata_relations_tables_test.go
+++ b/backup/predata_relations_tables_test.go
@@ -627,9 +627,9 @@ COMMENT ON FOREIGN TABLE public.tablename IS 'This is a foreign table comment.';
 ALTER FOREIGN TABLE public.tablename OWNER TO testrole;
 
 
-REVOKE ALL ON public.tablename FROM PUBLIC;
-REVOKE ALL ON public.tablename FROM testrole;
-GRANT ALL ON public.tablename TO testrole;
+REVOKE ALL ON TABLE public.tablename FROM PUBLIC;
+REVOKE ALL ON TABLE public.tablename FROM testrole;
+GRANT ALL ON TABLE public.tablename TO testrole;
 
 
 SECURITY LABEL FOR dummy ON FOREIGN TABLE public.tablename IS 'unclassified';`)

--- a/restore/restore_internal_test.go
+++ b/restore/restore_internal_test.go
@@ -38,6 +38,10 @@ var _ = Describe("restore internal tests", func() {
 			Schema: "foo", Name: "foo", ObjectType: toc.OBJ_SCHEMA,
 			Statement: "\n\nREVOKE ALL ON SCHEMA foo FROM PUBLIC;\nGRANT ALL ON SCHEMA foo TO testuser;\n",
 		},
+		{ // multi-line permissions block for a view
+			Schema: "foo", Name: "myview", ObjectType: toc.OBJ_VIEW,
+			Statement: "\n\nREVOKE ALL ON TABLE foo.myview FROM PUBLIC;\nGRANT ALL ON TABLE foo.myview TO testuser;\n",
+		},
 		{ // multi-line permissions block for a non-schema object
 			Schema: "foo", Name: "myfunc", ObjectType: toc.OBJ_FUNCTION,
 			Statement: "\n\nREVOKE ALL ON FUNCTION foo.myfunc(integer) FROM PUBLIC;\nGRANT ALL ON FUNCTION foo.myfunc(integer) TO testuser;\n",
@@ -104,6 +108,10 @@ var _ = Describe("restore internal tests", func() {
 				{
 					Schema: "foo2", Name: "foo2", ObjectType: toc.OBJ_SCHEMA,
 					Statement: "\n\nREVOKE ALL ON SCHEMA foo2 FROM PUBLIC;\nGRANT ALL ON SCHEMA foo2 TO testuser;\n",
+				},
+				{
+					Schema: "foo2", Name: "myview", ObjectType: toc.OBJ_VIEW,
+					Statement: "\n\nREVOKE ALL ON TABLE foo2.myview FROM PUBLIC;\nGRANT ALL ON TABLE foo2.myview TO testuser;\n",
 				},
 				{
 					Schema: "foo2", Name: "myfunc", ObjectType: toc.OBJ_FUNCTION,


### PR DESCRIPTION
The TABLE keyword in GRANT/REVOKE statements is optional and we omitted printing it for VIEWS, FOREIGN TABLES, and MATERIALIZED VIEWS likely because it looks a bit strange to say TABLE for a view. However, when we do `--redirect-schema` we have a regex that matches on GRANT statements and replaces the schema. Since all other objects have an OBJECT type, the regex wasn't matching properly for the above object types and ended up creating syntax errors when it tried to replace.

Now we print TABLE as the object type for TABLES, FOREIGN TABLES, VIEWS, and MATERIALIZED VIEWS so the format will match for all objects. Note that pg_dump also prints TABLE in the statements for these object types.