### PR TITLE
Skip localhost in copyPluginToAllHosts e2e test func

### DIFF
--- a/end_to_end/plugin_test.go
+++ b/end_to_end/plugin_test.go
@@ -20,6 +20,11 @@ func copyPluginToAllHosts(conn *dbconn.DBConn, pluginPath string) {
 	hostnameQuery := `SELECT DISTINCT hostname AS string FROM gp_segment_configuration WHERE content != -1`
 	hostnames := dbconn.MustSelectStringSlice(conn, hostnameQuery)
 	for _, hostname := range hostnames {
+		// Skip the local host
+		h, _ := os.Hostname()
+		if hostname == h {
+			continue
+		}
 		examplePluginTestDir, _ := path.Split(pluginPath)
 		command := exec.Command("ssh", hostname, fmt.Sprintf("mkdir -p %s", examplePluginTestDir))
 		mustRunCommand(command)


### PR DESCRIPTION
On some platforms, it seems an scp of a file to itself results in a truncated file. This has been observed on ubuntu 23.04 with openssl 3.0.8. Instead, skip localhost when copying the plugin since it already exists, which should be safe for all platforms.

Example:
```
stat /home/bdoil/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash
  File: /home/bdoil/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash
  Size: 3891            Blocks: 8          IO Block: 4096   regular file

scp /home/bdoil/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash \
 bdoil-ub:/home/bdoil/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash

stat /home/bdoil/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash
  File: /home/bdoil/go/src/github.com/greenplum-db/gpbackup/plugins/example_plugin.bash
  Size: 0               Blocks: 0          IO Block: 4096   regular empty file
```