### PR TITLE
CI: test s3 plugin using minio

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ info-report:
 test-s3-local: build install
 	${PWD}/plugins/generate_minio_config.sh
 	mkdir -p /tmp/minio/gpbackup-s3-test
-	docker run -d --name s3-minio -p 9000:9000 -p 9001:9001 -v /tmp/minio:/data/minio quay.io/minio/minio server /data/minio --console-address ":9001"
+	docker run -d --name s3-minio --memory="2g" -p 9000:9000 -p 9001:9001 -v /tmp/minio:/data/minio quay.io/minio/minio server /data/minio --console-address ":9001"
 	sleep 2 # Wait for minio server to start up
 	${PWD}/plugins/plugin_test.sh $(BIN_DIR)/gpbackup_s3_plugin /tmp/minio_config.yaml
 	docker stop s3-minio

--- a/ci/scripts/ddboost-plugin-tests.bash
+++ b/ci/scripts/ddboost-plugin-tests.bash
@@ -84,9 +84,9 @@ CONFIG
 
 pushd \${GOPATH}/src/github.com/greenplum-db/gpbackup/plugins
 
-./plugin_test.sh \${GPHOME}/bin/gpbackup_ddboost_plugin \${HOME}/ddboost_config_replication.yaml gpbackup_tests${GPDB_VERSION} \${HOME}/ddboost_config_replication_restore.yaml
+./plugin_test.sh \${GPHOME}/bin/gpbackup_ddboost_plugin \${HOME}/ddboost_config_replication.yaml \${HOME}/ddboost_config_replication_restore.yaml
 
-./plugin_test.sh \${GPHOME}/bin/gpbackup_ddboost_plugin \${HOME}/ddboost_config.yaml gpbackup_tests${GPDB_VERSION} \${HOME}/ddboost_config_replication_restore.yaml
+./plugin_test.sh \${GPHOME}/bin/gpbackup_ddboost_plugin \${HOME}/ddboost_config.yaml \${HOME}/ddboost_config_replication_restore.yaml
 
 # exercise boostfs, which is mounted at /data/gpdata/dd_dir
 pushd \${GOPATH}/src/github.com/greenplum-db/gpbackup

--- a/ci/scripts/s3-plugin-tests.bash
+++ b/ci/scripts/s3-plugin-tests.bash
@@ -30,7 +30,7 @@ options:
 CONFIG
 
   pushd ~/go/src/github.com/greenplum-db/gpbackup/plugins
-    ./plugin_test.sh \${GPHOME}/bin/gpbackup_s3_plugin \${HOME}/s3_config.yaml test/backup 
+    ./plugin_test.sh \${GPHOME}/bin/gpbackup_s3_plugin \${HOME}/s3_config.yaml
   popd
 SCRIPT
 

--- a/ci/scripts/s3-plugin-tests.bash
+++ b/ci/scripts/s3-plugin-tests.bash
@@ -11,13 +11,79 @@ tar -xzf gppkgs/gpbackup-gppkgs.tar.gz -C /tmp/untarred
 scp /tmp/untarred/gpbackup_tools*gp${GPDB_VERSION}*${OS}*.gppkg cdw:/home/gpadmin
 ssh -t cdw "source env.sh; gppkg -i gpbackup_tools*.gppkg"
 
-cat <<SCRIPT > /tmp/run_tests.bash
+cat <<SCRIPT > /tmp/setup_minio.bash
+# Install Minio
+wget https://dl.min.io/server/minio/release/linux-amd64/minio
+sudo mv minio /usr/local/bin/
+sudo chmod 777 /usr/local/bin/minio
+sudo chown rocky:rocky /usr/local/bin/minio
+
+# Setup Minio server
+mkdir -p /tmp/minio_root
+mkdir -p /tmp/.minio/logs
+touch /tmp/.minio/logs/minio_log
+chmod 777 /tmp/minio_root
+chmod 777 /tmp/.minio/logs
+chown -R rocky:rocky /tmp/minio_root
+chown -R rocky:rocky /tmp/.minio
+nohup minio server --console-address ":9001" /tmp/minio_root > /tmp/.minio/logs/minio_log 2>&1 &
+
+curl https://dl.min.io/client/mc/release/linux-amd64/mc \
+  --create-dirs \
+  -o \$HOME/minio-binaries/mc
+
+chmod +x \$HOME/minio-binaries/mc
+export PATH=\$PATH:\$HOME/minio-binaries/
+which mc
+
+#create test bucket
+mc mb /tmp/minio_root/minio-test-bucket
+
+SCRIPT
+
+chmod +x /tmp/setup_minio.bash
+scp /tmp/setup_minio.bash rocky@cdw:/home/rocky/setup_minio.bash
+ssh -t rocky@cdw "/home/rocky/setup_minio.bash"
+
+ssh -t rocky@cdw "ps aux | grep minio"
+
+cat <<SCRIPT > /tmp/minio_tests.bash
   #!/bin/bash
 
   set -ex
   source env.sh
 
