### PR TITLE
Revert "Add granular COPY progress reporting for GPDB 7"

### DIFF
--- a/backup/data_test.go
+++ b/backup/data_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/greenplum-db/gpbackup/report"
 	"github.com/greenplum-db/gpbackup/toc"
 	"github.com/greenplum-db/gpbackup/utils"
+	"gopkg.in/cheggaaa/pb.v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -156,7 +157,7 @@ var _ = Describe("backup/data tests", func() {
 		var (
 			testTable     backup.Table
 			rowsCopiedMap map[uint32]int64
-			progressBars  *utils.MultiProgressBar
+			counters      backup.BackupProgressCounters
 			copyFmtStr    = "COPY(.*)%s(.*)"
 		)
 		BeforeEach(func() {
@@ -166,7 +167,10 @@ var _ = Describe("backup/data tests", func() {
 			}
 			_ = cmdFlags.Set(options.SINGLE_DATA_FILE, "false")
 			rowsCopiedMap = make(map[uint32]int64)
-			progressBars = utils.NewMultiProgressBar(0, "", 0, false)
+			counters = backup.BackupProgressCounters{NumRegTables: 0, TotalRegTables: 1}
+			counters.ProgressBar = utils.NewProgressBar(int(counters.TotalRegTables), "Tables backed up: ", utils.PB_INFO)
+			counters.ProgressBar.(*pb.ProgressBar).NotPrint = true
+			counters.ProgressBar.Start()
 		})
 		It("backs up a single regular table with single data file", func() {
 			_ = cmdFlags.Set(options.SINGLE_DATA_FILE, "true")
@@ -174,11 +178,11 @@ var _ = Describe("backup/data tests", func() {
 			backupFile := fmt.Sprintf("<SEG_DATA_DIR>/gpbackup_<SEGID>_20170101010101_pipe_(.*)_%d", testTable.Oid)
 			copyCmd := fmt.Sprintf(copyFmtStr, backupFile)
 			mock.ExpectExec(copyCmd).WillReturnResult(sqlmock.NewResult(0, 10))
-			err := backup.BackupSingleTableData(testTable, rowsCopiedMap, progressBars, 0)
+			err := backup.BackupSingleTableData(testTable, rowsCopiedMap, &counters, 0)
 
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(rowsCopiedMap[0]).To(Equal(int64(10)))
-			Expect(progressBars.TablesBar.GetBar().Get()).To(Equal(int64(1)))
+			Expect(counters.NumRegTables).To(Equal(int64(1)))
 		})
 		It("backs up a single regular table without a single data file", func() {
 			_ = cmdFlags.Set(options.SINGLE_DATA_FILE, "false")
@@ -186,11 +190,11 @@ var _ = Describe("backup/data tests", func() {
 			backupFile := fmt.Sprintf("<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_%d", testTable.Oid)
 			copyCmd := fmt.Sprintf(copyFmtStr, backupFile)
 			mock.ExpectExec(copyCmd).WillReturnResult(sqlmock.NewResult(0, 10))
-			err := backup.BackupSingleTableData(testTable, rowsCopiedMap, progressBars, 0)
+			err := backup.BackupSingleTableData(testTable, rowsCopiedMap, &counters, 0)
 
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(rowsCopiedMap[0]).To(Equal(int64(10)))
-			Expect(progressBars.TablesBar.GetBar().Get()).To(Equal(int64(1)))
+			Expect(counters.NumRegTables).To(Equal(int64(1)))
 		})
 	})
 	Describe("GetBackupDataSet", func() {

--- a/go.sum
+++ b/go.sum
@@ -124,8 +124,6 @@ github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/go-sqlite3 v1.14.19 h1:fhGleo2h1p8tVChob4I9HpmVFIAkKGpiukdrgQbWfGI=
 github.com/mattn/go-sqlite3 v1.14.19/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
-github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJKjyR5WD3HYQSd+U=
-github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/nightlyone/lockfile v1.0.0 h1:RHep2cFKK4PonZJDdEl4GmkabuhbsRMgk/k3uAmxBiA=
 github.com/nightlyone/lockfile v1.0.0/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatROs6LzC841CI=
 github.com/onsi/ginkgo/v2 v2.8.4 h1:gf5mIQ8cLFieruNLAdgijHF1PYfLphKm2dxxcUtcqK0=

--- a/restore/data_test.go
+++ b/restore/data_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/greenplum-db/gpbackup/history"
 	"github.com/greenplum-db/gpbackup/options"
 	"github.com/greenplum-db/gpbackup/restore"
-	"github.com/greenplum-db/gpbackup/toc"
 	"github.com/greenplum-db/gpbackup/utils"
 	"github.com/jackc/pgconn"
 
@@ -22,7 +21,6 @@ import (
 
 var _ = Describe("restore/data tests", func() {
 	Describe("CopyTableIn", func() {
-		cdEntry := toc.CoordinatorDataEntry{AttributeString: "(i,j)"}
 		BeforeEach(func() {
 			utils.SetPipeThroughProgram(utils.PipeThroughProgram{Name: "cat", OutputCommand: "cat -", InputCommand: "cat -", Extension: ""})
 			backup.SetPluginConfig(nil)
@@ -35,7 +33,7 @@ var _ = Describe("restore/data tests", func() {
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.gz | gzip -d -c' WITH CSV DELIMITER ',' ON SEGMENT")
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.gz"
-			_, err := restore.CopyTableIn(connectionPool, "public.foo", cdEntry, filename, false, 0, nil)
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -44,7 +42,7 @@ var _ = Describe("restore/data tests", func() {
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.zst | zstd --decompress -c' WITH CSV DELIMITER ',' ON SEGMENT")
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456.zst"
-			_, err := restore.CopyTableIn(connectionPool, "public.foo", cdEntry, filename, false, 0, nil)
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -52,7 +50,7 @@ var _ = Describe("restore/data tests", func() {
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456 | cat -' WITH CSV DELIMITER ',' ON SEGMENT")
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456"
-			_, err := restore.CopyTableIn(connectionPool, "public.foo", cdEntry, filename, false, 0, nil)
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -60,7 +58,7 @@ var _ = Describe("restore/data tests", func() {
 			execStr := regexp.QuoteMeta("COPY public.foo(i,j) FROM PROGRAM 'cat <SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456 | cat -' WITH CSV DELIMITER ',' ON SEGMENT")
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456"
-			_, err := restore.CopyTableIn(connectionPool, "public.foo", cdEntry, filename, true, 0, nil)
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, true, 0)
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -73,7 +71,7 @@ var _ = Describe("restore/data tests", func() {
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz"
-			_, err := restore.CopyTableIn(connectionPool, "public.foo", cdEntry, filename, false, 0, nil)
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -86,7 +84,7 @@ var _ = Describe("restore/data tests", func() {
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.zst"
-			_, err := restore.CopyTableIn(connectionPool, "public.foo", cdEntry, filename, false, 0, nil)
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -98,7 +96,7 @@ var _ = Describe("restore/data tests", func() {
 			mock.ExpectExec(execStr).WillReturnResult(sqlmock.NewResult(10, 0))
 
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_pipe_3456.gz"
-			_, err := restore.CopyTableIn(connectionPool, "public.foo", cdEntry, filename, false, 0, nil)
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
 
 			Expect(err).ShouldNot(HaveOccurred())
 		})
@@ -112,7 +110,7 @@ var _ = Describe("restore/data tests", func() {
 			}
 			mock.ExpectExec(execStr).WillReturnError(pgErr)
 			filename := "<SEG_DATA_DIR>/backups/20170101/20170101010101/gpbackup_<SEGID>_20170101010101_3456"
-			_, err := restore.CopyTableIn(connectionPool, "public.foo", cdEntry, filename, false, 0, nil)
+			_, err := restore.CopyTableIn(connectionPool, "public.foo", "(i,j)", filename, false, 0)
 
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("Error loading data into table public.foo: " +

--- a/restore/parallel.go
+++ b/restore/parallel.go
@@ -139,7 +139,7 @@ func ExecuteStatements(statements []toc.StatementWithType, progressBar utils.Pro
 		panicChan := make(chan error)
 		splitStatements := scheduleStatementsOnWorkers(statements, connectionPool.NumConns)
 		chanMap := make(map[int]chan toc.StatementWithType, connectionPool.NumConns)
-		for i := 1; i < connectionPool.NumConns; i++ {
+		for i := 0; i < connectionPool.NumConns; i++ {
 			chanMap[i] = make(chan toc.StatementWithType, len(splitStatements[i]))
 			for _, statement := range splitStatements[i] {
 				chanMap[i] <- statement

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -63,21 +63,12 @@ func SetLoggerVerbosity() {
 }
 
 func CreateConnectionPool(unquotedDBName string) {
-	var numConns int
 	connectionPool = dbconn.NewDBConnFromEnvironment(unquotedDBName)
-	/*
-	 * The additional connection is used for COPY progress reporting, as a free
-	 * connection is needed to query gp_stat_progress_copy_summary.
-	 */
-	switch true {
-	case FlagChanged(options.COPY_QUEUE_SIZE):
-		numConns = MustGetFlagInt(options.COPY_QUEUE_SIZE) + 1
-	case FlagChanged(options.JOBS):
-		numConns = MustGetFlagInt(options.JOBS) + 1
-	default:
-		numConns = 2
+	if FlagChanged(options.COPY_QUEUE_SIZE) {
+		connectionPool.MustConnect(MustGetFlagInt(options.COPY_QUEUE_SIZE))
+	} else {
+		connectionPool.MustConnect(MustGetFlagInt(options.JOBS))
 	}
-	connectionPool.MustConnect(numConns)
 	utils.ValidateGPDBVersionCompatibility(connectionPool)
 }
 

--- a/utils/progress_bar.go
+++ b/utils/progress_bar.go
@@ -5,10 +5,8 @@ package utils
  */
 
 import (
-	"fmt"
 	"time"
 
-	"github.com/greenplum-db/gp-common-go-libs/dbconn"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
 	"gopkg.in/cheggaaa/pb.v1"
 )
@@ -47,26 +45,14 @@ func NewProgressBar(count int, prefix string, showProgressBar int) ProgressBar {
 		verboseProgressBar.ProgressBar = progressBar
 		return verboseProgressBar
 	}
-	return &InfoProgressBar{ProgressBar: progressBar}
+	return progressBar
 }
 
 type ProgressBar interface {
 	Start() *pb.ProgressBar
 	Finish()
-	Prefix(string) *pb.ProgressBar
 	Increment() int
 	Add(int) int
-	Set(int) *pb.ProgressBar
-	Reset(int) *pb.ProgressBar
-	GetBar() *pb.ProgressBar
-}
-
-type InfoProgressBar struct {
-	*pb.ProgressBar
-}
-
-func (ipb *InfoProgressBar) GetBar() *pb.ProgressBar {
-	return ipb.ProgressBar
 }
 
 type VerboseProgressBar struct {
@@ -74,49 +60,21 @@ type VerboseProgressBar struct {
 	total              int
 	prefix             string
 	nextPercentToPrint int
-	ShouldPrintCount   bool
 	*pb.ProgressBar
 }
 
 func NewVerboseProgressBar(count int, prefix string) *VerboseProgressBar {
-	newPb := VerboseProgressBar{total: count, prefix: prefix, nextPercentToPrint: INCR_PERCENT, ShouldPrintCount: true}
+	newPb := VerboseProgressBar{total: count, prefix: prefix, nextPercentToPrint: INCR_PERCENT}
 	return &newPb
 }
 
-func (vpb *VerboseProgressBar) GetBar() *pb.ProgressBar {
-	return vpb.ProgressBar
-}
-
 func (vpb *VerboseProgressBar) Increment() int {
+	vpb.ProgressBar.Increment()
 	if vpb.current < vpb.total {
 		vpb.current++
 		vpb.checkPercent()
 	}
-	return vpb.ProgressBar.Increment()
-}
-
-func (vpb *VerboseProgressBar) Add(add int) int {
-	if vpb.current < vpb.total {
-		vpb.current += add
-		vpb.checkPercent()
-	}
-	return vpb.ProgressBar.Add(add)
-}
-
-func (vpb *VerboseProgressBar) Set(current int) *pb.ProgressBar {
-	vpb.current = current
-	return vpb.ProgressBar.Set(current)
-}
-
-func (vpb *VerboseProgressBar) Reset(total int) *pb.ProgressBar {
-	vpb.current = 0
-	vpb.total = total
-	return vpb.ProgressBar.Reset(total)
-}
-
-func (vpb *VerboseProgressBar) Prefix(prefix string) *pb.ProgressBar {
-	vpb.prefix = prefix
-	return vpb.ProgressBar.Prefix(prefix)
+	return vpb.current
 }
 
 /*
@@ -129,148 +87,7 @@ func (vpb *VerboseProgressBar) checkPercent() {
 	closestMult := currPercent / INCR_PERCENT * INCR_PERCENT
 	if closestMult >= vpb.nextPercentToPrint {
 		vpb.nextPercentToPrint = closestMult
-		message := fmt.Sprintf("%s %d%%%%", vpb.prefix, vpb.nextPercentToPrint)
-		if vpb.ShouldPrintCount {
-			message += fmt.Sprintf(" (%d/%d)", vpb.current, vpb.total)
-		}
-		gplog.Verbose(message)
+		gplog.Verbose("%s %d%% (%d/%d)", vpb.prefix, vpb.nextPercentToPrint, vpb.current, vpb.total)
 		vpb.nextPercentToPrint += INCR_PERCENT
-	}
-}
-
-type MultiProgressBar struct {
-	TablesBar    ProgressBar
-	TuplesBars   []ProgressBar
-	TuplesCounts []int
-	Verbosity    int
-	ProgressPool *pb.Pool
-}
-
-func NewMultiProgressBar(tablesBarTotal int, tablesBarLabel string, numTuplesBars int, verbose bool) *MultiProgressBar {
-	verbosity := PB_INFO
-	if verbose {
-		verbosity = PB_VERBOSE
-	}
-	tablesBar := NewProgressBar(tablesBarTotal, tablesBarLabel, verbosity)
-	tablesBar.GetBar().ShowFinalTime = false
-	tablesBar.GetBar().NotPrint = verbose
-	progressBars := &MultiProgressBar{
-		TablesBar: tablesBar,
-		Verbosity: verbosity,
-	}
-	if numTuplesBars > 0 {
-		progressBars.TuplesBars = make([]ProgressBar, numTuplesBars)
-		progressBars.TuplesCounts = make([]int, numTuplesBars)
-		// In order to get all of the progress bars to play nicely with one another we have to
-		// create and start all of them in a single pool upfront, then edit their prefixes and
-		// totals later, instead of starting them one by one when each COPY is ready, so we don't
-		// initialize prefixes or totals here.
-		for i := 0; i < numTuplesBars; i++ {
-			tupleBar := NewProgressBar(0, "", verbosity)
-			tupleBar.GetBar().ShowFinalTime = false
-			tupleBar.GetBar().NotPrint = verbose
-			if verbose {
-				tupleBar.(*VerboseProgressBar).ShouldPrintCount = false
-			}
-			progressBars.TuplesBars[i] = tupleBar
-		}
-	}
-	return progressBars
-}
-
-func (mpb *MultiProgressBar) Start() error {
-	if mpb.Verbosity == PB_VERBOSE {
-		// We're not printing the bars, so this is a no-op
-		return nil
-	}
-	bars := []*pb.ProgressBar{mpb.TablesBar.GetBar()}
-	for _, bar := range mpb.TuplesBars {
-		bars = append(bars, bar.GetBar())
-	}
-	pool, err := pb.StartPool(bars...)
-	if err != nil {
-		return err
-	}
-	mpb.ProgressPool = pool
-	// Calling Start on a bar with a 0 total disables printing percentages, so we need
-	// to explicitly reenable that here.  Also, we don't want to print tuple counts, as
-	// on the backup side we're only using estimated tuple counts and don't want users
-	// to think we're backing up the wrong number of tuples, so we disable the built-in
-	// counters on these bars.
-	for _, bar := range mpb.TuplesBars {
-		bar.GetBar().ShowPercent = true
-		bar.GetBar().ShowCounters = false
-	}
-	return nil
-}
-
-func (mpb *MultiProgressBar) Finish() {
-	if mpb.Verbosity == PB_VERBOSE {
-		// We're not printing the bars, so this is a no-op
-		return
-	}
-	mpb.TablesBar.Finish()
-	for _, bar := range mpb.TuplesBars {
-		bar.Finish()
-	}
-	mpb.ProgressPool.Stop()
-}
-
-func (mpb *MultiProgressBar) TrackCopyProgress(tablename string, oid uint32, numTuples int, conn *dbconn.DBConn, whichConn int, tableNum int, done chan bool) {
-
-	progressBar := mpb.TuplesBars[tableNum]
-	progressBar.Prefix(fmt.Sprintf("%s: ", tablename))
-
-	if oid == 0 {
-		intOid, err := dbconn.SelectInt(conn, fmt.Sprintf("SELECT '%s'::regclass::oid", EscapeSingleQuotes(tablename)), whichConn)
-		if err != nil {
-			// Don't block the COPY for an error here, just note it and skip the progress bar for this table
-			gplog.Verbose("Could not retrieve oid for table %s, not printing COPY progress: %v", tablename, err)
-			return
-		}
-		oid = uint32(intOid)
-	}
-
-	// For performance reasons, we only get an estimate of tuple count; reltuples will only be populated
-	// if the table has been analyzed or there is an index on the table, but we can safely assume that
-	// will be true in any real backup scenario.
-	if numTuples < 0 {
-		var err error
-		numTuples, err = dbconn.SelectInt(conn, fmt.Sprintf("SELECT reltuples::bigint FROM pg_class WHERE oid = %d", oid), whichConn)
-		if err != nil {
-			// Don't block the COPY for an error here, just note it and skip the progress bar for this table
-			gplog.Verbose("Could not retrieve tuple count for table %s, not printing COPY progress: %v", tablename, err)
-			return
-		}
-	}
-	mpb.TuplesCounts[tableNum] = numTuples
-
-	// We call Finish and Reset at the beginning instead of the end because we start the whole process
-	// with empty progress bars that need to be set and there's no need to special-case those.
-	progressBar.Finish()
-	progressBar.Reset(numTuples)
-
-	processed := 0
-	for {
-		select {
-		case _ = <-done:
-			return
-		default:
-			// Ignore any error on this query: if there's a hiccup we'll get the number on the next pass, and if there's
-			// a real connection problem the COPY itself should error out elsewhere.
-			tuplesProcessed, _ := dbconn.SelectInt(conn, fmt.Sprintf("SELECT tuples_processed FROM gp_stat_progress_copy_summary WHERE relid = %d", oid), whichConn)
-			if tuplesProcessed == 0 { // Don't stop tracking yet, sometimes the table hiccups and has no rows for a bit
-				break
-			}
-			delta := int(tuplesProcessed) - processed
-			// TODO: There's a server bug that underreports tuples so it looks like the number processed went down.
-			// For now, if we see a negative delta, simply don't update the progress bar and wait for the next loop.
-			if delta < 0 {
-				break
-			}
-			progressBar.Add(delta)
-			processed += delta
-		}
-		time.Sleep(100 * time.Millisecond)
 	}
 }

--- a/utils/progress_bar_test.go
+++ b/utils/progress_bar_test.go
@@ -1,73 +1,113 @@
 package utils_test
 
 import (
+	"io"
+	"os"
+	"os/user"
 	"time"
 
-	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
+	"github.com/greenplum-db/gp-common-go-libs/operating"
 	"github.com/greenplum-db/gp-common-go-libs/testhelper"
 	"github.com/greenplum-db/gpbackup/utils"
+	"gopkg.in/cheggaaa/pb.v1"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("utils/log tests", func() {
+	var (
+		fakeInfo os.FileInfo
+	)
+
+	BeforeEach(func() {
+		err := operating.System.MkdirAll("/tmp/log_dir", 0755)
+		Expect(err).ToNot(HaveOccurred())
+		fakeInfo, err = os.Stat("/tmp/log_dir")
+		Expect(err).ToNot(HaveOccurred())
+
+		operating.System.OpenFileWrite = func(name string, flag int, perm os.FileMode) (io.WriteCloser, error) { return buffer, nil }
+		operating.System.CurrentUser = func() (*user.User, error) { return &user.User{Username: "testUser", HomeDir: "testDir"}, nil }
+		operating.System.Getpid = func() int { return 0 }
+		operating.System.Hostname = func() (string, error) { return "testHost", nil }
+		operating.System.IsNotExist = func(err error) bool { return false }
+		operating.System.Now = func() time.Time { return time.Date(2017, time.January, 1, 1, 1, 1, 1, time.Local) }
+		operating.System.Stat = func(name string) (os.FileInfo, error) { return fakeInfo, nil }
+	})
+	AfterEach(func() {
+		operating.System = operating.InitializeSystemFunctions()
+	})
+
 	Describe("NewProgressBar", func() {
 		Context("PB_NONE", func() {
 			It("will not print when passed a none value", func() {
-				infoPb := utils.NewProgressBar(10, "test progress bar", utils.PB_NONE)
-				Expect(infoPb.GetBar().NotPrint).To(Equal(true))
+				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_NONE)
+				infoPb, ok := progressBar.(*pb.ProgressBar)
+				Expect(ok).To(BeTrue())
+				Expect(infoPb.NotPrint).To(Equal(true))
 			})
 		})
 		Context("PB_INFO", func() {
-			It("will create an InfoProgressBar when passed an info value", func() {
+			It("will create a pb.ProgressBar when passed an info value", func() {
 				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_INFO)
-				_, ok := progressBar.(*utils.InfoProgressBar)
+				_, ok := progressBar.(*pb.ProgressBar)
 				Expect(ok).To(BeTrue())
 			})
 			It("will not print with verbosity LOGERROR", func() {
 				gplog.SetVerbosity(gplog.LOGERROR)
-				infoPb := utils.NewProgressBar(10, "test progress bar", utils.PB_INFO)
-				Expect(infoPb.GetBar().NotPrint).To(Equal(true))
+				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_INFO)
+				infoPb, _ := progressBar.(*pb.ProgressBar)
+				Expect(infoPb.NotPrint).To(Equal(true))
 			})
 			It("will print with verbosity LOGINFO", func() {
 				gplog.SetVerbosity(gplog.LOGINFO)
-				infoPb := utils.NewProgressBar(10, "test progress bar", utils.PB_INFO)
-				Expect(infoPb.GetBar().NotPrint).To(Equal(false))
+				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_INFO)
+				infoPb, _ := progressBar.(*pb.ProgressBar)
+				Expect(infoPb.NotPrint).To(Equal(false))
 			})
 			It("will not print with verbosity LOGVERBOSE", func() {
 				gplog.SetVerbosity(gplog.LOGVERBOSE)
-				infoPb := utils.NewProgressBar(10, "test progress bar", utils.PB_INFO)
-				Expect(infoPb.GetBar().NotPrint).To(Equal(true))
+				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_INFO)
+				infoPb, _ := progressBar.(*pb.ProgressBar)
+				Expect(infoPb.NotPrint).To(Equal(true))
 			})
 		})
 		Context("PB_VERBOSE", func() {
-			It("will create a VerboseProgressBar when passed a verbose value", func() {
+			It("will create a verboseProgressBar when passed a verbose value", func() {
 				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_VERBOSE)
 				_, ok := progressBar.(*utils.VerboseProgressBar)
 				Expect(ok).To(BeTrue())
 			})
 			It("verboseProgressBar's infoPb will not print with verbosity LOGERROR", func() {
 				gplog.SetVerbosity(gplog.LOGERROR)
-				vPb := utils.NewProgressBar(10, "test progress bar", utils.PB_VERBOSE)
-				Expect(vPb.GetBar().NotPrint).To(Equal(true))
+				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_VERBOSE)
+				vPb, _ := progressBar.(*utils.VerboseProgressBar)
+				Expect(vPb.ProgressBar.NotPrint).To(Equal(true))
 			})
 			It("verboseProgressBar's infoPb will print with verbosity LOGINFO", func() {
 				gplog.SetVerbosity(gplog.LOGINFO)
-				vPb := utils.NewProgressBar(10, "test progress bar", utils.PB_VERBOSE)
-				Expect(vPb.GetBar().NotPrint).To(Equal(false))
+				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_VERBOSE)
+				vPb, _ := progressBar.(*utils.VerboseProgressBar)
+				Expect(vPb.ProgressBar.NotPrint).To(Equal(false))
 			})
 			It("verboseProgressBar's infoPb will not print with verbosity LOGVERBOSE", func() {
 				gplog.SetVerbosity(gplog.LOGVERBOSE)
-				vPb := utils.NewProgressBar(10, "test progress bar", utils.PB_VERBOSE)
-				Expect(vPb.GetBar().NotPrint).To(Equal(true))
+				progressBar := utils.NewProgressBar(10, "test progress bar", utils.PB_VERBOSE)
+				vPb, _ := progressBar.(*utils.VerboseProgressBar)
+				Expect(vPb.ProgressBar.NotPrint).To(Equal(true))
 			})
 		})
 	})
 	Describe("Increment", func() {
+		var vPb *utils.VerboseProgressBar
+		BeforeEach(func() {
+			progressBar := utils.NewProgressBar(10, "test progress bar:", utils.PB_VERBOSE)
+			vPb, _ = progressBar.(*utils.VerboseProgressBar)
+		})
 		It("writes to the log file at 10% increments", func() {
-			vPb := utils.NewProgressBar(10, "test progress bar:", utils.PB_VERBOSE)
+			progressBar := utils.NewProgressBar(10, "test progress bar:", utils.PB_VERBOSE)
+			vPb, _ = progressBar.(*utils.VerboseProgressBar)
 			vPb.Increment()
 			expectedMessage := "test progress bar: 10% (1/10)"
 			testhelper.ExpectRegexp(logfile, expectedMessage)
@@ -76,7 +116,8 @@ var _ = Describe("utils/log tests", func() {
 			testhelper.ExpectRegexp(logfile, expectedMessage)
 		})
 		It("only logs when it hits a new % marker", func() {
-			vPb := utils.NewProgressBar(20, "test progress bar:", utils.PB_VERBOSE)
+			progressBar := utils.NewProgressBar(20, "test progress bar:", utils.PB_VERBOSE)
+			vPb, _ = progressBar.(*utils.VerboseProgressBar)
 
 			expectedMessage := "test progress bar: 10% (2/20)"
 			vPb.Increment()
@@ -90,7 +131,8 @@ var _ = Describe("utils/log tests", func() {
 			testhelper.ExpectRegexp(logfile, expectedMessage)
 		})
 		It("writes accurate percentages if < 10 items", func() {
-			vPb := utils.NewProgressBar(5, "test progress bar:", utils.PB_VERBOSE)
+			progressBar := utils.NewProgressBar(5, "test progress bar:", utils.PB_VERBOSE)
+			vPb, _ = progressBar.(*utils.VerboseProgressBar)
 			vPb.Increment()
 			expectedMessage := "test progress bar: 20% (1/5)"
 			testhelper.ExpectRegexp(logfile, expectedMessage)
@@ -99,201 +141,13 @@ var _ = Describe("utils/log tests", func() {
 			testhelper.ExpectRegexp(logfile, expectedMessage)
 		})
 		It("does not log if called again after hitting 100%", func() {
-			vPb := utils.NewProgressBar(1, "test progress bar:", utils.PB_VERBOSE)
+			progressBar := utils.NewProgressBar(1, "test progress bar:", utils.PB_VERBOSE)
+			vPb, _ = progressBar.(*utils.VerboseProgressBar)
 			vPb.Increment()
 			expectedMessage := "test progress bar: 100% (1/1)"
 			testhelper.ExpectRegexp(logfile, expectedMessage)
 			vPb.Increment()
 			testhelper.NotExpectRegexp(logfile, expectedMessage)
-		})
-		It("does not log the count if ShouldPrintCount is false", func() {
-			vPb := utils.NewProgressBar(1, "test progress bar:", utils.PB_VERBOSE)
-			vPb.(*utils.VerboseProgressBar).ShouldPrintCount = false
-			vPb.Increment()
-			expectedMessage := "test progress bar: 100%"
-			testhelper.ExpectRegexp(logfile, expectedMessage)
-		})
-	})
-	Describe("NewMultiProgressBar", func() {
-		It("can create a MultiProgressBar with info verbosity", func() {
-			multiPb := utils.NewMultiProgressBar(10, "test multi progress bar", 2, false)
-
-			Expect(multiPb.TablesBar).ToNot(BeNil())
-			Expect(multiPb.TuplesBars).ToNot(BeNil())
-			Expect(len(multiPb.TuplesBars)).To(Equal(2))
-			infoTablesBar, ok := multiPb.TablesBar.(*utils.InfoProgressBar)
-			Expect(ok).To(BeTrue())
-			Expect(infoTablesBar.GetBar().NotPrint).To(BeFalse())
-			infoTuplesBar1, ok := multiPb.TuplesBars[0].(*utils.InfoProgressBar)
-			Expect(ok).To(BeTrue())
-			Expect(infoTuplesBar1.GetBar().NotPrint).To(BeFalse())
-			infoTuplesBar2, ok := multiPb.TuplesBars[1].(*utils.InfoProgressBar)
-			Expect(ok).To(BeTrue())
-			Expect(infoTuplesBar2.GetBar().NotPrint).To(BeFalse())
-
-			Expect(multiPb.TablesBar.GetBar().Get()).To(Equal(int64(0)))
-			Expect(multiPb.Verbosity).To(Equal(utils.PB_INFO))
-			Expect(multiPb.ProgressPool).To(BeNil())
-		})
-		It("can create a MultiProgressBar with verbose verbosity", func() {
-			multiPb := utils.NewMultiProgressBar(10, "test multi progress bar", 2, true)
-
-			Expect(multiPb.TablesBar).ToNot(BeNil())
-			Expect(multiPb.TuplesBars).ToNot(BeNil())
-			Expect(len(multiPb.TuplesBars)).To(Equal(2))
-			verboseTablesBar, ok := multiPb.TablesBar.(*utils.VerboseProgressBar)
-			Expect(ok).To(BeTrue())
-			Expect(verboseTablesBar.GetBar().NotPrint).To(BeTrue())
-			verboseTuplesBar1, ok := multiPb.TuplesBars[0].(*utils.VerboseProgressBar)
-			Expect(ok).To(BeTrue())
-			Expect(verboseTuplesBar1.GetBar().NotPrint).To(BeTrue())
-			verboseTuplesBar2, ok := multiPb.TuplesBars[1].(*utils.VerboseProgressBar)
-			Expect(ok).To(BeTrue())
-			Expect(verboseTuplesBar2.GetBar().NotPrint).To(BeTrue())
-
-			Expect(multiPb.TablesBar.GetBar().Get()).To(Equal(int64(0)))
-			Expect(multiPb.Verbosity).To(Equal(utils.PB_VERBOSE))
-			Expect(multiPb.ProgressPool).To(BeNil())
-		})
-		It("can handle a MultiProgressBar without tuple progress bars", func() {
-			multiPb := utils.NewMultiProgressBar(10, "test multi progress bar", 0, false)
-
-			Expect(multiPb.TablesBar).ToNot(BeNil())
-			Expect(multiPb.TuplesBars).To(BeNil())
-			_, ok := multiPb.TablesBar.(*utils.InfoProgressBar)
-			Expect(ok).To(BeTrue())
-
-			Expect(multiPb.TablesBar.GetBar().Get()).To(Equal(int64(0)))
-			Expect(multiPb.ProgressPool).To(BeNil())
-		})
-	})
-	Describe("GetBar", func() {
-		It("returns a modifiable pb.ProgressBar struct", func() {
-			infoPb := utils.NewProgressBar(10, "test progress bar", utils.PB_NONE)
-			Expect(infoPb.GetBar().NotPrint).To(BeTrue())
-			infoPb.GetBar().NotPrint = false
-			Expect(infoPb.GetBar().NotPrint).To(BeFalse())
-		})
-	})
-	Describe("TrackCopyProgress", func() {
-		var (
-			row10       *sqlmock.Rows
-			row20       *sqlmock.Rows
-			row30       *sqlmock.Rows
-			row40       *sqlmock.Rows
-			row50       *sqlmock.Rows
-			rowNegative *sqlmock.Rows
-			rowEmpty    *sqlmock.Rows
-			mpb         *utils.MultiProgressBar
-			done        chan bool
-		)
-		BeforeEach(func() {
-			row10 = sqlmock.NewRows([]string{"tuples_processed"}).AddRow("10")
-			row20 = sqlmock.NewRows([]string{"tuples_processed"}).AddRow("20")
-			row30 = sqlmock.NewRows([]string{"tuples_processed"}).AddRow("30")
-			row40 = sqlmock.NewRows([]string{"tuples_processed"}).AddRow("40")
-			row50 = sqlmock.NewRows([]string{"tuples_processed"}).AddRow("50")
-			rowNegative = sqlmock.NewRows([]string{"tuples_processed"}).AddRow("-25")
-			rowEmpty = sqlmock.NewRows([]string{"tuples_processed"})
-			mpb = utils.NewMultiProgressBar(0, "test multi progress bar", 1, true)
-			done = make(chan bool, 1)
-		})
-		It("tracks a table's progress from start to finish", func() {
-			mock.ExpectQuery("SELECT .*").WillReturnRows(row10)
-			mock.ExpectQuery("SELECT .*").WillReturnRows(row20)
-			mock.ExpectQuery("SELECT .*").WillReturnRows(row30)
-			mock.ExpectQuery("SELECT .*").WillReturnRows(row40)
-			mock.ExpectQuery("SELECT .*").WillReturnRows(row50)
-
-			go mpb.TrackCopyProgress("public.foo", 1, 50, connectionPool, 0, 0, done)
-			time.Sleep(time.Second)
-			done <- true
-			time.Sleep(time.Second)
-			close(done)
-
-			tupleBar := mpb.TuplesBars[0].GetBar()
-			Expect(tupleBar.Total).To(Equal(int64(50)))
-			Expect(tupleBar.Get()).To(Equal(int64(50)))
-			testhelper.ExpectRegexp(logfile, "public.foo:  20%")
-			testhelper.ExpectRegexp(logfile, "public.foo:  40%")
-			testhelper.ExpectRegexp(logfile, "public.foo:  60%")
-			testhelper.ExpectRegexp(logfile, "public.foo:  80%")
-			testhelper.ExpectRegexp(logfile, "public.foo:  100%")
-		})
-		It("handles a table so small it never appears in gp_stat_progress_copy_summary", func() {
-			go mpb.TrackCopyProgress("public.foo", 1, 50, connectionPool, 0, 0, done)
-			done <- true
-			time.Sleep(time.Second)
-			close(done)
-
-			tupleBar := mpb.TuplesBars[0].GetBar()
-			// as in our COPY calls, manually set the bar at the end to ensure it always shows full
-			tupleBar.Set(50)
-			Expect(tupleBar.Total).To(Equal(int64(50)))
-			Expect(tupleBar.Get()).To(Equal(int64(50)))
-			testhelper.NotExpectRegexp(logfile, "public.foo:")
-		})
-		It("handles an instance of the database returning a negative tuple count", func() {
-			mock.ExpectQuery("SELECT .*").WillReturnRows(row10)
-			mock.ExpectQuery("SELECT .*").WillReturnRows(row20)
-			mock.ExpectQuery("SELECT .*").WillReturnRows(rowNegative)
-			mock.ExpectQuery("SELECT .*").WillReturnRows(row30)
-			mock.ExpectQuery("SELECT .*").WillReturnRows(row40)
-			mock.ExpectQuery("SELECT .*").WillReturnRows(row50)
-
-			go mpb.TrackCopyProgress("public.foo", 1, 50, connectionPool, 0, 0, done)
-			time.Sleep(time.Second)
-			done <- true
-			time.Sleep(time.Second)
-			close(done)
-
-			tupleBar := mpb.TuplesBars[0].GetBar()
-			Expect(tupleBar.Total).To(Equal(int64(50)))
-			Expect(tupleBar.Get()).To(Equal(int64(50)))
-			testhelper.ExpectRegexp(logfile, "public.foo:  20%")
-			testhelper.ExpectRegexp(logfile, "public.foo:  40%")
-			testhelper.ExpectRegexp(logfile, "public.foo:  60%")
-			testhelper.ExpectRegexp(logfile, "public.foo:  80%")
-			testhelper.ExpectRegexp(logfile, "public.foo:  100%")
-		})
-		It("handles instances of the table temporarily not appearing in gp_stat_progress_copy_summary", func() {
-			mock.ExpectQuery("SELECT tuples_processed .*").WillReturnRows(row10)
-			mock.ExpectQuery("SELECT tuples_processed .*").WillReturnRows(row20)
-			mock.ExpectQuery("SELECT tuples_processed .*").WillReturnRows(rowEmpty)
-			mock.ExpectQuery("SELECT tuples_processed .*").WillReturnRows(rowEmpty)
-			mock.ExpectQuery("SELECT tuples_processed .*").WillReturnRows(row30)
-			mock.ExpectQuery("SELECT tuples_processed .*").WillReturnRows(row40)
-			mock.ExpectQuery("SELECT tuples_processed .*").WillReturnRows(row50)
-
-			go mpb.TrackCopyProgress("public.foo", 1, 50, connectionPool, 0, 0, done)
-			time.Sleep(time.Second)
-			done <- true
-			time.Sleep(time.Second)
-			close(done)
-
-			tupleBar := mpb.TuplesBars[0].GetBar()
-			Expect(tupleBar.Total).To(Equal(int64(50)))
-			Expect(tupleBar.Get()).To(Equal(int64(50)))
-			testhelper.ExpectRegexp(logfile, "public.foo:  20%")
-			testhelper.ExpectRegexp(logfile, "public.foo:  40%")
-			testhelper.ExpectRegexp(logfile, "public.foo:  60%")
-			testhelper.ExpectRegexp(logfile, "public.foo:  80%")
-		})
-		It("handles a COPY failure", func() {
-			mock.ExpectQuery("SELECT tuples_processed .*").WillReturnRows(row10)
-			mock.ExpectQuery("SELECT tuples_processed .*").WillReturnRows(row20)
-			mock.ExpectQuery("SELECT tuples_processed .*").WillReturnRows(row30)
-
-			go mpb.TrackCopyProgress("public.foo", 1, 50, connectionPool, 0, 0, done)
-			time.Sleep(time.Second)
-			close(done)
-
-			tupleBar := mpb.TuplesBars[0].GetBar()
-			Expect(tupleBar.Total).To(Equal(int64(50)))
-			Expect(tupleBar.Get()).To(Equal(int64(30)))
-			testhelper.ExpectRegexp(logfile, "public.foo:  20%")
-			testhelper.ExpectRegexp(logfile, "public.foo:  40%")
-			testhelper.ExpectRegexp(logfile, "public.foo:  60%")
 		})
 	})
 })


### PR DESCRIPTION
Commit 6f71685 adds the GPDB7 feature where using --jobs will show N number of progress bars with the progress of the table each job is currently backing up. Unfortunately, this commit also introduces the issue where gpbackup will halt when run in the background using &. e.g. `gpbackup --dbname test &`.

The halt happens when the progress bar library gopkg.in/cheggaaa/pb starts printing a pool of progress bars, it will issue a system command to turn off terminal echoing. The default behavior when a background process tries to set a terminal mode is to halt the process [1].

Also included in this commit is a fix is a one-line fix to a --data-only
restore bug that surfaced as a result of reverting "granular progress
bars". Sequence data restore is a special case because the value of a
sequence is set using metadata sql statements. With the introduction of
granular progress bars. The number of default database connections was
changed from 1 to 2, (conn0 and conn1). This is because granular
progress bars requires an additional connection to continuously poll for
progress of table backup/restore. Because of this, parallel restore is
built with the assumption that conn0 is reserved for this polling. When
assigning statements to restore, parallel logic will not assign any
metadata statements be restored with conn0. When reverting granular
progress bars, the default number of connections came back down to 1 and
this causes restore to fail because sequence data restore statements
were being assigned to conn1, which now no longer exists.

The following gpbackup commits are reverted:
6f716850 - Add granular COPY progress reporting for GPDB 7 
https://github.com/greenplum-db/gpbackup/commit/6f716850

08339c04 - Fix unfinished copy progress bars
https://github.com/greenplum-db/gpbackup/commit/08339c04

[1] https://www.gnu.org/software/libc/manual/html_node/Job-Control-Signals.html

gpbackup pipeline: https://dp.ci.gpdb.pivotal.io/teams/main/pipelines/revert-progress-bars