### PR TITLE
Fix parallel restore of non-sortable statements

### DIFF
--- a/integration/parallel_queries_test.go
+++ b/integration/parallel_queries_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/greenplum-db/gpbackup/options"
 	"github.com/greenplum-db/gpbackup/restore"
 	"github.com/greenplum-db/gpbackup/toc"
-	"github.com/greenplum-db/gpbackup/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -93,14 +92,14 @@ var _ = Describe("backup, utils, and restore integration tests related to parall
 			})
 			It("can execute all statements in the list serially", func() {
 				expectedOrderArray := []string{"1", "2", "3", "4"}
-				restore.ExecuteStatementsAndCreateProgressBar(statements, "", utils.PB_NONE, false)
+				restore.ExecuteStatements(statements, nil, false)
 				resultOrderArray := dbconn.MustSelectStringSlice(tempConn, orderQuery)
 				Expect(resultOrderArray).To(Equal(expectedOrderArray))
 			})
 
 			It("can execute all statements in the list in parallel", func() {
-				expectedOrderArray := []string{"1", "2", "3", "4"}
-				restore.ExecuteStatementsAndCreateProgressBar(statements, "", utils.PB_NONE, true)
+				expectedOrderArray := []string{"3", "1", "4", "2"}
+				restore.ExecuteStatements(statements, nil, true)
 				resultOrderArray := dbconn.MustSelectStringSlice(tempConn, orderQuery)
 				Expect(resultOrderArray).To(Equal(expectedOrderArray))
 			})
@@ -124,7 +123,7 @@ var _ = Describe("backup, utils, and restore integration tests related to parall
 							Expect(errorMessage).To(Not(ContainSubstring("goroutine")))
 						}
 					}()
