### PR TITLE
Properly dump GRANT statements for aggregate functions

### DIFF
--- a/backup/predata_acl.go
+++ b/backup/predata_acl.go
@@ -381,6 +381,9 @@ func createPrivilegeStrings(acl ACL, objectType string) (string, string) {
 	case toc.OBJ_TYPE:
 		hasAllPrivileges = acl.Usage
 		hasAllPrivilegesWithGrant = acl.UsageWithGrant
+	case toc.OBJ_AGGREGATE:
+		hasAllPrivileges = acl.Execute
+		hasAllPrivilegesWithGrant = acl.ExecuteWithGrant
 	}
 	if hasAllPrivileges {
 		privStr = "ALL"

--- a/backup/predata_acl_test.go
+++ b/backup/predata_acl_test.go
@@ -149,7 +149,7 @@ REVOKE ALL ON FOREIGN SERVER foreignserver FROM PUBLIC;
 REVOKE ALL ON FOREIGN SERVER foreignserver FROM testrole;
 GRANT ALL ON FOREIGN SERVER foreignserver TO testrole;`)
 		})
-		It("prints FUNCTION for REVOKE and AGGREGATE for ALTER for an aggregate function", func() {
+		It("prints FUNCTION for GRANT/REVOKE and AGGREGATE for ALTER for an aggregate function", func() {
 			aggregate := backup.Aggregate{Schema: "public", Name: "testagg"}
 			aggregatePrivileges := testutils.DefaultACLForType("testrole", toc.OBJ_AGGREGATE)
 			aggregateMetadata := backup.ObjectMetadata{Privileges: []backup.ACL{aggregatePrivileges}, Owner: "testrole"}
@@ -160,7 +160,8 @@ ALTER AGGREGATE public.testagg(*) OWNER TO testrole;
 
 
 REVOKE ALL ON FUNCTION public.testagg(*) FROM PUBLIC;
-REVOKE ALL ON FUNCTION public.testagg(*) FROM testrole;`)
+REVOKE ALL ON FUNCTION public.testagg(*) FROM testrole;
+GRANT ALL ON FUNCTION public.testagg(*) TO testrole;`)
 		})
 		It("prints TABLE for a block of REVOKE and GRANT statements for a foreign table", func() {
 			table := backup.Table{Relation: backup.Relation{Schema: "public", Name: "foreigntablename"}}

--- a/backup/predata_functions_test.go
+++ b/backup/predata_functions_test.go
@@ -356,7 +356,7 @@ $_$`)
 		BeforeEach(func() {
 			aggDefinition = backup.Aggregate{Oid: 1, Schema: "public", Name: "agg_name", Arguments: sql.NullString{String: "integer, integer", Valid: true}, IdentArgs: sql.NullString{String: "integer, integer", Valid: true}, TransitionFunction: 1, TransitionDataType: "integer", InitValIsNull: true, MInitValIsNull: true}
 			emptyMetadata = backup.ObjectMetadata{}
-			aggMetadata = testutils.DefaultMetadata(toc.OBJ_AGGREGATE, false, true, true, true)
+			aggMetadata = testutils.DefaultMetadata(toc.OBJ_AGGREGATE, true, true, true, true)
 		})
 
 		It("prints an aggregate definition for an unordered aggregate with no optional specifications", func() {
@@ -579,6 +579,9 @@ $_$`)
 	STYPE = integer
 );`, "COMMENT ON AGGREGATE public.agg_name(integer, integer) IS 'This is an aggregate comment.';",
 				"ALTER AGGREGATE public.agg_name(integer, integer) OWNER TO testrole;",
+				`REVOKE ALL ON FUNCTION public.agg_name(integer, integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.agg_name(integer, integer) FROM testrole;
+GRANT ALL ON FUNCTION public.agg_name(integer, integer) TO testrole;`,
 				"SECURITY LABEL FOR dummy ON AGGREGATE public.agg_name(integer, integer) IS 'unclassified';"}
 			testutils.AssertBufferContents(tocfile.PredataEntries, buffer, expectedStatements...)
 		})
@@ -593,6 +596,9 @@ $_$`)
 );`,
 				"COMMENT ON AGGREGATE public.agg_name(*) IS 'This is an aggregate comment.';",
 				"ALTER AGGREGATE public.agg_name(*) OWNER TO testrole;",
+				`REVOKE ALL ON FUNCTION public.agg_name(*) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.agg_name(*) FROM testrole;
+GRANT ALL ON FUNCTION public.agg_name(*) TO testrole;`,
 				"SECURITY LABEL FOR dummy ON AGGREGATE public.agg_name(*) IS 'unclassified';"}
 			testutils.AssertBufferContents(tocfile.PredataEntries, buffer, expectedStatements...)
 		})


### PR DESCRIPTION
Aggregates don't have a GRANT ON AGGREGATE syntax, instead GRANT ON FUNCTION is used. However, aggregates are still distinct object types and createPrivilegeStrings did not consider this. Properly handle aggregates when creating privilege strings.
dev pipeline: https://dp.ci.gpdb.pivotal.io/teams/main/pipelines/grant_on_agg

