### PR TITLE
Add mutex to progress bar for concurrency safe incrementing

### DIFF
--- a/utils/progress_bar.go
+++ b/utils/progress_bar.go
@@ -5,6 +5,7 @@ package utils
  */
 
 import (
+	"sync"
 	"time"
 
 	"github.com/greenplum-db/gp-common-go-libs/gplog"
@@ -61,6 +62,7 @@ type VerboseProgressBar struct {
 	prefix             string
 	nextPercentToPrint int
 	*pb.ProgressBar
+	mu sync.Mutex
 }
 
 func NewVerboseProgressBar(count int, prefix string) *VerboseProgressBar {
@@ -69,6 +71,8 @@ func NewVerboseProgressBar(count int, prefix string) *VerboseProgressBar {
 }
 
 func (vpb *VerboseProgressBar) Increment() int {
+	vpb.mu.Lock()
+	defer vpb.mu.Unlock()
 	vpb.ProgressBar.Increment()
 	if vpb.current < vpb.total {
 		vpb.current++


### PR DESCRIPTION
Our progress bar is not concurrency safe since many go routines may be attempting to modify the values at the same time. Add a mutex to be used by the progress bar for safe incrementing in go routines.

Without this fix the following issue is found by the golang race detector

```
WARNING: DATA RACE
Write at 0x00c0005a2b40 by goroutine 59:
  github.com/greenplum-db/gpbackup/utils.(*VerboseProgressBar).Increment()
      /home/kyeap/workspace/gpbackup/utils/progress_bar.go:77 +0xbc
  github.com/greenplum-db/gpbackup/restore.executeStatementsForConn()
      /home/kyeap/workspace/gpbackup/restore/parallel.go:59 +0xaa
  github.com/greenplum-db/gpbackup/restore.ExecuteStatements.func1()
      /home/kyeap/workspace/gpbackup/restore/parallel.go:164 +0x209
  github.com/greenplum-db/gpbackup/restore.ExecuteStatements.func2()
      /home/kyeap/workspace/gpbackup/restore/parallel.go:165 +0x41

Previous read at 0x00c0005a2b40 by goroutine 60:
  github.com/greenplum-db/gpbackup/utils.(*VerboseProgressBar).Increment()
      /home/kyeap/workspace/gpbackup/utils/progress_bar.go:81 +0xe5
  github.com/greenplum-db/gpbackup/restore.executeStatementsForConn()
      /home/kyeap/workspace/gpbackup/restore/parallel.go:59 +0xaa
  github.com/greenplum-db/gpbackup/restore.ExecuteStatements.func1()
      /home/kyeap/workspace/gpbackup/restore/parallel.go:164 +0x209
  github.com/greenplum-db/gpbackup/restore.ExecuteStatements.func2()
      /home/kyeap/workspace/gpbackup/restore/parallel.go:165 +0x41
```