-					restore.ExecuteStatementsAndCreateProgressBar(statements, "", utils.PB_NONE, false)
+					restore.ExecuteStatements(statements, nil, false)
 				})
 				It("panics after exiting goroutines when running in parallel", func() {
 					errorMessage := ""
@@ -136,7 +135,7 @@ var _ = Describe("backup, utils, and restore integration tests related to parall
 							Expect(errorMessage).To(Not(ContainSubstring("goroutine")))
 						}
 					}()
-					restore.ExecuteStatementsAndCreateProgressBar(statements, "", utils.PB_NONE, true)
+					restore.ExecuteStatements(statements, nil, true)
 				})
 			})
 			Context("on-error-continue is set", func() {
@@ -144,13 +143,13 @@ var _ = Describe("backup, utils, and restore integration tests related to parall
 					_ = restoreCmdFlags.Set(options.ON_ERROR_CONTINUE, "true")
 				})
 				It("does not panic, but logs errors when running serially", func() {
-					restore.ExecuteStatementsAndCreateProgressBar(statements, "", utils.PB_NONE, false)
+					restore.ExecuteStatements(statements, nil, false)
 					Expect(logFile).To(Say(regexp.QuoteMeta(`[DEBUG]:-Error encountered when executing statement: BAD SYNTAX; Error was: ERROR: syntax error at or near "BAD"`)))
 					Expect(stderr).To(Say(regexp.QuoteMeta("[ERROR]:-Encountered 1 errors during metadata restore; see log file gbytes.Buffer for a list of failed statements.")))
 					Expect(stderr).To(Not(Say(regexp.QuoteMeta("goroutine"))))
 				})
 				It("does not panic, but logs errors when running in parallel", func() {
-					restore.ExecuteStatementsAndCreateProgressBar(statements, "", utils.PB_NONE, true)
+					restore.ExecuteStatements(statements, nil, true)
 					Expect(logFile).To(Say(regexp.QuoteMeta(`[DEBUG]:-Error encountered when executing statement: BAD SYNTAX; Error was: ERROR: syntax error at or near "BAD"`)))
 					Expect(stderr).To(Say(regexp.QuoteMeta("[ERROR]:-Encountered 1 errors during metadata restore; see log file gbytes.Buffer for a list of failed statements.")))
 					Expect(stderr).To(Not(Say(regexp.QuoteMeta("goroutine"))))

--- a/restore/wrappers.go
+++ b/restore/wrappers.go
@@ -313,10 +313,10 @@ func GetRestoreMetadataStatementsFiltered(section string, filename string, inclu
 	return statements
 }
 
-func ExecuteRestoreMetadataStatements(statements []toc.StatementWithType, objectsTitle string, progressBar utils.ProgressBar, showProgressBar int, executeInParallel bool) int32 {
+func ExecuteRestoreMetadataStatements(section string, statements []toc.StatementWithType, objectsTitle string, progressBar utils.ProgressBar, showProgressBar int, executeInParallel bool) int32 {
 	var numErrors int32
-	if progressBar == nil {
-		numErrors = ExecuteStatementsAndCreateProgressBar(statements, objectsTitle, showProgressBar, executeInParallel)
+	if section == "predata" {
+		numErrors = ExecutePredataStatements(statements, progressBar, executeInParallel)
 	} else {
 		numErrors = ExecuteStatements(statements, progressBar, executeInParallel)
 	}
@@ -353,7 +353,7 @@ func setGUCsForConnection(gucStatements []toc.StatementWithType, whichConn int) 
 		objectTypes := []string{toc.OBJ_SESSION_GUC}
 		gucStatements = GetRestoreMetadataStatements("global", globalFPInfo.GetMetadataFilePath(), objectTypes, []string{})
 	}
-	ExecuteStatementsAndCreateProgressBar(gucStatements, "", utils.PB_NONE, false, whichConn)
+	ExecuteStatements(gucStatements, nil, false, whichConn)
 	return gucStatements
 }
 


### PR DESCRIPTION
The parallel metadata restore implementation was only assigning valid Tier values to objects that were processes by TopologicalSort, i.e. statements handling objects with dependencies. Objects not in this set were assumed by the ExecuteStatements function to have Tier{0,0}, because there was no distinction between objects that could have a Tier set but it was missing (backups prior to parallel metadata restore feature), or objects that never are assigned  a tier (ANALYZE, CREATE INDEX, etc.).

The TopologicalSort comment states a tier[0]==0 value is used to indicate that this object must be restored serially and should not be parallelized. Because all metadata commands flow through the same execution functions, every statement not assigned a valid Tier > {0,0} would always execute in serial, regardless of the jobs flag.

The fix provided in this commit is short-term, but the performance impact of this regression is critical enough to require an immediate fix. The original ExecuteStatements function has been brought back, which doesn't split statements based on Tier. The Tier specific case has been moved into a new function ExecutePredataStatements. This results in some unfortunate code duplication that will need to be remedied. A 'section' argument has been added to ExecuteRestoreMetadataStatements, which is used to determine which of the Execute functions to run. Currently, passing "predata" will execute ExecutePredataStatements, while any other option executes ExecuteStatements.

The commit also refactors out the ExecuteStatementsAndCreateProgressBar so there aren't quite so many layers of function invocations.

Also it fixes some off-by-one issues with connections that are a result of recent reverts. The restore side does not create an extra communication connection, while the backup side does. This leads to a not so subtle footgun when handling the parallel workers. The connection pool and worker code should be unified for backup and restore.

Also of note, because scheduleStatementsOnWorkers assigns all statements up front before passing them into the worker channels, there is likely to be processing skew on certain workers. Before, workers simply grabbed the next free statement from the queue. This limitation further dampens some of the performance gains of parallel metadata restore.

dev pipeline: https://dp.ci.gpdb.pivotal.io/teams/main/pipelines/parallel_metadata_fix

Test DB is TPC-DS scale 10.
```
database name:         postgres
command line:          gpbackup --dbname postgres --jobs 4
compression:           gzip
backup section:        All Sections
data file format:      Multiple Data Files Per Segment
duration:              0:00:37
database size:         39 GB
segment count:         3
```

Before:
```
gprestore --timestamp 20240206132708 --create-db --redirect-db tpcds_res --jobs 4 --run-analyze
20240206:13:33:12 gprestore:bdoil:bdoil-ub:2230668-[INFO]:-Restore Key = 20240206132708
20240206:13:33:12 gprestore:bdoil:bdoil-ub:2230668-[INFO]:-gpbackup version = 1.30.0+dev.28.ga7e24ada
20240206:13:33:12 gprestore:bdoil:bdoil-ub:2230668-[INFO]:-gprestore version = 1.30.0+dev.28.ga7e24ada
20240206:13:33:12 gprestore:bdoil:bdoil-ub:2230668-[INFO]:-Greenplum Database Version = 6.26.2+dev.2.gaf903883053 build dev
20240206:13:33:12 gprestore:bdoil:bdoil-ub:2230668-[INFO]:-Creating database
20240206:13:33:13 gprestore:bdoil:bdoil-ub:2230668-[INFO]:-Database creation complete for: tpcds_res
20240206:13:33:13 gprestore:bdoil:bdoil-ub:2230668-[INFO]:-Restoring pre-data metadata
Pre-data objects restored:  179 / 179 [=================================================] 100.00% 3s
20240206:13:33:16 gprestore:bdoil:bdoil-ub:2230668-[INFO]:-Pre-data metadata restore complete
Tables restored:  30 / 30 [==========================================================] 100.00% 1m51s
20240206:13:35:08 gprestore:bdoil:bdoil-ub:2230668-[INFO]:-Data restore complete
20240206:13:35:08 gprestore:bdoil:bdoil-ub:2230668-[INFO]:-Restoring post-data metadata
Post-data objects restored:  62 / 62 [===============================================] 100.00% 6m20s
20240206:13:41:29 gprestore:bdoil:bdoil-ub:2230668-[INFO]:-Post-data metadata restore complete
20240206:13:41:29 gprestore:bdoil:bdoil-ub:2230668-[INFO]:-Running ANALYZE on restored tables
Tables analyzed:  30 / 30 [==========================================================] 100.00% 4m43s
```

After:
```
gprestore --timestamp 20240206160157 --create-db --redirect-db tpcds_res --run-analyze --jobs 4                                        
20240206:16:36:55 gprestore:bdoil:bdoil-ub:2289556-[INFO]:-Restore Key = 20240206160157
20240206:16:36:55 gprestore:bdoil:bdoil-ub:2289556-[INFO]:-gpbackup version = 1.30.0+dev.28.gba535d8a
20240206:16:36:55 gprestore:bdoil:bdoil-ub:2289556-[INFO]:-gprestore version = 1.30.0+dev.28.ge076af4d
20240206:16:36:55 gprestore:bdoil:bdoil-ub:2289556-[INFO]:-Greenplum Database Version = 6.26.2+dev.2.gaf903883053 build dev
20240206:16:36:55 gprestore:bdoil:bdoil-ub:2289556-[INFO]:-Creating database
20240206:16:36:56 gprestore:bdoil:bdoil-ub:2289556-[INFO]:-Database creation complete for: tpcds_res
20240206:16:36:56 gprestore:bdoil:bdoil-ub:2289556-[INFO]:-Restoring pre-data metadata
Pre-data objects restored:  173 / 173 [=================================================] 100.00% 1s
20240206:16:36:58 gprestore:bdoil:bdoil-ub:2289556-[INFO]:-Pre-data metadata restore complete
Tables restored:  27 / 27 [==========================================================] 100.00% 1m52s
20240206:16:38:50 gprestore:bdoil:bdoil-ub:2289556-[INFO]:-Data restore complete
20240206:16:38:50 gprestore:bdoil:bdoil-ub:2289556-[INFO]:-Restoring post-data metadata
Post-data objects restored:  62 / 62 [===============================================] 100.00% 3m29s
20240206:16:42:19 gprestore:bdoil:bdoil-ub:2289556-[INFO]:-Post-data metadata restore complete
20240206:16:42:19 gprestore:bdoil:bdoil-ub:2289556-[INFO]:-Running ANALYZE on restored tables
Tables analyzed:  27 / 27 [===========================================================] 100.00% 2m8s
```