-  cat << CONFIG > \${HOME}/s3_config.yaml
+  # config to test against s3-compliant storage minio
+  cat << MINIO_CONFIG > \${HOME}/minio_config.yaml
+executablepath: \${GPHOME}/bin/gpbackup_s3_plugin
+options:
+  endpoint: http://\$(hostname -I | awk '{print \$1}'):9000/
+  aws_access_key_id: minioadmin
+  aws_secret_access_key: minioadmin
+  bucket: minio-test-bucket
+  folder: minio-folder/test-cluster
+  backup_max_concurrent_requests: 2
+  backup_multipart_chunksize: 5MB
+  restore_max_concurrent_requests: 2
+  restore_multipart_chunksize: 5MB
+MINIO_CONFIG
+
+  pushd ~/go/src/github.com/greenplum-db/gpbackup/plugins
+    ./plugin_test.sh \${GPHOME}/bin/gpbackup_s3_plugin \${HOME}/minio_config.yaml
+  popd
+SCRIPT
+
+chmod +x /tmp/minio_tests.bash
+scp /tmp/minio_tests.bash cdw:/home/gpadmin/minio_tests.bash
+ssh -t cdw "/home/gpadmin/minio_tests.bash"
+
+cat <<SCRIPT > /tmp/s3_tests.bash
+  #!/bin/bash
+
+  set -ex
+  source env.sh
+
+  cat << S3_CONFIG > \${HOME}/s3_config.yaml
 executablepath: \${GPHOME}/bin/gpbackup_s3_plugin
 options:
   region: ${REGION}
@@ -27,13 +93,13 @@ options:
   folder: test/backup
   backup_multipart_chunksize: 100MB
   restore_multipart_chunksize: 100MB
-CONFIG
+S3_CONFIG
 
   pushd ~/go/src/github.com/greenplum-db/gpbackup/plugins
     ./plugin_test.sh \${GPHOME}/bin/gpbackup_s3_plugin \${HOME}/s3_config.yaml
   popd
 SCRIPT
 
-chmod +x /tmp/run_tests.bash
-scp /tmp/run_tests.bash cdw:/home/gpadmin/run_tests.bash
-ssh -t cdw "/home/gpadmin/run_tests.bash"
+chmod +x /tmp/s3_tests.bash
+scp /tmp/s3_tests.bash cdw:/home/gpadmin/s3_tests.bash
+ssh -t cdw "/home/gpadmin/s3_tests.bash"

--- a/end_to_end/plugin_test.go
+++ b/end_to_end/plugin_test.go
@@ -453,7 +453,7 @@ var _ = Describe("End to End plugin tests", func() {
 				Skip("This test is only needed for the latest backup version")
 			}
 			copyPluginToAllHosts(backupConn, examplePluginExec)
-			command := exec.Command("bash", "-c", fmt.Sprintf("%s/plugin_test.sh %s %s %s", examplePluginDir, examplePluginExec, examplePluginTestConfig, examplePluginTestDir))
+			command := exec.Command("bash", "-c", fmt.Sprintf("%s/plugin_test.sh %s %s", examplePluginDir, examplePluginExec, examplePluginTestConfig))
 			mustRunCommand(command)
 		})
 	})

--- a/plugins/example_plugin.bash
+++ b/plugins/example_plugin.bash
@@ -90,11 +90,13 @@ delete_backup() {
 
 }
 
+# utility/debugging function to maintain parity with ddboost and s3 plugin
 list_directory() {
   echo "list_directory $1 /tmp/plugin_dest" >> /tmp/plugin_out.txt
   ls /tmp/plugin_dest
 }
 
+# utility/debugging function to maintain parity with ddboost and s3 plugin
 delete_directory() {
   echo "delete_directory $1 /tmp/plugin_dest" >> /tmp/plugin_out.txt
   rm -rf /tmp/plugin_dest

--- a/plugins/generate_minio_config.sh
+++ b/plugins/generate_minio_config.sh
@@ -8,4 +8,8 @@ options:
   aws_secret_access_key: minioadmin
   bucket: gpbackup-s3-test
   folder: test/backup
+  backup_max_concurrent_requests: 2
+  backup_multipart_chunksize: 5MB
+  restore_max_concurrent_requests: 2
+  restore_multipart_chunksize: 5MB
 MINIO_CONFIG


### PR DESCRIPTION
Test the s3 plugin against s3-compliant object storage. Minio is a
popular lightweight s3 compliant storage solution. While we have a
makefile rule to test gpbackup/gprestore and the s3 plugin against a
minio instance, this does not run in the CI. Setup a local minio
instance in the CI and test basic functionality of the s3 plugin.

pipeline: https://dp.ci.gpdb.pivotal.io/teams/main/pipelines/fix-no-bucket