### PR TITLE
Filter out false errors for regression test

### DIFF
--- a/ci/scripts/icw-migr-restore.bash
+++ b/ci/scripts/icw-migr-restore.bash
@@ -65,6 +65,8 @@ gprestore --timestamp=\$TS --backup-dir=/tmp/icw-migr-backup --create-db --with-
 
 cat /home/gpadmin/gpAdminLogs/gprestore_* | grep -E "ERROR" | grep -Ev "Encountered [0-9]" \
     | grep -Ev "ALTER RESOURCE GROUP" \
+    | grep -Ev "LOG ERRORS" \
+    | grep -Ev "RAISE EXCEPTION" \
     | tee /tmp/error_list.log
 
 if [[ -s /tmp/error_list.log ]] ; then


### PR DESCRIPTION
LOG ERRORS is a keyword and RAISE EXCEPTION is part of a function definition so these are fine to skip

Authored-by: Karen Huddleston <khuddleston@vmware.com>