### PR TITLE
Fix ginkgo version mismatch warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ depend :
 	go mod download
 
 $(GINKGO) :
-	go install github.com/onsi/ginkgo/v2/ginkgo@v2.8.4
+	go install github.com/onsi/ginkgo/v2/ginkgo
 
 $(GOIMPORTS) :
 	go install golang.org/x/tools/cmd/goimports@latest


### PR DESCRIPTION
If we don't specify a version here it will use the one specified in the go.mod file so the cli version should match with the tests

Authored-by: Karen Huddleston <khuddleston@vmware.com>