### PR TITLE
Fix example plugin tests to use relative paths

### DIFF
--- a/end_to_end/end_to_end_suite_test.go
+++ b/end_to_end/end_to_end_suite_test.go
@@ -2021,8 +2021,7 @@ LANGUAGE plpgsql NO SQL;`)
 					gprestoreArgs = append(gprestoreArgs, "--include-schema", "schematwo")
 				}
 				gprestoreCmd := exec.Command(gprestorePath, gprestoreArgs...)
-				output, err := gprestoreCmd.CombinedOutput()
-				fmt.Println(string(output))
+				_, err := gprestoreCmd.CombinedOutput()
 				Expect(err).ToNot(HaveOccurred())
 
 				// check row counts
@@ -2057,8 +2056,7 @@ LANGUAGE plpgsql NO SQL;`)
 						"--backup-dir", extractDirectory,
 						"--resize-cluster",
 						"--on-error-continue")
-					incroutput, err := gprestoreincrCmd.CombinedOutput()
-					fmt.Println(string(incroutput))
+					_, err := gprestoreincrCmd.CombinedOutput()
 					Expect(err).ToNot(HaveOccurred())
 
 					// check row counts
@@ -2143,8 +2141,7 @@ LANGUAGE plpgsql NO SQL;`)
 						"--on-error-continue"}
 
 					gprestoreCmd := exec.Command(gprestorePath, gprestoreArgs...)
-					output, err := gprestoreCmd.CombinedOutput()
-					fmt.Println(string(output))
+					_, err := gprestoreCmd.CombinedOutput()
 					Expect(err).ToNot(HaveOccurred())
 
 					// check row counts on each segment and on coordinator, expecting 1 table with 100 rows, replicated across all

--- a/end_to_end/plugin_test.go
+++ b/end_to_end/plugin_test.go
@@ -20,8 +20,8 @@ func copyPluginToAllHosts(conn *dbconn.DBConn, pluginPath string) {
 	hostnameQuery := `SELECT DISTINCT hostname AS string FROM gp_segment_configuration WHERE content != -1`
 	hostnames := dbconn.MustSelectStringSlice(conn, hostnameQuery)
 	for _, hostname := range hostnames {
-		pluginDir, _ := path.Split(pluginPath)
-		command := exec.Command("ssh", hostname, fmt.Sprintf("mkdir -p %s", pluginDir))
+		examplePluginTestDir, _ := path.Split(pluginPath)
+		command := exec.Command("ssh", hostname, fmt.Sprintf("mkdir -p %s", examplePluginTestDir))
 		mustRunCommand(command)
 		command = exec.Command("scp", pluginPath, fmt.Sprintf("%s:%s", hostname, pluginPath))
 		mustRunCommand(command)
@@ -307,18 +307,17 @@ var _ = Describe("End to End plugin tests", func() {
 				}
 			})
 			It("runs gpbackup and gprestore with plugin, single-data-file, and no-compression", func() {
-				pluginExecutablePath := fmt.Sprintf("%s/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("GOPATH"))
-				copyPluginToAllHosts(backupConn, pluginExecutablePath)
+				copyPluginToAllHosts(backupConn, examplePluginExec)
 
 				timestamp := gpbackup(gpbackupPath, backupHelperPath,
 					"--single-data-file",
 					"--no-compression",
-					"--plugin-config", pluginConfigPath)
+					"--plugin-config", examplePluginTestConfig)
 				forceMetadataFileDownloadFromPlugin(backupConn, timestamp)
 
 				gprestore(gprestorePath, restoreHelperPath, timestamp,
 					"--redirect-db", "restoredb",
-					"--plugin-config", pluginConfigPath)
+					"--plugin-config", examplePluginTestConfig)
 
 				assertRelationsCreated(restoreConn, TOTAL_RELATIONS)
 				assertDataRestored(restoreConn, publicSchemaTupleCounts)
@@ -326,19 +325,18 @@ var _ = Describe("End to End plugin tests", func() {
 				assertArtifactsCleaned(restoreConn, timestamp)
 			})
 			It("runs gpbackup and gprestore with plugin, single-data-file, no-compression, and copy-queue-size", func() {
-				pluginExecutablePath := fmt.Sprintf("%s/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("GOPATH"))
-				copyPluginToAllHosts(backupConn, pluginExecutablePath)
+				copyPluginToAllHosts(backupConn, examplePluginExec)
 
 				timestamp := gpbackup(gpbackupPath, backupHelperPath,
 					"--single-data-file",
 					"--copy-queue-size", "4",
 					"--no-compression",
-					"--plugin-config", pluginConfigPath)
+					"--plugin-config", examplePluginTestConfig)
 				forceMetadataFileDownloadFromPlugin(backupConn, timestamp)
 
 				gprestore(gprestorePath, restoreHelperPath, timestamp,
 					"--redirect-db", "restoredb",
-					"--plugin-config", pluginConfigPath,
+					"--plugin-config", examplePluginTestConfig,
 					"--copy-queue-size", "4")
 
 				assertRelationsCreated(restoreConn, TOTAL_RELATIONS)
@@ -347,17 +345,16 @@ var _ = Describe("End to End plugin tests", func() {
 				assertArtifactsCleaned(restoreConn, timestamp)
 			})
 			It("runs gpbackup and gprestore with plugin and single-data-file", func() {
-				pluginExecutablePath := fmt.Sprintf("%s/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("GOPATH"))
-				copyPluginToAllHosts(backupConn, pluginExecutablePath)
+				copyPluginToAllHosts(backupConn, examplePluginExec)
 
 				timestamp := gpbackup(gpbackupPath, backupHelperPath,
 					"--single-data-file",
-					"--plugin-config", pluginConfigPath)
+					"--plugin-config", examplePluginTestConfig)
 				forceMetadataFileDownloadFromPlugin(backupConn, timestamp)
 
 				gprestore(gprestorePath, restoreHelperPath, timestamp,
 					"--redirect-db", "restoredb",
-					"--plugin-config", pluginConfigPath)
+					"--plugin-config", examplePluginTestConfig)
 
 				assertRelationsCreated(restoreConn, TOTAL_RELATIONS)
 				assertDataRestored(restoreConn, publicSchemaTupleCounts)
@@ -365,18 +362,17 @@ var _ = Describe("End to End plugin tests", func() {
 				assertArtifactsCleaned(restoreConn, timestamp)
 			})
 			It("runs gpbackup and gprestore with plugin, single-data-file, and copy-queue-size", func() {
-				pluginExecutablePath := fmt.Sprintf("%s/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("GOPATH"))
-				copyPluginToAllHosts(backupConn, pluginExecutablePath)
+				copyPluginToAllHosts(backupConn, examplePluginExec)
 
 				timestamp := gpbackup(gpbackupPath, backupHelperPath,
 					"--single-data-file",
 					"--copy-queue-size", "4",
-					"--plugin-config", pluginConfigPath)
+					"--plugin-config", examplePluginTestConfig)
 				forceMetadataFileDownloadFromPlugin(backupConn, timestamp)
 
 				gprestore(gprestorePath, restoreHelperPath, timestamp,
 					"--redirect-db", "restoredb",
-					"--plugin-config", pluginConfigPath,
+					"--plugin-config", examplePluginTestConfig,
 					"--copy-queue-size", "4")
 
 				assertRelationsCreated(restoreConn, TOTAL_RELATIONS)
@@ -385,17 +381,16 @@ var _ = Describe("End to End plugin tests", func() {
 				assertArtifactsCleaned(restoreConn, timestamp)
 			})
 			It("runs gpbackup and gprestore with plugin and metadata-only", func() {
-				pluginExecutablePath := fmt.Sprintf("%s/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("GOPATH"))
-				copyPluginToAllHosts(backupConn, pluginExecutablePath)
+				copyPluginToAllHosts(backupConn, examplePluginExec)
 
 				timestamp := gpbackup(gpbackupPath, backupHelperPath,
 					"--metadata-only",
-					"--plugin-config", pluginConfigPath)
+					"--plugin-config", examplePluginTestConfig)
 				forceMetadataFileDownloadFromPlugin(backupConn, timestamp)
 
 				gprestore(gprestorePath, restoreHelperPath, timestamp,
 					"--redirect-db", "restoredb",
-					"--plugin-config", pluginConfigPath)
+					"--plugin-config", examplePluginTestConfig)
 
 				assertRelationsCreated(restoreConn, TOTAL_RELATIONS)
 				assertArtifactsCleaned(restoreConn, timestamp)
@@ -410,17 +405,16 @@ var _ = Describe("End to End plugin tests", func() {
 			if useOldBackupVersion {
 				Skip("This test is only needed for the most recent backup versions")
 			}
-			pluginExecutablePath := fmt.Sprintf("%s/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("GOPATH"))
-			copyPluginToAllHosts(backupConn, pluginExecutablePath)
+			copyPluginToAllHosts(backupConn, examplePluginExec)
 
 			timestamp := gpbackup(gpbackupPath, backupHelperPath,
 				"--no-compression",
-				"--plugin-config", pluginConfigPath)
+				"--plugin-config", examplePluginTestConfig)
 			forceMetadataFileDownloadFromPlugin(backupConn, timestamp)
 
 			gprestore(gprestorePath, restoreHelperPath, timestamp,
 				"--redirect-db", "restoredb",
-				"--plugin-config", pluginConfigPath)
+				"--plugin-config", examplePluginTestConfig)
 
 			assertRelationsCreated(restoreConn, TOTAL_RELATIONS)
 			assertDataRestored(restoreConn, publicSchemaTupleCounts)
@@ -432,16 +426,15 @@ var _ = Describe("End to End plugin tests", func() {
 			if useOldBackupVersion {
 				Skip("This test is only needed for the most recent backup versions")
 			}
-			pluginExecutablePath := fmt.Sprintf("%s/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash", os.Getenv("GOPATH"))
-			copyPluginToAllHosts(backupConn, pluginExecutablePath)
+			copyPluginToAllHosts(backupConn, examplePluginExec)
 
 			timestamp := gpbackup(gpbackupPath, backupHelperPath,
-				"--plugin-config", pluginConfigPath)
+				"--plugin-config", examplePluginTestConfig)
 			forceMetadataFileDownloadFromPlugin(backupConn, timestamp)
 
 			gprestore(gprestorePath, restoreHelperPath, timestamp,
 				"--redirect-db", "restoredb",
-				"--plugin-config", pluginConfigPath)
+				"--plugin-config", examplePluginTestConfig)
 
 			assertRelationsCreated(restoreConn, TOTAL_RELATIONS)
 			assertDataRestored(restoreConn, publicSchemaTupleCounts)
@@ -454,12 +447,9 @@ var _ = Describe("End to End plugin tests", func() {
 			if useOldBackupVersion {
 				Skip("This test is only needed for the latest backup version")
 			}
-			pluginsDir := fmt.Sprintf("%s/src/github.com/greenplum-db/gpbackup/plugins", os.Getenv("GOPATH"))
-			copyPluginToAllHosts(backupConn, fmt.Sprintf("%s/example_plugin.bash", pluginsDir))
-			command := exec.Command("bash", "-c", fmt.Sprintf("%s/plugin_test.sh %s/example_plugin.bash %s/example_plugin_config.yaml /tmp/plugin_dest", pluginsDir, pluginsDir, pluginsDir))
+			copyPluginToAllHosts(backupConn, examplePluginExec)
+			command := exec.Command("bash", "-c", fmt.Sprintf("%s/plugin_test.sh %s %s %s", examplePluginDir, examplePluginExec, examplePluginTestConfig, examplePluginTestDir))
 			mustRunCommand(command)
-
-			_ = os.RemoveAll("/tmp/plugin_dest")
 		})
 	})
 })

--- a/integration/integration_suite_test.go
+++ b/integration/integration_suite_test.go
@@ -147,5 +147,5 @@ var _ = AfterSuite(func() {
 	testhelper.AssertQueryRuns(connection1, "DROP ROLE anothertestrole")
 	connection1.Close()
 	_ = os.RemoveAll("/tmp/helper_test")
-	_ = os.RemoveAll("/tmp/plugin_dest")
+	_ = os.RemoveAll(examplePluginTestDir)
 })


### PR DESCRIPTION
When gpbackup repo is not in $GOPATH and integration tests are run,
tests that use the example plugin will hang because the test cannot
proceed without the example plugin reading data from test pipes. This
happens because the example plugin and it's config file locations were
hardcoded to be in $GOPATH. This is a legacy issue from when go projects
were required to be in $GOPATH. This requirement was changed to be
optional in go1.11. This is an update to look for example plugin using a
relative path. The test plugin config file is also now setup before
tests run because the executablepath is also updated to be a relative
path.

pipeline: https://dp.ci.gpdb.pivotal.io/teams/main/pipelines/fix-tests-local