### PR TITLE
Fix parallel analyze

### DIFF
--- a/restore/parallel.go
+++ b/restore/parallel.go
@@ -84,10 +84,8 @@ func scheduleStatementsOnWorkers(statements []toc.StatementWithType, numConns in
 	splitStatements := make(map[int][]toc.StatementWithType, numConns)
 	cohortConnAssignments := make(map[uint32]int)
 
-	// We do not schedule statements onto connection 0, as our code expects that to be reserved for
-	// progress reporting and administrative tasks.
-	connStatementCounts := make(map[int]int, numConns-1)
-	for i := 1; i < numConns; i++ {
+	connStatementCounts := make(map[int]int, numConns)
+	for i := 0; i < numConns; i++ {
 		connStatementCounts[i] = 0
 	}
 	// During backup, we track objects into "cohorts" that must be backed up in the same


### PR DESCRIPTION
The parallel metadata restore implementation was assigning ANALYZE to Tier{0,0}. The TopologicalSort comment states
A tier[0]==0 value is used to indicate that this object must be restored serially and should not be parallelized. The ANALYZE
commands flow through the same execution as predata metadata, so this resulted in --run-analyze executing in serial regardless of number of jobs. Fix this by assigning ANALYZE statements to Tier 1 and giving each a unique cohort.

Also fix some off-by-one issues with connections that are a result of recent reverts. The restore side does not create an extra
communication connection, while the backup side does. This leads to a not so subtle footgun when handling the parallel workers. The connection pool and worker code should be unified for backup and restore.

Also of note, because scheduleStatementsOnWorkers assigns all statements up front before passing them into the worker channels, there is likely to be processing skew on certain workers. Before, workers simply grabbed the next free statement from the queue. This limitation dampens some of the performance gains of parallel metadata restore.

dev pipeline: https://dp.ci.gpdb.pivotal.io/teams/main/pipelines/parallel_analyze_fix